### PR TITLE
feat(toolkit): automatic rsjf UI schema models

### DIFF
--- a/unique_toolkit/CHANGELOG.md
+++ b/unique_toolkit/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), 
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2025-09-28
+- Add utilitiy to enhance pydantic model with metadata
+- Add capability to collect this metadata with same hierarchy as nested pydantic models
 
 ## [1.2.1] - 2025-09-28
 - Fix bug where camel case arguments were not properly validated.

--- a/unique_toolkit/pyproject.toml
+++ b/unique_toolkit/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "unique_toolkit"
-version = "1.2.1"
+version = "1.3.0"
 description = ""
 authors = [
     "Cedric Klinkert <cedric.klinkert@unique.ch>",


### PR DESCRIPTION
## 🚀 Summary

These PR enables us to add special tags to pydantic models via the `Annotated` method that can then be collected for RJSF ui schemas.

## ✅ Changes

- [x] Added feature 