### PR TITLE
fix(sdk): Use non blocking versions of  `Space.get_latest_message` and `Message.retrieve`

### DIFF
--- a/unique_sdk/CHANGELOG.md
+++ b/unique_sdk/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), 
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.28] - 2025-10-03
+- Use non blocking versions of `Space.get_latest_message` and `Message.retrieve` in `send_message_and_wait_for_completion`.
+
 ## [0.10.27] - 2025-09-24
 - Improve readme to use Unique AI.
 

--- a/unique_sdk/pyproject.toml
+++ b/unique_sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "unique_sdk"
-version = "0.10.27"
+version = "0.10.28"
 description = ""
 authors = [
     "Martin Fadler <martin.fadler@unique.ch>",

--- a/unique_sdk/unique_sdk/utils/chat_in_space.py
+++ b/unique_sdk/unique_sdk/utils/chat_in_space.py
@@ -49,10 +49,10 @@ async def send_message_and_wait_for_completion(
 
     max_attempts = int(max_wait // poll_interval)
     for _ in range(max_attempts):
-        answer = Space.get_latest_message(user_id, company_id, chat_id)
+        answer = await Space.get_latest_message_async(user_id, company_id, chat_id)
         if answer.get(stop_condition) is not None:
             try:
-                user_message = Message.retrieve(
+                user_message = await Message.retrieve_async(
                     user_id, company_id, message_id, chatId=chat_id
                 )
                 debug_info = user_message.get("debugInfo")


### PR DESCRIPTION
## 🚀 Summary

Use non blocking versions of  `Space.get_latest_message` and `Message.retrieve` in `send_message_and_wait_for_completion`

## ✅ Changes

- [x] Added feature / fixed bug / updated docs
- [ ] Refactored code / cleaned up
- [ ] Other (describe below)

## 🧪 Testing

Explain what has been tested and how.
