### PR TITLE
chore(toolkit): Providing content and original_content optional

### DIFF
--- a/unique_toolkit/CHANGELOG.md
+++ b/unique_toolkit/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.5.37] - 2024-11-26
 - `content` parameter in `ChatService.modify_assistant_message` and `ChatService.modify_assistant_message_async` is now optional
 - Added optional parameter `original_content` to `ChatService.modify_assistant_message` and `ChatService.modify_assistant_message_async`
+- Added optional parameter `original_content` to `ChatService.create_assistant_message` and `ChatService.create_assistant_message_async`
 
 ## [0.5.36] - 2024-11-19
 - Add possibility to return the response from the download file from chat request

--- a/unique_toolkit/CHANGELOG.md
+++ b/unique_toolkit/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), 
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.37] - 2024-11-26
+- `content` parameter in `ChatService.modify_assistant_message` and `ChatService.modify_assistant_message_async` is now optional
+- Added optional parameter `original_content` to `ChatService.modify_assistant_message` and `ChatService.modify_assistant_message_async`
+
 ## [0.5.36] - 2024-11-19
 - Add possibility to return the response from the download file from chat request
 - Add possibility to not specify a filename and use filename from response headers

--- a/unique_toolkit/pyproject.toml
+++ b/unique_toolkit/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "unique_toolkit"
-version = "0.5.36"
+version = "0.5.37"
 description = ""
 authors = [
     "Martin Fadler <martin.fadler@unique.ch>",

--- a/unique_toolkit/tests/chat/test_chat_service_unit.py
+++ b/unique_toolkit/tests/chat/test_chat_service_unit.py
@@ -31,7 +31,7 @@ class TestChatServiceUnit:
         )
         self.service = ChatService(self.event)
         self.mock_get_datetime_now = mock_get_datetime_now
-
+   
     def test_modify_assistant_message(self):
         # Test with update completedAt
         with patch.object(unique_sdk.Message, "modify", autospec=True) as mock_modify:
@@ -71,7 +71,7 @@ class TestChatServiceUnit:
                 id="test_assistant_message",
                 chatId="test_chat",
                 text="Modified message",
-                originalText="Modified message",
+                originalText=None,
                 references=[
                     {
                         "name": "Document 1",
@@ -122,7 +122,7 @@ class TestChatServiceUnit:
                 id="test_assistant_message",
                 chatId="test_chat",
                 text="Modified message",
-                originalText="Modified message",
+                originalText=None,
                 references=[
                     {
                         "name": "Document 1",
@@ -299,7 +299,7 @@ class TestChatServiceUnit:
                 id="test_assistant_message",
                 chatId="test_chat",
                 text="Modified message",
-                originalText="Modified message",
+                originalText=None,
                 references=[
                     {
                         "name": "Document 1",
@@ -352,7 +352,7 @@ class TestChatServiceUnit:
                 id="test_assistant_message",
                 chatId="test_chat",
                 text="Modified message",
-                originalText="Modified message",
+                originalText=None,
                 references=[
                     {
                         "name": "Document 1",

--- a/unique_toolkit/tests/chat/test_chat_service_unit.py
+++ b/unique_toolkit/tests/chat/test_chat_service_unit.py
@@ -31,7 +31,7 @@ class TestChatServiceUnit:
         )
         self.service = ChatService(self.event)
         self.mock_get_datetime_now = mock_get_datetime_now
-   
+
     def test_modify_assistant_message(self):
         # Test with update completedAt
         with patch.object(unique_sdk.Message, "modify", autospec=True) as mock_modify:

--- a/unique_toolkit/unique_toolkit/chat/service.py
+++ b/unique_toolkit/unique_toolkit/chat/service.py
@@ -179,7 +179,8 @@ class ChatService(BaseService):
 
     async def modify_assistant_message_async(
         self,
-        content: str,
+        content: str | None = None,
+        original_content: str | None = None,
         references: list[ContentReference] = [],
         debug_info: dict = {},
         message_id: Optional[str] = None,
@@ -205,6 +206,7 @@ class ChatService(BaseService):
             params = self._construct_message_modify_params(
                 assistant=True,
                 content=content,
+                original_content=original_content,
                 references=references,
                 debug_info=debug_info,
                 message_id=message_id,
@@ -497,6 +499,7 @@ class ChatService(BaseService):
         self,
         assistant: bool = True,
         content: Optional[str] = None,
+        original_content: Optional[str] = None,
         references: Optional[list[ContentReference]] = None,
         debug_info: Optional[dict] = None,
         message_id: Optional[str] = None,
@@ -525,7 +528,7 @@ class ChatService(BaseService):
             "id": message_id,
             "chatId": self.event.payload.chat_id,
             "text": content,
-            "originalText": content,
+            "originalText": original_content,
             "references": self._map_references(references) if references else [],
             "debugInfo": debug_info,
             "completedAt": completed_at_datetime,
@@ -559,7 +562,6 @@ class ChatService(BaseService):
             "role": role.value.upper(),
             "chatId": self.event.payload.chat_id,
             "text": content,
-            "originalText": content,
             "references": self._map_references(references) if references else [],
             "debugInfo": debug_info,
             "completedAt": completed_at_datetime,

--- a/unique_toolkit/unique_toolkit/chat/service.py
+++ b/unique_toolkit/unique_toolkit/chat/service.py
@@ -307,6 +307,7 @@ class ChatService(BaseService):
     def create_assistant_message(
         self,
         content: str,
+        original_content: str | None = None,
         references: list[ContentReference] = [],
         debug_info: dict = {},
         set_completed_at: Optional[bool] = False,
@@ -316,6 +317,7 @@ class ChatService(BaseService):
 
         Args:
             content (str): The content for the message.
+            original_content (str, optional): The original content for the message.
             references (list[ContentReference]): list of ContentReference objects. Defaults to None.
             debug_info (dict[str, Any]]): Debug information. Defaults to None.
             set_completed_at (Optional[bool]): Whether to set the completedAt field with the current date time. Defaults to False.
@@ -326,10 +328,13 @@ class ChatService(BaseService):
         Raises:
             Exception: If the creation fails.
         """
+        if original_content is None:
+            original_content = content
 
         try:
             params = self._construct_message_create_params(
                 content=content,
+                original_content=original_content,
                 references=references,
                 debug_info=debug_info,
                 set_completed_at=set_completed_at,
@@ -344,6 +349,7 @@ class ChatService(BaseService):
     async def create_assistant_message_async(
         self,
         content: str,
+        original_content: str | None = None,
         references: list[ContentReference] = [],
         debug_info: dict = {},
         set_completed_at: Optional[bool] = False,
@@ -353,6 +359,7 @@ class ChatService(BaseService):
 
         Args:
             content (str): The content for the message.
+            original_content (str, optional): The original content for the message.
             references (list[ContentReference]): list of references. Defaults to None.
             debug_info (dict[str, Any]]): Debug information. Defaults to None.
             set_completed_at (Optional[bool]): Whether to set the completedAt field with the current date time. Defaults to False.
@@ -363,9 +370,13 @@ class ChatService(BaseService):
         Raises:
             Exception: If the creation fails.
         """
+        if original_content is None:
+            original_content = content
+
         try:
             params = self._construct_message_create_params(
                 content=content,
+                original_content=original_content,
                 references=references,
                 debug_info=debug_info,
                 set_completed_at=set_completed_at,
@@ -543,6 +554,7 @@ class ChatService(BaseService):
         self,
         role: ChatMessageRole = ChatMessageRole.ASSISTANT,
         content: Optional[str] = None,
+        original_content: Optional[str] = None,
         references: Optional[list[ContentReference]] = None,
         debug_info: Optional[dict] = None,
         assistantId: Optional[str] = None,
@@ -559,6 +571,9 @@ class ChatService(BaseService):
         else:
             completed_at_datetime = None
 
+        if original_content is None:
+            original_content = content
+
         params = {
             "user_id": self.event.user_id,
             "company_id": self.event.company_id,
@@ -566,6 +581,7 @@ class ChatService(BaseService):
             "role": role.value.upper(),
             "chatId": self.event.payload.chat_id,
             "text": content,
+            "originalText": original_content,
             "references": self._map_references(references) if references else [],
             "debugInfo": debug_info,
             "completedAt": completed_at_datetime,

--- a/unique_toolkit/unique_toolkit/chat/service.py
+++ b/unique_toolkit/unique_toolkit/chat/service.py
@@ -140,7 +140,8 @@ class ChatService(BaseService):
 
     def modify_assistant_message(
         self,
-        content: str,
+        content: str | None = None,
+        original_content: str | None = None,
         references: list[ContentReference] = [],
         debug_info: dict = {},
         message_id: Optional[str] = None,
@@ -150,7 +151,8 @@ class ChatService(BaseService):
         Modifies a message in the chat session synchronously.
 
         Args:
-            content (str): The new content for the message.
+            content (str, optional): The new content for the message.
+            original_content (str, optional): The original content for the message.
             references (list[ContentReference]): list of ContentReference objects. Defaults to [].
             debug_info (dict[str, Any]]]): Debug information. Defaults to {}.
             message_id (Optional[str]): The message ID. Defaults to None.
@@ -166,6 +168,7 @@ class ChatService(BaseService):
             params = self._construct_message_modify_params(
                 assistant=True,
                 content=content,
+                original_content=original_content,
                 references=references,
                 debug_info=debug_info,
                 message_id=message_id,
@@ -190,7 +193,8 @@ class ChatService(BaseService):
         Modifies a message in the chat session asynchronously.
 
         Args:
-            content (str): The new content for the message.
+            content (str, optional): The new content for the message.
+            original_content (str, optional): The original content for the message.
             message_id (str, optional): The message ID. Defaults to None, then the ChatState assistant message id is used.
             references (list[ContentReference]): list of ContentReference objects. Defaults to None.
             debug_info (Optional[dict[str, Any]]], optional): Debug information. Defaults to None.


### PR DESCRIPTION
Refs: UN-8901

This should enable us to set the completed at flag without updating the message content.