### PR TITLE
fix(unique-toolkit): graceful tool initialization [UN-17197]

### DIFF
--- a/unique_toolkit/tests/agentic/tools/test_config.py
+++ b/unique_toolkit/tests/agentic/tools/test_config.py
@@ -1309,3 +1309,210 @@ def test_tool_build_config__by_alias_and_exclude_defaults__combined() -> None:
         assert "optionalNote" not in cfg
     finally:
         ToolFactory.tool_config_map.pop("combined_tool", None)
+
+
+# ============================================================================
+# Graceful Degradation Tests (UN-17197)
+# ============================================================================
+
+
+@pytest.mark.ai
+def test_tool_build_config__disables_tool__with_wrong_config_type(
+    test_tool_class,
+    test_tool_config_class,
+) -> None:
+    """
+    Purpose: Verify tool with wrong config type is disabled instead of crashing.
+    Why this matters: Graceful degradation when config type doesn't match tool.
+    Setup summary: Register tool, provide wrong config type, assert tool is disabled.
+    """
+    # Arrange
+    ToolFactory.register_tool(test_tool_class, test_tool_config_class)
+
+    class WrongConfig(BaseToolConfig):
+        wrong_param: str = "wrong"
+
+    wrong_config = WrongConfig()
+    config_data = {"name": "test_tool", "configuration": wrong_config}
+
+    # Act
+    config = ToolBuildConfig(**config_data)
+
+    # Assert
+    assert config.is_enabled is False
+    assert isinstance(config.configuration, BaseToolConfig)
+
+    # Cleanup
+    ToolFactory.tool_map.pop("test_tool", None)
+    ToolFactory.tool_config_map.pop("test_tool", None)
+
+
+@pytest.mark.ai
+def test_tool_build_config__skips_validation__when_disabled() -> None:
+    """
+    Purpose: Verify disabled tools skip config validation entirely.
+    Why this matters: Disabled tools should never crash due to invalid config.
+    Setup summary: Create config with is_enabled=False and unregistered name; assert no error.
+    """
+    # Arrange — tool name is not registered, config is garbage, but tool is disabled
+    config_data = {
+        "name": "nonexistent_tool_xyz",
+        "is_enabled": False,
+        "configuration": {"completely": "invalid", "garbage": 999},
+    }
+
+    # Act
+    config = ToolBuildConfig(**config_data)
+
+    # Assert
+    assert config.is_enabled is False
+    assert config.name == "nonexistent_tool_xyz"
+    assert isinstance(config.configuration, BaseToolConfig)
+
+
+@pytest.mark.ai
+def test_tool_build_config__skips_validation__when_disabled_with_camel_case_key() -> (
+    None
+):
+    """
+    Purpose: Verify disabled tools skip validation when isEnabled uses camelCase.
+    Why this matters: Backend payloads use alias_generator=to_camel keys.
+    Setup summary: Create config with isEnabled=False and invalid config; assert no error.
+    """
+    config_data = {
+        "name": "nonexistent_tool_xyz",
+        "isEnabled": False,
+        "configuration": {"completely": "invalid", "garbage": 999},
+    }
+
+    config = ToolBuildConfig(**config_data)
+
+    assert config.is_enabled is False
+    assert config.name == "nonexistent_tool_xyz"
+    assert isinstance(config.configuration, BaseToolConfig)
+
+
+@pytest.mark.ai
+def test_tool_build_config__skips_validation__when_disabled_with_null_configuration() -> (
+    None
+):
+    """
+    Purpose: Verify disabled tools with null configuration do not crash validation.
+    Why this matters: Disabled tools may carry incomplete backend payloads.
+    Setup summary: Create disabled config with configuration=null; assert BaseToolConfig fallback.
+    """
+    config_data = {
+        "name": "disabled_tool",
+        "isEnabled": False,
+        "configuration": None,
+    }
+
+    config = ToolBuildConfig(**config_data)
+
+    assert config.is_enabled is False
+    assert isinstance(config.configuration, BaseToolConfig)
+
+
+@pytest.mark.ai
+def test_tool_build_config__disables_tool__when_demotion_overrides_camel_case_enabled(
+    caplog,
+) -> None:
+    """
+    Purpose: Verify demotion sets both is_enabled and isEnabled to false.
+    Why this matters: Pydantic prefers alias keys when both snake and camel are present.
+    Setup summary: Pass isEnabled=true with invalid config; assert tool ends disabled.
+    """
+    import logging
+
+    config_data = {
+        "name": "totally_unknown_tool",
+        "isEnabled": True,
+        "configuration": {"some_param": "value"},
+    }
+
+    with caplog.at_level(logging.WARNING):
+        config = ToolBuildConfig(**config_data)
+
+    assert config.is_enabled is False
+    assert isinstance(config.configuration, BaseToolConfig)
+
+
+@pytest.mark.ai
+def test_tool_build_config__handles_mcp_tool__with_camel_case_mcp_source_id() -> None:
+    """
+    Purpose: Verify validator recognizes MCP tools when mcpSourceId uses camelCase.
+    Why this matters: Backend payloads use camelCase alias keys for MCP metadata.
+    Setup summary: Create config with mcpSourceId and assert factory validation is skipped.
+    """
+    config_data = {
+        "name": "mcp_test_tool",
+        "mcpSourceId": "mcp-server-123",
+        "configuration": {
+            "server_id": "server-123",
+            "server_name": "Test Server",
+            "mcpSourceId": "mcp-server-123",
+        },
+    }
+
+    config = ToolBuildConfig(**config_data)
+
+    assert config.name == "mcp_test_tool"
+    assert isinstance(config.configuration, BaseToolConfig)
+
+
+@pytest.mark.ai
+def test_tool_build_config__disables_tool__with_unregistered_name(
+    caplog,
+) -> None:
+    """
+    Purpose: Verify unregistered tool name disables tool instead of crashing.
+    Why this matters: Graceful degradation for unknown tools.
+    Setup summary: Create config with unregistered tool name, assert is_enabled=False and warning logged.
+    """
+    import logging
+
+    config_data = {
+        "name": "totally_unknown_tool",
+        "configuration": {"some_param": "value"},
+    }
+
+    # Act
+    with caplog.at_level(logging.WARNING):
+        config = ToolBuildConfig(**config_data)
+
+    # Assert
+    assert config.is_enabled is False
+    assert isinstance(config.configuration, BaseToolConfig)
+    assert "totally_unknown_tool" in caplog.text
+    assert (
+        "invalid configuration" in caplog.text.lower()
+        or "disabled" in caplog.text.lower()
+    )
+
+
+@pytest.mark.ai
+def test_tool_build_config__disables_tool__with_invalid_config_values(
+    register_simple_tool,
+    caplog,
+) -> None:
+    """
+    Purpose: Verify registered tool with bad config values is disabled instead of crashing.
+    Why this matters: Pydantic validation errors in config should not crash the system.
+    Setup summary: Register tool, pass invalid config values, assert is_enabled=False.
+    """
+    import logging
+
+    # SimpleToolConfig expects param_two: int, we pass a non-coercible string
+    config_data = {
+        "name": "test_tool",
+        "configuration": {"param_one": "ok", "param_two": "not_an_integer_at_all"},
+    }
+
+    # Act
+    with caplog.at_level(logging.WARNING):
+        config = ToolBuildConfig(**config_data)
+
+    # Assert
+    assert config.is_enabled is False
+    assert isinstance(config.configuration, BaseToolConfig)
+    assert "test_tool" in caplog.text

--- a/unique_toolkit/tests/agentic/tools/test_config.py
+++ b/unique_toolkit/tests/agentic/tools/test_config.py
@@ -633,9 +633,10 @@ def test_tool_build_config__validates_config_type__with_wrong_type(
     test_tool_config_class,
 ) -> None:
     """
-    Purpose: Verify validator raises error when config type doesn't match tool.
-    Why this matters: Ensures type safety between tool and configuration.
-    Setup summary: Register tool, provide wrong config type, assert error raised.
+    Purpose: Verify validator demotes the tool when config type doesn't match.
+    Why this matters: Ensures type safety between tool and configuration while
+    keeping invalid tools from crashing the load (graceful degradation).
+    Setup summary: Register tool, provide wrong config type, assert demotion.
     """
     # Arrange
     ToolFactory.register_tool(test_tool_class, test_tool_config_class)
@@ -646,12 +647,12 @@ def test_tool_build_config__validates_config_type__with_wrong_type(
     wrong_config = WrongConfig()
     config_data = {"name": "test_tool", "configuration": wrong_config}
 
-    # Act & Assert
-    # Pydantic v2 raises ValidationError for assertion failures
-    from pydantic import ValidationError
+    # Act
+    config = ToolBuildConfig(**config_data)
 
-    with pytest.raises((AssertionError, ValidationError)):
-        ToolBuildConfig(**config_data)
+    # Assert: invalid config type demotes the tool to disabled
+    assert config.is_enabled is False
+    assert isinstance(config.configuration, BaseToolConfig)
 
     # Cleanup
     ToolFactory.tool_map.pop("test_tool", None)

--- a/unique_toolkit/tests/agentic/tools/test_tool_build_config_and_factory.py
+++ b/unique_toolkit/tests/agentic/tools/test_tool_build_config_and_factory.py
@@ -11,6 +11,7 @@ This test demonstrates the complete lifecycle of tool configuration and factory 
 
 import json
 from typing import cast
+from unittest.mock import Mock
 
 import pytest
 from pydantic import RootModel
@@ -24,6 +25,7 @@ from unique_toolkit.agentic.tools.config import (
 from unique_toolkit.agentic.tools.factory import ToolFactory
 from unique_toolkit.agentic.tools.schemas import BaseToolConfig, ToolCallResponse
 from unique_toolkit.agentic.tools.tool import Tool
+from unique_toolkit.app.schemas import ChatEvent
 from unique_toolkit.language_model.schemas import (
     LanguageModelFunction,
     LanguageModelToolDescription,
@@ -43,7 +45,18 @@ class TestTool(Tool[TestToolConfig]):
     name = "test_tool"
 
     def __init__(self, configuration: TestToolConfig, *args, **kwargs):
-        super().__init__(configuration)
+        mock_event = Mock(spec=ChatEvent)
+        mock_event.company_id = "test_company"
+        mock_event.user_id = "test_user"
+        mock_event.chat_id = "test_chat"
+        mock_event.assistant_id = "test_assistant"
+
+        mock_payload = Mock()
+        mock_payload.assistant_message = Mock()
+        mock_payload.assistant_message.id = "test_assistant_message_id"
+        mock_event.payload = mock_payload
+
+        super().__init__(configuration, mock_event)
         self.settings.configuration = configuration
         # settings will be set by factory, but we need to initialize it properly
         self.settings = ToolBuildConfig(name=self.name, configuration=configuration)
@@ -282,31 +295,28 @@ class TestToolBuildConfigAndFactory:
             ToolFactory.build_tool("unregistered_tool", None)
 
     def test_tool_build_config_validation_with_unregistered_tool(self):
-        """Test ToolBuildConfig validation with unregistered tool."""
-        # Try to create config for unregistered tool
+        """Test ToolBuildConfig marks unregistered tool as disabled."""
         config_data = {
             "name": "unregistered_tool",
             "configuration": {"test_param": "test"},
         }
 
-        # This should raise an error during validation
-        with pytest.raises((ValueError, KeyError)):
-            ToolBuildConfig(**config_data)
+        config = ToolBuildConfig(**config_data)
+        assert config.is_enabled is False
+        assert isinstance(config.configuration, BaseToolConfig)
 
     def test_tool_build_config_with_invalid_configuration_type(self):
-        """Test ToolBuildConfig with invalid configuration type."""
-        # Register the tool
+        """Test ToolBuildConfig marks tool with invalid config type as disabled."""
         ToolFactory.register_tool(TestTool, TestToolConfig)
 
-        # Create config with wrong configuration type
         config_data = {
             "name": "test_tool",
-            "configuration": "invalid_config_type",  # Should be dict or TestToolConfig
+            "configuration": "invalid_config_type",
         }
 
-        # This should raise an error during validation
-        with pytest.raises((TypeError, ValueError, AssertionError)):
-            ToolBuildConfig(**config_data)
+        config = ToolBuildConfig(**config_data)
+        assert config.is_enabled is False
+        assert isinstance(config.configuration, BaseToolConfig)
 
     def test_tool_build_config_model_rebuild(self):
         """Test model rebuild functionality."""
@@ -379,7 +389,18 @@ class TestToolBuildConfigAndFactory:
             name = "another_test_tool"
 
             def __init__(self, configuration: AnotherTestToolConfig, *args, **kwargs):
-                super().__init__(configuration)
+                mock_event = Mock(spec=ChatEvent)
+                mock_event.company_id = "test_company"
+                mock_event.user_id = "test_user"
+                mock_event.chat_id = "test_chat"
+                mock_event.assistant_id = "test_assistant"
+
+                mock_payload = Mock()
+                mock_payload.assistant_message = Mock()
+                mock_payload.assistant_message.id = "test_assistant_message_id"
+                mock_event.payload = mock_payload
+
+                super().__init__(configuration, mock_event)
                 self.settings.configuration = configuration
                 # settings will be set by factory, but we need to initialize it properly
                 self.settings = ToolBuildConfig(

--- a/unique_toolkit/tests/agentic/tools/test_tool_manager.py
+++ b/unique_toolkit/tests/agentic/tools/test_tool_manager.py
@@ -2609,3 +2609,241 @@ def test_responses_api_tool_manager__exclude_tool__removes_builtin_from_all_list
         ["openai_builtin"],
     )
     assert filtered == []
+
+
+# ============================================================================
+# Graceful Degradation Tests (UN-17197)
+# ============================================================================
+
+
+class FailingToolConfig(BaseToolConfig):
+    """Config for a tool whose constructor raises."""
+
+    pass
+
+
+class FailingTool(Tool[FailingToolConfig]):
+    """Tool that raises during construction."""
+
+    name = "failing_tool"
+
+    def __init__(self, config, event=None, tool_progress_reporter=None):
+        raise RuntimeError("Simulated tool init failure")
+
+    def tool_description(self):
+        raise NotImplementedError
+
+    def evaluation_check_list(self):
+        return []
+
+    def get_evaluation_checks_based_on_tool_response(self, tool_response):
+        return []
+
+    async def run(self, tool_call):
+        raise NotImplementedError
+
+
+@pytest.fixture
+def register_failing_tool():
+    """Register and cleanup FailingTool in ToolFactory."""
+    ToolFactory.register_tool(FailingTool, FailingToolConfig)
+    yield
+    ToolFactory.tool_map.pop("failing_tool", None)
+    ToolFactory.tool_config_map.pop("failing_tool", None)
+
+
+@pytest.mark.ai
+def test_tool_manager__init_with_failing_tool__skips_bad_tool_keeps_others(
+    logger,
+    base_event,
+    tool_progress_reporter,
+    mcp_manager,
+    a2a_manager,
+    register_failing_tool,
+    caplog,
+) -> None:
+    """
+    Purpose: Verify ToolManager skips a failing tool but keeps healthy ones.
+    Why this matters: A single broken tool must not crash the entire system.
+    Setup summary: Register one healthy and one failing tool, assert only healthy is loaded.
+    """
+    # Arrange
+    healthy_config = ToolBuildConfig(
+        name="mock_tool",
+        configuration=MockToolConfig(),
+        display_name="Healthy Tool",
+        is_enabled=True,
+    )
+    failing_config = ToolBuildConfig(
+        name="failing_tool",
+        configuration=FailingToolConfig(),
+        display_name="Failing Tool",
+        is_enabled=True,
+    )
+    config = ToolManagerConfig(tools=[healthy_config, failing_config])
+
+    # Act
+    with caplog.at_level(logging.WARNING):
+        tm = ToolManager(
+            logger=logger,
+            config=config,
+            event=base_event,
+            tool_progress_reporter=tool_progress_reporter,
+            mcp_manager=mcp_manager,
+            a2a_manager=a2a_manager,
+        )
+
+    # Assert
+    tools = tm.get_tools()
+    tool_names = [t.name for t in tools]
+    assert "mock_tool" in tool_names
+    assert "failing_tool" not in tool_names
+    assert "Skipping tool" in caplog.text or "initialization failure" in caplog.text
+
+
+@pytest.mark.ai
+def test_tool_manager__init_with_all_tools_failing__initializes_empty(
+    logger,
+    base_event,
+    tool_progress_reporter,
+    mcp_manager,
+    a2a_manager,
+    register_failing_tool,
+) -> None:
+    """
+    Purpose: Verify ToolManager initializes even when all tools fail.
+    Why this matters: System must remain operational even with no working tools.
+    Setup summary: Register only a failing tool, assert ToolManager has empty tool list.
+    """
+    # Arrange
+    failing_config = ToolBuildConfig(
+        name="failing_tool",
+        configuration=FailingToolConfig(),
+        display_name="Failing Tool",
+        is_enabled=True,
+    )
+    config = ToolManagerConfig(tools=[failing_config])
+
+    # Act
+    tm = ToolManager(
+        logger=logger,
+        config=config,
+        event=base_event,
+        tool_progress_reporter=tool_progress_reporter,
+        mcp_manager=mcp_manager,
+        a2a_manager=a2a_manager,
+    )
+
+    # Assert
+    assert tm.get_tools() == []
+
+
+@pytest.mark.ai
+def test_tool_manager__init_skips_disabled_tool__does_not_build_it(
+    logger,
+    base_event,
+    tool_progress_reporter,
+    mcp_manager,
+    a2a_manager,
+    caplog,
+) -> None:
+    """
+    Purpose: Verify disabled tools are skipped during init and not built.
+    Why this matters: Disabled tools must not consume resources or cause failures.
+    Setup summary: Create a tool config with is_enabled=False, assert it is skipped.
+    """
+    # Arrange
+    disabled_config = ToolBuildConfig(
+        name="mock_tool",
+        configuration=MockToolConfig(),
+        display_name="Disabled Tool",
+        is_enabled=False,
+    )
+    config = ToolManagerConfig(tools=[disabled_config])
+
+    # Act
+    with caplog.at_level(logging.INFO):
+        tm = ToolManager(
+            logger=logger,
+            config=config,
+            event=base_event,
+            tool_progress_reporter=tool_progress_reporter,
+            mcp_manager=mcp_manager,
+            a2a_manager=a2a_manager,
+        )
+
+    # Assert
+    assert tm.get_tools() == []
+    assert "Skipping disabled tool" in caplog.text
+
+
+@pytest.mark.ai
+def test_tool_manager__excludes_disabled_exclusive_tool__from_exclusive_list(
+    logger,
+    base_event,
+    tool_progress_reporter,
+    mcp_manager,
+    a2a_manager,
+) -> None:
+    """
+    Purpose: Verify disabled exclusive tools are not treated as exclusive constraints.
+    Why this matters: Disabled tools must not affect tool-choice filtering logic.
+    Setup summary: Create disabled exclusive tool; assert it is omitted from exclusive list.
+    """
+    disabled_exclusive_config = ToolBuildConfig(
+        name="exclusive_tool",
+        configuration=MockToolConfig(),
+        display_name="Disabled Exclusive Tool",
+        is_exclusive=True,
+        is_enabled=False,
+    )
+    config = ToolManagerConfig(tools=[disabled_exclusive_config])
+
+    tool_manager = ToolManager(
+        logger=logger,
+        config=config,
+        event=base_event,
+        tool_progress_reporter=tool_progress_reporter,
+        mcp_manager=mcp_manager,
+        a2a_manager=a2a_manager,
+    )
+
+    assert tool_manager.get_exclusive_tools() == []
+
+
+@pytest.mark.ai
+def test_a2a_manager__skips_disabled_sub_agent__does_not_initialize(
+    logger,
+    base_event,
+    tool_progress_reporter,
+    caplog,
+) -> None:
+    """
+    Purpose: Verify disabled sub-agents are skipped during A2A initialization.
+    Why this matters: Disabled sub-agents must not attempt SubAgentTool construction.
+    Setup summary: Pass disabled sub-agent config; assert empty sub-agent list and info log.
+    """
+    from unique_toolkit.agentic.tools.a2a.tool.config import SubAgentToolConfig
+
+    disabled_sub_agent = ToolBuildConfig(
+        name="disabled_sub_agent",
+        configuration=SubAgentToolConfig(assistant_id="sub_agent_assistant_123"),
+        display_name="Disabled Sub Agent",
+        is_sub_agent=True,
+        is_enabled=False,
+    )
+    manager = A2AManager(
+        logger=logger,
+        tool_progress_reporter=tool_progress_reporter,
+        response_watcher=SubAgentResponseWatcher(),
+    )
+
+    with caplog.at_level(logging.INFO):
+        filtered_configs, sub_agents = manager.get_all_sub_agents(
+            [disabled_sub_agent],
+            base_event,
+        )
+
+    assert sub_agents == []
+    assert filtered_configs == []
+    assert "Skipping disabled sub-agent" in caplog.text

--- a/unique_toolkit/unique_toolkit/agentic/tools/a2a/manager.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/a2a/manager.py
@@ -29,6 +29,13 @@ class A2AManager:
             if not tool_config.is_sub_agent:
                 continue
 
+            if not tool_config.is_enabled:
+                self._logger.info(
+                    "Skipping disabled sub-agent '%s'",
+                    tool_config.name,
+                )
+                continue
+
             if not isinstance(tool_config.configuration, SubAgentToolConfig):
                 self._logger.error(
                     "tool_config.configuration must be of type SubAgentToolConfig"
@@ -37,16 +44,23 @@ class A2AManager:
 
             sub_agent_tool_config = tool_config.configuration
 
-            sub_agents.append(
-                SubAgentTool(
-                    configuration=sub_agent_tool_config,
-                    event=event,
-                    tool_progress_reporter=self._tool_progress_reporter,
-                    name=tool_config.name,
-                    display_name=tool_config.display_name,
-                    response_watcher=self._response_watcher,
+            try:
+                sub_agents.append(
+                    SubAgentTool(
+                        configuration=sub_agent_tool_config,
+                        event=event,
+                        tool_progress_reporter=self._tool_progress_reporter,
+                        name=tool_config.name,
+                        display_name=tool_config.display_name,
+                        response_watcher=self._response_watcher,
+                    )
                 )
-            )
+            except Exception:
+                self._logger.warning(
+                    "Skipping sub-agent '%s' due to initialization failure.",
+                    tool_config.name,
+                    exc_info=True,
+                )
 
         filtered_tool_config = [
             tool_config for tool_config in tool_configs if not tool_config.is_sub_agent

--- a/unique_toolkit/unique_toolkit/agentic/tools/config.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/config.py
@@ -1,3 +1,4 @@
+import logging
 from enum import StrEnum
 from typing import Annotated, Any, Generic
 
@@ -14,7 +15,51 @@ from typing_extensions import TypeVar
 from unique_toolkit._common.pydantic_helpers import get_configuration_dict
 from unique_toolkit.agentic.tools.schemas import BaseToolConfig
 
+logger = logging.getLogger(__name__)
+
 T = TypeVar("T", bound=BaseToolConfig, default=BaseToolConfig)
+
+
+def _dict_get_bool(
+    value: dict[str, Any],
+    snake_key: str,
+    camel_key: str,
+    default: bool = True,
+) -> bool:
+    if camel_key in value:
+        return bool(value[camel_key])
+    if snake_key in value:
+        return bool(value[snake_key])
+    return default
+
+
+def _set_enabled(value: dict[str, Any], enabled: bool) -> None:
+    value["is_enabled"] = enabled
+    value["isEnabled"] = enabled
+
+
+def _normalize_disabled_configuration(value: dict[str, Any]) -> None:
+    configuration = value.get("configuration")
+    if not isinstance(configuration, BaseToolConfig):
+        value["configuration"] = BaseToolConfig()
+
+
+def _non_empty_str(value: dict[str, Any], snake_key: str, camel_key: str) -> str:
+    raw = value.get(snake_key, value.get(camel_key, ""))
+    if raw is None:
+        return ""
+    return str(raw)
+
+
+def _is_mcp_tool_payload(value: dict[str, Any]) -> bool:
+    if _non_empty_str(value, "mcp_source_id", "mcpSourceId"):
+        return True
+
+    configuration = value.get("configuration", {})
+    if isinstance(configuration, dict):
+        if _non_empty_str(configuration, "mcp_source_id", "mcpSourceId"):
+            return True
+    return False
 
 
 class ToolIcon(StrEnum):
@@ -76,11 +121,19 @@ class ToolBuildConfig(BaseModel, Generic[T]):
         value: Any,
         info: ValidationInfo,
     ) -> Any:
-        """Check the given values for."""
+        """Validate and resolve tool configuration based on tool type and name.
+
+        Disabled tools skip validation entirely.
+        Enabled tools that fail validation are demoted to disabled.
+        """
         if not isinstance(value, dict):
             return value
 
-        is_mcp_tool = value.get("mcp_source_id", "") != ""
+        if not _dict_get_bool(value, "is_enabled", "isEnabled"):
+            _normalize_disabled_configuration(value)
+            return value
+
+        is_mcp_tool = _is_mcp_tool_payload(value)
         mcp_configuration = value.get("configuration", {})
 
         # Import at runtime to avoid circular imports
@@ -102,26 +155,38 @@ class ToolBuildConfig(BaseModel, Generic[T]):
 
         configuration = value.get("configuration", {})
 
-        if is_sub_agent_tool:
-            from unique_toolkit.agentic.tools.a2a import ExtendedSubAgentToolConfig
+        try:
+            if is_sub_agent_tool:
+                from unique_toolkit.agentic.tools.a2a import ExtendedSubAgentToolConfig
 
-            config = ExtendedSubAgentToolConfig.model_validate(configuration)
-        elif isinstance(configuration, dict):
-            # Local import to avoid circular import at module import time
-            from unique_toolkit.agentic.tools.factory import ToolFactory
+                config = ExtendedSubAgentToolConfig.model_validate(configuration)
+            elif isinstance(configuration, dict):
+                # Local import to avoid circular import at module import time
+                from unique_toolkit.agentic.tools.factory import ToolFactory
 
-            config = ToolFactory.build_tool_config(
-                value["name"],
-                **configuration,
+                config = ToolFactory.build_tool_config(
+                    value["name"],
+                    **configuration,
+                )
+            else:
+                # Check that the type of config matches the tool name
+                from unique_toolkit.agentic.tools.factory import ToolFactory
+
+                assert isinstance(
+                    configuration,
+                    ToolFactory.tool_config_map[value["name"]],  # pyright: ignore[reportArgumentType]
+                )
+                config = configuration
+        except Exception:
+            tool_name = value.get("name", "<unknown>")
+            logger.warning(
+                "Tool '%s' has invalid configuration and will be disabled.",
+                tool_name,
+                exc_info=True,
             )
-        else:
-            # Check that the type of config matches the tool name
-            from unique_toolkit.agentic.tools.factory import ToolFactory
+            _set_enabled(value, False)
+            _normalize_disabled_configuration(value)
+            return value
 
-            assert isinstance(
-                configuration,
-                ToolFactory.tool_config_map[value["name"]],  # pyright: ignore[reportArgumentType]
-            )
-            config = configuration
         value["configuration"] = config
         return value

--- a/unique_toolkit/unique_toolkit/agentic/tools/config.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/config.py
@@ -20,25 +20,7 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T", bound=BaseToolConfig, default=BaseToolConfig)
 
 
-def _dict_get_bool(
-    value: dict[str, Any],
-    snake_key: str,
-    camel_key: str,
-    default: bool = True,
-) -> bool:
-    if camel_key in value:
-        return bool(value[camel_key])
-    if snake_key in value:
-        return bool(value[snake_key])
-    return default
-
-
-def _set_enabled(value: dict[str, Any], enabled: bool) -> None:
-    value["is_enabled"] = enabled
-    value["isEnabled"] = enabled
-
-
-def _normalize_disabled_configuration(value: dict[str, Any]) -> None:
+def _ensure_base_tool_config(value: dict[str, Any]) -> None:
     configuration = value.get("configuration")
     if not isinstance(configuration, BaseToolConfig):
         value["configuration"] = BaseToolConfig()
@@ -129,8 +111,15 @@ class ToolBuildConfig(BaseModel, Generic[T]):
         if not isinstance(value, dict):
             return value
 
-        if not _dict_get_bool(value, "is_enabled", "isEnabled"):
-            _normalize_disabled_configuration(value)
+        if "isEnabled" in value:
+            is_enabled = bool(value["isEnabled"])
+        elif "is_enabled" in value:
+            is_enabled = bool(value["is_enabled"])
+        else:
+            is_enabled = True
+
+        if not is_enabled:
+            _ensure_base_tool_config(value)
             return value
 
         is_mcp_tool = _is_mcp_tool_payload(value)
@@ -184,8 +173,9 @@ class ToolBuildConfig(BaseModel, Generic[T]):
                 tool_name,
                 exc_info=True,
             )
-            _set_enabled(value, False)
-            _normalize_disabled_configuration(value)
+            value["is_enabled"] = False
+            value["isEnabled"] = False
+            _ensure_base_tool_config(value)
             return value
 
         value["configuration"] = config

--- a/unique_toolkit/unique_toolkit/agentic/tools/config.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/config.py
@@ -21,6 +21,7 @@ T = TypeVar("T", bound=BaseToolConfig, default=BaseToolConfig)
 
 
 def _ensure_base_tool_config(value: dict[str, Any]) -> None:
+    """Make configuration parseable; disabled/demoted tools are never built at runtime."""
     configuration = value.get("configuration")
     if not isinstance(configuration, BaseToolConfig):
         value["configuration"] = BaseToolConfig()

--- a/unique_toolkit/unique_toolkit/agentic/tools/tool_manager.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/tool_manager.py
@@ -147,7 +147,9 @@ class _ToolManager(Generic[_ApiMode]):
         self._tool_choices = run_context.tool_choices
         self._disabled_tools = run_context.disabled_tools
         self._exclusive_tools = [
-            tool.name for tool in self._config.tools if tool.is_exclusive
+            tool.name
+            for tool in self._config.tools
+            if tool.is_exclusive and tool.is_enabled
         ]
         # this needs to be a set of strings to avoid duplicates
         self._tool_evaluation_check_list: set[EvaluationMetricName] = set()
@@ -199,28 +201,39 @@ class _ToolManager(Generic[_ApiMode]):
 
         registered_tool_names.update(t.name for t in self._mcp_tools)
 
-        # Build internal tools from configurations
+        # Build internal tools from configurations, skipping disabled and failing tools
         self._internal_tools.clear()
+        safe_executor = SafeTaskExecutor(logger=self._logger)
         for t in tool_configs:
             if t.name in registered_tool_names:
                 continue
             if t.name in OpenAIBuiltInToolName:
                 continue
-            if tool_init_event is not None:
-                built_tool = ToolFactory.build_tool_with_settings(
-                    t.name,
-                    t,
-                    t.configuration,
-                    tool_init_event,
-                    tool_progress_reporter=self._tool_progress_reporter,
-                )
-            else:
+            if not t.is_enabled:
+                self._logger.info("Skipping disabled tool '%s'", t.name)
+                continue
+            if tool_init_event is None:
                 self._logger.info(
                     "Skipping internal tool '%s' (requires chat event for initialization)",
                     t.name,
                 )
                 continue
-            self._internal_tools.append(built_tool)
+            result = safe_executor.execute(
+                ToolFactory.build_tool_with_settings,
+                t.name,
+                t,
+                t.configuration,
+                tool_init_event,
+                tool_progress_reporter=self._tool_progress_reporter,
+            )
+            if result.success:
+                self._internal_tools.append(result.unpack())
+            else:
+                self._logger.warning(
+                    "Skipping tool '%s' due to initialization failure: %s",
+                    t.name,
+                    result.exception,
+                )
 
         # Combine all types of tools
         self.available_tools = (
@@ -237,6 +250,8 @@ class _ToolManager(Generic[_ApiMode]):
                 continue
             # if tool choices are given, only include those tools
             if len(self._tool_choices) > 0 and t.name not in self._tool_choices:
+                if t.name == OpenAIBuiltInToolName.CODE_INTERPRETER:
+                    self._tools.append(t)
                 continue
             # is the tool exclusive and has been choosen by the user?
             if t.is_exclusive() and len(tool_choices) > 0 and t.name in tool_choices:

--- a/unique_toolkit/unique_toolkit/agentic/tools/tool_manager.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/tool_manager.py
@@ -203,7 +203,7 @@ class _ToolManager(Generic[_ApiMode]):
 
         # Build internal tools from configurations, skipping disabled and failing tools
         self._internal_tools.clear()
-        safe_executor = SafeTaskExecutor(logger=self._logger)
+        safe_executor = SafeTaskExecutor(logger=self._logger, log_exceptions=False)
         for t in tool_configs:
             if t.name in registered_tool_names:
                 continue
@@ -230,9 +230,9 @@ class _ToolManager(Generic[_ApiMode]):
                 self._internal_tools.append(result.unpack())
             else:
                 self._logger.warning(
-                    "Skipping tool '%s' due to initialization failure: %s",
+                    "Skipping tool '%s' due to initialization failure.",
                     t.name,
-                    result.exception,
+                    exc_info=result.exception,
                 )
 
         # Combine all types of tools

--- a/unique_toolkit/unique_toolkit/agentic/tools/tool_manager.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/tool_manager.py
@@ -250,8 +250,6 @@ class _ToolManager(Generic[_ApiMode]):
                 continue
             # if tool choices are given, only include those tools
             if len(self._tool_choices) > 0 and t.name not in self._tool_choices:
-                if t.name == OpenAIBuiltInToolName.CODE_INTERPRETER:
-                    self._tools.append(t)
                 continue
             # is the tool exclusive and has been choosen by the user?
             if t.is_exclusive() and len(tool_choices) > 0 and t.name in tool_choices:


### PR DESCRIPTION
## 🚀 Summary

Refs: UN-17197

UniqueAI could crash on startup when a single tool had invalid or misconfigured settings (e.g. WebSearch with a bad `request_method` in UAT). This PR makes tool loading resilient: bad tools are skipped or demoted to disabled while the rest of the orchestrator keeps running.

AI assist: medium

## ✅ Changes

**Config layer** (`config.py`)
- Disabled tools (`is_enabled` / `isEnabled`) skip `ToolFactory` validation entirely.
- Enabled tools with invalid config (unknown name, bad values, type mismatch) are logged, demoted to `is_enabled=False`, and get a fallback `BaseToolConfig()`.
- camelCase payload keys are handled on read (`_dict_get_bool`) and write (`_set_enabled` sets both `is_enabled` and `isEnabled` so demotion cannot be overridden by a stale alias key).
- MCP tool detection accepts `mcpSourceId` in camelCase.

**Tool manager** (`tool_manager.py`)
- Per-tool init uses `SafeTaskExecutor` with `log_exceptions=False` so failures produce a single warning with `exc_info`.
- Disabled tools are skipped before build; failing tools are skipped without aborting the rest.
- Exclusive-tool filtering respects `is_enabled`.
- Removed redundant code-interpreter `tool_choices` bypass (capability-tool path on `main` already covers it).

**A2A manager** (`a2a/manager.py`)
- Skips disabled sub-agents.
- Wraps `SubAgentTool()` construction in try/except with warning log.

**Tests**
- New coverage for graceful demotion, disabled-tool skip paths, camelCase keys, tool manager partial failure, and factory demotion behavior.
- Existing wrong-config-type test updated to expect demotion instead of `ValidationError`.

### Out of scope (follow-ups)
- Lazy tool config loading (validate on first invocation)
- WebSearch-specific settings split
- Upstream filtering of disabled tools before they reach the AI service

## 🧪 Testing

- [x] `pytest unique_toolkit/tests/agentic/tools/test_config.py` — demotion, disabled skip, camelCase
- [x] `pytest unique_toolkit/tests/agentic/tools/test_tool_manager.py` — partial failure, all failing, disabled skip
- [x] `pytest unique_toolkit/tests/agentic/tools/test_tool_build_config_and_factory.py` — factory demotion
- [x] Local manual: injected enabled unknown tool (`totally_unknown_tool_xyz`) into a Unique AI space module config via DB; assistant-core demoted it at parse time and logged `Skipping disabled tool 'totally_unknown_tool_xyz'`; chat completed normally (other tools including WebSearch still worked)
- [x] CI green on PR (rebased onto latest `main`, force-pushed)