### PR TITLE
improvement: Allow another stopping creteria (stoppedStreamingAT which remains the default value). Loading debug info from user_message

### DIFF
--- a/unique_sdk/CHANGELOG.md
+++ b/unique_sdk/CHANGELOG.md
@@ -5,8 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), 
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.19] - 2025-09-02
+- Improve `send_message_and_wait_for_completion`:
+    - Add option to select stop_condition `["stoppedStreamingAt", "completedAt"]`. 
+    - Load `debugInfo` from `last_user_message` for better developer experience.
+
 ## [0.10.18] - 2025-09-02
-- Temporarily remove support for udpate and delete files by filePath.
+- Temporarily remove support for update and delete files by filePath.
 
 ## [0.10.17] - 2025-09-01
 - Add function to update a file

--- a/unique_sdk/README.md
+++ b/unique_sdk/README.md
@@ -1450,11 +1450,13 @@ The script sends a prompt asynchronously and continuously polls for completion, 
 - `chat_id`: The ID of the chat where the message should be sent. If omitted, a new chat will be created.
 - `poll_interval`: The number of seconds to wait between polling attempts (default: `1` second).
 - `max_wait`: The maximum number of seconds to wait for the message to complete (default: `60` seconds).
+- `stop_condition`: Defines when to expect a response back, when the assistant stop streaming or when it completes the message. (default: "stoppedStreamingAt")
 
 The script ensures you can flexibly interact with spaces in new or ongoing chats, with fine-grained control over tools, context, and polling behavior.
 
 ```python
-latest_message = await unique_sdk.utils.chat_in_space.send_message_and_wait_for_completion(
+from unique_sdk.utils.chat_in_space import send_message_and_wait_for_completion
+latest_message = await send_message_and_wait_for_completion(
     user_id=user_id,
     company_id=company_id,
     assistant_id=assistant_id,
@@ -1481,6 +1483,7 @@ latest_message = await unique_sdk.utils.chat_in_space.send_message_and_wait_for_
             }
         ]
     },
+    stop_condition = "completedAt" # If not specified, stoppedStreamingAt will be set by default
 )
 ```
 

--- a/unique_sdk/pyproject.toml
+++ b/unique_sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "unique_sdk"
-version = "0.10.18"
+version = "0.10.19"
 description = ""
 authors = [
     "Martin Fadler <martin.fadler@unique.ch>",

--- a/unique_sdk/unique_sdk/utils/chat_in_space.py
+++ b/unique_sdk/unique_sdk/utils/chat_in_space.py
@@ -50,9 +50,13 @@ async def send_message_and_wait_for_completion(
     for _ in range(max_attempts):
         answer = Space.get_latest_message(user_id, company_id, chat_id)
         if answer.get(stopping_condition) is not None:
-            user_message = Message.retrieve(user_id, company_id, message_id, chatId=chat_id)
-            debug_info = user_message.get("debugInfo")
-            answer["debugInfo"] = debug_info
+            try:
+                user_message = Message.retrieve(user_id, company_id, message_id, chatId=chat_id)
+                debug_info = user_message.get("debugInfo")
+                answer["debugInfo"] = debug_info
+            except Exception as e:
+                print(f"Failed to load debug info from user message: {e}")
+                
             return answer
         await asyncio.sleep(poll_interval)
 

--- a/unique_sdk/unique_sdk/utils/chat_in_space.py
+++ b/unique_sdk/unique_sdk/utils/chat_in_space.py
@@ -29,6 +29,7 @@ async def send_message_and_wait_for_completion(
         text: The prompt text.
         poll_interval: Seconds between polls.
         max_wait: Maximum seconds to wait for completion.
+        stop_condition: Defines when to expect a response back, when the assistant stop streaming or when it completes the message. (default: "stoppedStreamingAt")
         **kwargs: Additional parameters for the prompt.
 
     Returns:

--- a/unique_sdk/unique_sdk/utils/chat_in_space.py
+++ b/unique_sdk/unique_sdk/utils/chat_in_space.py
@@ -17,9 +17,7 @@ async def send_message_and_wait_for_completion(
     chat_id: str = None,
     poll_interval: float = 1.0,
     max_wait: float = 60.0,
-    stopping_condition: Literal[
-        "stoppedStreamingAt", "completedAt"
-    ] = "stoppedStreamingAt",
+    stop_condition: Literal["stoppedStreamingAt", "completedAt"] = "stoppedStreamingAt",
 ) -> "Space.Message":
     """
     Sends a prompt asynchronously and polls for completion. (until stoppedStreamingAt is not None)
@@ -51,7 +49,7 @@ async def send_message_and_wait_for_completion(
     max_attempts = int(max_wait // poll_interval)
     for _ in range(max_attempts):
         answer = Space.get_latest_message(user_id, company_id, chat_id)
-        if answer.get(stopping_condition) is not None:
+        if answer.get(stop_condition) is not None:
             try:
                 user_message = Message.retrieve(
                     user_id, company_id, message_id, chatId=chat_id

--- a/unique_sdk/unique_sdk/utils/chat_in_space.py
+++ b/unique_sdk/unique_sdk/utils/chat_in_space.py
@@ -17,7 +17,9 @@ async def send_message_and_wait_for_completion(
     chat_id: str = None,
     poll_interval: float = 1.0,
     max_wait: float = 60.0,
-    stopping_condition: Literal["stoppedStreamingAt", "completedAt"] = "stoppedStreamingAt",
+    stopping_condition: Literal[
+        "stoppedStreamingAt", "completedAt"
+    ] = "stoppedStreamingAt",
 ) -> "Space.Message":
     """
     Sends a prompt asynchronously and polls for completion. (until stoppedStreamingAt is not None)
@@ -51,12 +53,14 @@ async def send_message_and_wait_for_completion(
         answer = Space.get_latest_message(user_id, company_id, chat_id)
         if answer.get(stopping_condition) is not None:
             try:
-                user_message = Message.retrieve(user_id, company_id, message_id, chatId=chat_id)
+                user_message = Message.retrieve(
+                    user_id, company_id, message_id, chatId=chat_id
+                )
                 debug_info = user_message.get("debugInfo")
                 answer["debugInfo"] = debug_info
             except Exception as e:
                 print(f"Failed to load debug info from user message: {e}")
-                
+
             return answer
         await asyncio.sleep(poll_interval)
 


### PR DESCRIPTION
## 🚀 Summary
Refs: UN-13306

- The changes introduce a different stopping criteria for searching latest message.
Some information, such as assessment is loaded only after the end of streaming, meaning that we need to stop the search when the message is completed (completedAt)

- Inject the debug info from the user message, as it's the one that saves them. the assistant message debug info is always empty. This is handy for the devolpers, as they don't need to make another call and retrieve the debug info (especially that they don't have access to the messafe id creaed by Space.create_message_async)

## ✅ Changes

- [x] Added feature / fixed bug / updated docs
- [ ] Refactored code / cleaned up
- [ ] Other (describe below)

## 🧪 Testing
Tested the changes locally, on my benchmarking app. The changes do not affect old behaviour, only introduce additional features.

## ⛙ Merging workflow
Once you have finished developing your feature and done **all** the testing listed above you can perform the process below

1. Ensure you bumped the version of `unique-sdk` and `unique-toolkit` if changed. (Done in `pyproject.toml`)
2. Open PR against `Unique-AG/ai`
3. Get review and fix any requested changes
4. Merge PR
5. Confirm publish action to PyPI succeeds
6. _Unique employees only: perform testing against monorepo and sync versions_
