### PR TITLE
feat(toolkit): Auto init services from env via settings object

### DIFF
--- a/unique_toolkit/CHANGELOG.md
+++ b/unique_toolkit/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.8.34] - 2025-09-01
+- Automatic initializations of services and event generator
+
 ## [0.8.33] - 2025-08-31
 
 fixed tool for `web_search`

--- a/unique_toolkit/pyproject.toml
+++ b/unique_toolkit/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "unique_toolkit"
-version = "0.8.33"
+version = "0.8.34"
 description = ""
 authors = [
     "Martin Fadler <martin.fadler@unique.ch>",

--- a/unique_toolkit/unique_toolkit/app/dev_util.py
+++ b/unique_toolkit/unique_toolkit/app/dev_util.py
@@ -80,7 +80,7 @@ def get_event_generator(
 
 def get_event_stream(
     event_type: type[T] = BaseEvent,
-    settings_or_filename: UniqueSettings | str | None = None,
+    settings_config: UniqueSettings | str | None = None,
 ) -> Generator[T, None, None]:
     """
     Get an event stream from the SSE client.
@@ -90,12 +90,12 @@ def get_event_stream(
         settings_or_filename: The settings or filename to use to setup the Unique settings object
     """
 
-    if isinstance(settings_or_filename, str):
+    if isinstance(settings_config, str):
         unique_settings = UniqueSettings.from_env_auto_with_sdk_init(
-            filename=settings_or_filename
+            filename=settings_config
         )
-    elif isinstance(settings_or_filename, UniqueSettings):
-        unique_settings = settings_or_filename
+    elif isinstance(settings_config, UniqueSettings):
+        unique_settings = settings_config
     else:
         unique_settings = UniqueSettings.from_env_auto_with_sdk_init()
 

--- a/unique_toolkit/unique_toolkit/app/dev_util.py
+++ b/unique_toolkit/unique_toolkit/app/dev_util.py
@@ -78,6 +78,30 @@ def get_event_generator(
             continue
 
 
+def get_event_stream(
+    event_type: type[T] = BaseEvent,
+    settings_or_filename: UniqueSettings | str | None = None,
+) -> Generator[T, None, None]:
+    """
+    Get an event stream from the SSE client.
+
+    Args:
+        event_type: The type of event to get
+        settings_or_filename: The settings or filename to use to setup the Unique settings object
+    """
+
+    if isinstance(settings_or_filename, str):
+        unique_settings = UniqueSettings.from_env_auto_with_sdk_init(
+            filename=settings_or_filename
+        )
+    elif isinstance(settings_or_filename, UniqueSettings):
+        unique_settings = settings_or_filename
+    else:
+        unique_settings = UniqueSettings.from_env_auto_with_sdk_init()
+
+    return get_event_generator(unique_settings, event_type)
+
+
 def run_demo_with_sse_client(
     unique_settings: UniqueSettings,
     handler: Callable[[BaseEvent], Awaitable[None] | None],

--- a/unique_toolkit/unique_toolkit/content/service.py
+++ b/unique_toolkit/unique_toolkit/content/service.py
@@ -136,22 +136,33 @@ class ContentService:
     @classmethod
     def from_settings(
         cls,
-        settings: UniqueSettings | None = None,
+        settings: UniqueSettings,
         metadata_filter: dict | None = None,
-        env_filename: str = "unique.env",
     ):
         """
         Initialize the ContentService with a settings object and metadata filter.
-        If the settings object is not provided, it will be initialized from the environment.
         """
-        if settings is None:
-            settings = UniqueSettings.from_env_auto_with_sdk_init(filename=env_filename)
 
         return cls(
             company_id=settings.auth.company_id.get_secret_value(),
             user_id=settings.auth.user_id.get_secret_value(),
             metadata_filter=metadata_filter,
         )
+
+    @classmethod
+    def from_settings_filename(
+        cls,
+        settings_filename: str = "unique.env",
+        metadata_filter: dict | None = None,
+    ):
+        """
+        Initialize the ContentService with automatically from a settings file placed in the
+        common plattform folders or the folder that the executed file is placed and metadata filter.
+        """
+        settings = UniqueSettings.from_env_auto_with_sdk_init(
+            filename=settings_filename
+        )
+        return cls.from_settings(settings=settings, metadata_filter=metadata_filter)
 
     @property
     @deprecated(

--- a/unique_toolkit/unique_toolkit/content/service.py
+++ b/unique_toolkit/unique_toolkit/content/service.py
@@ -135,11 +135,15 @@ class ContentService:
 
     @classmethod
     def from_settings(
-        cls, settings: UniqueSettings, metadata_filter: dict | None = None
+        cls, settings: UniqueSettings | None = None, metadata_filter: dict | None = None
     ):
         """
-        Initialize the ContentService with a settings object.
+        Initialize the ContentService with a settings object and metadata filter.
+        If the settings object is not provided, it will be initialized from the environment.
         """
+        if settings is None:
+            settings = UniqueSettings.from_env_auto_with_sdk_init()
+
         return cls(
             company_id=settings.auth.company_id.get_secret_value(),
             user_id=settings.auth.user_id.get_secret_value(),

--- a/unique_toolkit/unique_toolkit/content/service.py
+++ b/unique_toolkit/unique_toolkit/content/service.py
@@ -135,14 +135,17 @@ class ContentService:
 
     @classmethod
     def from_settings(
-        cls, settings: UniqueSettings | None = None, metadata_filter: dict | None = None
+        cls,
+        settings: UniqueSettings | None = None,
+        metadata_filter: dict | None = None,
+        env_filename: str = "unique.env",
     ):
         """
         Initialize the ContentService with a settings object and metadata filter.
         If the settings object is not provided, it will be initialized from the environment.
         """
         if settings is None:
-            settings = UniqueSettings.from_env_auto_with_sdk_init()
+            settings = UniqueSettings.from_env_auto_with_sdk_init(filename=env_filename)
 
         return cls(
             company_id=settings.auth.company_id.get_secret_value(),

--- a/unique_toolkit/unique_toolkit/content/service.py
+++ b/unique_toolkit/unique_toolkit/content/service.py
@@ -136,33 +136,23 @@ class ContentService:
     @classmethod
     def from_settings(
         cls,
-        settings: UniqueSettings,
+        settings: UniqueSettings | str | None = None,
         metadata_filter: dict | None = None,
     ):
         """
         Initialize the ContentService with a settings object and metadata filter.
         """
 
+        if settings is None:
+            settings = UniqueSettings.from_env_auto_with_sdk_init()
+        elif isinstance(settings, str):
+            settings = UniqueSettings.from_env_auto_with_sdk_init(filename=settings)
+
         return cls(
             company_id=settings.auth.company_id.get_secret_value(),
             user_id=settings.auth.user_id.get_secret_value(),
             metadata_filter=metadata_filter,
         )
-
-    @classmethod
-    def from_settings_filename(
-        cls,
-        settings_filename: str = "unique.env",
-        metadata_filter: dict | None = None,
-    ):
-        """
-        Initialize the ContentService with automatically from a settings file placed in the
-        common plattform folders or the folder that the executed file is placed and metadata filter.
-        """
-        settings = UniqueSettings.from_env_auto_with_sdk_init(
-            filename=settings_filename
-        )
-        return cls.from_settings(settings=settings, metadata_filter=metadata_filter)
 
     @property
     @deprecated(

--- a/unique_toolkit/unique_toolkit/embedding/service.py
+++ b/unique_toolkit/unique_toolkit/embedding/service.py
@@ -56,28 +56,20 @@ class EmbeddingService(BaseService):
         return cls(company_id=event.company_id, user_id=event.user_id)
 
     @classmethod
-    def from_settings(cls, settings: UniqueSettings):
+    def from_settings(cls, settings: UniqueSettings | str | None = None):
         """
         Initialize the EmbeddingService with a settings object.
         """
+
+        if settings is None:
+            settings = UniqueSettings.from_env_auto_with_sdk_init()
+        elif isinstance(settings, str):
+            settings = UniqueSettings.from_env_auto_with_sdk_init(filename=settings)
+
         return cls(
             company_id=settings.auth.company_id.get_secret_value(),
             user_id=settings.auth.user_id.get_secret_value(),
         )
-
-    @classmethod
-    def from_settings_filename(
-        cls,
-        settings_filename: str = "unique.env",
-    ):
-        """
-        Initialize the EmbeddingService with automatically from a settings file placed in the
-        common plattform folders or the folder that the executed file is placed.
-        """
-        settings = UniqueSettings.from_env_auto_with_sdk_init(
-            filename=settings_filename
-        )
-        return cls.from_settings(settings=settings)
 
     @property
     @deprecated(

--- a/unique_toolkit/unique_toolkit/embedding/service.py
+++ b/unique_toolkit/unique_toolkit/embedding/service.py
@@ -56,20 +56,28 @@ class EmbeddingService(BaseService):
         return cls(company_id=event.company_id, user_id=event.user_id)
 
     @classmethod
-    def from_settings(
-        cls, settings: UniqueSettings | None = None, env_filename: str = "unique.env"
-    ):
+    def from_settings(cls, settings: UniqueSettings):
         """
         Initialize the EmbeddingService with a settings object.
-        If the settings object is not provided, it will be initialized from the environment.
         """
-        if settings is None:
-            settings = UniqueSettings.from_env_auto_with_sdk_init(filename=env_filename)
-
         return cls(
             company_id=settings.auth.company_id.get_secret_value(),
             user_id=settings.auth.user_id.get_secret_value(),
         )
+
+    @classmethod
+    def from_settings_filename(
+        cls,
+        settings_filename: str = "unique.env",
+    ):
+        """
+        Initialize the EmbeddingService with automatically from a settings file placed in the
+        common plattform folders or the folder that the executed file is placed.
+        """
+        settings = UniqueSettings.from_env_auto_with_sdk_init(
+            filename=settings_filename
+        )
+        return cls.from_settings(settings=settings)
 
     @property
     @deprecated(

--- a/unique_toolkit/unique_toolkit/embedding/service.py
+++ b/unique_toolkit/unique_toolkit/embedding/service.py
@@ -56,13 +56,15 @@ class EmbeddingService(BaseService):
         return cls(company_id=event.company_id, user_id=event.user_id)
 
     @classmethod
-    def from_settings(cls, settings: UniqueSettings | None = None):
+    def from_settings(
+        cls, settings: UniqueSettings | None = None, env_filename: str = "unique.env"
+    ):
         """
         Initialize the EmbeddingService with a settings object.
         If the settings object is not provided, it will be initialized from the environment.
         """
         if settings is None:
-            settings = UniqueSettings.from_env_auto_with_sdk_init()
+            settings = UniqueSettings.from_env_auto_with_sdk_init(filename=env_filename)
 
         return cls(
             company_id=settings.auth.company_id.get_secret_value(),

--- a/unique_toolkit/unique_toolkit/embedding/service.py
+++ b/unique_toolkit/unique_toolkit/embedding/service.py
@@ -56,10 +56,14 @@ class EmbeddingService(BaseService):
         return cls(company_id=event.company_id, user_id=event.user_id)
 
     @classmethod
-    def from_settings(cls, settings: UniqueSettings):
+    def from_settings(cls, settings: UniqueSettings | None = None):
         """
         Initialize the EmbeddingService with a settings object.
+        If the settings object is not provided, it will be initialized from the environment.
         """
+        if settings is None:
+            settings = UniqueSettings.from_env_auto_with_sdk_init()
+
         return cls(
             company_id=settings.auth.company_id.get_secret_value(),
             user_id=settings.auth.user_id.get_secret_value(),

--- a/unique_toolkit/unique_toolkit/language_model/service.py
+++ b/unique_toolkit/unique_toolkit/language_model/service.py
@@ -91,20 +91,28 @@ class LanguageModelService:
         return cls(company_id=event.company_id, user_id=event.user_id)
 
     @classmethod
-    def from_settings(
-        cls, settings: UniqueSettings | None = None, env_filename: str = "unique.env"
-    ):
+    def from_settings(cls, settings: UniqueSettings):
         """
         Initialize the LanguageModelService with a settings object.
-        If the settings object is not provided, it will be initialized from the environment.
         """
-        if settings is None:
-            settings = UniqueSettings.from_env_auto_with_sdk_init(filename=env_filename)
-
         return cls(
             company_id=settings.auth.company_id.get_secret_value(),
             user_id=settings.auth.user_id.get_secret_value(),
         )
+
+    @classmethod
+    def from_settings_filename(
+        cls,
+        settings_filename: str = "unique.env",
+    ):
+        """
+        Initialize the LanguageModelService with automatically from a settings file placed in the
+        common plattform folders or the folder that the executed file is placed.
+        """
+        settings = UniqueSettings.from_env_auto_with_sdk_init(
+            filename=settings_filename
+        )
+        return cls.from_settings(settings=settings)
 
     @property
     @deprecated(

--- a/unique_toolkit/unique_toolkit/language_model/service.py
+++ b/unique_toolkit/unique_toolkit/language_model/service.py
@@ -91,13 +91,15 @@ class LanguageModelService:
         return cls(company_id=event.company_id, user_id=event.user_id)
 
     @classmethod
-    def from_settings(cls, settings: UniqueSettings | None = None):
+    def from_settings(
+        cls, settings: UniqueSettings | None = None, env_filename: str = "unique.env"
+    ):
         """
         Initialize the LanguageModelService with a settings object.
         If the settings object is not provided, it will be initialized from the environment.
         """
         if settings is None:
-            settings = UniqueSettings.from_env_auto_with_sdk_init()
+            settings = UniqueSettings.from_env_auto_with_sdk_init(filename=env_filename)
 
         return cls(
             company_id=settings.auth.company_id.get_secret_value(),

--- a/unique_toolkit/unique_toolkit/language_model/service.py
+++ b/unique_toolkit/unique_toolkit/language_model/service.py
@@ -91,10 +91,14 @@ class LanguageModelService:
         return cls(company_id=event.company_id, user_id=event.user_id)
 
     @classmethod
-    def from_settings(cls, settings: UniqueSettings):
+    def from_settings(cls, settings: UniqueSettings | None = None):
         """
         Initialize the LanguageModelService with a settings object.
+        If the settings object is not provided, it will be initialized from the environment.
         """
+        if settings is None:
+            settings = UniqueSettings.from_env_auto_with_sdk_init()
+
         return cls(
             company_id=settings.auth.company_id.get_secret_value(),
             user_id=settings.auth.user_id.get_secret_value(),

--- a/unique_toolkit/unique_toolkit/language_model/service.py
+++ b/unique_toolkit/unique_toolkit/language_model/service.py
@@ -91,28 +91,19 @@ class LanguageModelService:
         return cls(company_id=event.company_id, user_id=event.user_id)
 
     @classmethod
-    def from_settings(cls, settings: UniqueSettings):
+    def from_settings(cls, settings: UniqueSettings | str | None = None):
         """
         Initialize the LanguageModelService with a settings object.
         """
+        if settings is None:
+            settings = UniqueSettings.from_env_auto_with_sdk_init()
+        elif isinstance(settings, str):
+            settings = UniqueSettings.from_env_auto_with_sdk_init(filename=settings)
+
         return cls(
             company_id=settings.auth.company_id.get_secret_value(),
             user_id=settings.auth.user_id.get_secret_value(),
         )
-
-    @classmethod
-    def from_settings_filename(
-        cls,
-        settings_filename: str = "unique.env",
-    ):
-        """
-        Initialize the LanguageModelService with automatically from a settings file placed in the
-        common plattform folders or the folder that the executed file is placed.
-        """
-        settings = UniqueSettings.from_env_auto_with_sdk_init(
-            filename=settings_filename
-        )
-        return cls.from_settings(settings=settings)
 
     @property
     @deprecated(


### PR DESCRIPTION
## 🚀 Summary

All services can be initialized as `Service.from_settings_filename()`. The settings are automatically obtained from the `env` or from the usual env file locations
