### PR TITLE
feat(ai): add remove content functionality to get_user_visible_chat_history

### DIFF
--- a/unique_toolkit/CHANGELOG.md
+++ b/unique_toolkit/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), 
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.0] - 2025-10-01
+- Add functionality to remove text in `get_user_visible_chat_history`
+
 ## [1.6.0] - 2025-10-01
 - revert and simplify 1.5.0 
 

--- a/unique_toolkit/pyproject.toml
+++ b/unique_toolkit/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "unique_toolkit"
-version = "1.6.0"
+version = "1.7.0"
 description = ""
 authors = [
     "Cedric Klinkert <cedric.klinkert@unique.ch>",

--- a/unique_toolkit/unique_toolkit/agentic/history_manager/history_manager.py
+++ b/unique_toolkit/unique_toolkit/agentic/history_manager/history_manager.py
@@ -217,18 +217,21 @@ class HistoryManager:
         return messages
 
     async def get_user_visible_chat_history(
-        self, assistant_message_text: str | None = None
+        self,
+        assistant_message_text: str | None = None,
+        remove_from_text: Callable[[str], Awaitable[str]] | None = None,
     ) -> LanguageModelMessages:
         """Get the user visible chat history.
 
         Args:
             assistant_message_text (str | None): The latest assistant message to append to the history, as this is not extracted from the history.
             If None, the history will be returned without the latest assistant message.
+            remove_from_text (Callable[[str], Awaitable[str]] | None): A function to remove text from the history before returning it.
 
         Returns:
             LanguageModelMessages: The user visible chat history.
         """
-        history = await self._token_reducer.get_history_from_db()
+        history = await self._token_reducer.get_history_from_db(remove_from_text)
         if assistant_message_text:
             history.append(
                 LanguageModelAssistantMessage(content=assistant_message_text)


### PR DESCRIPTION
## 🚀 Summary
- add remove content functionality to get_user_visible_chat_history

## ✅ Changes

- [x] Added feature / fixed bug / updated docs
- [ ] Refactored code / cleaned up
- [ ] Other (describe below)

## 🧪 Testing

Explain what has been tested and how.
