### PR TITLE
feat(services): register ContentService in UniqueServiceFactory [UN-18568]

### DIFF
--- a/unique_toolkit/unique_toolkit/content/service.py
+++ b/unique_toolkit/unique_toolkit/content/service.py
@@ -172,6 +172,7 @@ class ContentService:
         cls,
         settings: UniqueSettings | str | None = None,
         metadata_filter: dict | None = None,
+        **kwargs: Any,
     ):
         """
         Initialize the ContentService with a settings object and metadata filter.

--- a/unique_toolkit/unique_toolkit/services/__init__.py
+++ b/unique_toolkit/unique_toolkit/services/__init__.py
@@ -3,6 +3,7 @@ from unique_toolkit.app.unique_settings import (
     ChatContext,
     UniqueContext,
 )
+from unique_toolkit.content.service import ContentService
 from unique_toolkit.services.chat_service import ChatService
 from unique_toolkit.services.factory import (
     ServiceNotRegisteredError,
@@ -16,6 +17,7 @@ __all__ = [
     "AuthContext",
     "ChatContext",
     "ChatService",
+    "ContentService",
     "KnowledgeBaseService",
     "UniqueContext",
     "UniqueServiceFactory",

--- a/unique_toolkit/unique_toolkit/services/factory.py
+++ b/unique_toolkit/unique_toolkit/services/factory.py
@@ -5,6 +5,7 @@ from typing import Any, Callable, ClassVar, Protocol, overload
 from typing_extensions import Self, TypeVar
 
 from unique_toolkit.app.unique_settings import UniqueSettings
+from unique_toolkit.content.service import ContentService
 from unique_toolkit.services.chat_service import ChatService
 from unique_toolkit.services.knowledge_base import KnowledgeBaseService
 
@@ -95,6 +96,10 @@ class UniqueServiceFactory:
         """Create a :class:`KnowledgeBaseService` using the pre-bound context."""
         return self.get(KnowledgeBaseService, **kwargs)
 
+    def content_service(self, **kwargs: Any) -> ContentService:
+        """Create a :class:`ContentService` using the pre-bound context."""
+        return self.get(ContentService, **kwargs)
+
     # ── Class-level registry operations ──────────────────────────────────────
 
     @classmethod
@@ -126,7 +131,7 @@ class UniqueServiceFactory:
         from unique_toolkit.services.chat_service import ChatService
         from unique_toolkit.services.knowledge_base import KnowledgeBaseService
 
-        for service_class in [KnowledgeBaseService, ChatService]:
+        for service_class in [KnowledgeBaseService, ChatService, ContentService]:
             if service_class.__name__ not in cls._registry:
                 cls.register(service_class=service_class)
 

--- a/unique_toolkit/unique_toolkit/services/factory.py
+++ b/unique_toolkit/unique_toolkit/services/factory.py
@@ -126,11 +126,8 @@ class UniqueServiceFactory:
     @classmethod
     def register_known_services(cls) -> None:
         """Register the default services with the factory.
-        Currently only registers the KnowledgeBaseService and ChatService.
+        Currently only registers the KnowledgeBaseService, ChatService and ContentService.
         """
-        from unique_toolkit.services.chat_service import ChatService
-        from unique_toolkit.services.knowledge_base import KnowledgeBaseService
-
         for service_class in [KnowledgeBaseService, ChatService, ContentService]:
             if service_class.__name__ not in cls._registry:
                 cls.register(service_class=service_class)


### PR DESCRIPTION
## Summary

- Registers `ContentService` in `UniqueServiceFactory` alongside `KnowledgeBaseService` and `ChatService`
- Adds `content_service()` typed convenience method on the factory instance
- Exports `ContentService` from `unique_toolkit.services`

`ContentService` already implements `from_settings(settings: UniqueSettings)` and is compatible with `ServiceProtocol` — this just wires it into the registry.

## Why

Prerequisite for [UN-18565](https://unique-ch.atlassian.net/browse/UN-18565) / [UN-18568](https://unique-ch.atlassian.net/browse/UN-18568): enables tools to construct `ContentService` from `UniqueSettings` (user_id + company_id) per request, rather than from a `ChatEvent` at construction time. This is the foundation for exposing internal tools as MCP servers without binding them to a specific event at startup.

## Test plan

- [ ] `UniqueServiceFactory(settings=settings).content_service()` returns a `ContentService` instance
- [ ] `UniqueServiceFactory.create(ContentService, settings=settings)` works
- [ ] `from unique_toolkit.services import ContentService` works

[UN-18565]: https://unique-ch.atlassian.net/browse/UN-18565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[UN-18568]: https://unique-ch.atlassian.net/browse/UN-18568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ