### PR TITLE
feat(tool): Add fraction_input param to token limit model

### DIFF
--- a/unique_toolkit/CHANGELOG.md
+++ b/unique_toolkit/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), 
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.41] - 2024-12-11
+- Update `LanguageModelTokenLimits` includes a fraction_input now to always have input/output token limits available.
+
 ## [0.5.40] - 2024-12-11
 - Add `other_options` to `LanguageModelService.complete`, `LanguageModelService.complete_async`, `LanguageModelService.stream_complete` and `LanguageModelService.stream_complete_async`
 

--- a/unique_toolkit/pyproject.toml
+++ b/unique_toolkit/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "unique_toolkit"
-version = "0.5.40"
+version = "0.5.41"
 description = ""
 authors = [
     "Martin Fadler <martin.fadler@unique.ch>",

--- a/unique_toolkit/tests/language_model/test_language_models_infos.py
+++ b/unique_toolkit/tests/language_model/test_language_models_infos.py
@@ -9,6 +9,7 @@ from unique_toolkit.language_model.infos import (
     LanguageModelName,
     LanguageModelProvider,
 )
+from unique_toolkit.language_model.schemas import LanguageModelTokenLimits
 
 
 class TestLanguageModelInfos:
@@ -63,3 +64,60 @@ class TestLanguageModelInfos:
     def test_get_language_model_raises_error_for_invalid_model(self):
         with pytest.raises(ValueError):
             LanguageModel("")
+
+    # New tests for LanguageModelTokenLimits
+    def test_language_model_token_limits_with_input_output(self):
+        test_cases = [
+            {
+                "input": 2000,
+                "output": 2000,
+                "expected_total": 4000,
+                "expected_fraction": 0.5,
+            },
+            {
+                "input": 3000,
+                "output": 1000,
+                "expected_total": 4000,
+                "expected_fraction": 0.75,
+            },
+            {
+                "input": 1000,
+                "output": 3000,
+                "expected_total": 4000,
+                "expected_fraction": 0.25,
+            },
+        ]
+
+        for case in test_cases:
+            limits = LanguageModelTokenLimits(
+                token_limit_input=case["input"], token_limit_output=case["output"]
+            )
+            assert limits.token_limit == case["expected_total"]
+            assert abs(limits.fraction_input - case["expected_fraction"]) < 1e-10
+
+    def test_language_model_token_limits_with_total(self):
+        limits = LanguageModelTokenLimits(token_limit=10000)
+        assert limits.token_limit_input == 4000.0
+        assert limits.token_limit_output == 6000.0
+
+    def test_language_model_token_limits_with_total_and_fraction(self):
+        limits = LanguageModelTokenLimits(token_limit=10000, fraction_input=0.2)
+        assert limits.token_limit_input == 2000.0
+        assert limits.token_limit_output == 8000.0
+
+    def test_language_model_token_limits_raises_error_empty(self):
+        with pytest.raises(ValueError):
+            LanguageModelTokenLimits()
+
+    def test_language_model_token_limits_raises_error_for_partial_input(self):
+        with pytest.raises(ValueError):
+            LanguageModelTokenLimits(token_limit_input=1000)
+
+        with pytest.raises(ValueError):
+            LanguageModelTokenLimits(token_limit_output=1000)
+
+        with pytest.raises(ValueError):
+            LanguageModelTokenLimits(fraction_input=0.5)
+
+        with pytest.raises(ValueError):
+            LanguageModelTokenLimits(token_limit_input=1000, fraction_input=0.5)

--- a/unique_toolkit/unique_toolkit/language_model/schemas.py
+++ b/unique_toolkit/unique_toolkit/language_model/schemas.py
@@ -197,29 +197,28 @@ class LanguageModelTokenLimits(BaseModel):
     token_limit_input: Optional[int] = None
     token_limit_output: Optional[int] = None
 
+    fraction_input: float = Field(default=0.4, le=1, ge=0)
+
     @model_validator(mode="after")
-    def validate_model(self):
-        token_limit = self.token_limit
-        token_limit_input = self.token_limit_input
-        token_limit_output = self.token_limit_output
+    def check_required_fields(self):
+        # Best case input and output is determined
+        if self.token_limit_input and self.token_limit_output:
+            self.token_limit = self.token_limit_input + self.token_limit_output
+            self.fraction_input = self.token_limit_input / self.token_limit
+            return self
 
-        if (
-            token_limit is None
-            and token_limit_input is None
-            and token_limit_output is None
-        ):
-            raise ValueError(
-                "At least one of token_limit, token_limit_input or token_limit_output must be set"
-            )
+        # Deal with case where only token_limit and optional fraction_input is given
+        if self.token_limit:
+            if not self.fraction_input:
+                self.fraction_input = 0.4
 
-        if (
-            token_limit is None
-            and token_limit_input is not None
-            and token_limit_output is not None
-        ):
-            self.token_limit = token_limit_input + token_limit_output
+            self.token_limit_input = self.fraction_input * self.token_limit
+            self.token_limit_output = (1 - self.fraction_input) * self.token_limit
+            return self
 
-        return self
+        raise ValueError(
+            'Either "token_limit_input" and "token_limit_output" must be provided together, or "token_limit" must be provided.'
+        )
 
 
 class LanguageModelToolParameterProperty(BaseModel):


### PR DESCRIPTION
- Used to always have a default for limits on input and output tokens.

- CI/CD edits will be done if code is accepted