### PR TITLE
fix(ai): Revert toolkit change breaking `backend-ingestion` 

### DIFF
--- a/unique_toolkit/CHANGELOG.md
+++ b/unique_toolkit/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), 
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.28] - 2025-06-17
+- Revert default factory change on `ChatEventPayload` for attribute `metadata_filter` due to error in `backend-ingestion` on empty dict
 
 ## [0.7.27] - 2025-06-16
 - Introduce a protocol for `complete_with_references` to enable testable services

--- a/unique_toolkit/pyproject.toml
+++ b/unique_toolkit/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "unique_toolkit"
-version = "0.7.27"
+version = "0.7.28"
 description = ""
 authors = [
     "Martin Fadler <martin.fadler@unique.ch>",

--- a/unique_toolkit/unique_toolkit/app/schemas.py
+++ b/unique_toolkit/unique_toolkit/app/schemas.py
@@ -120,8 +120,9 @@ class ChatEventPayload(BaseModel):
         default_factory=dict,
         description="Parameters extracted from module selection function calling the tool.",
     )
-    metadata_filter: dict[str, Any] = Field(
-        default_factory=dict,
+    # Default is None as empty dict triggers error in `backend-ingestion`
+    metadata_filter: dict[str, Any] | None = Field(
+        default=None,
         description="Metadata filter compiled after module selection function calling and scope rules.",
     )
     raw_scope_rules: UniqueQL | None = Field(


### PR DESCRIPTION
- Revert default factory change on `ChatEventPayload` for attribute `metadata_filter` due to error in `backend-ingestion` on empty dict
