### PR TITLE
feat(toolkit): allow to pass other arbitrary options in lm service

### DIFF
--- a/unique_toolkit/CHANGELOG.md
+++ b/unique_toolkit/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), 
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
+## [0.5.40] - 2024-12-11
+- Add `other_options` to `LanguageModelService.complete`, `LanguageModelService.complete_async`, `LanguageModelService.stream_complete` and `LanguageModelService.stream_complete_async`
 
 ## [0.5.39] - 2024-12-09
 - Add `contentIds` to `Search.create` and `Search.create_async`

--- a/unique_toolkit/pyproject.toml
+++ b/unique_toolkit/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "unique_toolkit"
-version = "0.5.39"
+version = "0.5.40"
 description = ""
 authors = [
     "Martin Fadler <martin.fadler@unique.ch>",

--- a/unique_toolkit/tests/language_model/test_language_models_service_unit.py
+++ b/unique_toolkit/tests/language_model/test_language_models_service_unit.py
@@ -487,13 +487,13 @@ class TestLanguageModelServiceUnit:
         assert arguments is not None
         assert "London, UK" in arguments.values()
 
-    def test_prepare_completion_params_basic(self):
+    def testprepare_completion_params_util_basic(self):
         messages = LanguageModelMessages([])
         model_name = LanguageModelName.AZURE_GPT_4_TURBO_1106
         temperature = 0.5
 
         options, model, messages_dict, search_context = (
-            LanguageModelService._prepare_completion_params(
+            LanguageModelService.prepare_completion_params_util(
                 messages=messages,
                 model_name=model_name,
                 temperature=temperature,
@@ -505,12 +505,12 @@ class TestLanguageModelServiceUnit:
         assert messages_dict == []
         assert search_context is None
 
-    def test_prepare_completion_params_with_tools_and_other_options(self):
+    def testprepare_completion_params_util_with_tools_and_other_options(self):
         messages = LanguageModelMessages([])
         other_options = {"max_tokens": 100, "top_p": 0.9}
 
         options, model, messages_dict, search_context = (
-            LanguageModelService._prepare_completion_params(
+            LanguageModelService.prepare_completion_params_util(
                 messages=messages,
                 model_name="custom_model",
                 temperature=0.7,

--- a/unique_toolkit/tests/language_model/test_language_models_service_unit.py
+++ b/unique_toolkit/tests/language_model/test_language_models_service_unit.py
@@ -50,150 +50,127 @@ class TestLanguageModelServiceUnit:
         )
         self.service = LanguageModelService(self.event)
 
-    def test_complete(self):
-        with patch.object(unique_sdk.ChatCompletion, "create") as mock_create:
-            mock_create.return_value = {
-                "choices": [
-                    {
-                        "index": 0,
-                        "finishReason": "completed",
-                        "message": {
-                            "content": "Test response",
-                            "role": "assistant",
-                        },
-                    }
-                ]
-            }
-            messages = LanguageModelMessages([])
-            model_name = LanguageModelName.AZURE_GPT_4_TURBO_1106
-
-            result = self.service.complete(messages, model_name)
-
-            assert isinstance(result, LanguageModelResponse)
-            assert result.choices[0].message.content == "Test response"
-            mock_create.assert_called_once_with(
-                company_id="test_company",
-                model=model_name.name,
-                messages=[],
-                timeout=240000,
-                options={
-                    "temperature": 0.0,
-                },
-            )
-
-    def test_stream_complete(self):
-        with patch.object(
-            unique_sdk.Integrated, "chat_stream_completion"
-        ) as mock_stream_complete:
-            mock_stream_complete.return_value = {
-                "message": {
-                    "id": "test_message",
-                    "previousMessageId": "test_previous_message",
-                    "role": "ASSISTANT",
-                    "text": "Streamed response",
-                    "originalText": "Streamed response original",
+    @patch.object(unique_sdk.ChatCompletion, "create")
+    def test_complete(self, mock_create):
+        mock_create.return_value = {
+            "choices": [
+                {
+                    "index": 0,
+                    "finishReason": "completed",
+                    "message": {
+                        "content": "Test response",
+                        "role": "assistant",
+                    },
                 }
-            }
-            messages = LanguageModelMessages([])
-            model_name = LanguageModelName.AZURE_GPT_4_TURBO_1106
-            content_chunks = [
-                ContentChunk(id="1", chunk_id="1", key="test", order=1, text="test")
             ]
+        }
+        messages = LanguageModelMessages([])
+        model_name = LanguageModelName.AZURE_GPT_4_TURBO_1106
 
-            result = self.service.stream_complete(messages, model_name, content_chunks)
+        result = self.service.complete(messages, model_name)
 
-            assert isinstance(result, LanguageModelStreamResponse)
-            assert result.message.text == "Streamed response"
-            mock_stream_complete.assert_called_once()
+        assert isinstance(result, LanguageModelResponse)
+        assert result.choices[0].message.content == "Test response"
+        mock_create.assert_called_once_with(
+            company_id="test_company",
+            model=model_name.name,
+            messages=[],
+            timeout=240000,
+            options={
+                "temperature": 0.0,
+            },
+        )
 
-    def test_complete_with_custom_model(self):
-        with patch.object(unique_sdk.ChatCompletion, "create") as mock_create:
-            mock_create.return_value = {
-                "choices": [
-                    {
-                        "index": 0,
-                        "finishReason": "completed",
-                        "message": {
-                            "content": "Test response",
-                            "role": "assistant",
-                        },
-                    }
-                ]
+    @patch.object(unique_sdk.Integrated, "chat_stream_completion")
+    def test_stream_complete(self, mock_stream_complete):
+        mock_stream_complete.return_value = {
+            "message": {
+                "id": "test_message",
+                "previousMessageId": "test_previous_message",
+                "role": "ASSISTANT",
+                "text": "Streamed response",
+                "originalText": "Streamed response original",
             }
-            messages = LanguageModelMessages([])
-            model_name = "My Custom Model"
+        }
+        messages = LanguageModelMessages([])
+        model_name = LanguageModelName.AZURE_GPT_4_TURBO_1106
+        content_chunks = [
+            ContentChunk(id="1", chunk_id="1", key="test", order=1, text="test")
+        ]
 
-            result = self.service.complete(messages, model_name)
+        result = self.service.stream_complete(messages, model_name, content_chunks)
 
-            assert isinstance(result, LanguageModelResponse)
-            assert result.choices[0].message.content == "Test response"
-            mock_create.assert_called_once_with(
-                company_id="test_company",
-                model=model_name,
-                messages=[],
-                timeout=240000,
-                options={
-                    "temperature": 0.0,
-                },
-            )
+        assert isinstance(result, LanguageModelStreamResponse)
+        assert result.message.text == "Streamed response"
+        mock_stream_complete.assert_called_once()
 
-    def test_stream_complete_with_custom_model(self):
-        with patch.object(
-            unique_sdk.Integrated, "chat_stream_completion"
-        ) as mock_stream_complete:
-            mock_stream_complete.return_value = {
-                "message": {
-                    "id": "test_message",
-                    "previousMessageId": "test_previous_message",
-                    "role": "ASSISTANT",
-                    "text": "Streamed response",
-                    "originalText": "Streamed response original",
+    @patch.object(unique_sdk.ChatCompletion, "create")
+    def test_complete_with_custom_model(self, mock_create):
+        mock_create.return_value = {
+            "choices": [
+                {
+                    "index": 0,
+                    "finishReason": "completed",
+                    "message": {
+                        "content": "Test response",
+                        "role": "assistant",
+                    },
                 }
+            ]
+        }
+        messages = LanguageModelMessages([])
+        model_name = "My Custom Model"
+
+        result = self.service.complete(messages, model_name)
+
+        assert isinstance(result, LanguageModelResponse)
+        assert result.choices[0].message.content == "Test response"
+        mock_create.assert_called_once_with(
+            company_id="test_company",
+            model=model_name,
+            messages=[],
+            timeout=240000,
+            options={
+                "temperature": 0.0,
+            },
+        )
+
+    @patch.object(unique_sdk.Integrated, "chat_stream_completion")
+    def test_stream_complete_with_custom_model(self, mock_stream_complete):
+        mock_stream_complete.return_value = {
+            "message": {
+                "id": "test_message",
+                "previousMessageId": "test_previous_message",
+                "role": "ASSISTANT",
+                "text": "Streamed response",
+                "originalText": "Streamed response original",
             }
-            messages = LanguageModelMessages([])
-            model_name = "My Custom Model"
+        }
+        messages = LanguageModelMessages([])
+        model_name = "My Custom Model"
 
-            result = self.service.stream_complete(messages, model_name)
+        result = self.service.stream_complete(messages, model_name)
 
-            assert isinstance(result, LanguageModelStreamResponse)
-            assert result.message.text == "Streamed response"
-            mock_stream_complete.assert_called_once_with(
-                user_id="test_user",
-                company_id="test_company",
-                assistantMessageId="assistant_message_id",
-                userMessageId="user_message_id",
-                messages=[],
-                chatId="test_chat",
-                searchContext=None,
-                model=model_name,
-                timeout=240000,
-                assistantId="test_assistant",
-                debugInfo={},
-                options={"temperature": 0.0},
-                startText=None,
-            )
+        assert isinstance(result, LanguageModelStreamResponse)
+        assert result.message.text == "Streamed response"
+        mock_stream_complete.assert_called_once_with(
+            user_id="test_user",
+            company_id="test_company",
+            assistantMessageId="assistant_message_id",
+            userMessageId="user_message_id",
+            messages=[],
+            chatId="test_chat",
+            searchContext=None,
+            model=model_name,
+            timeout=240000,
+            assistantId="test_assistant",
+            debugInfo={},
+            options={"temperature": 0.0},
+            startText=None,
+        )
 
-    def test_error_handling_complete(self):
-        with patch.object(
-            unique_sdk.ChatCompletion, "create", side_effect=Exception("API Error")
-        ):
-            with pytest.raises(Exception, match="API Error"):
-                self.service.complete(
-                    LanguageModelMessages([]), LanguageModelName.AZURE_GPT_4_TURBO_1106
-                )
-
-    def test_error_handling_stream_complete(self):
-        with patch.object(
-            unique_sdk.Integrated,
-            "chat_stream_completion",
-            side_effect=Exception("Stream Error"),
-        ):
-            with pytest.raises(Exception, match="Stream Error"):
-                self.service.stream_complete(
-                    LanguageModelMessages([]), LanguageModelName.AZURE_GPT_4_TURBO_1106
-                )
-
-    def test_complete_with_tool(self):
+    @patch.object(unique_sdk.ChatCompletion, "create")
+    def test_complete_with_tool(self, mock_create):
         messages = LanguageModelMessages(
             [
                 LanguageModelMessage(
@@ -203,50 +180,44 @@ class TestLanguageModelServiceUnit:
             ]
         )
 
-        with patch.object(unique_sdk.ChatCompletion, "create") as mock_create:
-            mock_create.return_value = {
-                "choices": [
-                    {
-                        "index": 0,
-                        "message": {
-                            "role": "assistant",
-                            "content": "The weather in New York is 70 degrees Fahrenheit.",
-                            "toolCalls": [
-                                {
-                                    "id": "test_tool_id",
-                                    "type": "function",
-                                    "function": {
-                                        "id": "test_function_id",
-                                        "name": "get_weather",
-                                        "arguments": '{"location": "New York, NY","unit": "fahrenheit"}',
-                                    },
+        mock_create.return_value = {
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": "The weather in New York is 70 degrees Fahrenheit.",
+                        "toolCalls": [
+                            {
+                                "id": "test_tool_id",
+                                "type": "function",
+                                "function": {
+                                    "id": "test_function_id",
+                                    "name": "get_weather",
+                                    "arguments": '{"location": "New York, NY","unit": "fahrenheit"}',
                                 },
-                            ],
-                        },
-                        "finishReason": "function_call",
-                    }
-                ],
-            }
+                            },
+                        ],
+                    },
+                    "finishReason": "function_call",
+                }
+            ],
+        }
 
-            response = self.service.complete(
-                messages=messages,
-                model_name=LanguageModelName.AZURE_GPT_35_TURBO,
-                tools=[mock_tool],
-            )
+        response = self.service.complete(
+            messages=messages,
+            model_name=LanguageModelName.AZURE_GPT_35_TURBO,
+            tools=[mock_tool],
+        )
 
-            # This block is happening during a change, should be deleted later
+        assert response.choices[0].message.tool_calls is not None
+        assert response.choices[0].message.tool_calls[0].function.name == "get_weather"
+        arguments = response.choices[0].message.tool_calls[0].function.arguments
+        assert arguments is not None
+        assert "New York, NY" in arguments.values()
 
-            assert response.choices[0].message.tool_calls is not None
-            assert (
-                response.choices[0].message.tool_calls[0].function.name == "get_weather"
-            )
-
-            arguments = response.choices[0].message.tool_calls[0].function.arguments
-            assert arguments is not None
-            assert "New York, NY" in arguments.values()
-            # -----------------------------------------------------------
-
-    def test_stream_complete_with_tool(self):
+    @patch.object(unique_sdk.Integrated, "chat_stream_completion")
+    def test_stream_complete_with_tool(self, mock_stream):
         messages = LanguageModelMessages(
             [
                 LanguageModelMessage(
@@ -256,193 +227,181 @@ class TestLanguageModelServiceUnit:
             ]
         )
 
-        with patch.object(
-            unique_sdk.Integrated, "chat_stream_completion"
-        ) as mock_stream:
-            mock_stream.return_value = {
-                "message": {
-                    "id": "test_stream_id",
-                    "previousMessageId": "test_previous_message_id",
-                    "role": "ASSISTANT",
-                    "text": "Streamed response",
-                    "originalText": "Streamed response original",
-                },
-                "toolCalls": [
-                    {
-                        "id": "test_tool_id",
-                        "name": "get_weather",
-                        "arguments": '{"location": "London, UK", "unit": "celsius"}',
-                    }
-                ],
-            }
-
-            response = self.service.stream_complete(
-                messages=messages,
-                model_name=LanguageModelName.AZURE_GPT_35_TURBO,
-                tools=[mock_tool],
-            )
-
-            assert response.tool_calls is not None
-            assert response.tool_calls[0].name == "get_weather"
-            arguments = response.tool_calls[0].arguments
-            assert arguments is not None
-            assert "London, UK" in arguments.values()
-
-    @pytest.mark.asyncio
-    async def test_complete_async(self):
-        with patch.object(unique_sdk.ChatCompletion, "create_async") as mock_create:
-            mock_create.return_value = {
-                "choices": [
-                    {
-                        "index": 0,
-                        "finishReason": "completed",
-                        "message": {
-                            "content": "Test response",
-                            "role": "assistant",
-                        },
-                    }
-                ]
-            }
-            messages = LanguageModelMessages([])
-            model_name = LanguageModelName.AZURE_GPT_4_TURBO_1106
-
-            result = await self.service.complete_async(messages, model_name)
-
-            assert isinstance(result, LanguageModelResponse)
-            assert result.choices[0].message.content == "Test response"
-            mock_create.assert_called_once_with(
-                company_id="test_company",
-                model=model_name.name,
-                messages=[],
-                timeout=240000,
-                options={
-                    "temperature": 0.0,
-                },
-            )
-
-    @pytest.mark.asyncio
-    async def test_complete_async_with_custom_model(self):
-        with patch.object(unique_sdk.ChatCompletion, "create_async") as mock_create:
-            mock_create.return_value = {
-                "choices": [
-                    {
-                        "index": 0,
-                        "finishReason": "completed",
-                        "message": {
-                            "content": "Test response",
-                            "role": "assistant",
-                        },
-                    }
-                ]
-            }
-            messages = LanguageModelMessages([])
-            model_name = "My custom model"
-
-            result = await self.service.complete_async(messages, model_name)
-
-            assert isinstance(result, LanguageModelResponse)
-            assert result.choices[0].message.content == "Test response"
-            mock_create.assert_called_once_with(
-                company_id="test_company",
-                model=model_name,
-                messages=[],
-                timeout=240000,
-                options={
-                    "temperature": 0.0,
-                },
-            )
-
-    @pytest.mark.asyncio
-    async def test_stream_complete_async(self):
-        with patch.object(
-            unique_sdk.Integrated, "chat_stream_completion_async"
-        ) as mock_stream_complete:
-            mock_stream_complete.return_value = {
-                "message": {
-                    "id": "test_message",
-                    "previousMessageId": "test_previous_message",
-                    "role": "ASSISTANT",
-                    "text": "Streamed response",
-                    "originalText": "Streamed response original",
+        mock_stream.return_value = {
+            "message": {
+                "id": "test_stream_id",
+                "previousMessageId": "test_previous_message_id",
+                "role": "ASSISTANT",
+                "text": "Streamed response",
+                "originalText": "Streamed response original",
+            },
+            "toolCalls": [
+                {
+                    "id": "test_tool_id",
+                    "name": "get_weather",
+                    "arguments": '{"location": "London, UK", "unit": "celsius"}',
                 }
-            }
-            messages = LanguageModelMessages([])
-            model_name = LanguageModelName.AZURE_GPT_4_TURBO_1106
-            content_chunks = [
-                ContentChunk(id="1", chunk_id="1", key="test", order=1, text="test")
+            ],
+        }
+
+        response = self.service.stream_complete(
+            messages=messages,
+            model_name=LanguageModelName.AZURE_GPT_35_TURBO,
+            tools=[mock_tool],
+        )
+
+        assert response.tool_calls is not None
+        assert response.tool_calls[0].name == "get_weather"
+        arguments = response.tool_calls[0].arguments
+        assert arguments is not None
+        assert "London, UK" in arguments.values()
+
+    @pytest.mark.asyncio
+    @patch.object(unique_sdk.ChatCompletion, "create_async")
+    async def test_complete_async(self, mock_create):
+        mock_create.return_value = {
+            "choices": [
+                {
+                    "index": 0,
+                    "finishReason": "completed",
+                    "message": {
+                        "content": "Test response",
+                        "role": "assistant",
+                    },
+                }
             ]
+        }
+        messages = LanguageModelMessages([])
+        model_name = LanguageModelName.AZURE_GPT_4_TURBO_1106
 
-            result = await self.service.stream_complete_async(
-                messages, model_name, content_chunks
-            )
+        result = await self.service.complete_async(messages, model_name)
 
-            assert isinstance(result, LanguageModelStreamResponse)
-            assert result.message.text == "Streamed response"
-            mock_stream_complete.assert_called_once()
+        assert isinstance(result, LanguageModelResponse)
+        assert result.choices[0].message.content == "Test response"
+        mock_create.assert_called_once_with(
+            company_id="test_company",
+            model=model_name.name,
+            messages=[],
+            timeout=240000,
+            options={
+                "temperature": 0.0,
+            },
+        )
 
     @pytest.mark.asyncio
-    async def test_stream_complete_async_with_custom_model(self):
-        with patch.object(
-            unique_sdk.Integrated, "chat_stream_completion_async"
-        ) as mock_stream_complete:
-            mock_stream_complete.return_value = {
-                "message": {
-                    "id": "test_message",
-                    "previousMessageId": "test_previous_message",
-                    "role": "ASSISTANT",
-                    "text": "Streamed response",
-                    "originalText": "Streamed response original",
-                }
+    @patch.object(unique_sdk.Integrated, "chat_stream_completion_async")
+    async def test_stream_complete_async(self, mock_stream_complete):
+        mock_stream_complete.return_value = {
+            "message": {
+                "id": "test_message",
+                "previousMessageId": "test_previous_message",
+                "role": "ASSISTANT",
+                "text": "Streamed response",
+                "originalText": "Streamed response original",
             }
-            messages = LanguageModelMessages([])
-            model_name = "My custom model"
+        }
+        messages = LanguageModelMessages([])
+        model_name = LanguageModelName.AZURE_GPT_4_TURBO_1106
+        content_chunks = [
+            ContentChunk(id="1", chunk_id="1", key="test", order=1, text="test")
+        ]
 
-            result = await self.service.stream_complete_async(messages, model_name)
+        result = await self.service.stream_complete_async(
+            messages, model_name, content_chunks
+        )
 
-            assert isinstance(result, LanguageModelStreamResponse)
-            assert result.message.text == "Streamed response"
-            mock_stream_complete.assert_awaited_once_with(
-                user_id="test_user",
-                company_id="test_company",
-                assistantMessageId="assistant_message_id",
-                userMessageId="user_message_id",
-                messages=[],
-                chatId="test_chat",
-                searchContext=None,
-                model=model_name,
-                timeout=240000,
-                assistantId="test_assistant",
-                debugInfo={},
-                options={"temperature": 0.0},
-                startText=None,
+        assert isinstance(result, LanguageModelStreamResponse)
+        assert result.message.text == "Streamed response"
+        mock_stream_complete.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch.object(unique_sdk.ChatCompletion, "create_async")
+    async def test_complete_async_with_custom_model(self, mock_create):
+        mock_create.return_value = {
+            "choices": [
+                {
+                    "index": 0,
+                    "finishReason": "completed",
+                    "message": {
+                        "content": "Test response",
+                        "role": "assistant",
+                    },
+                }
+            ]
+        }
+        messages = LanguageModelMessages([])
+        model_name = "My custom model"
+
+        result = await self.service.complete_async(messages, model_name)
+
+        assert isinstance(result, LanguageModelResponse)
+        assert result.choices[0].message.content == "Test response"
+        mock_create.assert_called_once_with(
+            company_id="test_company",
+            model=model_name,
+            messages=[],
+            timeout=240000,
+            options={
+                "temperature": 0.0,
+            },
+        )
+
+    @pytest.mark.asyncio
+    @patch.object(unique_sdk.Integrated, "chat_stream_completion_async")
+    async def test_stream_complete_async_with_custom_model(self, mock_stream_complete):
+        mock_stream_complete.return_value = {
+            "message": {
+                "id": "test_message",
+                "previousMessageId": "test_previous_message",
+                "role": "ASSISTANT",
+                "text": "Streamed response",
+                "originalText": "Streamed response original",
+            }
+        }
+        messages = LanguageModelMessages([])
+        model_name = "My custom model"
+
+        result = await self.service.stream_complete_async(messages, model_name)
+
+        assert isinstance(result, LanguageModelStreamResponse)
+        assert result.message.text == "Streamed response"
+        mock_stream_complete.assert_awaited_once_with(
+            user_id="test_user",
+            company_id="test_company",
+            assistantMessageId="assistant_message_id",
+            userMessageId="user_message_id",
+            messages=[],
+            chatId="test_chat",
+            searchContext=None,
+            model=model_name,
+            timeout=240000,
+            assistantId="test_assistant",
+            debugInfo={},
+            options={"temperature": 0.0},
+            startText=None,
+        )
+
+    @pytest.mark.asyncio
+    @patch.object(unique_sdk.ChatCompletion, "create_async")
+    async def test_error_handling_complete_async(self, mock_create):
+        mock_create.side_effect = Exception("API Error")
+        with pytest.raises(Exception, match="API Error"):
+            await self.service.complete_async(
+                LanguageModelMessages([]), LanguageModelName.AZURE_GPT_4_TURBO_1106
             )
 
     @pytest.mark.asyncio
-    async def test_error_handling_complete_async(self):
-        with patch.object(
-            unique_sdk.ChatCompletion,
-            "create_async",
-            side_effect=Exception("API Error"),
-        ):
-            with pytest.raises(Exception, match="API Error"):
-                await self.service.complete_async(
-                    LanguageModelMessages([]), LanguageModelName.AZURE_GPT_4_TURBO_1106
-                )
+    @patch.object(unique_sdk.Integrated, "chat_stream_completion_async")
+    async def test_error_handling_stream_complete_async(self, mock_stream_complete):
+        mock_stream_complete.side_effect = Exception("Stream Error")
+        with pytest.raises(Exception, match="Stream Error"):
+            await self.service.stream_complete_async(
+                LanguageModelMessages([]), LanguageModelName.AZURE_GPT_4_TURBO_1106
+            )
 
     @pytest.mark.asyncio
-    async def test_error_handling_stream_complete_async(self):
-        with patch.object(
-            unique_sdk.Integrated,
-            "chat_stream_completion_async",
-            side_effect=Exception("Stream Error"),
-        ):
-            with pytest.raises(Exception, match="Stream Error"):
-                await self.service.stream_complete_async(
-                    LanguageModelMessages([]), LanguageModelName.AZURE_GPT_4_TURBO_1106
-                )
-
-    @pytest.mark.asyncio
-    async def test_complete_with_tool_async(self):
+    @patch.object(unique_sdk.ChatCompletion, "create_async")
+    async def test_complete_with_tool_async(self, mock_create):
         messages = LanguageModelMessages(
             [
                 LanguageModelMessage(
@@ -452,51 +411,44 @@ class TestLanguageModelServiceUnit:
             ]
         )
 
-        with patch.object(unique_sdk.ChatCompletion, "create_async") as mock_create:
-            mock_create.return_value = {
-                "choices": [
-                    {
-                        "index": 0,
-                        "message": {
-                            "role": "assistant",
-                            "content": "The weather in New York is 70 degrees Fahrenheit.",
-                            "toolCalls": [
-                                {
-                                    "id": "test_tool_id",
-                                    "type": "function",
-                                    "function": {
-                                        "id": "test_function_id",
-                                        "name": "get_weather",
-                                        "arguments": '{"location": "New York, NY","unit": "fahrenheit"}',
-                                    },
+        mock_create.return_value = {
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": "The weather in New York is 70 degrees Fahrenheit.",
+                        "toolCalls": [
+                            {
+                                "id": "test_tool_id",
+                                "type": "function",
+                                "function": {
+                                    "id": "test_function_id",
+                                    "name": "get_weather",
+                                    "arguments": '{"location": "New York, NY","unit": "fahrenheit"}',
                                 },
-                            ],
-                        },
-                        "finishReason": "function_call",
-                    }
-                ],
-            }
+                            },
+                        ],
+                    },
+                    "finishReason": "function_call",
+                }
+            ],
+        }
 
-            response = await self.service.complete_async(
-                messages=messages,
-                model_name=LanguageModelName.AZURE_GPT_35_TURBO,
-                tools=[mock_tool],
-            )
-            # This block is happening during a change, should be deleted later
-
-            print("TAGGGGGGGGGG: ", response.choices[0].message.tool_calls)
-            assert response.choices[0].message.tool_calls is not None
-
-            assert (
-                response.choices[0].message.tool_calls[0].function.name == "get_weather"
-            )
-            arguments = response.choices[0].message.tool_calls[0].function.arguments
-            assert arguments is not None
-            assert "New York, NY" in arguments.values()
-            #     # --------------------------------------------------------------
+        response = await self.service.complete_async(
+            messages=messages,
+            model_name=LanguageModelName.AZURE_GPT_35_TURBO,
+            tools=[mock_tool],
+        )
+        assert response.choices[0].message.tool_calls is not None
+        assert response.choices[0].message.tool_calls[0].function.name == "get_weather"
+        arguments = response.choices[0].message.tool_calls[0].function.arguments
+        assert arguments is not None
+        assert "New York, NY" in arguments.values()
 
     @pytest.mark.asyncio
-    async def test_stream_complete_with_tool_async(self):
+    @patch.object(unique_sdk.Integrated, "chat_stream_completion_async")
+    async def test_stream_complete_with_tool_async(self, mock_stream):
         messages = LanguageModelMessages(
             [
                 LanguageModelMessage(
@@ -506,34 +458,237 @@ class TestLanguageModelServiceUnit:
             ]
         )
 
-        with patch.object(
-            unique_sdk.Integrated, "chat_stream_completion_async"
-        ) as mock_stream:
-            mock_stream.return_value = {
-                "message": {
-                    "id": "test_stream_id",
-                    "previousMessageId": "test_previous_message_id",
-                    "role": "ASSISTANT",
-                    "text": "Streamed response",
-                    "originalText": "Streamed response original",
-                },
-                "toolCalls": [
-                    {
-                        "id": "test_tool_id",
-                        "name": "get_weather",
-                        "arguments": '{"location": "London, UK", "unit": "celsius"}',
-                    }
-                ],
-            }
+        mock_stream.return_value = {
+            "message": {
+                "id": "test_stream_id",
+                "previousMessageId": "test_previous_message_id",
+                "role": "ASSISTANT",
+                "text": "Streamed response",
+                "originalText": "Streamed response original",
+            },
+            "toolCalls": [
+                {
+                    "id": "test_tool_id",
+                    "name": "get_weather",
+                    "arguments": '{"location": "London, UK", "unit": "celsius"}',
+                }
+            ],
+        }
 
-            response = await self.service.stream_complete_async(
+        response = await self.service.stream_complete_async(
+            messages=messages,
+            model_name=LanguageModelName.AZURE_GPT_35_TURBO,
+            tools=[mock_tool],
+        )
+
+        assert response.tool_calls is not None
+        assert response.tool_calls[0].name == "get_weather"
+        arguments = response.tool_calls[0].arguments
+        assert arguments is not None
+        assert "London, UK" in arguments.values()
+
+    def test_prepare_completion_params_basic(self):
+        messages = LanguageModelMessages([])
+        model_name = LanguageModelName.AZURE_GPT_4_TURBO_1106
+        temperature = 0.5
+
+        options, model, messages_dict, search_context = (
+            LanguageModelService._prepare_completion_params(
                 messages=messages,
-                model_name=LanguageModelName.AZURE_GPT_35_TURBO,
-                tools=[mock_tool],
+                model_name=model_name,
+                temperature=temperature,
             )
+        )
 
-            assert response.tool_calls is not None
-            assert response.tool_calls[0].name == "get_weather"
-            arguments = response.tool_calls[0].arguments
-            assert arguments is not None
-            assert "London, UK" in arguments.values()
+        assert options == {"temperature": 0.5}
+        assert model == model_name.name
+        assert messages_dict == []
+        assert search_context is None
+
+    def test_prepare_completion_params_with_tools_and_other_options(self):
+        messages = LanguageModelMessages([])
+        other_options = {"max_tokens": 100, "top_p": 0.9}
+
+        options, model, messages_dict, search_context = (
+            LanguageModelService._prepare_completion_params(
+                messages=messages,
+                model_name="custom_model",
+                temperature=0.7,
+                tools=[mock_tool],
+                other_options=other_options,
+            )
+        )
+
+        expected_options = {
+            "temperature": 0.7,
+            "max_tokens": 100,
+            "top_p": 0.9,
+            "tools": [
+                {
+                    "type": "function",
+                    "function": mock_tool.model_dump(exclude_none=True),
+                }
+            ],
+        }
+
+        assert options == expected_options
+        assert model == "custom_model"
+        assert messages_dict == []
+        assert search_context is None
+
+    @patch.object(unique_sdk.ChatCompletion, "create")
+    def test_complete_with_other_options(self, mock_create):
+        mock_create.return_value = {
+            "choices": [
+                {
+                    "index": 0,
+                    "finishReason": "completed",
+                    "message": {
+                        "content": "Test response",
+                        "role": "assistant",
+                    },
+                }
+            ]
+        }
+        messages = LanguageModelMessages([])
+        model_name = LanguageModelName.AZURE_GPT_4_TURBO_1106
+        other_options = {"max_tokens": 100, "top_p": 0.9}
+
+        result = self.service.complete(
+            messages, model_name, other_options=other_options
+        )
+
+        assert isinstance(result, LanguageModelResponse)
+        assert result.choices[0].message.content == "Test response"
+        mock_create.assert_called_once_with(
+            company_id="test_company",
+            model=model_name.name,
+            messages=[],
+            timeout=240000,
+            options={
+                "temperature": 0.0,
+                "max_tokens": 100,
+                "top_p": 0.9,
+            },
+        )
+
+    @pytest.mark.asyncio
+    @patch.object(unique_sdk.Integrated, "chat_stream_completion")
+    async def test_stream_complete_with_other_options(self, mock_stream_complete):
+        mock_stream_complete.return_value = {
+            "message": {
+                "id": "test_message",
+                "previousMessageId": "test_previous_message",
+                "role": "ASSISTANT",
+                "text": "Streamed response",
+                "originalText": "Streamed response original",
+            }
+        }
+        messages = LanguageModelMessages([])
+        model_name = LanguageModelName.AZURE_GPT_4_TURBO_1106
+        other_options = {"presence_penalty": 0.6, "frequency_penalty": 0.8}
+
+        result = self.service.stream_complete(
+            messages, model_name, other_options=other_options
+        )
+
+        assert isinstance(result, LanguageModelStreamResponse)
+        assert result.message.text == "Streamed response"
+        mock_stream_complete.assert_called_once_with(
+            user_id="test_user",
+            company_id="test_company",
+            assistantMessageId="assistant_message_id",
+            userMessageId="user_message_id",
+            messages=[],
+            chatId="test_chat",
+            searchContext=None,
+            model=model_name.name,
+            timeout=240000,
+            assistantId="test_assistant",
+            debugInfo={},
+            options={
+                "temperature": 0.0,
+                "presence_penalty": 0.6,
+                "frequency_penalty": 0.8,
+            },
+            startText=None,
+        )
+
+    @pytest.mark.asyncio
+    @patch.object(unique_sdk.ChatCompletion, "create_async")
+    async def test_complete_async_with_other_options(self, mock_create):
+        mock_create.return_value = {
+            "choices": [
+                {
+                    "index": 0,
+                    "finishReason": "completed",
+                    "message": {
+                        "content": "Test response",
+                        "role": "assistant",
+                    },
+                }
+            ]
+        }
+        messages = LanguageModelMessages([])
+        model_name = LanguageModelName.AZURE_GPT_4_TURBO_1106
+        other_options = {"best_of": 2, "stop": ["\n"]}
+
+        result = await self.service.complete_async(
+            messages, model_name, other_options=other_options
+        )
+
+        assert isinstance(result, LanguageModelResponse)
+        assert result.choices[0].message.content == "Test response"
+        mock_create.assert_called_once_with(
+            company_id="test_company",
+            model=model_name.name,
+            messages=[],
+            timeout=240000,
+            options={
+                "temperature": 0.0,
+                "best_of": 2,
+                "stop": ["\n"],
+            },
+        )
+
+    @pytest.mark.asyncio
+    @patch.object(unique_sdk.Integrated, "chat_stream_completion_async")
+    async def test_stream_complete_async_with_other_options(self, mock_stream_complete):
+        mock_stream_complete.return_value = {
+            "message": {
+                "id": "test_message",
+                "previousMessageId": "test_previous_message",
+                "role": "ASSISTANT",
+                "text": "Streamed response",
+                "originalText": "Streamed response original",
+            }
+        }
+        messages = LanguageModelMessages([])
+        model_name = LanguageModelName.AZURE_GPT_4_TURBO_1106
+        other_options = {"presence_penalty": 0.6, "frequency_penalty": 0.8}
+
+        result = await self.service.stream_complete_async(
+            messages, model_name, other_options=other_options
+        )
+
+        assert isinstance(result, LanguageModelStreamResponse)
+        assert result.message.text == "Streamed response"
+        mock_stream_complete.assert_awaited_once_with(
+            user_id="test_user",
+            company_id="test_company",
+            assistantMessageId="assistant_message_id",
+            userMessageId="user_message_id",
+            messages=[],
+            chatId="test_chat",
+            searchContext=None,
+            model=model_name.name,
+            timeout=240000,
+            assistantId="test_assistant",
+            debugInfo={},
+            options={
+                "temperature": 0.0,
+                "presence_penalty": 0.6,
+                "frequency_penalty": 0.8,
+            },
+            startText=None,
+        )

--- a/unique_toolkit/unique_toolkit/language_model/service.py
+++ b/unique_toolkit/unique_toolkit/language_model/service.py
@@ -356,7 +356,7 @@ class LanguageModelService(BaseService):
             - search_context (Optional[dict]): Processed content chunks if provided
         """
 
-        options = LanguageModelService._add_tools_to_options({}, tools)
+        options = cls._add_tools_to_options({}, tools)
         options["temperature"] = temperature
         if other_options:
             options.update(other_options)

--- a/unique_toolkit/unique_toolkit/language_model/service.py
+++ b/unique_toolkit/unique_toolkit/language_model/service.py
@@ -53,7 +53,7 @@ class LanguageModelService(BaseService):
         Returns:
             LanguageModelResponse: The LanguageModelResponse object.
         """
-        options, model, messages_dict, _ = self._prepare_completion_params(
+        options, model, messages_dict, _ = self.prepare_completion_params_util(
             messages=messages,
             model_name=model_name,
             temperature=temperature,
@@ -112,7 +112,7 @@ class LanguageModelService(BaseService):
         Raises:
             Exception: If an error occurs during the request, an exception is raised and logged.
         """
-        options, model, messages_dict, _ = cls._prepare_completion_params(
+        options, model, messages_dict, _ = cls.prepare_completion_params_util(
             messages=messages,
             model_name=model_name,
             temperature=temperature,
@@ -204,13 +204,15 @@ class LanguageModelService(BaseService):
         Returns:
             The LanguageModelStreamResponse object once the stream has finished.
         """
-        options, model, messages_dict, search_context = self._prepare_completion_params(
-            messages=messages,
-            model_name=model_name,
-            temperature=temperature,
-            tools=tools,
-            other_options=other_options,
-            content_chunks=content_chunks,
+        options, model, messages_dict, search_context = (
+            self.prepare_completion_params_util(
+                messages=messages,
+                model_name=model_name,
+                temperature=temperature,
+                tools=tools,
+                other_options=other_options,
+                content_chunks=content_chunks,
+            )
         )
 
         try:
@@ -265,13 +267,15 @@ class LanguageModelService(BaseService):
         Returns:
             The LanguageModelStreamResponse object once the stream has finished.
         """
-        options, model, messages_dict, search_context = self._prepare_completion_params(
-            messages=messages,
-            model_name=model_name,
-            temperature=temperature,
-            tools=tools,
-            other_options=other_options,
-            content_chunks=content_chunks,
+        options, model, messages_dict, search_context = (
+            self.prepare_completion_params_util(
+                messages=messages,
+                model_name=model_name,
+                temperature=temperature,
+                tools=tools,
+                other_options=other_options,
+                content_chunks=content_chunks,
+            )
         )
 
         try:
@@ -331,8 +335,9 @@ class LanguageModelService(BaseService):
             ]
         return options
 
-    @staticmethod
-    def _prepare_completion_params(
+    @classmethod
+    def prepare_completion_params_util(
+        cls,
         messages: LanguageModelMessages,
         model_name: LanguageModelName | str,
         temperature: float,


### PR DESCRIPTION
In this way, we can use any new features without explicitly typing them, e.g., seed.