### PR TITLE
feat: Extending type of content in LanguageModelMessage

### DIFF
--- a/unique_toolkit/CHANGELOG.md
+++ b/unique_toolkit/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), 
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.19] - 2024-09-11
+- `LanguageModelMessage` now supports content as a list of dictionnary. Useful when adding image_url content along user message. 
+
 ## [0.5.18] - 2024-09-03
 - Adds option to use `metadata_filter` with search.
 - Adds `user_metadata`, `tool_parameters` and `metadata_filter` to `EventPayload`.

--- a/unique_toolkit/pyproject.toml
+++ b/unique_toolkit/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "unique_toolkit"
-version = "0.5.18"
+version = "0.5.19"
 description = ""
 authors = [
     "Martin Fadler <martin.fadler@unique.ch>",

--- a/unique_toolkit/tests/language_model/test_language_models_schemas.py
+++ b/unique_toolkit/tests/language_model/test_language_models_schemas.py
@@ -19,6 +19,31 @@ class TestLanguageModelSchemas:
         expected = """{"role":"user","content":"blah"}"""
         assert message.model_dump_json(exclude_none=True) == expected
 
+    def test_can_serialize_message_with_image(self):
+        message = LanguageModelUserMessage(
+            content=[
+                {"type": "text", "content": "text_content"},
+                {
+                    "type": "image_url",
+                    "imageUrl": {"url": "image_string_base64"},
+                },
+            ]
+        )
+        expected = """{"role":"user","content":[{"type":"text","content":"text_content"},{"type":"image_url","imageUrl":{"url":"image_string_base64"}}]}"""
+        assert message.model_dump_json(exclude_none=True) == expected
+
+        message = LanguageModelSystemMessage(
+            content=[
+                {"type": "text", "content": "text_content"},
+                {
+                    "type": "image_url",
+                    "imageUrl": {"url": "image_string_base64"},
+                },
+            ]
+        )
+        expected = """{"role":"system","content":[{"type":"text","content":"text_content"},{"type":"image_url","imageUrl":{"url":"image_string_base64"}}]}"""
+        assert message.model_dump_json(exclude_none=True) == expected
+
     def test_can_serialize_messages(self):
         messages = LanguageModelMessages(
             [

--- a/unique_toolkit/unique_toolkit/language_model/schemas.py
+++ b/unique_toolkit/unique_toolkit/language_model/schemas.py
@@ -43,7 +43,7 @@ class LanguageModelMessage(BaseModel):
     model_config = model_config
 
     role: LanguageModelMessageRole
-    content: Optional[str] = None
+    content: Optional[str | list[dict]] = None
     name: Optional[str] = None
     tool_calls: Optional[list[LanguageModelFunctionCall]] = None
 


### PR DESCRIPTION
Currently, we are unable to send a list of dictionnary to the llm completion requests (which is allowed by OpenAI). This feature is useful when there is a need to add an encoded image along the user message.