### PR TITLE
feat(internal-search): replace ContentService with KnowledgeBaseService via UniqueServiceFactory [UN-18568]

### DIFF
--- a/tool_packages/unique_internal_search/CHANGELOG.md
+++ b/tool_packages/unique_internal_search/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), 
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.35] - 2026-03-26
+- Replace `ContentService` with `KnowledgeBaseService` throughout `InternalSearchService` and `InternalSearchTool` (UN-18568)
+- Use `UniqueSettings.from_chat_event` / `UniqueSettings.from_event` + `UniqueServiceFactory.create` for service construction in all event branches
+- Rename `content_service` → `kb_service` in `InternalSearchService`
+- Fix `_metadata_filter` mutation: `InternalSearchService` now owns its own `_metadata_filter` captured at init; passes explicit `{}` when `chat_only=True` instead of temporarily nulling out `kb_service._metadata_filter`
+
 ## [1.2.34] - 2026-03-26
 - Expose Experimental Configs
 

--- a/tool_packages/unique_internal_search/pyproject.toml
+++ b/tool_packages/unique_internal_search/pyproject.toml
@@ -14,7 +14,7 @@ requires-python = ">=3.12,<4"
 dependencies = [
     "pydantic>=2.8.2,<3",
     "typing-extensions>=4.9.0,<5",
-    "unique-toolkit>=1.47.7,<2",
+    "unique-toolkit>=1.63.2,<2",
 ]
 
 [build-system]

--- a/tool_packages/unique_internal_search/pyproject.toml
+++ b/tool_packages/unique_internal_search/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "unique_internal_search"
-version = "1.2.34"
+version = "1.2.35"
 description = ""
 readme = "README.md"
 license = { text = "Proprietary" }

--- a/tool_packages/unique_internal_search/tests/fixtures.py
+++ b/tool_packages/unique_internal_search/tests/fixtures.py
@@ -1,3 +1,4 @@
+from collections.abc import Generator
 from datetime import datetime
 from logging import Logger
 from typing import Any
@@ -10,8 +11,9 @@ from unique_toolkit.agentic.tools.schemas import ToolCallResponse
 from unique_toolkit.agentic.tools.tool_progress_reporter import ToolProgressReporter
 from unique_toolkit.app.schemas import BaseEvent, ChatEvent, Event
 from unique_toolkit.content.schemas import Content, ContentChunk, ContentMetadata
-from unique_toolkit.content.service import ContentService
 from unique_toolkit.language_model.schemas import LanguageModelFunction
+from unique_toolkit.services.factory import UniqueServiceFactory
+from unique_toolkit.services.knowledge_base import KnowledgeBaseService
 
 from unique_internal_search.config import InternalSearchConfig
 
@@ -24,11 +26,18 @@ def mock_logger() -> Logger:
 
 
 @pytest.fixture
-def mock_content_service() -> ContentService:
-    """Create a mock ContentService for testing."""
-    service: ContentService = Mock(spec=ContentService)
+def mock_kb_service() -> Generator[KnowledgeBaseService, None, None]:
+    """Create a mock KnowledgeBaseService and register it in UniqueServiceFactory.
+
+    Registers the mock as the KnowledgeBaseService creator for the duration of the
+    test so that InternalSearchTool (which uses UniqueServiceFactory.create) receives
+    the mock without any per-test patching.
+    """
+    service: KnowledgeBaseService = Mock(spec=KnowledgeBaseService)
     service._metadata_filter = None
-    return service
+    UniqueServiceFactory.register_known_services()
+    with UniqueServiceFactory.override(KnowledgeBaseService, lambda s, **kw: service):
+        yield service
 
 
 @pytest.fixture

--- a/tool_packages/unique_internal_search/tests/test_service.py
+++ b/tool_packages/unique_internal_search/tests/test_service.py
@@ -21,7 +21,7 @@ class TestInternalSearchService:
     def test_service__initializes__with_all_dependencies(
         self,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: KnowledgeBaseService,
+        mock_kb_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
     ) -> None:
@@ -36,7 +36,7 @@ class TestInternalSearchService:
         # Act
         service = InternalSearchService(
             config=base_internal_search_config,
-            content_service=mock_content_service,
+            kb_service=mock_kb_service,
             chunk_relevancy_sorter=mock_chunk_relevancy_sorter,
             chat_id=chat_id,
             logger=mock_logger,
@@ -44,7 +44,7 @@ class TestInternalSearchService:
 
         # Assert
         assert service.config == base_internal_search_config
-        assert service.content_service == mock_content_service
+        assert service.kb_service == mock_kb_service
         assert service.chunk_relevancy_sorter == mock_chunk_relevancy_sorter
         assert service.chat_id == chat_id
         assert service.logger == mock_logger
@@ -55,7 +55,7 @@ class TestInternalSearchService:
     async def test_get_uploaded_files__returns_sorted_by_created_at__descending(
         self,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: KnowledgeBaseService,
+        mock_kb_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
         sample_content_list: list[Any],
@@ -68,12 +68,12 @@ class TestInternalSearchService:
         # Arrange
         service = InternalSearchService(
             config=base_internal_search_config,
-            content_service=mock_content_service,
+            kb_service=mock_kb_service,
             chunk_relevancy_sorter=mock_chunk_relevancy_sorter,
             chat_id="chat_123",
             logger=mock_logger,
         )
-        mock_content_service.search_contents_async = AsyncMock(
+        mock_kb_service.search_contents_async = AsyncMock(
             return_value=sample_content_list
         )
 
@@ -84,7 +84,7 @@ class TestInternalSearchService:
         assert len(result) == 2
         assert result[0].id == "content_1"
         assert result[1].id == "content_2"
-        mock_content_service.search_contents_async.assert_called_once_with(
+        mock_kb_service.search_contents_async.assert_called_once_with(
             where={"ownerId": {"equals": "chat_123"}}
         )
 
@@ -93,7 +93,7 @@ class TestInternalSearchService:
     async def test_is_chat_only__returns_true__when_config_chat_only_is_true(
         self,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: KnowledgeBaseService,
+        mock_kb_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
     ) -> None:
@@ -106,7 +106,7 @@ class TestInternalSearchService:
         base_internal_search_config.chat_only = True
         service = InternalSearchService(
             config=base_internal_search_config,
-            content_service=mock_content_service,
+            kb_service=mock_kb_service,
             chunk_relevancy_sorter=mock_chunk_relevancy_sorter,
             chat_id="chat_123",
             logger=mock_logger,
@@ -123,7 +123,7 @@ class TestInternalSearchService:
     async def test_is_chat_only__returns_false__when_config_chat_only_is_false_and_no_uploaded_files(
         self,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: KnowledgeBaseService,
+        mock_kb_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
     ) -> None:
@@ -137,12 +137,12 @@ class TestInternalSearchService:
         base_internal_search_config.scope_to_chat_on_upload = True
         service = InternalSearchService(
             config=base_internal_search_config,
-            content_service=mock_content_service,
+            kb_service=mock_kb_service,
             chunk_relevancy_sorter=mock_chunk_relevancy_sorter,
             chat_id="chat_123",
             logger=mock_logger,
         )
-        mock_content_service.search_contents_async = AsyncMock(return_value=[])
+        mock_kb_service.search_contents_async = AsyncMock(return_value=[])
 
         # Act
         result = await service.is_chat_only()
@@ -155,7 +155,7 @@ class TestInternalSearchService:
     async def test_is_chat_only__returns_true__when_scope_to_chat_on_upload_and_files_exist(
         self,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: KnowledgeBaseService,
+        mock_kb_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
         sample_content_list: list[Any],
@@ -170,12 +170,12 @@ class TestInternalSearchService:
         base_internal_search_config.scope_to_chat_on_upload = True
         service = InternalSearchService(
             config=base_internal_search_config,
-            content_service=mock_content_service,
+            kb_service=mock_kb_service,
             chunk_relevancy_sorter=mock_chunk_relevancy_sorter,
             chat_id="chat_123",
             logger=mock_logger,
         )
-        mock_content_service.search_contents_async = AsyncMock(
+        mock_kb_service.search_contents_async = AsyncMock(
             return_value=sample_content_list
         )
 
@@ -190,7 +190,7 @@ class TestInternalSearchService:
     async def test_search__calls_content_service__with_correct_parameters(
         self,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: KnowledgeBaseService,
+        mock_kb_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
         sample_content_chunks: list[ContentChunk],
@@ -203,13 +203,13 @@ class TestInternalSearchService:
         # Arrange
         service = InternalSearchService(
             config=base_internal_search_config,
-            content_service=mock_content_service,
+            kb_service=mock_kb_service,
             chunk_relevancy_sorter=mock_chunk_relevancy_sorter,
             chat_id="chat_123",
             logger=mock_logger,
         )
-        mock_content_service.search_contents_async = AsyncMock(return_value=[])
-        mock_content_service.search_content_chunks_async = AsyncMock(
+        mock_kb_service.search_contents_async = AsyncMock(return_value=[])
+        mock_kb_service.search_content_chunks_async = AsyncMock(
             return_value=sample_content_chunks
         )
         search_string = "test query"
@@ -219,8 +219,8 @@ class TestInternalSearchService:
 
         # Assert
         assert len(result) == 2
-        mock_content_service.search_content_chunks_async.assert_called_once()
-        call_kwargs = mock_content_service.search_content_chunks_async.call_args[1]
+        mock_kb_service.search_content_chunks_async.assert_called_once()
+        call_kwargs = mock_kb_service.search_content_chunks_async.call_args[1]
         assert call_kwargs["search_string"] == search_string
         assert call_kwargs["search_type"] == base_internal_search_config.search_type
         assert call_kwargs["limit"] == base_internal_search_config.limit
@@ -230,7 +230,7 @@ class TestInternalSearchService:
     async def test_search__handles_metadata_filter__when_chat_only_is_true(
         self,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: KnowledgeBaseService,
+        mock_kb_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
         sample_content_chunks: list[ContentChunk],
@@ -242,16 +242,17 @@ class TestInternalSearchService:
         """
         # Arrange
         base_internal_search_config.chat_only = True
+        # _metadata_filter must be set before init so it is captured by InternalSearchService
+        mock_kb_service._metadata_filter = {"key": "value"}
         service = InternalSearchService(
             config=base_internal_search_config,
-            content_service=mock_content_service,
+            kb_service=mock_kb_service,
             chunk_relevancy_sorter=mock_chunk_relevancy_sorter,
             chat_id="chat_123",
             logger=mock_logger,
         )
-        mock_content_service.search_contents_async = AsyncMock(return_value=[])
-        mock_content_service._metadata_filter = {"key": "value"}
-        mock_content_service.search_content_chunks_async = AsyncMock(
+        mock_kb_service.search_contents_async = AsyncMock(return_value=[])
+        mock_kb_service.search_content_chunks_async = AsyncMock(
             return_value=sample_content_chunks
         )
         metadata_filter = {"some": "filter"}
@@ -259,54 +260,56 @@ class TestInternalSearchService:
         # Act
         await service.search("test query", metadata_filter=metadata_filter)
 
-        # Assert
-        assert mock_content_service._metadata_filter == {"key": "value"}
-        call_kwargs = mock_content_service.search_content_chunks_async.call_args[1]
-        assert call_kwargs["metadata_filter"] is None
+        # Assert: kb_service._metadata_filter is never mutated
+        assert mock_kb_service._metadata_filter == {"key": "value"}
+        # When chat_only=True, an explicit empty dict is passed to suppress any filter
+        call_kwargs = mock_kb_service.search_content_chunks_async.call_args[1]
+        assert call_kwargs["metadata_filter"] == {}
 
     @pytest.mark.ai
     @pytest.mark.asyncio
     async def test_search__resets_metadata_filter__after_search_completes(
         self,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: KnowledgeBaseService,
+        mock_kb_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
         sample_content_chunks: list[ContentChunk],
     ) -> None:
         """
-        Purpose: Verify metadata_filter is restored after search completes.
-        Why this matters: Ensures metadata_filter state is preserved for subsequent operations.
-        Setup summary: Set initial metadata_filter, perform search, verify filter restored.
+        Purpose: Verify kb_service._metadata_filter is never mutated during search.
+        Why this matters: InternalSearchService owns its metadata_filter state; kb_service state is untouched.
+        Setup summary: Set initial metadata_filter before init (so it is captured), perform search, verify unchanged.
         """
         # Arrange
         base_internal_search_config.chat_only = True
+        original_filter = {"original": "filter"}
+        # _metadata_filter must be set before init so it is captured by InternalSearchService
+        mock_kb_service._metadata_filter = original_filter
         service = InternalSearchService(
             config=base_internal_search_config,
-            content_service=mock_content_service,
+            kb_service=mock_kb_service,
             chunk_relevancy_sorter=mock_chunk_relevancy_sorter,
             chat_id="chat_123",
             logger=mock_logger,
         )
-        mock_content_service.search_contents_async = AsyncMock(return_value=[])
-        original_filter = {"original": "filter"}
-        mock_content_service._metadata_filter = original_filter
-        mock_content_service.search_content_chunks_async = AsyncMock(
+        mock_kb_service.search_contents_async = AsyncMock(return_value=[])
+        mock_kb_service.search_content_chunks_async = AsyncMock(
             return_value=sample_content_chunks
         )
 
         # Act
         await service.search("test query", metadata_filter={"temp": "filter"})
 
-        # Assert
-        assert mock_content_service._metadata_filter == original_filter
+        # Assert: kb_service._metadata_filter is never mutated by InternalSearchService
+        assert mock_kb_service._metadata_filter == original_filter
 
     @pytest.mark.ai
     @pytest.mark.asyncio
     async def test_search__resorts_chunks__when_chunk_relevancy_sort_enabled(
         self,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: KnowledgeBaseService,
+        mock_kb_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
         sample_content_chunks: list[ContentChunk],
@@ -320,13 +323,13 @@ class TestInternalSearchService:
         base_internal_search_config.chunk_relevancy_sort_config.enabled = True
         service = InternalSearchService(
             config=base_internal_search_config,
-            content_service=mock_content_service,
+            kb_service=mock_kb_service,
             chunk_relevancy_sorter=mock_chunk_relevancy_sorter,
             chat_id="chat_123",
             logger=mock_logger,
         )
-        mock_content_service.search_contents_async = AsyncMock(return_value=[])
-        mock_content_service.search_content_chunks_async = AsyncMock(
+        mock_kb_service.search_contents_async = AsyncMock(return_value=[])
+        mock_kb_service.search_content_chunks_async = AsyncMock(
             return_value=sample_content_chunks
         )
         resort_result = Mock()
@@ -347,7 +350,7 @@ class TestInternalSearchService:
     async def test_search__handles_chunk_relevancy_sorter_exception__gracefully(
         self,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: KnowledgeBaseService,
+        mock_kb_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
         sample_content_chunks: list[ContentChunk],
@@ -361,13 +364,13 @@ class TestInternalSearchService:
         base_internal_search_config.chunk_relevancy_sort_config.enabled = True
         service = InternalSearchService(
             config=base_internal_search_config,
-            content_service=mock_content_service,
+            kb_service=mock_kb_service,
             chunk_relevancy_sorter=mock_chunk_relevancy_sorter,
             chat_id="chat_123",
             logger=mock_logger,
         )
-        mock_content_service.search_contents_async = AsyncMock(return_value=[])
-        mock_content_service.search_content_chunks_async = AsyncMock(
+        mock_kb_service.search_contents_async = AsyncMock(return_value=[])
+        mock_kb_service.search_content_chunks_async = AsyncMock(
             return_value=sample_content_chunks
         )
         error = ChunkRelevancySorterException(
@@ -389,7 +392,7 @@ class TestInternalSearchService:
     async def test_search__merges_chunks__when_chunked_sources_is_false(
         self,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: KnowledgeBaseService,
+        mock_kb_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
         sample_content_chunks: list[ContentChunk],
@@ -403,13 +406,13 @@ class TestInternalSearchService:
         base_internal_search_config.chunked_sources = False
         service = InternalSearchService(
             config=base_internal_search_config,
-            content_service=mock_content_service,
+            kb_service=mock_kb_service,
             chunk_relevancy_sorter=mock_chunk_relevancy_sorter,
             chat_id="chat_123",
             logger=mock_logger,
         )
-        mock_content_service.search_contents_async = AsyncMock(return_value=[])
-        mock_content_service.search_content_chunks_async = AsyncMock(
+        mock_kb_service.search_contents_async = AsyncMock(return_value=[])
+        mock_kb_service.search_content_chunks_async = AsyncMock(
             return_value=sample_content_chunks
         )
         service.post_progress_message = AsyncMock()
@@ -425,7 +428,7 @@ class TestInternalSearchService:
     async def test_search__sorts_chunks__when_chunked_sources_is_true(
         self,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: KnowledgeBaseService,
+        mock_kb_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
         sample_content_chunks: list[ContentChunk],
@@ -439,13 +442,13 @@ class TestInternalSearchService:
         base_internal_search_config.chunked_sources = True
         service = InternalSearchService(
             config=base_internal_search_config,
-            content_service=mock_content_service,
+            kb_service=mock_kb_service,
             chunk_relevancy_sorter=mock_chunk_relevancy_sorter,
             chat_id="chat_123",
             logger=mock_logger,
         )
-        mock_content_service.search_contents_async = AsyncMock(return_value=[])
-        mock_content_service.search_content_chunks_async = AsyncMock(
+        mock_kb_service.search_contents_async = AsyncMock(return_value=[])
+        mock_kb_service.search_content_chunks_async = AsyncMock(
             return_value=sample_content_chunks
         )
         service.post_progress_message = AsyncMock()
@@ -461,7 +464,7 @@ class TestInternalSearchService:
     async def test_search__logs_error__when_search_fails(
         self,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: KnowledgeBaseService,
+        mock_kb_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
     ) -> None:
@@ -473,16 +476,14 @@ class TestInternalSearchService:
         # Arrange
         service = InternalSearchService(
             config=base_internal_search_config,
-            content_service=mock_content_service,
+            kb_service=mock_kb_service,
             chunk_relevancy_sorter=mock_chunk_relevancy_sorter,
             chat_id="chat_123",
             logger=mock_logger,
         )
-        mock_content_service.search_contents_async = AsyncMock(return_value=[])
+        mock_kb_service.search_contents_async = AsyncMock(return_value=[])
         test_error = ValueError("Search failed")
-        mock_content_service.search_content_chunks_async = AsyncMock(
-            side_effect=test_error
-        )
+        mock_kb_service.search_content_chunks_async = AsyncMock(side_effect=test_error)
 
         # Act
         result = await service.search("test query")
@@ -497,7 +498,7 @@ class TestInternalSearchService:
     async def test_search__sets_debug_info__with_search_parameters(
         self,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: KnowledgeBaseService,
+        mock_kb_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
         sample_content_chunks: list[ContentChunk],
@@ -510,13 +511,13 @@ class TestInternalSearchService:
         # Arrange
         service = InternalSearchService(
             config=base_internal_search_config,
-            content_service=mock_content_service,
+            kb_service=mock_kb_service,
             chunk_relevancy_sorter=mock_chunk_relevancy_sorter,
             chat_id="chat_123",
             logger=mock_logger,
         )
-        mock_content_service.search_contents_async = AsyncMock(return_value=[])
-        mock_content_service.search_content_chunks_async = AsyncMock(
+        mock_kb_service.search_contents_async = AsyncMock(return_value=[])
+        mock_kb_service.search_content_chunks_async = AsyncMock(
             return_value=sample_content_chunks
         )
         service.post_progress_message = AsyncMock()
@@ -535,7 +536,7 @@ class TestInternalSearchService:
     def test_get_max_tokens__returns_percentage_of_language_model_max__when_set(
         self,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: KnowledgeBaseService,
+        mock_kb_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
     ) -> None:
@@ -549,7 +550,7 @@ class TestInternalSearchService:
         base_internal_search_config.percentage_of_input_tokens_for_sources = 0.4
         service = InternalSearchService(
             config=base_internal_search_config,
-            content_service=mock_content_service,
+            kb_service=mock_kb_service,
             chunk_relevancy_sorter=mock_chunk_relevancy_sorter,
             chat_id="chat_123",
             logger=mock_logger,
@@ -566,7 +567,7 @@ class TestInternalSearchService:
     def test_get_max_tokens__returns_max_tokens_for_sources__when_language_model_max_not_set(
         self,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: KnowledgeBaseService,
+        mock_kb_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
     ) -> None:
@@ -580,7 +581,7 @@ class TestInternalSearchService:
         base_internal_search_config.max_tokens_for_sources = 30000
         service = InternalSearchService(
             config=base_internal_search_config,
-            content_service=mock_content_service,
+            kb_service=mock_kb_service,
             chunk_relevancy_sorter=mock_chunk_relevancy_sorter,
             chat_id="chat_123",
             logger=mock_logger,
@@ -598,7 +599,7 @@ class TestInternalSearchService:
     async def test_resort_found_chunks_if_enabled__returns_sorted_chunks__on_success(
         self,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: KnowledgeBaseService,
+        mock_kb_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
         sample_content_chunks: list[ContentChunk],
@@ -611,7 +612,7 @@ class TestInternalSearchService:
         # Arrange
         service = InternalSearchService(
             config=base_internal_search_config,
-            content_service=mock_content_service,
+            kb_service=mock_kb_service,
             chunk_relevancy_sorter=mock_chunk_relevancy_sorter,
             chat_id="chat_123",
             logger=mock_logger,
@@ -635,7 +636,7 @@ class TestInternalSearchService:
     async def test_post_progress_message__does_nothing__in_base_service(
         self,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: KnowledgeBaseService,
+        mock_kb_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
     ) -> None:
@@ -647,7 +648,7 @@ class TestInternalSearchService:
         # Arrange
         service = InternalSearchService(
             config=base_internal_search_config,
-            content_service=mock_content_service,
+            kb_service=mock_kb_service,
             chunk_relevancy_sorter=mock_chunk_relevancy_sorter,
             chat_id="chat_123",
             logger=mock_logger,
@@ -662,40 +663,31 @@ class TestInternalSearchTool:
 
     @pytest.mark.ai
     @patch("unique_internal_search.service.UniqueSettings")
-    @patch("unique_internal_search.service.KnowledgeBaseService")
     @patch("unique_internal_search.service.ChunkRelevancySorter")
     def test_tool__initializes__with_chat_event(
         self,
         mock_chunk_relevancy_sorter_class: Any,
-        mock_content_service_class: Any,
         mock_unique_settings_class: Any,
         base_internal_search_config: InternalSearchConfig,
         mock_chat_event: Any,
         mock_logger: Any,
+        mock_kb_service: KnowledgeBaseService,
     ) -> None:
         """
         Purpose: Verify InternalSearchTool initializes correctly with ChatEvent.
         Why this matters: Ensures proper tool initialization and chat_id extraction from ChatEvent.
-        Setup summary: Mock KnowledgeBaseService and ChunkRelevancySorter, verify initialization.
+        Setup summary: Override KnowledgeBaseService via factory, verify UniqueSettings.from_chat_event called.
         """
         # Arrange
-        mock_content_service = Mock(spec=KnowledgeBaseService)
-        mock_content_service._metadata_filter = None
-        mock_content_service_class.from_settings.return_value = mock_content_service
-
         mock_sorter = Mock()
         mock_chunk_relevancy_sorter_class.return_value = mock_sorter
 
-        mock_tool_base = Mock()
-        mock_tool_base.logger = mock_logger
-
-        # Act
         def setup_tool(self, configuration, event, *args, **kwargs):
-            # Set attributes that Tool base class expects
             setattr(self, "_event", event)
             setattr(self, "logger", mock_logger)
             setattr(self, "_message_step_logger", None)
 
+        # Act
         with patch("unique_internal_search.service.Tool.__init__", setup_tool):
             tool = InternalSearchTool(
                 configuration=base_internal_search_config,
@@ -706,9 +698,6 @@ class TestInternalSearchTool:
         mock_unique_settings_class.from_chat_event.assert_called_once_with(
             mock_chat_event
         )
-        mock_content_service_class.from_settings.assert_called_once_with(
-            mock_unique_settings_class.from_chat_event.return_value
-        )
         mock_chunk_relevancy_sorter_class.assert_called_once_with(
             company_id=mock_chat_event.company_id,
             user_id=mock_chat_event.user_id,
@@ -718,16 +707,15 @@ class TestInternalSearchTool:
 
     @pytest.mark.ai
     @patch("unique_internal_search.service.UniqueSettings")
-    @patch("unique_internal_search.service.KnowledgeBaseService")
     @patch("unique_internal_search.service.ChunkRelevancySorter")
     def test_tool__initializes__with_chat_event__uses_parent_chat_id__when_correlation_set(
         self,
         mock_chunk_relevancy_sorter_class: Any,
-        mock_content_service_class: Any,
         mock_unique_settings_class: Any,
         base_internal_search_config: InternalSearchConfig,
         mock_chat_event_with_correlation: Any,
         mock_logger: Any,
+        mock_kb_service: KnowledgeBaseService,
     ) -> None:
         """
         Purpose: Verify InternalSearchTool uses payload.correlation.parent_chat_id when correlation is set.
@@ -735,19 +723,15 @@ class TestInternalSearchTool:
         Setup summary: ChatEvent with payload.correlation.parent_chat_id set, verify tool.chat_id equals it.
         """
         # Arrange
-        mock_content_service = Mock(spec=KnowledgeBaseService)
-        mock_content_service._metadata_filter = None
-        mock_content_service_class.from_settings.return_value = mock_content_service
-
         mock_sorter = Mock()
         mock_chunk_relevancy_sorter_class.return_value = mock_sorter
 
-        # Act
         def setup_tool(self, configuration, event, *args, **kwargs):
             setattr(self, "_event", event)
             setattr(self, "logger", mock_logger)
             setattr(self, "_message_step_logger", None)
 
+        # Act
         with patch("unique_internal_search.service.Tool.__init__", setup_tool):
             tool = InternalSearchTool(
                 configuration=base_internal_search_config,
@@ -758,9 +742,6 @@ class TestInternalSearchTool:
         mock_unique_settings_class.from_chat_event.assert_called_once_with(
             mock_chat_event_with_correlation
         )
-        mock_content_service_class.from_settings.assert_called_once_with(
-            mock_unique_settings_class.from_chat_event.return_value
-        )
         mock_chunk_relevancy_sorter_class.assert_called_once_with(
             company_id=mock_chat_event_with_correlation.company_id,
             user_id=mock_chat_event_with_correlation.user_id,
@@ -769,36 +750,32 @@ class TestInternalSearchTool:
         assert tool.chat_id == "parent_chat_456"
 
     @pytest.mark.ai
-    @patch("unique_internal_search.service.KnowledgeBaseService")
+    @patch("unique_internal_search.service.UniqueSettings")
     @patch("unique_internal_search.service.ChunkRelevancySorter")
     def test_tool__initializes__with_base_event(
         self,
         mock_chunk_relevancy_sorter_class: Any,
-        mock_content_service_class: Any,
+        mock_unique_settings_class: Any,
         base_internal_search_config: InternalSearchConfig,
         mock_base_event: Any,
         mock_logger: Any,
+        mock_kb_service: KnowledgeBaseService,
     ) -> None:
         """
         Purpose: Verify InternalSearchTool initializes correctly with BaseEvent (no chat_id).
         Why this matters: Ensures tool works with non-chat events that don't have chat_id.
-        Setup summary: Mock KnowledgeBaseService and ChunkRelevancySorter from_event, verify chat_id is None.
+        Setup summary: Override KnowledgeBaseService via factory, verify UniqueSettings.from_event called.
         """
         # Arrange
-        mock_content_service = Mock(spec=KnowledgeBaseService)
-        mock_content_service._metadata_filter = None
-        mock_content_service_class.from_settings.return_value = mock_content_service
-
         mock_sorter = Mock()
         mock_chunk_relevancy_sorter_class.return_value = mock_sorter
 
-        # Act
         def setup_tool(self, configuration, event, *args, **kwargs):
-            # Set attributes that Tool base class expects
             setattr(self, "_event", event)
             setattr(self, "logger", mock_logger)
             setattr(self, "_message_step_logger", None)
 
+        # Act
         with patch("unique_internal_search.service.Tool.__init__", setup_tool):
             tool = InternalSearchTool(
                 configuration=base_internal_search_config,
@@ -806,6 +783,7 @@ class TestInternalSearchTool:
             )
 
         # Assert
+        mock_unique_settings_class.from_event.assert_called_once_with(mock_base_event)
         assert tool.config == base_internal_search_config
         assert tool.chat_id is None
 
@@ -818,57 +796,49 @@ class TestInternalSearchTool:
         mock_tool_progress_reporter: Any,
         mock_logger: Any,
         mock_language_model_function: Any,
+        mock_kb_service: KnowledgeBaseService,
     ) -> None:
         """
         Purpose: Verify post_progress_message notifies reporter when tool_progress_reporter exists.
         Why this matters: Ensures progress updates are communicated to users during tool execution.
-        Setup summary: Mock tool_progress_reporter, call post_progress_message, verify notification sent.
+        Setup summary: mock_kb_service fixture provides factory override; verify notification sent.
         """
+
         # Arrange
+        def setup_tool(self, configuration, event, *args, **kwargs):
+            setattr(self, "_event", event)
+            setattr(self, "logger", mock_logger)
+            setattr(self, "_message_step_logger", None)
+
         with (
-            patch(
-                "unique_internal_search.service.KnowledgeBaseService"
-            ) as mock_content_service_class,
             patch(
                 "unique_internal_search.service.ChunkRelevancySorter"
             ) as mock_sorter_class,
+            patch("unique_internal_search.service.Tool.__init__", setup_tool),
+            patch.object(
+                InternalSearchTool,
+                "tool_progress_reporter",
+                new_callable=PropertyMock,
+                return_value=mock_tool_progress_reporter,
+            ),
         ):
-            mock_content_service = Mock(spec=KnowledgeBaseService)
-            mock_content_service._metadata_filter = None
-            mock_content_service_class.from_settings.return_value = mock_content_service
             mock_sorter_class.return_value = Mock()
+            tool = InternalSearchTool(
+                configuration=base_internal_search_config,
+                event=mock_chat_event,
+            )
 
-            def setup_tool(self, configuration, event, *args, **kwargs):
-                # Set attributes that Tool base class expects
-                setattr(self, "_event", event)
-                setattr(self, "logger", mock_logger)
-                setattr(self, "_message_step_logger", None)
+            # Act
+            await tool.post_progress_message(
+                "test message", mock_language_model_function
+            )
 
-            with (
-                patch("unique_internal_search.service.Tool.__init__", setup_tool),
-                patch.object(
-                    InternalSearchTool,
-                    "tool_progress_reporter",
-                    new_callable=PropertyMock,
-                    return_value=mock_tool_progress_reporter,
-                ),
-            ):
-                tool = InternalSearchTool(
-                    configuration=base_internal_search_config,
-                    event=mock_chat_event,
-                )
-
-                # Act
-                await tool.post_progress_message(
-                    "test message", mock_language_model_function
-                )
-
-            # Assert
-            mock_tool_progress_reporter.notify_from_tool_call.assert_called_once()
-            call_kwargs = mock_tool_progress_reporter.notify_from_tool_call.call_args[1]
-            assert call_kwargs["tool_call"] == mock_language_model_function
-            assert call_kwargs["message"] == "test message"
-            assert "**Internal search**" in call_kwargs["name"]
+        # Assert
+        mock_tool_progress_reporter.notify_from_tool_call.assert_called_once()
+        call_kwargs = mock_tool_progress_reporter.notify_from_tool_call.call_args[1]
+        assert call_kwargs["tool_call"] == mock_language_model_function
+        assert call_kwargs["message"] == "test message"
+        assert "**Internal search**" in call_kwargs["name"]
 
     @pytest.mark.ai
     @pytest.mark.asyncio
@@ -878,50 +848,42 @@ class TestInternalSearchTool:
         mock_chat_event: Any,
         mock_logger: Any,
         mock_language_model_function: Any,
+        mock_kb_service: KnowledgeBaseService,
     ) -> None:
         """
         Purpose: Verify post_progress_message does nothing when tool_progress_reporter is None.
         Why this matters: Ensures graceful handling when progress reporting is not available.
-        Setup summary: Set tool_progress_reporter to None, call post_progress_message, verify no exception.
+        Setup summary: mock_kb_service fixture provides factory override; verify no exception raised.
         """
+
         # Arrange
+        def setup_tool(self, configuration, event, *args, **kwargs):
+            setattr(self, "_event", event)
+            setattr(self, "logger", mock_logger)
+            setattr(self, "_message_step_logger", None)
+
         with (
-            patch(
-                "unique_internal_search.service.KnowledgeBaseService"
-            ) as mock_content_service_class,
             patch(
                 "unique_internal_search.service.ChunkRelevancySorter"
             ) as mock_sorter_class,
+            patch("unique_internal_search.service.Tool.__init__", setup_tool),
+            patch.object(
+                InternalSearchTool,
+                "tool_progress_reporter",
+                new_callable=PropertyMock,
+                return_value=None,
+            ),
         ):
-            mock_content_service = Mock(spec=KnowledgeBaseService)
-            mock_content_service._metadata_filter = None
-            mock_content_service_class.from_settings.return_value = mock_content_service
             mock_sorter_class.return_value = Mock()
+            tool = InternalSearchTool(
+                configuration=base_internal_search_config,
+                event=mock_chat_event,
+            )
 
-            def setup_tool(self, configuration, event, *args, **kwargs):
-                # Set attributes that Tool base class expects
-                setattr(self, "_event", event)
-                setattr(self, "logger", mock_logger)
-                setattr(self, "_message_step_logger", None)
-
-            with (
-                patch("unique_internal_search.service.Tool.__init__", setup_tool),
-                patch.object(
-                    InternalSearchTool,
-                    "tool_progress_reporter",
-                    new_callable=PropertyMock,
-                    return_value=None,
-                ),
-            ):
-                tool = InternalSearchTool(
-                    configuration=base_internal_search_config,
-                    event=mock_chat_event,
-                )
-
-                # Act & Assert
-                await tool.post_progress_message(
-                    "test message", mock_language_model_function
-                )
+            # Act & Assert
+            await tool.post_progress_message(
+                "test message", mock_language_model_function
+            )
 
     @pytest.mark.ai
     @pytest.mark.asyncio
@@ -930,7 +892,7 @@ class TestInternalSearchTool:
         base_internal_search_config: InternalSearchConfig,
         mock_chat_event: Any,
         mock_logger: Any,
-        mock_content_service: KnowledgeBaseService,
+        mock_kb_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
     ) -> None:
         """
@@ -942,17 +904,11 @@ class TestInternalSearchTool:
         base_internal_search_config.chat_only = False
         base_internal_search_config.scope_to_chat_on_upload = False
 
-        with (
-            patch(
-                "unique_internal_search.service.KnowledgeBaseService"
-            ) as mock_content_service_class,
-            patch(
-                "unique_internal_search.service.ChunkRelevancySorter"
-            ) as mock_sorter_class,
-        ):
-            mock_content_service_class.from_settings.return_value = mock_content_service
+        with patch(
+            "unique_internal_search.service.ChunkRelevancySorter"
+        ) as mock_sorter_class:
             mock_sorter_class.return_value = mock_chunk_relevancy_sorter
-            mock_content_service.search_contents_async = AsyncMock(return_value=[])
+            mock_kb_service.search_contents_async = AsyncMock(return_value=[])
 
             def setup_tool(self, configuration, event, *args, **kwargs):
                 # Set attributes that Tool base class expects
@@ -983,7 +939,7 @@ class TestInternalSearchTool:
         base_internal_search_config: InternalSearchConfig,
         mock_chat_event: Any,
         mock_logger: Any,
-        mock_content_service: KnowledgeBaseService,
+        mock_kb_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
     ) -> None:
         """
@@ -995,17 +951,11 @@ class TestInternalSearchTool:
         base_internal_search_config.chat_only = False
         base_internal_search_config.scope_to_chat_on_upload = False
 
-        with (
-            patch(
-                "unique_internal_search.service.KnowledgeBaseService"
-            ) as mock_content_service_class,
-            patch(
-                "unique_internal_search.service.ChunkRelevancySorter"
-            ) as mock_sorter_class,
-        ):
-            mock_content_service_class.from_settings.return_value = mock_content_service
+        with patch(
+            "unique_internal_search.service.ChunkRelevancySorter"
+        ) as mock_sorter_class:
             mock_sorter_class.return_value = mock_chunk_relevancy_sorter
-            mock_content_service.search_contents_async = AsyncMock(return_value=[])
+            mock_kb_service.search_contents_async = AsyncMock(return_value=[])
 
             def setup_tool(self, configuration, event, *args, **kwargs):
                 # Set attributes that Tool base class expects
@@ -1036,7 +986,7 @@ class TestInternalSearchTool:
         base_internal_search_config: InternalSearchConfig,
         mock_chat_event: Any,
         mock_logger: Any,
-        mock_content_service: KnowledgeBaseService,
+        mock_kb_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
     ) -> None:
         """
@@ -1048,17 +998,11 @@ class TestInternalSearchTool:
         base_internal_search_config.chat_only = False
         base_internal_search_config.scope_to_chat_on_upload = False
 
-        with (
-            patch(
-                "unique_internal_search.service.KnowledgeBaseService"
-            ) as mock_content_service_class,
-            patch(
-                "unique_internal_search.service.ChunkRelevancySorter"
-            ) as mock_sorter_class,
-        ):
-            mock_content_service_class.from_settings.return_value = mock_content_service
+        with patch(
+            "unique_internal_search.service.ChunkRelevancySorter"
+        ) as mock_sorter_class:
             mock_sorter_class.return_value = mock_chunk_relevancy_sorter
-            mock_content_service.search_contents_async = AsyncMock(return_value=[])
+            mock_kb_service.search_contents_async = AsyncMock(return_value=[])
 
             def setup_tool(self, configuration, event, *args, **kwargs):
                 # Set attributes that Tool base class expects
@@ -1095,17 +1039,9 @@ class TestInternalSearchTool:
         Setup summary: Create tool, call tool_description, verify schema structure and descriptions.
         """
         # Arrange
-        with (
-            patch(
-                "unique_internal_search.service.KnowledgeBaseService"
-            ) as mock_content_service_class,
-            patch(
-                "unique_internal_search.service.ChunkRelevancySorter"
-            ) as mock_sorter_class,
-        ):
-            mock_content_service = Mock(spec=KnowledgeBaseService)
-            mock_content_service._metadata_filter = None
-            mock_content_service_class.from_settings.return_value = mock_content_service
+        with patch(
+            "unique_internal_search.service.ChunkRelevancySorter"
+        ) as mock_sorter_class:
             mock_sorter_class.return_value = Mock()
 
             def setup_tool(self, configuration, event, *args, **kwargs):
@@ -1149,17 +1085,9 @@ class TestInternalSearchTool:
         Setup summary: Create tool, call tool_description_for_system_prompt, verify returns config value.
         """
         # Arrange
-        with (
-            patch(
-                "unique_internal_search.service.KnowledgeBaseService"
-            ) as mock_content_service_class,
-            patch(
-                "unique_internal_search.service.ChunkRelevancySorter"
-            ) as mock_sorter_class,
-        ):
-            mock_content_service = Mock(spec=KnowledgeBaseService)
-            mock_content_service._metadata_filter = None
-            mock_content_service_class.from_settings.return_value = mock_content_service
+        with patch(
+            "unique_internal_search.service.ChunkRelevancySorter"
+        ) as mock_sorter_class:
             mock_sorter_class.return_value = Mock()
 
             def setup_tool(self, configuration, event, *args, **kwargs):
@@ -1196,17 +1124,9 @@ class TestInternalSearchTool:
         Setup summary: Create tool, call tool_format_information_for_system_prompt, verify returns config value.
         """
         # Arrange
-        with (
-            patch(
-                "unique_internal_search.service.KnowledgeBaseService"
-            ) as mock_content_service_class,
-            patch(
-                "unique_internal_search.service.ChunkRelevancySorter"
-            ) as mock_sorter_class,
-        ):
-            mock_content_service = Mock(spec=KnowledgeBaseService)
-            mock_content_service._metadata_filter = None
-            mock_content_service_class.from_settings.return_value = mock_content_service
+        with patch(
+            "unique_internal_search.service.ChunkRelevancySorter"
+        ) as mock_sorter_class:
             mock_sorter_class.return_value = Mock()
 
             def setup_tool(self, configuration, event, *args, **kwargs):
@@ -1244,17 +1164,9 @@ class TestInternalSearchTool:
         Setup summary: Create tool, call evaluation_check_list, verify returns config value.
         """
         # Arrange
-        with (
-            patch(
-                "unique_internal_search.service.KnowledgeBaseService"
-            ) as mock_content_service_class,
-            patch(
-                "unique_internal_search.service.ChunkRelevancySorter"
-            ) as mock_sorter_class,
-        ):
-            mock_content_service = Mock(spec=KnowledgeBaseService)
-            mock_content_service._metadata_filter = None
-            mock_content_service_class.from_settings.return_value = mock_content_service
+        with patch(
+            "unique_internal_search.service.ChunkRelevancySorter"
+        ) as mock_sorter_class:
             mock_sorter_class.return_value = Mock()
 
             def setup_tool(self, configuration, event, *args, **kwargs):
@@ -1292,17 +1204,9 @@ class TestInternalSearchTool:
         # Arrange
         mock_tool_call_response.content_chunks = []
 
-        with (
-            patch(
-                "unique_internal_search.service.KnowledgeBaseService"
-            ) as mock_content_service_class,
-            patch(
-                "unique_internal_search.service.ChunkRelevancySorter"
-            ) as mock_sorter_class,
-        ):
-            mock_content_service = Mock(spec=KnowledgeBaseService)
-            mock_content_service._metadata_filter = None
-            mock_content_service_class.from_settings.return_value = mock_content_service
+        with patch(
+            "unique_internal_search.service.ChunkRelevancySorter"
+        ) as mock_sorter_class:
             mock_sorter_class.return_value = Mock()
 
             def setup_tool(self, configuration, event, *args, **kwargs):
@@ -1343,17 +1247,9 @@ class TestInternalSearchTool:
         # Arrange
         mock_tool_call_response.content_chunks = sample_content_chunks
 
-        with (
-            patch(
-                "unique_internal_search.service.KnowledgeBaseService"
-            ) as mock_content_service_class,
-            patch(
-                "unique_internal_search.service.ChunkRelevancySorter"
-            ) as mock_sorter_class,
-        ):
-            mock_content_service = Mock(spec=KnowledgeBaseService)
-            mock_content_service._metadata_filter = None
-            mock_content_service_class.from_settings.return_value = mock_content_service
+        with patch(
+            "unique_internal_search.service.ChunkRelevancySorter"
+        ) as mock_sorter_class:
             mock_sorter_class.return_value = Mock()
 
             def setup_tool(self, configuration, event, *args, **kwargs):
@@ -1391,17 +1287,9 @@ class TestInternalSearchTool:
         Setup summary: Create tool, call run with invalid tool_call, verify error response returned.
         """
         # Arrange
-        with (
-            patch(
-                "unique_internal_search.service.KnowledgeBaseService"
-            ) as mock_content_service_class,
-            patch(
-                "unique_internal_search.service.ChunkRelevancySorter"
-            ) as mock_sorter_class,
-        ):
-            mock_content_service = Mock(spec=KnowledgeBaseService)
-            mock_content_service._metadata_filter = None
-            mock_content_service_class.from_settings.return_value = mock_content_service
+        with patch(
+            "unique_internal_search.service.ChunkRelevancySorter"
+        ) as mock_sorter_class:
             mock_sorter_class.return_value = Mock()
 
             def setup_tool(self, configuration, event, *args, **kwargs):
@@ -1444,17 +1332,9 @@ class TestInternalSearchTool:
         Setup summary: Create tool, call run with tool_call missing search_string, verify error response.
         """
         # Arrange
-        with (
-            patch(
-                "unique_internal_search.service.KnowledgeBaseService"
-            ) as mock_content_service_class,
-            patch(
-                "unique_internal_search.service.ChunkRelevancySorter"
-            ) as mock_sorter_class,
-        ):
-            mock_content_service = Mock(spec=KnowledgeBaseService)
-            mock_content_service._metadata_filter = None
-            mock_content_service_class.from_settings.return_value = mock_content_service
+        with patch(
+            "unique_internal_search.service.ChunkRelevancySorter"
+        ) as mock_sorter_class:
             mock_sorter_class.return_value = Mock()
 
             def setup_tool(self, configuration, event, *args, **kwargs):
@@ -1501,9 +1381,6 @@ class TestInternalSearchTool:
         # Arrange
         with (
             patch(
-                "unique_internal_search.service.KnowledgeBaseService"
-            ) as mock_content_service_class,
-            patch(
                 "unique_internal_search.service.ChunkRelevancySorter"
             ) as mock_sorter_class,
             patch(
@@ -1511,13 +1388,12 @@ class TestInternalSearchTool:
                 return_value=sample_content_chunks,
             ),
         ):
-            mock_content_service = Mock(spec=KnowledgeBaseService)
-            mock_content_service._metadata_filter = None
-            mock_content_service.search_contents_async = AsyncMock(return_value=[])
-            mock_content_service.search_content_chunks_async = AsyncMock(
+            mock_kb_service = Mock(spec=KnowledgeBaseService)
+            mock_kb_service._metadata_filter = None
+            mock_kb_service.search_contents_async = AsyncMock(return_value=[])
+            mock_kb_service.search_content_chunks_async = AsyncMock(
                 return_value=sample_content_chunks
             )
-            mock_content_service_class.from_settings.return_value = mock_content_service
             mock_sorter_class.return_value = Mock()
 
             def setup_tool(self, configuration, event, *args, **kwargs):
@@ -1548,7 +1424,7 @@ class TestInternalSearchTool:
             assert result.content_chunks is not None
             assert len(result.content_chunks) == 2
             assert result.id == "tool_call_123"
-            mock_content_service.search_content_chunks_async.assert_called_once()
+            mock_kb_service.search_content_chunks_async.assert_called_once()
             mock_tool_progress_reporter.notify_from_tool_call.assert_called()
 
     @pytest.mark.ai
@@ -1570,9 +1446,6 @@ class TestInternalSearchTool:
         with (
             patch("unique_internal_search.service.UniqueSettings"),
             patch(
-                "unique_internal_search.service.KnowledgeBaseService"
-            ) as mock_content_service_class,
-            patch(
                 "unique_internal_search.service.ChunkRelevancySorter"
             ) as mock_sorter_class,
             patch(
@@ -1580,13 +1453,12 @@ class TestInternalSearchTool:
                 return_value=sample_content_chunks,
             ),
         ):
-            mock_content_service = Mock(spec=KnowledgeBaseService)
-            mock_content_service._metadata_filter = None
-            mock_content_service.search_contents_async = AsyncMock(return_value=[])
-            mock_content_service.search_content_chunks_async = AsyncMock(
+            mock_kb_service = Mock(spec=KnowledgeBaseService)
+            mock_kb_service._metadata_filter = None
+            mock_kb_service.search_contents_async = AsyncMock(return_value=[])
+            mock_kb_service.search_content_chunks_async = AsyncMock(
                 return_value=sample_content_chunks
             )
-            mock_content_service_class.from_settings.return_value = mock_content_service
             mock_sorter_class.return_value = Mock()
 
             def setup_tool(self, configuration, event, *args, **kwargs):
@@ -1638,9 +1510,6 @@ class TestInternalSearchTool:
         with (
             patch("unique_internal_search.service.UniqueSettings"),
             patch(
-                "unique_internal_search.service.KnowledgeBaseService"
-            ) as mock_content_service_class,
-            patch(
                 "unique_internal_search.service.ChunkRelevancySorter"
             ) as mock_sorter_class,
             patch(
@@ -1648,13 +1517,12 @@ class TestInternalSearchTool:
                 return_value=sample_content_chunks,
             ),
         ):
-            mock_content_service = Mock(spec=KnowledgeBaseService)
-            mock_content_service._metadata_filter = None
-            mock_content_service.search_contents_async = AsyncMock(return_value=[])
-            mock_content_service.search_content_chunks_async = AsyncMock(
+            mock_kb_service = Mock(spec=KnowledgeBaseService)
+            mock_kb_service._metadata_filter = None
+            mock_kb_service.search_contents_async = AsyncMock(return_value=[])
+            mock_kb_service.search_content_chunks_async = AsyncMock(
                 return_value=sample_content_chunks
             )
-            mock_content_service_class.from_settings.return_value = mock_content_service
             mock_sorter_class.return_value = Mock()
 
             def setup_tool(self, configuration, event, *args, **kwargs):
@@ -1704,9 +1572,6 @@ class TestInternalSearchTool:
         # Arrange
         with (
             patch(
-                "unique_internal_search.service.KnowledgeBaseService"
-            ) as mock_content_service_class,
-            patch(
                 "unique_internal_search.service.ChunkRelevancySorter"
             ) as mock_sorter_class,
             patch(
@@ -1714,13 +1579,12 @@ class TestInternalSearchTool:
                 return_value=sample_content_chunks,
             ),
         ):
-            mock_content_service = Mock(spec=KnowledgeBaseService)
-            mock_content_service._metadata_filter = None
-            mock_content_service.search_contents_async = AsyncMock(return_value=[])
-            mock_content_service.search_content_chunks_async = AsyncMock(
+            mock_kb_service = Mock(spec=KnowledgeBaseService)
+            mock_kb_service._metadata_filter = None
+            mock_kb_service.search_contents_async = AsyncMock(return_value=[])
+            mock_kb_service.search_content_chunks_async = AsyncMock(
                 return_value=sample_content_chunks
             )
-            mock_content_service_class.from_settings.return_value = mock_content_service
             mock_sorter_class.return_value = Mock()
 
             def setup_tool(self, configuration, event, *args, **kwargs):
@@ -1765,15 +1629,13 @@ class TestInternalSearchTool:
 
     @pytest.mark.ai
     @pytest.mark.asyncio
-    @patch("unique_internal_search.service.KnowledgeBaseService")
     @patch("unique_internal_search.service.ChunkRelevancySorter")
     async def test_define_reference_list_for_message_log__returns_list__with_internal_chunks(
         self,
         mock_sorter_class: Any,
-        mock_content_service_class: Any,
         sample_content_chunk: ContentChunk,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: KnowledgeBaseService,
+        mock_kb_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
         mock_chat_event: Any,
@@ -1784,7 +1646,6 @@ class TestInternalSearchTool:
         Setup summary: Create internal content chunk, call _define_reference_list_for_message_log, verify returns list.
         """
         # Arrange
-        mock_content_service_class.from_settings.return_value = mock_content_service
         mock_sorter_class.return_value = mock_chunk_relevancy_sorter
         content_chunks = [sample_content_chunk]
 
@@ -1810,15 +1671,13 @@ class TestInternalSearchTool:
 
     @pytest.mark.ai
     @pytest.mark.asyncio
-    @patch("unique_internal_search.service.KnowledgeBaseService")
     @patch("unique_internal_search.service.ChunkRelevancySorter")
     async def test_define_reference_list_for_message_log__sets_sequence_number__for_first_chunk(
         self,
         mock_sorter_class: Any,
-        mock_content_service_class: Any,
         sample_content_chunk: ContentChunk,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: KnowledgeBaseService,
+        mock_kb_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
         mock_chat_event: Any,
@@ -1829,7 +1688,6 @@ class TestInternalSearchTool:
         Setup summary: Create internal content chunk, call _define_reference_list_for_message_log, verify sequence_number is 0.
         """
         # Arrange
-        mock_content_service_class.from_settings.return_value = mock_content_service
         mock_sorter_class.return_value = mock_chunk_relevancy_sorter
         content_chunks = [sample_content_chunk]
 
@@ -1855,15 +1713,13 @@ class TestInternalSearchTool:
 
     @pytest.mark.ai
     @pytest.mark.asyncio
-    @patch("unique_internal_search.service.KnowledgeBaseService")
     @patch("unique_internal_search.service.ChunkRelevancySorter")
     async def test_define_reference_list_for_message_log__sets_source_id__from_chunk_id(
         self,
         mock_sorter_class: Any,
-        mock_content_service_class: Any,
         sample_content_chunk: ContentChunk,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: KnowledgeBaseService,
+        mock_kb_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
         mock_chat_event: Any,
@@ -1874,7 +1730,6 @@ class TestInternalSearchTool:
         Setup summary: Create internal content chunk with ID, call _define_reference_list_for_message_log, verify source_id matches.
         """
         # Arrange
-        mock_content_service_class.from_settings.return_value = mock_content_service
         mock_sorter_class.return_value = mock_chunk_relevancy_sorter
         content_chunks = [sample_content_chunk]
 
@@ -1900,15 +1755,13 @@ class TestInternalSearchTool:
 
     @pytest.mark.ai
     @pytest.mark.asyncio
-    @patch("unique_internal_search.service.KnowledgeBaseService")
     @patch("unique_internal_search.service.ChunkRelevancySorter")
     async def test_define_reference_list_for_message_log__sets_source__to_internal(
         self,
         mock_sorter_class: Any,
-        mock_content_service_class: Any,
         sample_content_chunk: ContentChunk,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: KnowledgeBaseService,
+        mock_kb_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
         mock_chat_event: Any,
@@ -1919,7 +1772,6 @@ class TestInternalSearchTool:
         Setup summary: Create internal content chunk, call _define_reference_list_for_message_log, verify reference source is "internal".
         """
         # Arrange
-        mock_content_service_class.from_settings.return_value = mock_content_service
         mock_sorter_class.return_value = mock_chunk_relevancy_sorter
         content_chunks = [sample_content_chunk]
 
@@ -1945,14 +1797,12 @@ class TestInternalSearchTool:
 
     @pytest.mark.ai
     @pytest.mark.asyncio
-    @patch("unique_internal_search.service.KnowledgeBaseService")
     @patch("unique_internal_search.service.ChunkRelevancySorter")
     async def test_define_reference_list_for_message_log__sets_name__from_chunk_key_when_no_title(
         self,
         mock_sorter_class: Any,
-        mock_content_service_class: Any,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: KnowledgeBaseService,
+        mock_kb_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
         mock_chat_event: Any,
@@ -1964,7 +1814,6 @@ class TestInternalSearchTool:
         """
 
         # Arrange
-        mock_content_service_class.from_settings.return_value = mock_content_service
         mock_sorter_class.return_value = mock_chunk_relevancy_sorter
 
         content_chunk = ContentChunk(
@@ -1996,14 +1845,12 @@ class TestInternalSearchTool:
 
     @pytest.mark.ai
     @pytest.mark.asyncio
-    @patch("unique_internal_search.service.KnowledgeBaseService")
     @patch("unique_internal_search.service.ChunkRelevancySorter")
     async def test_define_reference_list_for_message_log__sets_name__from_chunk_title_when_available(
         self,
         mock_sorter_class: Any,
-        mock_content_service_class: Any,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: KnowledgeBaseService,
+        mock_kb_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
         mock_chat_event: Any,
@@ -2015,7 +1862,6 @@ class TestInternalSearchTool:
         """
 
         # Arrange
-        mock_content_service_class.from_settings.return_value = mock_content_service
         mock_sorter_class.return_value = mock_chunk_relevancy_sorter
 
         content_chunk = ContentChunk(
@@ -2048,15 +1894,13 @@ class TestInternalSearchTool:
 
     @pytest.mark.ai
     @pytest.mark.asyncio
-    @patch("unique_internal_search.service.KnowledgeBaseService")
     @patch("unique_internal_search.service.ChunkRelevancySorter")
     async def test_define_reference_list_for_message_log__sets_unique_url__for_internal_chunks(
         self,
         mock_sorter_class: Any,
-        mock_content_service_class: Any,
         sample_content_chunk: ContentChunk,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: KnowledgeBaseService,
+        mock_kb_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
         mock_chat_event: Any,
@@ -2067,7 +1911,6 @@ class TestInternalSearchTool:
         Setup summary: Create internal content chunk, call _define_reference_list_for_message_log, verify URL format.
         """
         # Arrange
-        mock_content_service_class.from_settings.return_value = mock_content_service
         mock_sorter_class.return_value = mock_chunk_relevancy_sorter
         content_chunks = [sample_content_chunk]
 
@@ -2093,14 +1936,12 @@ class TestInternalSearchTool:
 
     @pytest.mark.ai
     @pytest.mark.asyncio
-    @patch("unique_internal_search.service.KnowledgeBaseService")
     @patch("unique_internal_search.service.ChunkRelevancySorter")
     async def test_define_reference_list_for_message_log__increments_sequence_number__for_multiple_chunks(
         self,
         mock_sorter_class: Any,
-        mock_content_service_class: Any,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: KnowledgeBaseService,
+        mock_kb_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
         mock_chat_event: Any,
@@ -2112,7 +1953,6 @@ class TestInternalSearchTool:
         """
 
         # Arrange
-        mock_content_service_class.from_settings.return_value = mock_content_service
         mock_sorter_class.return_value = mock_chunk_relevancy_sorter
 
         content_chunks = [
@@ -2152,14 +1992,12 @@ class TestInternalSearchTool:
 
     @pytest.mark.ai
     @pytest.mark.asyncio
-    @patch("unique_internal_search.service.KnowledgeBaseService")
     @patch("unique_internal_search.service.ChunkRelevancySorter")
     async def test_define_reference_list_for_message_log__includes_chunks__with_empty_name(
         self,
         mock_sorter_class: Any,
-        mock_content_service_class: Any,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: KnowledgeBaseService,
+        mock_kb_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
         mock_chat_event: Any,
@@ -2171,7 +2009,6 @@ class TestInternalSearchTool:
         """
 
         # Arrange
-        mock_content_service_class.from_settings.return_value = mock_content_service
         mock_sorter_class.return_value = mock_chunk_relevancy_sorter
 
         content_chunks = [
@@ -2229,9 +2066,6 @@ class TestInternalSearchTool:
 
         with (
             patch(
-                "unique_internal_search.service.KnowledgeBaseService"
-            ) as mock_content_service_class,
-            patch(
                 "unique_internal_search.service.ChunkRelevancySorter"
             ) as mock_sorter_class,
             patch(
@@ -2239,13 +2073,12 @@ class TestInternalSearchTool:
                 return_value=sample_content_chunks,
             ),
         ):
-            mock_content_service = Mock(spec=KnowledgeBaseService)
-            mock_content_service._metadata_filter = None
-            mock_content_service.search_contents_async = AsyncMock(return_value=[])
-            mock_content_service.search_content_chunks_async = AsyncMock(
+            mock_kb_service = Mock(spec=KnowledgeBaseService)
+            mock_kb_service._metadata_filter = None
+            mock_kb_service.search_contents_async = AsyncMock(return_value=[])
+            mock_kb_service.search_content_chunks_async = AsyncMock(
                 return_value=sample_content_chunks
             )
-            mock_content_service_class.from_settings.return_value = mock_content_service
             mock_sorter_class.return_value = Mock()
 
             def setup_tool(self, configuration, event, *args, **kwargs):
@@ -2283,14 +2116,14 @@ class TestInternalSearchTool:
             assert result.name == "InternalSearch"
             assert result.id == "tool_call_123"
             # Verify only 2 search calls were made (the limit)
-            assert mock_content_service.search_content_chunks_async.call_count == 2
+            assert mock_kb_service.search_content_chunks_async.call_count == 2
 
     @pytest.mark.ai
     @pytest.mark.asyncio
     async def test_search__executes_searches_in_parallel__when_multiple_search_strings(
         self,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: KnowledgeBaseService,
+        mock_kb_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
         sample_content_chunks: list[ContentChunk],
@@ -2304,7 +2137,7 @@ class TestInternalSearchTool:
         base_internal_search_config.enable_multiple_search_strings_execution = True
         service = InternalSearchService(
             config=base_internal_search_config,
-            content_service=mock_content_service,
+            kb_service=mock_kb_service,
             chunk_relevancy_sorter=mock_chunk_relevancy_sorter,
             chat_id="chat_123",
             logger=mock_logger,
@@ -2318,9 +2151,7 @@ class TestInternalSearchTool:
             call_count += 1
             return sample_content_chunks.copy()
 
-        mock_content_service.search_content_chunks_async = AsyncMock(
-            side_effect=mock_search
-        )
+        mock_kb_service.search_content_chunks_async = AsyncMock(side_effect=mock_search)
         search_strings = ["query1", "query2", "query3"]
 
         # Act
@@ -2328,7 +2159,7 @@ class TestInternalSearchTool:
 
         # Assert - all searches should be called
         assert call_count == 3
-        assert mock_content_service.search_content_chunks_async.call_count == 3
+        assert mock_kb_service.search_content_chunks_async.call_count == 3
         # Verify results are returned (deduplication may reduce final count)
         assert len(result) >= 0
 
@@ -2337,7 +2168,7 @@ class TestInternalSearchTool:
     async def test_search__deduplicates_search_strings__when_duplicates_provided(
         self,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: KnowledgeBaseService,
+        mock_kb_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
         sample_content_chunks: list[ContentChunk],
@@ -2351,12 +2182,12 @@ class TestInternalSearchTool:
         base_internal_search_config.enable_multiple_search_strings_execution = True
         service = InternalSearchService(
             config=base_internal_search_config,
-            content_service=mock_content_service,
+            kb_service=mock_kb_service,
             chunk_relevancy_sorter=mock_chunk_relevancy_sorter,
             chat_id="chat_123",
             logger=mock_logger,
         )
-        mock_content_service.search_content_chunks_async = AsyncMock(
+        mock_kb_service.search_content_chunks_async = AsyncMock(
             return_value=sample_content_chunks
         )
         # Provide duplicate search strings
@@ -2366,11 +2197,11 @@ class TestInternalSearchTool:
         await service.search(search_strings)
 
         # Assert - only 3 unique searches should be executed
-        assert mock_content_service.search_content_chunks_async.call_count == 3
+        assert mock_kb_service.search_content_chunks_async.call_count == 3
         # Verify all unique search strings were used
         called_strings = [
             call[1]["search_string"]
-            for call in mock_content_service.search_content_chunks_async.call_args_list
+            for call in mock_kb_service.search_content_chunks_async.call_args_list
         ]
         assert set(called_strings) == {"query1", "query2", "query3"}
 
@@ -2379,7 +2210,7 @@ class TestInternalSearchTool:
     async def test_search__limits_search_strings__to_max_search_strings_config(
         self,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: KnowledgeBaseService,
+        mock_kb_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
         sample_content_chunks: list[ContentChunk],
@@ -2394,12 +2225,12 @@ class TestInternalSearchTool:
         base_internal_search_config.max_search_strings = 3
         service = InternalSearchService(
             config=base_internal_search_config,
-            content_service=mock_content_service,
+            kb_service=mock_kb_service,
             chunk_relevancy_sorter=mock_chunk_relevancy_sorter,
             chat_id="chat_123",
             logger=mock_logger,
         )
-        mock_content_service.search_content_chunks_async = AsyncMock(
+        mock_kb_service.search_content_chunks_async = AsyncMock(
             return_value=sample_content_chunks
         )
         # Provide more search strings than the limit
@@ -2409,11 +2240,11 @@ class TestInternalSearchTool:
         await service.search(search_strings)
 
         # Assert - only max_search_strings (3) should be executed
-        assert mock_content_service.search_content_chunks_async.call_count == 3
+        assert mock_kb_service.search_content_chunks_async.call_count == 3
         # Verify only the first 3 strings were used (after limit is applied)
         called_strings = [
             call[1]["search_string"]
-            for call in mock_content_service.search_content_chunks_async.call_args_list
+            for call in mock_kb_service.search_content_chunks_async.call_args_list
         ]
         assert len(called_strings) == 3
         # Should be the first 3 from the original list
@@ -2426,7 +2257,7 @@ class TestInternalSearchTool:
     async def test_search__continues_with_other_searches__when_one_search_fails(
         self,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: KnowledgeBaseService,
+        mock_kb_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
         sample_content_chunks: list[ContentChunk],
@@ -2439,13 +2270,13 @@ class TestInternalSearchTool:
         # Arrange
         service = InternalSearchService(
             config=base_internal_search_config,
-            content_service=mock_content_service,
+            kb_service=mock_kb_service,
             chunk_relevancy_sorter=mock_chunk_relevancy_sorter,
             chat_id="chat_123",
             logger=mock_logger,
             company_id="company_123",
         )
-        mock_content_service.search_contents_async = AsyncMock(return_value=[])
+        mock_kb_service.search_contents_async = AsyncMock(return_value=[])
 
         # Make the second search fail, others succeed
         call_count = 0
@@ -2457,7 +2288,7 @@ class TestInternalSearchTool:
                 raise ValueError("Search failed")
             return sample_content_chunks
 
-        mock_content_service.search_content_chunks_async = AsyncMock(
+        mock_kb_service.search_content_chunks_async = AsyncMock(
             side_effect=side_effect_func
         )
         service.post_progress_message = AsyncMock()
@@ -2468,7 +2299,7 @@ class TestInternalSearchTool:
 
         # Assert
         # Should have called search 3 times (once for each query)
-        assert mock_content_service.search_content_chunks_async.call_count == 3
+        assert mock_kb_service.search_content_chunks_async.call_count == 3
         # Should have logged an error for the failing query
         assert mock_logger.error.call_count >= 1
         # Should have results from the 2 successful queries (not from the failed one)
@@ -2480,7 +2311,7 @@ class TestInternalSearchTool:
     async def test_prepare_message_log_details__returns_message_log_details__with_queries(
         self,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: KnowledgeBaseService,
+        mock_kb_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
     ) -> None:
@@ -2492,7 +2323,7 @@ class TestInternalSearchTool:
         # Arrange
         service = InternalSearchService(
             config=base_internal_search_config,
-            content_service=mock_content_service,
+            kb_service=mock_kb_service,
             chunk_relevancy_sorter=mock_chunk_relevancy_sorter,
             chat_id="chat_123",
             logger=mock_logger,
@@ -2515,7 +2346,7 @@ class TestInternalSearchTool:
     async def test_prepare_message_log_details__returns_empty_data__when_empty_query_list(
         self,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: KnowledgeBaseService,
+        mock_kb_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
     ) -> None:
@@ -2527,7 +2358,7 @@ class TestInternalSearchTool:
         # Arrange
         service = InternalSearchService(
             config=base_internal_search_config,
-            content_service=mock_content_service,
+            kb_service=mock_kb_service,
             chunk_relevancy_sorter=mock_chunk_relevancy_sorter,
             chat_id="chat_123",
             logger=mock_logger,
@@ -2546,7 +2377,7 @@ class TestInternalSearchTool:
     async def test_create_or_update_active_message_log__returns_none__when_no_message_step_logger(
         self,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: KnowledgeBaseService,
+        mock_kb_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
     ) -> None:
@@ -2558,7 +2389,7 @@ class TestInternalSearchTool:
         # Arrange
         service = InternalSearchService(
             config=base_internal_search_config,
-            content_service=mock_content_service,
+            kb_service=mock_kb_service,
             chunk_relevancy_sorter=mock_chunk_relevancy_sorter,
             chat_id="chat_123",
             logger=mock_logger,
@@ -2576,12 +2407,10 @@ class TestInternalSearchTool:
         assert result is None
 
     @pytest.mark.ai
-    @patch("unique_internal_search.service.KnowledgeBaseService")
     @patch("unique_internal_search.service.ChunkRelevancySorter")
     def test_get_tool_call_result_for_loop_history__returns_tool_message__with_sources(
         self,
         mock_chunk_relevancy_sorter_class: Any,
-        mock_content_service_class: Any,
         base_internal_search_config: InternalSearchConfig,
         mock_chat_event: Any,
         mock_logger: Any,
@@ -2594,9 +2423,8 @@ class TestInternalSearchTool:
         Setup summary: Create tool, call get_tool_call_result_for_loop_history, verify message structure.
         """
         # Arrange
-        mock_content_service = Mock(spec=KnowledgeBaseService)
-        mock_content_service._metadata_filter = None
-        mock_content_service_class.from_settings.return_value = mock_content_service
+        mock_kb_service = Mock(spec=KnowledgeBaseService)
+        mock_kb_service._metadata_filter = None
 
         mock_sorter = Mock()
         mock_chunk_relevancy_sorter_class.return_value = mock_sorter
@@ -2632,12 +2460,10 @@ class TestInternalSearchTool:
         assert isinstance(result.content, str)
 
     @pytest.mark.ai
-    @patch("unique_internal_search.service.KnowledgeBaseService")
     @patch("unique_internal_search.service.ChunkRelevancySorter")
     def test_get_tool_call_result_for_loop_history__handles_empty_chunks__gracefully(
         self,
         mock_chunk_relevancy_sorter_class: Any,
-        mock_content_service_class: Any,
         base_internal_search_config: InternalSearchConfig,
         mock_chat_event: Any,
         mock_logger: Any,
@@ -2649,9 +2475,8 @@ class TestInternalSearchTool:
         Setup summary: Create tool, call get_tool_call_result_for_loop_history with empty chunks, verify no error.
         """
         # Arrange
-        mock_content_service = Mock(spec=KnowledgeBaseService)
-        mock_content_service._metadata_filter = None
-        mock_content_service_class.from_settings.return_value = mock_content_service
+        mock_kb_service = Mock(spec=KnowledgeBaseService)
+        mock_kb_service._metadata_filter = None
 
         mock_sorter = Mock()
         mock_chunk_relevancy_sorter_class.return_value = mock_sorter
@@ -2686,12 +2511,10 @@ class TestInternalSearchTool:
         assert result.name == "InternalSearch"
 
     @pytest.mark.ai
-    @patch("unique_internal_search.service.KnowledgeBaseService")
     @patch("unique_internal_search.service.ChunkRelevancySorter")
     def test_get_tool_call_result_for_loop_history__handles_none_chunks__gracefully(
         self,
         mock_chunk_relevancy_sorter_class: Any,
-        mock_content_service_class: Any,
         base_internal_search_config: InternalSearchConfig,
         mock_chat_event: Any,
         mock_logger: Any,
@@ -2703,9 +2526,8 @@ class TestInternalSearchTool:
         Setup summary: Create tool, call get_tool_call_result_for_loop_history with None chunks, verify no error.
         """
         # Arrange
-        mock_content_service = Mock(spec=KnowledgeBaseService)
-        mock_content_service._metadata_filter = None
-        mock_content_service_class.from_settings.return_value = mock_content_service
+        mock_kb_service = Mock(spec=KnowledgeBaseService)
+        mock_kb_service._metadata_filter = None
 
         mock_sorter = Mock()
         mock_chunk_relevancy_sorter_class.return_value = mock_sorter
@@ -2740,12 +2562,10 @@ class TestInternalSearchTool:
         assert result.name == "InternalSearch"
 
     @pytest.mark.ai
-    @patch("unique_internal_search.service.KnowledgeBaseService")
     @patch("unique_internal_search.service.ChunkRelevancySorter")
     def test_get_tool_call_result_for_loop_history__uses_correct_source_numbering(
         self,
         mock_chunk_relevancy_sorter_class: Any,
-        mock_content_service_class: Any,
         base_internal_search_config: InternalSearchConfig,
         mock_chat_event: Any,
         mock_logger: Any,
@@ -2757,9 +2577,8 @@ class TestInternalSearchTool:
         Setup summary: Create tool with existing chunks in handler, verify source numbering continues correctly.
         """
         # Arrange
-        mock_content_service = Mock(spec=KnowledgeBaseService)
-        mock_content_service._metadata_filter = None
-        mock_content_service_class.from_settings.return_value = mock_content_service
+        mock_kb_service = Mock(spec=KnowledgeBaseService)
+        mock_kb_service._metadata_filter = None
 
         mock_sorter = Mock()
         mock_chunk_relevancy_sorter_class.return_value = mock_sorter
@@ -2799,12 +2618,10 @@ class TestInternalSearchTool:
         mock_logger.debug.assert_called()
 
     @pytest.mark.ai
-    @patch("unique_internal_search.service.KnowledgeBaseService")
     @patch("unique_internal_search.service.ChunkRelevancySorter")
     def test_get_tool_call_result_for_loop_history__preserves_readable_unicode_content(
         self,
         mock_chunk_relevancy_sorter_class: Any,
-        mock_content_service_class: Any,
         base_internal_search_config: InternalSearchConfig,
         mock_chat_event: Any,
         mock_logger: Any,
@@ -2814,9 +2631,8 @@ class TestInternalSearchTool:
         Why this matters: InternalSearch tool messages are forwarded to the next LLM call as-is.
         Setup summary: Create tool, serialize non-ASCII chunks into loop history, and verify both raw and decoded content.
         """
-        mock_content_service = Mock(spec=KnowledgeBaseService)
-        mock_content_service._metadata_filter = None
-        mock_content_service_class.from_settings.return_value = mock_content_service
+        mock_kb_service = Mock(spec=KnowledgeBaseService)
+        mock_kb_service._metadata_filter = None
 
         mock_sorter = Mock()
         mock_chunk_relevancy_sorter_class.return_value = mock_sorter

--- a/tool_packages/unique_internal_search/tests/test_service.py
+++ b/tool_packages/unique_internal_search/tests/test_service.py
@@ -661,12 +661,14 @@ class TestInternalSearchTool:
     """Tests for InternalSearchTool class."""
 
     @pytest.mark.ai
+    @patch("unique_internal_search.service.UniqueSettings")
     @patch("unique_internal_search.service.KnowledgeBaseService")
     @patch("unique_internal_search.service.ChunkRelevancySorter")
     def test_tool__initializes__with_chat_event(
         self,
         mock_chunk_relevancy_sorter_class: Any,
         mock_content_service_class: Any,
+        mock_unique_settings_class: Any,
         base_internal_search_config: InternalSearchConfig,
         mock_chat_event: Any,
         mock_logger: Any,
@@ -674,15 +676,15 @@ class TestInternalSearchTool:
         """
         Purpose: Verify InternalSearchTool initializes correctly with ChatEvent.
         Why this matters: Ensures proper tool initialization and chat_id extraction from ChatEvent.
-        Setup summary: Mock KnowledgeBaseService and ChunkRelevancySorter from_event, verify initialization.
+        Setup summary: Mock KnowledgeBaseService and ChunkRelevancySorter, verify initialization.
         """
         # Arrange
         mock_content_service = Mock(spec=KnowledgeBaseService)
         mock_content_service._metadata_filter = None
-        mock_content_service_class.from_event.return_value = mock_content_service
+        mock_content_service_class.from_settings.return_value = mock_content_service
 
         mock_sorter = Mock()
-        mock_chunk_relevancy_sorter_class.from_event.return_value = mock_sorter
+        mock_chunk_relevancy_sorter_class.return_value = mock_sorter
 
         mock_tool_base = Mock()
         mock_tool_base.logger = mock_logger
@@ -701,20 +703,28 @@ class TestInternalSearchTool:
             )
 
         # Assert
-        mock_content_service_class.from_event.assert_called_once_with(mock_chat_event)
-        mock_chunk_relevancy_sorter_class.from_event.assert_called_once_with(
+        mock_unique_settings_class.from_chat_event.assert_called_once_with(
             mock_chat_event
+        )
+        mock_content_service_class.from_settings.assert_called_once_with(
+            mock_unique_settings_class.from_chat_event.return_value
+        )
+        mock_chunk_relevancy_sorter_class.assert_called_once_with(
+            company_id=mock_chat_event.company_id,
+            user_id=mock_chat_event.user_id,
         )
         assert tool.config == base_internal_search_config
         assert tool.chat_id == "chat_123"
 
     @pytest.mark.ai
+    @patch("unique_internal_search.service.UniqueSettings")
     @patch("unique_internal_search.service.KnowledgeBaseService")
     @patch("unique_internal_search.service.ChunkRelevancySorter")
     def test_tool__initializes__with_chat_event__uses_parent_chat_id__when_correlation_set(
         self,
         mock_chunk_relevancy_sorter_class: Any,
         mock_content_service_class: Any,
+        mock_unique_settings_class: Any,
         base_internal_search_config: InternalSearchConfig,
         mock_chat_event_with_correlation: Any,
         mock_logger: Any,
@@ -727,10 +737,10 @@ class TestInternalSearchTool:
         # Arrange
         mock_content_service = Mock(spec=KnowledgeBaseService)
         mock_content_service._metadata_filter = None
-        mock_content_service_class.from_event.return_value = mock_content_service
+        mock_content_service_class.from_settings.return_value = mock_content_service
 
         mock_sorter = Mock()
-        mock_chunk_relevancy_sorter_class.from_event.return_value = mock_sorter
+        mock_chunk_relevancy_sorter_class.return_value = mock_sorter
 
         # Act
         def setup_tool(self, configuration, event, *args, **kwargs):
@@ -745,11 +755,15 @@ class TestInternalSearchTool:
             )
 
         # Assert: chat_id comes from correlation.parent_chat_id, not payload.chat_id
-        mock_content_service_class.from_event.assert_called_once_with(
+        mock_unique_settings_class.from_chat_event.assert_called_once_with(
             mock_chat_event_with_correlation
         )
-        mock_chunk_relevancy_sorter_class.from_event.assert_called_once_with(
-            mock_chat_event_with_correlation
+        mock_content_service_class.from_settings.assert_called_once_with(
+            mock_unique_settings_class.from_chat_event.return_value
+        )
+        mock_chunk_relevancy_sorter_class.assert_called_once_with(
+            company_id=mock_chat_event_with_correlation.company_id,
+            user_id=mock_chat_event_with_correlation.user_id,
         )
         assert tool.config == base_internal_search_config
         assert tool.chat_id == "parent_chat_456"
@@ -773,10 +787,10 @@ class TestInternalSearchTool:
         # Arrange
         mock_content_service = Mock(spec=KnowledgeBaseService)
         mock_content_service._metadata_filter = None
-        mock_content_service_class.from_event.return_value = mock_content_service
+        mock_content_service_class.from_settings.return_value = mock_content_service
 
         mock_sorter = Mock()
-        mock_chunk_relevancy_sorter_class.from_event.return_value = mock_sorter
+        mock_chunk_relevancy_sorter_class.return_value = mock_sorter
 
         # Act
         def setup_tool(self, configuration, event, *args, **kwargs):
@@ -821,8 +835,8 @@ class TestInternalSearchTool:
         ):
             mock_content_service = Mock(spec=KnowledgeBaseService)
             mock_content_service._metadata_filter = None
-            mock_content_service_class.from_event.return_value = mock_content_service
-            mock_sorter_class.from_event.return_value = Mock()
+            mock_content_service_class.from_settings.return_value = mock_content_service
+            mock_sorter_class.return_value = Mock()
 
             def setup_tool(self, configuration, event, *args, **kwargs):
                 # Set attributes that Tool base class expects
@@ -881,8 +895,8 @@ class TestInternalSearchTool:
         ):
             mock_content_service = Mock(spec=KnowledgeBaseService)
             mock_content_service._metadata_filter = None
-            mock_content_service_class.from_event.return_value = mock_content_service
-            mock_sorter_class.from_event.return_value = Mock()
+            mock_content_service_class.from_settings.return_value = mock_content_service
+            mock_sorter_class.return_value = Mock()
 
             def setup_tool(self, configuration, event, *args, **kwargs):
                 # Set attributes that Tool base class expects
@@ -936,8 +950,8 @@ class TestInternalSearchTool:
                 "unique_internal_search.service.ChunkRelevancySorter"
             ) as mock_sorter_class,
         ):
-            mock_content_service_class.from_event.return_value = mock_content_service
-            mock_sorter_class.from_event.return_value = mock_chunk_relevancy_sorter
+            mock_content_service_class.from_settings.return_value = mock_content_service
+            mock_sorter_class.return_value = mock_chunk_relevancy_sorter
             mock_content_service.search_contents_async = AsyncMock(return_value=[])
 
             def setup_tool(self, configuration, event, *args, **kwargs):
@@ -989,8 +1003,8 @@ class TestInternalSearchTool:
                 "unique_internal_search.service.ChunkRelevancySorter"
             ) as mock_sorter_class,
         ):
-            mock_content_service_class.from_event.return_value = mock_content_service
-            mock_sorter_class.from_event.return_value = mock_chunk_relevancy_sorter
+            mock_content_service_class.from_settings.return_value = mock_content_service
+            mock_sorter_class.return_value = mock_chunk_relevancy_sorter
             mock_content_service.search_contents_async = AsyncMock(return_value=[])
 
             def setup_tool(self, configuration, event, *args, **kwargs):
@@ -1042,8 +1056,8 @@ class TestInternalSearchTool:
                 "unique_internal_search.service.ChunkRelevancySorter"
             ) as mock_sorter_class,
         ):
-            mock_content_service_class.from_event.return_value = mock_content_service
-            mock_sorter_class.from_event.return_value = mock_chunk_relevancy_sorter
+            mock_content_service_class.from_settings.return_value = mock_content_service
+            mock_sorter_class.return_value = mock_chunk_relevancy_sorter
             mock_content_service.search_contents_async = AsyncMock(return_value=[])
 
             def setup_tool(self, configuration, event, *args, **kwargs):
@@ -1091,8 +1105,8 @@ class TestInternalSearchTool:
         ):
             mock_content_service = Mock(spec=KnowledgeBaseService)
             mock_content_service._metadata_filter = None
-            mock_content_service_class.from_event.return_value = mock_content_service
-            mock_sorter_class.from_event.return_value = Mock()
+            mock_content_service_class.from_settings.return_value = mock_content_service
+            mock_sorter_class.return_value = Mock()
 
             def setup_tool(self, configuration, event, *args, **kwargs):
                 # Set attributes that Tool base class expects
@@ -1145,8 +1159,8 @@ class TestInternalSearchTool:
         ):
             mock_content_service = Mock(spec=KnowledgeBaseService)
             mock_content_service._metadata_filter = None
-            mock_content_service_class.from_event.return_value = mock_content_service
-            mock_sorter_class.from_event.return_value = Mock()
+            mock_content_service_class.from_settings.return_value = mock_content_service
+            mock_sorter_class.return_value = Mock()
 
             def setup_tool(self, configuration, event, *args, **kwargs):
                 # Set attributes that Tool base class expects
@@ -1192,8 +1206,8 @@ class TestInternalSearchTool:
         ):
             mock_content_service = Mock(spec=KnowledgeBaseService)
             mock_content_service._metadata_filter = None
-            mock_content_service_class.from_event.return_value = mock_content_service
-            mock_sorter_class.from_event.return_value = Mock()
+            mock_content_service_class.from_settings.return_value = mock_content_service
+            mock_sorter_class.return_value = Mock()
 
             def setup_tool(self, configuration, event, *args, **kwargs):
                 # Set attributes that Tool base class expects
@@ -1240,8 +1254,8 @@ class TestInternalSearchTool:
         ):
             mock_content_service = Mock(spec=KnowledgeBaseService)
             mock_content_service._metadata_filter = None
-            mock_content_service_class.from_event.return_value = mock_content_service
-            mock_sorter_class.from_event.return_value = Mock()
+            mock_content_service_class.from_settings.return_value = mock_content_service
+            mock_sorter_class.return_value = Mock()
 
             def setup_tool(self, configuration, event, *args, **kwargs):
                 # Set attributes that Tool base class expects
@@ -1288,8 +1302,8 @@ class TestInternalSearchTool:
         ):
             mock_content_service = Mock(spec=KnowledgeBaseService)
             mock_content_service._metadata_filter = None
-            mock_content_service_class.from_event.return_value = mock_content_service
-            mock_sorter_class.from_event.return_value = Mock()
+            mock_content_service_class.from_settings.return_value = mock_content_service
+            mock_sorter_class.return_value = Mock()
 
             def setup_tool(self, configuration, event, *args, **kwargs):
                 # Set attributes that Tool base class expects
@@ -1339,8 +1353,8 @@ class TestInternalSearchTool:
         ):
             mock_content_service = Mock(spec=KnowledgeBaseService)
             mock_content_service._metadata_filter = None
-            mock_content_service_class.from_event.return_value = mock_content_service
-            mock_sorter_class.from_event.return_value = Mock()
+            mock_content_service_class.from_settings.return_value = mock_content_service
+            mock_sorter_class.return_value = Mock()
 
             def setup_tool(self, configuration, event, *args, **kwargs):
                 # Set attributes that Tool base class expects
@@ -1387,8 +1401,8 @@ class TestInternalSearchTool:
         ):
             mock_content_service = Mock(spec=KnowledgeBaseService)
             mock_content_service._metadata_filter = None
-            mock_content_service_class.from_event.return_value = mock_content_service
-            mock_sorter_class.from_event.return_value = Mock()
+            mock_content_service_class.from_settings.return_value = mock_content_service
+            mock_sorter_class.return_value = Mock()
 
             def setup_tool(self, configuration, event, *args, **kwargs):
                 # Set attributes that Tool base class expects
@@ -1440,8 +1454,8 @@ class TestInternalSearchTool:
         ):
             mock_content_service = Mock(spec=KnowledgeBaseService)
             mock_content_service._metadata_filter = None
-            mock_content_service_class.from_event.return_value = mock_content_service
-            mock_sorter_class.from_event.return_value = Mock()
+            mock_content_service_class.from_settings.return_value = mock_content_service
+            mock_sorter_class.return_value = Mock()
 
             def setup_tool(self, configuration, event, *args, **kwargs):
                 # Set attributes that Tool base class expects
@@ -1503,8 +1517,8 @@ class TestInternalSearchTool:
             mock_content_service.search_content_chunks_async = AsyncMock(
                 return_value=sample_content_chunks
             )
-            mock_content_service_class.from_event.return_value = mock_content_service
-            mock_sorter_class.from_event.return_value = Mock()
+            mock_content_service_class.from_settings.return_value = mock_content_service
+            mock_sorter_class.return_value = Mock()
 
             def setup_tool(self, configuration, event, *args, **kwargs):
                 # Set attributes that Tool base class expects
@@ -1554,8 +1568,9 @@ class TestInternalSearchTool:
         Setup summary: Default config (reminder disabled), run tool, assert system_reminder is empty.
         """
         with (
+            patch("unique_internal_search.service.UniqueSettings"),
             patch(
-                "unique_internal_search.service.ContentService"
+                "unique_internal_search.service.KnowledgeBaseService"
             ) as mock_content_service_class,
             patch(
                 "unique_internal_search.service.ChunkRelevancySorter"
@@ -1565,14 +1580,14 @@ class TestInternalSearchTool:
                 return_value=sample_content_chunks,
             ),
         ):
-            mock_content_service = Mock(spec=ContentService)
+            mock_content_service = Mock(spec=KnowledgeBaseService)
             mock_content_service._metadata_filter = None
             mock_content_service.search_contents_async = AsyncMock(return_value=[])
             mock_content_service.search_content_chunks_async = AsyncMock(
                 return_value=sample_content_chunks
             )
-            mock_content_service_class.from_event.return_value = mock_content_service
-            mock_sorter_class.from_event.return_value = Mock()
+            mock_content_service_class.from_settings.return_value = mock_content_service
+            mock_sorter_class.return_value = Mock()
 
             def setup_tool(self, configuration, event, *args, **kwargs):
                 setattr(self, "_event", event)
@@ -1621,8 +1636,9 @@ class TestInternalSearchTool:
             }
         )
         with (
+            patch("unique_internal_search.service.UniqueSettings"),
             patch(
-                "unique_internal_search.service.ContentService"
+                "unique_internal_search.service.KnowledgeBaseService"
             ) as mock_content_service_class,
             patch(
                 "unique_internal_search.service.ChunkRelevancySorter"
@@ -1632,14 +1648,14 @@ class TestInternalSearchTool:
                 return_value=sample_content_chunks,
             ),
         ):
-            mock_content_service = Mock(spec=ContentService)
+            mock_content_service = Mock(spec=KnowledgeBaseService)
             mock_content_service._metadata_filter = None
             mock_content_service.search_contents_async = AsyncMock(return_value=[])
             mock_content_service.search_content_chunks_async = AsyncMock(
                 return_value=sample_content_chunks
             )
-            mock_content_service_class.from_event.return_value = mock_content_service
-            mock_sorter_class.from_event.return_value = Mock()
+            mock_content_service_class.from_settings.return_value = mock_content_service
+            mock_sorter_class.return_value = Mock()
 
             def setup_tool(self, configuration, event, *args, **kwargs):
                 setattr(self, "_event", event)
@@ -1704,8 +1720,8 @@ class TestInternalSearchTool:
             mock_content_service.search_content_chunks_async = AsyncMock(
                 return_value=sample_content_chunks
             )
-            mock_content_service_class.from_event.return_value = mock_content_service
-            mock_sorter_class.from_event.return_value = Mock()
+            mock_content_service_class.from_settings.return_value = mock_content_service
+            mock_sorter_class.return_value = Mock()
 
             def setup_tool(self, configuration, event, *args, **kwargs):
                 # Set attributes that Tool base class expects
@@ -1768,8 +1784,8 @@ class TestInternalSearchTool:
         Setup summary: Create internal content chunk, call _define_reference_list_for_message_log, verify returns list.
         """
         # Arrange
-        mock_content_service_class.from_event.return_value = mock_content_service
-        mock_sorter_class.from_event.return_value = mock_chunk_relevancy_sorter
+        mock_content_service_class.from_settings.return_value = mock_content_service
+        mock_sorter_class.return_value = mock_chunk_relevancy_sorter
         content_chunks = [sample_content_chunk]
 
         def setup_tool(self, configuration, event, *args, **kwargs):
@@ -1813,8 +1829,8 @@ class TestInternalSearchTool:
         Setup summary: Create internal content chunk, call _define_reference_list_for_message_log, verify sequence_number is 0.
         """
         # Arrange
-        mock_content_service_class.from_event.return_value = mock_content_service
-        mock_sorter_class.from_event.return_value = mock_chunk_relevancy_sorter
+        mock_content_service_class.from_settings.return_value = mock_content_service
+        mock_sorter_class.return_value = mock_chunk_relevancy_sorter
         content_chunks = [sample_content_chunk]
 
         def setup_tool(self, configuration, event, *args, **kwargs):
@@ -1858,8 +1874,8 @@ class TestInternalSearchTool:
         Setup summary: Create internal content chunk with ID, call _define_reference_list_for_message_log, verify source_id matches.
         """
         # Arrange
-        mock_content_service_class.from_event.return_value = mock_content_service
-        mock_sorter_class.from_event.return_value = mock_chunk_relevancy_sorter
+        mock_content_service_class.from_settings.return_value = mock_content_service
+        mock_sorter_class.return_value = mock_chunk_relevancy_sorter
         content_chunks = [sample_content_chunk]
 
         def setup_tool(self, configuration, event, *args, **kwargs):
@@ -1903,8 +1919,8 @@ class TestInternalSearchTool:
         Setup summary: Create internal content chunk, call _define_reference_list_for_message_log, verify reference source is "internal".
         """
         # Arrange
-        mock_content_service_class.from_event.return_value = mock_content_service
-        mock_sorter_class.from_event.return_value = mock_chunk_relevancy_sorter
+        mock_content_service_class.from_settings.return_value = mock_content_service
+        mock_sorter_class.return_value = mock_chunk_relevancy_sorter
         content_chunks = [sample_content_chunk]
 
         def setup_tool(self, configuration, event, *args, **kwargs):
@@ -1948,8 +1964,8 @@ class TestInternalSearchTool:
         """
 
         # Arrange
-        mock_content_service_class.from_event.return_value = mock_content_service
-        mock_sorter_class.from_event.return_value = mock_chunk_relevancy_sorter
+        mock_content_service_class.from_settings.return_value = mock_content_service
+        mock_sorter_class.return_value = mock_chunk_relevancy_sorter
 
         content_chunk = ContentChunk(
             id="chunk_internal_2",
@@ -1999,8 +2015,8 @@ class TestInternalSearchTool:
         """
 
         # Arrange
-        mock_content_service_class.from_event.return_value = mock_content_service
-        mock_sorter_class.from_event.return_value = mock_chunk_relevancy_sorter
+        mock_content_service_class.from_settings.return_value = mock_content_service
+        mock_sorter_class.return_value = mock_chunk_relevancy_sorter
 
         content_chunk = ContentChunk(
             id="chunk_internal_1",
@@ -2051,8 +2067,8 @@ class TestInternalSearchTool:
         Setup summary: Create internal content chunk, call _define_reference_list_for_message_log, verify URL format.
         """
         # Arrange
-        mock_content_service_class.from_event.return_value = mock_content_service
-        mock_sorter_class.from_event.return_value = mock_chunk_relevancy_sorter
+        mock_content_service_class.from_settings.return_value = mock_content_service
+        mock_sorter_class.return_value = mock_chunk_relevancy_sorter
         content_chunks = [sample_content_chunk]
 
         def setup_tool(self, configuration, event, *args, **kwargs):
@@ -2096,8 +2112,8 @@ class TestInternalSearchTool:
         """
 
         # Arrange
-        mock_content_service_class.from_event.return_value = mock_content_service
-        mock_sorter_class.from_event.return_value = mock_chunk_relevancy_sorter
+        mock_content_service_class.from_settings.return_value = mock_content_service
+        mock_sorter_class.return_value = mock_chunk_relevancy_sorter
 
         content_chunks = [
             ContentChunk(
@@ -2155,8 +2171,8 @@ class TestInternalSearchTool:
         """
 
         # Arrange
-        mock_content_service_class.from_event.return_value = mock_content_service
-        mock_sorter_class.from_event.return_value = mock_chunk_relevancy_sorter
+        mock_content_service_class.from_settings.return_value = mock_content_service
+        mock_sorter_class.return_value = mock_chunk_relevancy_sorter
 
         content_chunks = [
             ContentChunk(
@@ -2229,8 +2245,8 @@ class TestInternalSearchTool:
             mock_content_service.search_content_chunks_async = AsyncMock(
                 return_value=sample_content_chunks
             )
-            mock_content_service_class.from_event.return_value = mock_content_service
-            mock_sorter_class.from_event.return_value = Mock()
+            mock_content_service_class.from_settings.return_value = mock_content_service
+            mock_sorter_class.return_value = Mock()
 
             def setup_tool(self, configuration, event, *args, **kwargs):
                 # Set attributes that Tool base class expects
@@ -2580,10 +2596,10 @@ class TestInternalSearchTool:
         # Arrange
         mock_content_service = Mock(spec=KnowledgeBaseService)
         mock_content_service._metadata_filter = None
-        mock_content_service_class.from_event.return_value = mock_content_service
+        mock_content_service_class.from_settings.return_value = mock_content_service
 
         mock_sorter = Mock()
-        mock_chunk_relevancy_sorter_class.from_event.return_value = mock_sorter
+        mock_chunk_relevancy_sorter_class.return_value = mock_sorter
 
         def setup_tool(self, configuration, event, *args, **kwargs):
             setattr(self, "_event", event)
@@ -2635,10 +2651,10 @@ class TestInternalSearchTool:
         # Arrange
         mock_content_service = Mock(spec=KnowledgeBaseService)
         mock_content_service._metadata_filter = None
-        mock_content_service_class.from_event.return_value = mock_content_service
+        mock_content_service_class.from_settings.return_value = mock_content_service
 
         mock_sorter = Mock()
-        mock_chunk_relevancy_sorter_class.from_event.return_value = mock_sorter
+        mock_chunk_relevancy_sorter_class.return_value = mock_sorter
 
         def setup_tool(self, configuration, event, *args, **kwargs):
             setattr(self, "_event", event)
@@ -2689,10 +2705,10 @@ class TestInternalSearchTool:
         # Arrange
         mock_content_service = Mock(spec=KnowledgeBaseService)
         mock_content_service._metadata_filter = None
-        mock_content_service_class.from_event.return_value = mock_content_service
+        mock_content_service_class.from_settings.return_value = mock_content_service
 
         mock_sorter = Mock()
-        mock_chunk_relevancy_sorter_class.from_event.return_value = mock_sorter
+        mock_chunk_relevancy_sorter_class.return_value = mock_sorter
 
         def setup_tool(self, configuration, event, *args, **kwargs):
             setattr(self, "_event", event)
@@ -2743,10 +2759,10 @@ class TestInternalSearchTool:
         # Arrange
         mock_content_service = Mock(spec=KnowledgeBaseService)
         mock_content_service._metadata_filter = None
-        mock_content_service_class.from_event.return_value = mock_content_service
+        mock_content_service_class.from_settings.return_value = mock_content_service
 
         mock_sorter = Mock()
-        mock_chunk_relevancy_sorter_class.from_event.return_value = mock_sorter
+        mock_chunk_relevancy_sorter_class.return_value = mock_sorter
 
         def setup_tool(self, configuration, event, *args, **kwargs):
             setattr(self, "_event", event)
@@ -2800,10 +2816,10 @@ class TestInternalSearchTool:
         """
         mock_content_service = Mock(spec=KnowledgeBaseService)
         mock_content_service._metadata_filter = None
-        mock_content_service_class.from_event.return_value = mock_content_service
+        mock_content_service_class.from_settings.return_value = mock_content_service
 
         mock_sorter = Mock()
-        mock_chunk_relevancy_sorter_class.from_event.return_value = mock_sorter
+        mock_chunk_relevancy_sorter_class.return_value = mock_sorter
 
         def setup_tool(self, configuration, event, *args, **kwargs):
             setattr(self, "_event", event)

--- a/tool_packages/unique_internal_search/tests/test_service.py
+++ b/tool_packages/unique_internal_search/tests/test_service.py
@@ -8,7 +8,7 @@ from unique_toolkit._common.chunk_relevancy_sorter.exception import (
 )
 from unique_toolkit.agentic.tools.schemas import ToolCallResponse
 from unique_toolkit.content.schemas import ContentChunk
-from unique_toolkit.content.service import ContentService
+from unique_toolkit.services.knowledge_base import KnowledgeBaseService
 
 from unique_internal_search.config import InternalSearchConfig
 from unique_internal_search.service import InternalSearchService, InternalSearchTool
@@ -21,7 +21,7 @@ class TestInternalSearchService:
     def test_service__initializes__with_all_dependencies(
         self,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: ContentService,
+        mock_content_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
     ) -> None:
@@ -55,7 +55,7 @@ class TestInternalSearchService:
     async def test_get_uploaded_files__returns_sorted_by_created_at__descending(
         self,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: ContentService,
+        mock_content_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
         sample_content_list: list[Any],
@@ -93,7 +93,7 @@ class TestInternalSearchService:
     async def test_is_chat_only__returns_true__when_config_chat_only_is_true(
         self,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: ContentService,
+        mock_content_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
     ) -> None:
@@ -123,7 +123,7 @@ class TestInternalSearchService:
     async def test_is_chat_only__returns_false__when_config_chat_only_is_false_and_no_uploaded_files(
         self,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: ContentService,
+        mock_content_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
     ) -> None:
@@ -155,7 +155,7 @@ class TestInternalSearchService:
     async def test_is_chat_only__returns_true__when_scope_to_chat_on_upload_and_files_exist(
         self,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: ContentService,
+        mock_content_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
         sample_content_list: list[Any],
@@ -190,7 +190,7 @@ class TestInternalSearchService:
     async def test_search__calls_content_service__with_correct_parameters(
         self,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: ContentService,
+        mock_content_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
         sample_content_chunks: list[ContentChunk],
@@ -230,7 +230,7 @@ class TestInternalSearchService:
     async def test_search__handles_metadata_filter__when_chat_only_is_true(
         self,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: ContentService,
+        mock_content_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
         sample_content_chunks: list[ContentChunk],
@@ -269,7 +269,7 @@ class TestInternalSearchService:
     async def test_search__resets_metadata_filter__after_search_completes(
         self,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: ContentService,
+        mock_content_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
         sample_content_chunks: list[ContentChunk],
@@ -306,7 +306,7 @@ class TestInternalSearchService:
     async def test_search__resorts_chunks__when_chunk_relevancy_sort_enabled(
         self,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: ContentService,
+        mock_content_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
         sample_content_chunks: list[ContentChunk],
@@ -347,7 +347,7 @@ class TestInternalSearchService:
     async def test_search__handles_chunk_relevancy_sorter_exception__gracefully(
         self,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: ContentService,
+        mock_content_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
         sample_content_chunks: list[ContentChunk],
@@ -389,7 +389,7 @@ class TestInternalSearchService:
     async def test_search__merges_chunks__when_chunked_sources_is_false(
         self,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: ContentService,
+        mock_content_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
         sample_content_chunks: list[ContentChunk],
@@ -425,7 +425,7 @@ class TestInternalSearchService:
     async def test_search__sorts_chunks__when_chunked_sources_is_true(
         self,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: ContentService,
+        mock_content_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
         sample_content_chunks: list[ContentChunk],
@@ -461,7 +461,7 @@ class TestInternalSearchService:
     async def test_search__logs_error__when_search_fails(
         self,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: ContentService,
+        mock_content_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
     ) -> None:
@@ -497,7 +497,7 @@ class TestInternalSearchService:
     async def test_search__sets_debug_info__with_search_parameters(
         self,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: ContentService,
+        mock_content_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
         sample_content_chunks: list[ContentChunk],
@@ -535,7 +535,7 @@ class TestInternalSearchService:
     def test_get_max_tokens__returns_percentage_of_language_model_max__when_set(
         self,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: ContentService,
+        mock_content_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
     ) -> None:
@@ -566,7 +566,7 @@ class TestInternalSearchService:
     def test_get_max_tokens__returns_max_tokens_for_sources__when_language_model_max_not_set(
         self,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: ContentService,
+        mock_content_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
     ) -> None:
@@ -598,7 +598,7 @@ class TestInternalSearchService:
     async def test_resort_found_chunks_if_enabled__returns_sorted_chunks__on_success(
         self,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: ContentService,
+        mock_content_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
         sample_content_chunks: list[ContentChunk],
@@ -635,7 +635,7 @@ class TestInternalSearchService:
     async def test_post_progress_message__does_nothing__in_base_service(
         self,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: ContentService,
+        mock_content_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
     ) -> None:
@@ -661,7 +661,7 @@ class TestInternalSearchTool:
     """Tests for InternalSearchTool class."""
 
     @pytest.mark.ai
-    @patch("unique_internal_search.service.ContentService")
+    @patch("unique_internal_search.service.KnowledgeBaseService")
     @patch("unique_internal_search.service.ChunkRelevancySorter")
     def test_tool__initializes__with_chat_event(
         self,
@@ -674,10 +674,10 @@ class TestInternalSearchTool:
         """
         Purpose: Verify InternalSearchTool initializes correctly with ChatEvent.
         Why this matters: Ensures proper tool initialization and chat_id extraction from ChatEvent.
-        Setup summary: Mock ContentService and ChunkRelevancySorter from_event, verify initialization.
+        Setup summary: Mock KnowledgeBaseService and ChunkRelevancySorter from_event, verify initialization.
         """
         # Arrange
-        mock_content_service = Mock(spec=ContentService)
+        mock_content_service = Mock(spec=KnowledgeBaseService)
         mock_content_service._metadata_filter = None
         mock_content_service_class.from_event.return_value = mock_content_service
 
@@ -709,7 +709,7 @@ class TestInternalSearchTool:
         assert tool.chat_id == "chat_123"
 
     @pytest.mark.ai
-    @patch("unique_internal_search.service.ContentService")
+    @patch("unique_internal_search.service.KnowledgeBaseService")
     @patch("unique_internal_search.service.ChunkRelevancySorter")
     def test_tool__initializes__with_chat_event__uses_parent_chat_id__when_correlation_set(
         self,
@@ -725,7 +725,7 @@ class TestInternalSearchTool:
         Setup summary: ChatEvent with payload.correlation.parent_chat_id set, verify tool.chat_id equals it.
         """
         # Arrange
-        mock_content_service = Mock(spec=ContentService)
+        mock_content_service = Mock(spec=KnowledgeBaseService)
         mock_content_service._metadata_filter = None
         mock_content_service_class.from_event.return_value = mock_content_service
 
@@ -755,7 +755,7 @@ class TestInternalSearchTool:
         assert tool.chat_id == "parent_chat_456"
 
     @pytest.mark.ai
-    @patch("unique_internal_search.service.ContentService")
+    @patch("unique_internal_search.service.KnowledgeBaseService")
     @patch("unique_internal_search.service.ChunkRelevancySorter")
     def test_tool__initializes__with_base_event(
         self,
@@ -768,10 +768,10 @@ class TestInternalSearchTool:
         """
         Purpose: Verify InternalSearchTool initializes correctly with BaseEvent (no chat_id).
         Why this matters: Ensures tool works with non-chat events that don't have chat_id.
-        Setup summary: Mock ContentService and ChunkRelevancySorter from_event, verify chat_id is None.
+        Setup summary: Mock KnowledgeBaseService and ChunkRelevancySorter from_event, verify chat_id is None.
         """
         # Arrange
-        mock_content_service = Mock(spec=ContentService)
+        mock_content_service = Mock(spec=KnowledgeBaseService)
         mock_content_service._metadata_filter = None
         mock_content_service_class.from_event.return_value = mock_content_service
 
@@ -813,13 +813,13 @@ class TestInternalSearchTool:
         # Arrange
         with (
             patch(
-                "unique_internal_search.service.ContentService"
+                "unique_internal_search.service.KnowledgeBaseService"
             ) as mock_content_service_class,
             patch(
                 "unique_internal_search.service.ChunkRelevancySorter"
             ) as mock_sorter_class,
         ):
-            mock_content_service = Mock(spec=ContentService)
+            mock_content_service = Mock(spec=KnowledgeBaseService)
             mock_content_service._metadata_filter = None
             mock_content_service_class.from_event.return_value = mock_content_service
             mock_sorter_class.from_event.return_value = Mock()
@@ -873,13 +873,13 @@ class TestInternalSearchTool:
         # Arrange
         with (
             patch(
-                "unique_internal_search.service.ContentService"
+                "unique_internal_search.service.KnowledgeBaseService"
             ) as mock_content_service_class,
             patch(
                 "unique_internal_search.service.ChunkRelevancySorter"
             ) as mock_sorter_class,
         ):
-            mock_content_service = Mock(spec=ContentService)
+            mock_content_service = Mock(spec=KnowledgeBaseService)
             mock_content_service._metadata_filter = None
             mock_content_service_class.from_event.return_value = mock_content_service
             mock_sorter_class.from_event.return_value = Mock()
@@ -916,7 +916,7 @@ class TestInternalSearchTool:
         base_internal_search_config: InternalSearchConfig,
         mock_chat_event: Any,
         mock_logger: Any,
-        mock_content_service: ContentService,
+        mock_content_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
     ) -> None:
         """
@@ -930,7 +930,7 @@ class TestInternalSearchTool:
 
         with (
             patch(
-                "unique_internal_search.service.ContentService"
+                "unique_internal_search.service.KnowledgeBaseService"
             ) as mock_content_service_class,
             patch(
                 "unique_internal_search.service.ChunkRelevancySorter"
@@ -969,7 +969,7 @@ class TestInternalSearchTool:
         base_internal_search_config: InternalSearchConfig,
         mock_chat_event: Any,
         mock_logger: Any,
-        mock_content_service: ContentService,
+        mock_content_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
     ) -> None:
         """
@@ -983,7 +983,7 @@ class TestInternalSearchTool:
 
         with (
             patch(
-                "unique_internal_search.service.ContentService"
+                "unique_internal_search.service.KnowledgeBaseService"
             ) as mock_content_service_class,
             patch(
                 "unique_internal_search.service.ChunkRelevancySorter"
@@ -1022,7 +1022,7 @@ class TestInternalSearchTool:
         base_internal_search_config: InternalSearchConfig,
         mock_chat_event: Any,
         mock_logger: Any,
-        mock_content_service: ContentService,
+        mock_content_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
     ) -> None:
         """
@@ -1036,7 +1036,7 @@ class TestInternalSearchTool:
 
         with (
             patch(
-                "unique_internal_search.service.ContentService"
+                "unique_internal_search.service.KnowledgeBaseService"
             ) as mock_content_service_class,
             patch(
                 "unique_internal_search.service.ChunkRelevancySorter"
@@ -1083,13 +1083,13 @@ class TestInternalSearchTool:
         # Arrange
         with (
             patch(
-                "unique_internal_search.service.ContentService"
+                "unique_internal_search.service.KnowledgeBaseService"
             ) as mock_content_service_class,
             patch(
                 "unique_internal_search.service.ChunkRelevancySorter"
             ) as mock_sorter_class,
         ):
-            mock_content_service = Mock(spec=ContentService)
+            mock_content_service = Mock(spec=KnowledgeBaseService)
             mock_content_service._metadata_filter = None
             mock_content_service_class.from_event.return_value = mock_content_service
             mock_sorter_class.from_event.return_value = Mock()
@@ -1137,13 +1137,13 @@ class TestInternalSearchTool:
         # Arrange
         with (
             patch(
-                "unique_internal_search.service.ContentService"
+                "unique_internal_search.service.KnowledgeBaseService"
             ) as mock_content_service_class,
             patch(
                 "unique_internal_search.service.ChunkRelevancySorter"
             ) as mock_sorter_class,
         ):
-            mock_content_service = Mock(spec=ContentService)
+            mock_content_service = Mock(spec=KnowledgeBaseService)
             mock_content_service._metadata_filter = None
             mock_content_service_class.from_event.return_value = mock_content_service
             mock_sorter_class.from_event.return_value = Mock()
@@ -1184,13 +1184,13 @@ class TestInternalSearchTool:
         # Arrange
         with (
             patch(
-                "unique_internal_search.service.ContentService"
+                "unique_internal_search.service.KnowledgeBaseService"
             ) as mock_content_service_class,
             patch(
                 "unique_internal_search.service.ChunkRelevancySorter"
             ) as mock_sorter_class,
         ):
-            mock_content_service = Mock(spec=ContentService)
+            mock_content_service = Mock(spec=KnowledgeBaseService)
             mock_content_service._metadata_filter = None
             mock_content_service_class.from_event.return_value = mock_content_service
             mock_sorter_class.from_event.return_value = Mock()
@@ -1232,13 +1232,13 @@ class TestInternalSearchTool:
         # Arrange
         with (
             patch(
-                "unique_internal_search.service.ContentService"
+                "unique_internal_search.service.KnowledgeBaseService"
             ) as mock_content_service_class,
             patch(
                 "unique_internal_search.service.ChunkRelevancySorter"
             ) as mock_sorter_class,
         ):
-            mock_content_service = Mock(spec=ContentService)
+            mock_content_service = Mock(spec=KnowledgeBaseService)
             mock_content_service._metadata_filter = None
             mock_content_service_class.from_event.return_value = mock_content_service
             mock_sorter_class.from_event.return_value = Mock()
@@ -1280,13 +1280,13 @@ class TestInternalSearchTool:
 
         with (
             patch(
-                "unique_internal_search.service.ContentService"
+                "unique_internal_search.service.KnowledgeBaseService"
             ) as mock_content_service_class,
             patch(
                 "unique_internal_search.service.ChunkRelevancySorter"
             ) as mock_sorter_class,
         ):
-            mock_content_service = Mock(spec=ContentService)
+            mock_content_service = Mock(spec=KnowledgeBaseService)
             mock_content_service._metadata_filter = None
             mock_content_service_class.from_event.return_value = mock_content_service
             mock_sorter_class.from_event.return_value = Mock()
@@ -1331,13 +1331,13 @@ class TestInternalSearchTool:
 
         with (
             patch(
-                "unique_internal_search.service.ContentService"
+                "unique_internal_search.service.KnowledgeBaseService"
             ) as mock_content_service_class,
             patch(
                 "unique_internal_search.service.ChunkRelevancySorter"
             ) as mock_sorter_class,
         ):
-            mock_content_service = Mock(spec=ContentService)
+            mock_content_service = Mock(spec=KnowledgeBaseService)
             mock_content_service._metadata_filter = None
             mock_content_service_class.from_event.return_value = mock_content_service
             mock_sorter_class.from_event.return_value = Mock()
@@ -1379,13 +1379,13 @@ class TestInternalSearchTool:
         # Arrange
         with (
             patch(
-                "unique_internal_search.service.ContentService"
+                "unique_internal_search.service.KnowledgeBaseService"
             ) as mock_content_service_class,
             patch(
                 "unique_internal_search.service.ChunkRelevancySorter"
             ) as mock_sorter_class,
         ):
-            mock_content_service = Mock(spec=ContentService)
+            mock_content_service = Mock(spec=KnowledgeBaseService)
             mock_content_service._metadata_filter = None
             mock_content_service_class.from_event.return_value = mock_content_service
             mock_sorter_class.from_event.return_value = Mock()
@@ -1432,13 +1432,13 @@ class TestInternalSearchTool:
         # Arrange
         with (
             patch(
-                "unique_internal_search.service.ContentService"
+                "unique_internal_search.service.KnowledgeBaseService"
             ) as mock_content_service_class,
             patch(
                 "unique_internal_search.service.ChunkRelevancySorter"
             ) as mock_sorter_class,
         ):
-            mock_content_service = Mock(spec=ContentService)
+            mock_content_service = Mock(spec=KnowledgeBaseService)
             mock_content_service._metadata_filter = None
             mock_content_service_class.from_event.return_value = mock_content_service
             mock_sorter_class.from_event.return_value = Mock()
@@ -1487,7 +1487,7 @@ class TestInternalSearchTool:
         # Arrange
         with (
             patch(
-                "unique_internal_search.service.ContentService"
+                "unique_internal_search.service.KnowledgeBaseService"
             ) as mock_content_service_class,
             patch(
                 "unique_internal_search.service.ChunkRelevancySorter"
@@ -1497,7 +1497,7 @@ class TestInternalSearchTool:
                 return_value=sample_content_chunks,
             ),
         ):
-            mock_content_service = Mock(spec=ContentService)
+            mock_content_service = Mock(spec=KnowledgeBaseService)
             mock_content_service._metadata_filter = None
             mock_content_service.search_contents_async = AsyncMock(return_value=[])
             mock_content_service.search_content_chunks_async = AsyncMock(
@@ -1688,7 +1688,7 @@ class TestInternalSearchTool:
         # Arrange
         with (
             patch(
-                "unique_internal_search.service.ContentService"
+                "unique_internal_search.service.KnowledgeBaseService"
             ) as mock_content_service_class,
             patch(
                 "unique_internal_search.service.ChunkRelevancySorter"
@@ -1698,7 +1698,7 @@ class TestInternalSearchTool:
                 return_value=sample_content_chunks,
             ),
         ):
-            mock_content_service = Mock(spec=ContentService)
+            mock_content_service = Mock(spec=KnowledgeBaseService)
             mock_content_service._metadata_filter = None
             mock_content_service.search_contents_async = AsyncMock(return_value=[])
             mock_content_service.search_content_chunks_async = AsyncMock(
@@ -1749,7 +1749,7 @@ class TestInternalSearchTool:
 
     @pytest.mark.ai
     @pytest.mark.asyncio
-    @patch("unique_internal_search.service.ContentService")
+    @patch("unique_internal_search.service.KnowledgeBaseService")
     @patch("unique_internal_search.service.ChunkRelevancySorter")
     async def test_define_reference_list_for_message_log__returns_list__with_internal_chunks(
         self,
@@ -1757,7 +1757,7 @@ class TestInternalSearchTool:
         mock_content_service_class: Any,
         sample_content_chunk: ContentChunk,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: ContentService,
+        mock_content_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
         mock_chat_event: Any,
@@ -1794,7 +1794,7 @@ class TestInternalSearchTool:
 
     @pytest.mark.ai
     @pytest.mark.asyncio
-    @patch("unique_internal_search.service.ContentService")
+    @patch("unique_internal_search.service.KnowledgeBaseService")
     @patch("unique_internal_search.service.ChunkRelevancySorter")
     async def test_define_reference_list_for_message_log__sets_sequence_number__for_first_chunk(
         self,
@@ -1802,7 +1802,7 @@ class TestInternalSearchTool:
         mock_content_service_class: Any,
         sample_content_chunk: ContentChunk,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: ContentService,
+        mock_content_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
         mock_chat_event: Any,
@@ -1839,7 +1839,7 @@ class TestInternalSearchTool:
 
     @pytest.mark.ai
     @pytest.mark.asyncio
-    @patch("unique_internal_search.service.ContentService")
+    @patch("unique_internal_search.service.KnowledgeBaseService")
     @patch("unique_internal_search.service.ChunkRelevancySorter")
     async def test_define_reference_list_for_message_log__sets_source_id__from_chunk_id(
         self,
@@ -1847,7 +1847,7 @@ class TestInternalSearchTool:
         mock_content_service_class: Any,
         sample_content_chunk: ContentChunk,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: ContentService,
+        mock_content_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
         mock_chat_event: Any,
@@ -1884,7 +1884,7 @@ class TestInternalSearchTool:
 
     @pytest.mark.ai
     @pytest.mark.asyncio
-    @patch("unique_internal_search.service.ContentService")
+    @patch("unique_internal_search.service.KnowledgeBaseService")
     @patch("unique_internal_search.service.ChunkRelevancySorter")
     async def test_define_reference_list_for_message_log__sets_source__to_internal(
         self,
@@ -1892,7 +1892,7 @@ class TestInternalSearchTool:
         mock_content_service_class: Any,
         sample_content_chunk: ContentChunk,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: ContentService,
+        mock_content_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
         mock_chat_event: Any,
@@ -1929,14 +1929,14 @@ class TestInternalSearchTool:
 
     @pytest.mark.ai
     @pytest.mark.asyncio
-    @patch("unique_internal_search.service.ContentService")
+    @patch("unique_internal_search.service.KnowledgeBaseService")
     @patch("unique_internal_search.service.ChunkRelevancySorter")
     async def test_define_reference_list_for_message_log__sets_name__from_chunk_key_when_no_title(
         self,
         mock_sorter_class: Any,
         mock_content_service_class: Any,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: ContentService,
+        mock_content_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
         mock_chat_event: Any,
@@ -1980,14 +1980,14 @@ class TestInternalSearchTool:
 
     @pytest.mark.ai
     @pytest.mark.asyncio
-    @patch("unique_internal_search.service.ContentService")
+    @patch("unique_internal_search.service.KnowledgeBaseService")
     @patch("unique_internal_search.service.ChunkRelevancySorter")
     async def test_define_reference_list_for_message_log__sets_name__from_chunk_title_when_available(
         self,
         mock_sorter_class: Any,
         mock_content_service_class: Any,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: ContentService,
+        mock_content_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
         mock_chat_event: Any,
@@ -2032,7 +2032,7 @@ class TestInternalSearchTool:
 
     @pytest.mark.ai
     @pytest.mark.asyncio
-    @patch("unique_internal_search.service.ContentService")
+    @patch("unique_internal_search.service.KnowledgeBaseService")
     @patch("unique_internal_search.service.ChunkRelevancySorter")
     async def test_define_reference_list_for_message_log__sets_unique_url__for_internal_chunks(
         self,
@@ -2040,7 +2040,7 @@ class TestInternalSearchTool:
         mock_content_service_class: Any,
         sample_content_chunk: ContentChunk,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: ContentService,
+        mock_content_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
         mock_chat_event: Any,
@@ -2077,14 +2077,14 @@ class TestInternalSearchTool:
 
     @pytest.mark.ai
     @pytest.mark.asyncio
-    @patch("unique_internal_search.service.ContentService")
+    @patch("unique_internal_search.service.KnowledgeBaseService")
     @patch("unique_internal_search.service.ChunkRelevancySorter")
     async def test_define_reference_list_for_message_log__increments_sequence_number__for_multiple_chunks(
         self,
         mock_sorter_class: Any,
         mock_content_service_class: Any,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: ContentService,
+        mock_content_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
         mock_chat_event: Any,
@@ -2136,14 +2136,14 @@ class TestInternalSearchTool:
 
     @pytest.mark.ai
     @pytest.mark.asyncio
-    @patch("unique_internal_search.service.ContentService")
+    @patch("unique_internal_search.service.KnowledgeBaseService")
     @patch("unique_internal_search.service.ChunkRelevancySorter")
     async def test_define_reference_list_for_message_log__includes_chunks__with_empty_name(
         self,
         mock_sorter_class: Any,
         mock_content_service_class: Any,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: ContentService,
+        mock_content_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
         mock_chat_event: Any,
@@ -2213,7 +2213,7 @@ class TestInternalSearchTool:
 
         with (
             patch(
-                "unique_internal_search.service.ContentService"
+                "unique_internal_search.service.KnowledgeBaseService"
             ) as mock_content_service_class,
             patch(
                 "unique_internal_search.service.ChunkRelevancySorter"
@@ -2223,7 +2223,7 @@ class TestInternalSearchTool:
                 return_value=sample_content_chunks,
             ),
         ):
-            mock_content_service = Mock(spec=ContentService)
+            mock_content_service = Mock(spec=KnowledgeBaseService)
             mock_content_service._metadata_filter = None
             mock_content_service.search_contents_async = AsyncMock(return_value=[])
             mock_content_service.search_content_chunks_async = AsyncMock(
@@ -2274,7 +2274,7 @@ class TestInternalSearchTool:
     async def test_search__executes_searches_in_parallel__when_multiple_search_strings(
         self,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: ContentService,
+        mock_content_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
         sample_content_chunks: list[ContentChunk],
@@ -2321,7 +2321,7 @@ class TestInternalSearchTool:
     async def test_search__deduplicates_search_strings__when_duplicates_provided(
         self,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: ContentService,
+        mock_content_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
         sample_content_chunks: list[ContentChunk],
@@ -2363,7 +2363,7 @@ class TestInternalSearchTool:
     async def test_search__limits_search_strings__to_max_search_strings_config(
         self,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: ContentService,
+        mock_content_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
         sample_content_chunks: list[ContentChunk],
@@ -2410,7 +2410,7 @@ class TestInternalSearchTool:
     async def test_search__continues_with_other_searches__when_one_search_fails(
         self,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: ContentService,
+        mock_content_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
         sample_content_chunks: list[ContentChunk],
@@ -2464,7 +2464,7 @@ class TestInternalSearchTool:
     async def test_prepare_message_log_details__returns_message_log_details__with_queries(
         self,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: ContentService,
+        mock_content_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
     ) -> None:
@@ -2499,7 +2499,7 @@ class TestInternalSearchTool:
     async def test_prepare_message_log_details__returns_empty_data__when_empty_query_list(
         self,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: ContentService,
+        mock_content_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
     ) -> None:
@@ -2530,7 +2530,7 @@ class TestInternalSearchTool:
     async def test_create_or_update_active_message_log__returns_none__when_no_message_step_logger(
         self,
         base_internal_search_config: InternalSearchConfig,
-        mock_content_service: ContentService,
+        mock_content_service: KnowledgeBaseService,
         mock_chunk_relevancy_sorter: Any,
         mock_logger: Any,
     ) -> None:
@@ -2560,7 +2560,7 @@ class TestInternalSearchTool:
         assert result is None
 
     @pytest.mark.ai
-    @patch("unique_internal_search.service.ContentService")
+    @patch("unique_internal_search.service.KnowledgeBaseService")
     @patch("unique_internal_search.service.ChunkRelevancySorter")
     def test_get_tool_call_result_for_loop_history__returns_tool_message__with_sources(
         self,
@@ -2578,7 +2578,7 @@ class TestInternalSearchTool:
         Setup summary: Create tool, call get_tool_call_result_for_loop_history, verify message structure.
         """
         # Arrange
-        mock_content_service = Mock(spec=ContentService)
+        mock_content_service = Mock(spec=KnowledgeBaseService)
         mock_content_service._metadata_filter = None
         mock_content_service_class.from_event.return_value = mock_content_service
 
@@ -2616,7 +2616,7 @@ class TestInternalSearchTool:
         assert isinstance(result.content, str)
 
     @pytest.mark.ai
-    @patch("unique_internal_search.service.ContentService")
+    @patch("unique_internal_search.service.KnowledgeBaseService")
     @patch("unique_internal_search.service.ChunkRelevancySorter")
     def test_get_tool_call_result_for_loop_history__handles_empty_chunks__gracefully(
         self,
@@ -2633,7 +2633,7 @@ class TestInternalSearchTool:
         Setup summary: Create tool, call get_tool_call_result_for_loop_history with empty chunks, verify no error.
         """
         # Arrange
-        mock_content_service = Mock(spec=ContentService)
+        mock_content_service = Mock(spec=KnowledgeBaseService)
         mock_content_service._metadata_filter = None
         mock_content_service_class.from_event.return_value = mock_content_service
 
@@ -2670,7 +2670,7 @@ class TestInternalSearchTool:
         assert result.name == "InternalSearch"
 
     @pytest.mark.ai
-    @patch("unique_internal_search.service.ContentService")
+    @patch("unique_internal_search.service.KnowledgeBaseService")
     @patch("unique_internal_search.service.ChunkRelevancySorter")
     def test_get_tool_call_result_for_loop_history__handles_none_chunks__gracefully(
         self,
@@ -2687,7 +2687,7 @@ class TestInternalSearchTool:
         Setup summary: Create tool, call get_tool_call_result_for_loop_history with None chunks, verify no error.
         """
         # Arrange
-        mock_content_service = Mock(spec=ContentService)
+        mock_content_service = Mock(spec=KnowledgeBaseService)
         mock_content_service._metadata_filter = None
         mock_content_service_class.from_event.return_value = mock_content_service
 
@@ -2724,7 +2724,7 @@ class TestInternalSearchTool:
         assert result.name == "InternalSearch"
 
     @pytest.mark.ai
-    @patch("unique_internal_search.service.ContentService")
+    @patch("unique_internal_search.service.KnowledgeBaseService")
     @patch("unique_internal_search.service.ChunkRelevancySorter")
     def test_get_tool_call_result_for_loop_history__uses_correct_source_numbering(
         self,
@@ -2741,7 +2741,7 @@ class TestInternalSearchTool:
         Setup summary: Create tool with existing chunks in handler, verify source numbering continues correctly.
         """
         # Arrange
-        mock_content_service = Mock(spec=ContentService)
+        mock_content_service = Mock(spec=KnowledgeBaseService)
         mock_content_service._metadata_filter = None
         mock_content_service_class.from_event.return_value = mock_content_service
 
@@ -2783,7 +2783,7 @@ class TestInternalSearchTool:
         mock_logger.debug.assert_called()
 
     @pytest.mark.ai
-    @patch("unique_internal_search.service.ContentService")
+    @patch("unique_internal_search.service.KnowledgeBaseService")
     @patch("unique_internal_search.service.ChunkRelevancySorter")
     def test_get_tool_call_result_for_loop_history__preserves_readable_unicode_content(
         self,
@@ -2798,7 +2798,7 @@ class TestInternalSearchTool:
         Why this matters: InternalSearch tool messages are forwarded to the next LLM call as-is.
         Setup summary: Create tool, serialize non-ASCII chunks into loop history, and verify both raw and decoded content.
         """
-        mock_content_service = Mock(spec=ContentService)
+        mock_content_service = Mock(spec=KnowledgeBaseService)
         mock_content_service._metadata_filter = None
         mock_content_service_class.from_event.return_value = mock_content_service
 

--- a/tool_packages/unique_internal_search/unique_internal_search/service.py
+++ b/tool_packages/unique_internal_search/unique_internal_search/service.py
@@ -21,6 +21,7 @@ from unique_toolkit.agentic.tools.schemas import ToolCallResponse
 from unique_toolkit.agentic.tools.tool import Tool
 from unique_toolkit.agentic.tools.tool_progress_reporter import ProgressState
 from unique_toolkit.app.schemas import BaseEvent, ChatEvent, Event
+from unique_toolkit.app.unique_settings import UniqueSettings
 from unique_toolkit.chat.schemas import (
     MessageLog,
     MessageLogDetails,
@@ -423,16 +424,23 @@ class InternalSearchTool(Tool[InternalSearchConfig], InternalSearchService):
     ):
         Tool.__init__(self, configuration, event, *args, **kwargs)
 
-        content_service = KnowledgeBaseService.from_event(self.event)
-        chunk_relevancy_sorter = ChunkRelevancySorter.from_event(self.event)
-        # Determing chat_id if possible
+        chunk_relevancy_sorter = ChunkRelevancySorter(
+            company_id=self.event.company_id,
+            user_id=self.event.user_id,
+        )
         if isinstance(self.event, (ChatEvent, Event)):
-            if self.event.payload.correlation:
-                # Use parent chat id if correlation is present
-                chat_id = self.event.payload.correlation.parent_chat_id
-            else:
-                chat_id = self.event.payload.chat_id
+            settings = UniqueSettings.from_chat_event(self.event)
+            content_service = KnowledgeBaseService.from_settings(settings)
+            chat_id = (
+                self.event.payload.correlation.parent_chat_id
+                if self.event.payload.correlation
+                else self.event.payload.chat_id
+            )
         else:
+            content_service = KnowledgeBaseService(
+                company_id=self.event.company_id,
+                user_id=self.event.user_id,
+            )
             chat_id = None
         self._display_name = kwargs.get("display_name", "Internal Search")
         InternalSearchService.__init__(

--- a/tool_packages/unique_internal_search/unique_internal_search/service.py
+++ b/tool_packages/unique_internal_search/unique_internal_search/service.py
@@ -40,6 +40,7 @@ from unique_toolkit.language_model.schemas import (
     LanguageModelMessage,
     LanguageModelToolMessage,
 )
+from unique_toolkit.services.factory import UniqueServiceFactory
 from unique_toolkit.services.knowledge_base import KnowledgeBaseService
 
 from unique_internal_search.config import InternalSearchConfig
@@ -55,7 +56,7 @@ class InternalSearchService:
     def __init__(
         self,
         config: InternalSearchConfig,
-        content_service: KnowledgeBaseService,
+        kb_service: KnowledgeBaseService,
         chunk_relevancy_sorter: ChunkRelevancySorter,
         chat_id: str | None,
         logger: Logger,
@@ -65,7 +66,8 @@ class InternalSearchService:
         language_model_orchestrator: "LanguageModelInfo | None" = None,
     ):
         self.config = config
-        self.content_service = content_service
+        self.kb_service = kb_service
+        self._metadata_filter: dict | None = kb_service._metadata_filter
         self.chunk_relevancy_sorter = chunk_relevancy_sorter
         self.chat_id = chat_id
         self.company_id = company_id
@@ -81,7 +83,7 @@ class InternalSearchService:
         pass
 
     async def get_uploaded_files(self) -> list[Content]:
-        chat_results = await self.content_service.search_contents_async(
+        chat_results = await self.kb_service.search_contents_async(
             where={
                 "ownerId": {
                     "equals": self.chat_id,
@@ -141,27 +143,24 @@ class InternalSearchService:
         ###
         chat_only = await self.is_chat_only(**kwargs)
 
-        """
-        Handle the fact that metadata can exclude uploaded content
-        and that the search service is hardcoded to use the metadata_filter 
-        from the event if set to None
-        """
-        # Take a backup of the metadata filter
-        metadata_filter_copy = self.content_service._metadata_filter
-
-        if metadata_filter is None:
-            metadata_filter = self.content_service._metadata_filter
-        if chat_only and metadata_filter:
-            # if this is not set to none search_content_chunks_async will overwrite it inside its call thats why it needs to stay.
-            self.content_service._metadata_filter = None
-            metadata_filter = None
+        # Resolve effective metadata filter for this search.
+        # self._metadata_filter is captured at init from kb_service and used as the
+        # fallback when no explicit filter is provided by the caller.
+        # When chat_only=True, we must pass an explicit empty dict ({}) rather than None,
+        # because kb_service.search_content_chunks_async treats None as "use instance
+        # default", which would re-apply the filter we want to suppress.
+        effective_metadata_filter = (
+            metadata_filter if metadata_filter is not None else self._metadata_filter
+        )
+        if chat_only and effective_metadata_filter:
+            effective_metadata_filter = {}
 
         # Run all searches in parallel
         results = await asyncio.gather(
             *[
                 self._search_single_string(
                     search_string=search_string,
-                    metadata_filter=metadata_filter,
+                    metadata_filter=effective_metadata_filter,
                     chat_only=chat_only,
                     content_ids=content_ids,
                 )
@@ -174,9 +173,6 @@ class InternalSearchService:
         found_chunks_per_search_string = self._process_search_results(
             results, search_strings
         )
-
-        # Reset the metadata filter in case it was disabled
-        self.content_service._metadata_filter = metadata_filter_copy
 
         # Apply chunk relevancy sorter if enabled
         if self.config.chunk_relevancy_sort_config.enabled:
@@ -243,7 +239,7 @@ class InternalSearchService:
 
         self.debug_info = {
             "searchStrings": search_strings,
-            "metadataFilter": metadata_filter,
+            "metadataFilter": effective_metadata_filter,
             "chatOnly": chat_only,
         }
         return selected_chunks
@@ -259,7 +255,7 @@ class InternalSearchService:
         try:
             found_chunks: list[
                 ContentChunk
-            ] = await self.content_service.search_content_chunks_async(
+            ] = await self.kb_service.search_content_chunks_async(
                 search_string=search_string,  # type: ignore
                 search_type=self.config.search_type,
                 limit=self.config.limit,
@@ -430,23 +426,23 @@ class InternalSearchTool(Tool[InternalSearchConfig], InternalSearchService):
         )
         if isinstance(self.event, (ChatEvent, Event)):
             settings = UniqueSettings.from_chat_event(self.event)
-            content_service = KnowledgeBaseService.from_settings(settings)
             chat_id = (
                 self.event.payload.correlation.parent_chat_id
                 if self.event.payload.correlation
                 else self.event.payload.chat_id
             )
         else:
-            content_service = KnowledgeBaseService(
-                company_id=self.event.company_id,
-                user_id=self.event.user_id,
-            )
+            settings = UniqueSettings.from_event(self.event)
             chat_id = None
+        UniqueServiceFactory.register_known_services()
+        kb_service = UniqueServiceFactory.create(
+            KnowledgeBaseService, settings=settings
+        )
         self._display_name = kwargs.get("display_name", "Internal Search")
         InternalSearchService.__init__(
             self,
             config=configuration,
-            content_service=content_service,
+            kb_service=kb_service,
             chunk_relevancy_sorter=chunk_relevancy_sorter,
             chat_id=chat_id,
             company_id=self.event.company_id,

--- a/tool_packages/unique_internal_search/unique_internal_search/service.py
+++ b/tool_packages/unique_internal_search/unique_internal_search/service.py
@@ -29,7 +29,6 @@ from unique_toolkit.chat.schemas import (
 )
 from unique_toolkit.chat.service import LanguageModelToolDescription
 from unique_toolkit.content.schemas import Content, ContentChunk, ContentReference
-from unique_toolkit.content.service import ContentService
 from unique_toolkit.content.utils import (
     merge_content_chunks,
     pick_content_chunks_for_token_window,
@@ -40,6 +39,7 @@ from unique_toolkit.language_model.schemas import (
     LanguageModelMessage,
     LanguageModelToolMessage,
 )
+from unique_toolkit.services.knowledge_base import KnowledgeBaseService
 
 from unique_internal_search.config import InternalSearchConfig
 from unique_internal_search.utils import (
@@ -54,7 +54,7 @@ class InternalSearchService:
     def __init__(
         self,
         config: InternalSearchConfig,
-        content_service: ContentService,
+        content_service: KnowledgeBaseService,
         chunk_relevancy_sorter: ChunkRelevancySorter,
         chat_id: str | None,
         logger: Logger,
@@ -423,7 +423,7 @@ class InternalSearchTool(Tool[InternalSearchConfig], InternalSearchService):
     ):
         Tool.__init__(self, configuration, event, *args, **kwargs)
 
-        content_service = ContentService.from_event(self.event)
+        content_service = KnowledgeBaseService.from_event(self.event)
         chunk_relevancy_sorter = ChunkRelevancySorter.from_event(self.event)
         # Determing chat_id if possible
         if isinstance(self.event, (ChatEvent, Event)):

--- a/tool_packages/unique_internal_search/uv.lock
+++ b/tool_packages/unique_internal_search/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12, <4"
 
 [manifest]
@@ -2058,7 +2058,7 @@ wheels = [
 
 [[package]]
 name = "unique-toolkit"
-version = "1.64.0"
+version = "1.64.3"
 source = { editable = "../../unique_toolkit" }
 dependencies = [
     { name = "aiohttp" },

--- a/tool_packages/unique_internal_search/uv.lock
+++ b/tool_packages/unique_internal_search/uv.lock
@@ -2000,7 +2000,7 @@ wheels = [
 
 [[package]]
 name = "unique-internal-search"
-version = "1.2.34"
+version = "1.2.35"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },
@@ -2058,7 +2058,7 @@ wheels = [
 
 [[package]]
 name = "unique-toolkit"
-version = "1.64.3"
+version = "1.63.2"
 source = { editable = "../../unique_toolkit" }
 dependencies = [
     { name = "aiohttp" },

--- a/unique_toolkit/CHANGELOG.md
+++ b/unique_toolkit/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.64.4] - 2026-03-26
+- Add `UniqueSettings.from_event(event: BaseEvent)` — auth-only settings factory for non-chat events, mirroring `from_chat_event` (UN-18568)
+
 ## [1.64.3] - 2026-03-26
 - Config checker: CLI and validator improvements
 

--- a/unique_toolkit/CHANGELOG.md
+++ b/unique_toolkit/CHANGELOG.md
@@ -5,30 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.64.4] - 2026-03-26
-- Add `UniqueSettings.from_event(event: BaseEvent)` — auth-only settings factory for non-chat events, mirroring `from_chat_event` (UN-18568)
-
-## [1.64.3] - 2026-03-26
-- Config checker: CLI and validator improvements
-
-## [1.64.2] - 2026-03-26
-- Add `UniqueSettings.with_auth` to return a new settings instance with a given auth context while preserving app, api, chat, filter options, and env file reference (UN-18484)
-- Add tests for `UniqueSettings`
-
-## [1.64.1] - 2026-03-26
-- Add `enable_tool_call_persistence_un_15977` feature flag; when disabled (default), `get_full_history_with_contents` is used instead of `get_full_history_with_contents_and_tool_calls` and `enable_tool_call_persistence` is threaded through `HistoryManagerConfig` and `LoopTokenReducer` (UN-15977)
-
-## [1.64.0] - 2026-03-25
-- Code interpreter (UN-17972): orphan code runs — synthesise a `.txt` artifact and `fileWithSource` fence when code produces no container files, gated on `enable_code_execution_fence_un_17972` (replaces legacy `<details>` for that case)
-- Code interpreter (UN-17972): `OpenAICodeInterpreterTool.get_required_include_params()` returns `["code_interpreter_call.outputs"]` when the fence FF is on; add `OpenAIBuiltInTool.get_required_include_params()`, `OpenAIBuiltInToolManager.get_required_include_params()`, and `ResponsesApiToolManager.get_required_include_params()`; add `_collect_stdout` for `ResponseCodeInterpreterToolCall.outputs` (end-to-end `include` requires orchestrator PR)
-- Code interpreter (UN-17972): when fence FF is on, `ShowExecutedCodePostprocessor` is a no-op; remove `strip_executed_code_blocks` and its use in `DisplayCodeInterpreterFilesPostProcessor`; add optional `company_id` on `ShowExecutedCodePostprocessor` (orchestrator should pass company id alongside generated-files postprocessor)
-- Add unit test for `message.text is None` handling in `DisplayCodeInterpreterFilesPostProcessor.apply_postprocessing_to_response`
-
-## [1.63.2] - 2026-03-25
-- Code interpreter (UN-17972): emit `htmlWithSource` fences for `.html` artifacts when `enable_code_execution_fence_un_17972` is on; HTML uses the same sandbox-link → fence injection path as other files. Legacy `HtmlRendering` block is used only when the fence FF is off and `enable_html_rendering_un_15131` is on.
-- Fence-mode system prompt (`DEFAULT_TOOL_DESCRIPTION_FOR_SYSTEM_PROMPT_FENCE`): require HTML only as saved files under `/mnt/data/`, not inline in the assistant text; add UI-oriented best practices (HTML5 shell, self-contained CSS/JS, fluid layout, contrast, semantic elements, no parent-frame access).
-- `get_tool_prompts()`: treat stored `tool_description_for_system_prompt` as the unmodified default when it equals either `DEFAULT_TOOL_DESCRIPTION_FOR_SYSTEM_PROMPT` or `DEFAULT_TOOL_DESCRIPTION_FOR_SYSTEM_PROMPT_FENCE`, so spaces created across toolkit versions still receive the fence prompt when the FF is on.
-
 ## [1.63.1] - 2026-03-25
 - Broaden internal API URL matching to include hostnames that contain `.svc.` or end with `.svc`
 

--- a/unique_toolkit/pyproject.toml
+++ b/unique_toolkit/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "unique_toolkit"
-version = "1.64.4"
+version = "1.63.1"
 description = ""
 readme = "README.md"
 requires-python = ">=3.12"

--- a/unique_toolkit/pyproject.toml
+++ b/unique_toolkit/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "unique_toolkit"
-version = "1.64.3"
+version = "1.64.4"
 description = ""
 readme = "README.md"
 requires-python = ">=3.12"

--- a/unique_toolkit/tests/app/test_unique_settings.py
+++ b/unique_toolkit/tests/app/test_unique_settings.py
@@ -1339,3 +1339,73 @@ class TestUniqueContext:
         )
         ctx = UniqueContext.from_event(event)
         assert ctx.chat is None
+
+
+class TestUniqueSettingsFromEvent:
+    """Tests for UniqueSettings.from_event (auth-only settings from a plain BaseEvent)."""
+
+    @pytest.mark.ai
+    def test_from_event__maps_company_id(self) -> None:
+        """
+        Purpose: Verify company_id is extracted from the event into auth.
+        Why this matters: Wrong company_id silently routes requests to another tenant.
+        Setup summary: BaseEvent with company-base; assert authcontext.company_id matches.
+        """
+        event = BaseEvent(
+            id="evt-1",
+            event=EventName.EXTERNAL_MODULE_CHOSEN,
+            user_id="user-1",
+            company_id="company-base",
+        )
+        settings = UniqueSettings.from_event(event)
+        assert settings.authcontext.get_confidential_company_id() == "company-base"
+
+    @pytest.mark.ai
+    def test_from_event__maps_user_id(self) -> None:
+        """
+        Purpose: Verify user_id is extracted from the event into auth.
+        Why this matters: Wrong user_id attributes actions to the wrong user.
+        Setup summary: BaseEvent with user-base; assert authcontext.user_id matches.
+        """
+        event = BaseEvent(
+            id="evt-1",
+            event=EventName.EXTERNAL_MODULE_CHOSEN,
+            user_id="user-base",
+            company_id="company-1",
+        )
+        settings = UniqueSettings.from_event(event)
+        assert settings.authcontext.get_confidential_user_id() == "user-base"
+
+    @pytest.mark.ai
+    def test_from_event__has_no_chat_context(self) -> None:
+        """
+        Purpose: Verify settings built from a BaseEvent carry no chat context.
+        Why this matters: Callers using UniqueServiceFactory.create with these settings must not
+        accidentally receive a chat-scoped KnowledgeBaseService.
+        Setup summary: BaseEvent; assert settings.context.chat is None.
+        """
+        event = BaseEvent(
+            id="evt-1",
+            event=EventName.EXTERNAL_MODULE_CHOSEN,
+            user_id="user-1",
+            company_id="company-1",
+        )
+        settings = UniqueSettings.from_event(event)
+        assert settings.context.chat is None
+
+    @pytest.mark.ai
+    def test_from_event__uses_default_app_and_api(self) -> None:
+        """
+        Purpose: Verify that app and api are populated with default values, not None.
+        Why this matters: Services may read app/api; None would cause AttributeErrors.
+        Setup summary: BaseEvent; assert settings.app and settings.api are not None.
+        """
+        event = BaseEvent(
+            id="evt-1",
+            event=EventName.EXTERNAL_MODULE_CHOSEN,
+            user_id="user-1",
+            company_id="company-1",
+        )
+        settings = UniqueSettings.from_event(event)
+        assert settings.app is not None
+        assert settings.api is not None

--- a/unique_toolkit/tests/app/test_unique_settings.py
+++ b/unique_toolkit/tests/app/test_unique_settings.py
@@ -15,7 +15,6 @@ from unique_toolkit.app.schemas import (
 )
 from unique_toolkit.app.unique_settings import (
     AuthContext,
-    ChatContext,
     EnvFileNotFoundError,
     UniqueApi,
     UniqueApp,
@@ -1043,58 +1042,6 @@ def test_unique_settings__init__ignores_env_file__when_not_exists(
 
 
 @pytest.mark.ai
-def test_unique_settings__with_auth__returns_distinct_instance__with_new_auth(
-    valid_auth: UniqueAuth, valid_app: UniqueApp, valid_api: UniqueApi
-) -> None:
-    """Branch settings with a new AuthContext; app/api shared, original auth unchanged."""
-    settings = UniqueSettings(auth=valid_auth, app=valid_app, api=valid_api)
-    new_auth = AuthContext(
-        company_id=SecretStr("branch-co"), user_id=SecretStr("branch-user")
-    )
-    branched = settings.with_auth(new_auth)
-    assert branched is not settings
-    assert branched.authcontext is new_auth
-    assert branched.authcontext.get_confidential_company_id() == "branch-co"
-    assert branched.authcontext.get_confidential_user_id() == "branch-user"
-    assert settings.authcontext is valid_auth
-    assert branched.app is valid_app
-    assert branched.api is valid_api
-    assert branched.context.chat is None
-
-
-@pytest.mark.ai
-def test_unique_settings__with_auth__preserves_chat_filters_and_env_file(
-    valid_auth: UniqueAuth,
-    valid_app: UniqueApp,
-    valid_api: UniqueApi,
-    tmp_path: Path,
-) -> None:
-    """with_auth keeps chat, filter options, and stored env file path on the clone."""
-    env_file = tmp_path / "branch.env"
-    env_file.write_text("FOO=bar")
-    chat = ChatContext(chat_id="chat-z", assistant_id="asst-z")
-    filters = UniqueChatEventFilterOptions(
-        assistant_ids=["a1"], references_in_code=["m1"]
-    )
-    settings = UniqueSettings(
-        auth=valid_auth,
-        app=valid_app,
-        api=valid_api,
-        chat_event_filter_options=filters,
-        chat=chat,
-        env_file=env_file,
-    )
-    new_auth = AuthContext(
-        company_id=SecretStr("other-co"), user_id=SecretStr("other-user")
-    )
-    branched = settings.with_auth(new_auth)
-    assert branched.authcontext is new_auth
-    assert branched.context.chat is chat
-    assert branched.chat_event_filter_options is filters
-    assert branched._env_file == env_file
-
-
-@pytest.mark.ai
 def test_env_file_not_found_error__is_file_not_found_error() -> None:
     """
     Purpose: Verify EnvFileNotFoundError is a subclass of FileNotFoundError.
@@ -1339,73 +1286,3 @@ class TestUniqueContext:
         )
         ctx = UniqueContext.from_event(event)
         assert ctx.chat is None
-
-
-class TestUniqueSettingsFromEvent:
-    """Tests for UniqueSettings.from_event (auth-only settings from a plain BaseEvent)."""
-
-    @pytest.mark.ai
-    def test_from_event__maps_company_id(self) -> None:
-        """
-        Purpose: Verify company_id is extracted from the event into auth.
-        Why this matters: Wrong company_id silently routes requests to another tenant.
-        Setup summary: BaseEvent with company-base; assert authcontext.company_id matches.
-        """
-        event = BaseEvent(
-            id="evt-1",
-            event=EventName.EXTERNAL_MODULE_CHOSEN,
-            user_id="user-1",
-            company_id="company-base",
-        )
-        settings = UniqueSettings.from_event(event)
-        assert settings.authcontext.get_confidential_company_id() == "company-base"
-
-    @pytest.mark.ai
-    def test_from_event__maps_user_id(self) -> None:
-        """
-        Purpose: Verify user_id is extracted from the event into auth.
-        Why this matters: Wrong user_id attributes actions to the wrong user.
-        Setup summary: BaseEvent with user-base; assert authcontext.user_id matches.
-        """
-        event = BaseEvent(
-            id="evt-1",
-            event=EventName.EXTERNAL_MODULE_CHOSEN,
-            user_id="user-base",
-            company_id="company-1",
-        )
-        settings = UniqueSettings.from_event(event)
-        assert settings.authcontext.get_confidential_user_id() == "user-base"
-
-    @pytest.mark.ai
-    def test_from_event__has_no_chat_context(self) -> None:
-        """
-        Purpose: Verify settings built from a BaseEvent carry no chat context.
-        Why this matters: Callers using UniqueServiceFactory.create with these settings must not
-        accidentally receive a chat-scoped KnowledgeBaseService.
-        Setup summary: BaseEvent; assert settings.context.chat is None.
-        """
-        event = BaseEvent(
-            id="evt-1",
-            event=EventName.EXTERNAL_MODULE_CHOSEN,
-            user_id="user-1",
-            company_id="company-1",
-        )
-        settings = UniqueSettings.from_event(event)
-        assert settings.context.chat is None
-
-    @pytest.mark.ai
-    def test_from_event__uses_default_app_and_api(self) -> None:
-        """
-        Purpose: Verify that app and api are populated with default values, not None.
-        Why this matters: Services may read app/api; None would cause AttributeErrors.
-        Setup summary: BaseEvent; assert settings.app and settings.api are not None.
-        """
-        event = BaseEvent(
-            id="evt-1",
-            event=EventName.EXTERNAL_MODULE_CHOSEN,
-            user_id="user-1",
-            company_id="company-1",
-        )
-        settings = UniqueSettings.from_event(event)
-        assert settings.app is not None
-        assert settings.api is not None

--- a/unique_toolkit/unique_toolkit/app/unique_settings.py
+++ b/unique_toolkit/unique_toolkit/app/unique_settings.py
@@ -622,6 +622,26 @@ class UniqueSettings:
             chat=ChatContext.from_chat_event(event),
         )
 
+    @classmethod
+    def from_event(cls, event: "BaseEvent") -> "UniqueSettings":
+        """Build an auth-only :class:`UniqueSettings` from any :class:`BaseEvent`.
+
+        No chat context is set — use :meth:`from_chat_event` when a chat
+        context is available.  App and API settings are left at their
+        default values.
+
+        Args:
+            event: Any incoming event carrying company_id and user_id.
+
+        Returns:
+            UniqueSettings with only auth context populated from the event.
+        """
+        return cls(
+            auth=AuthContext.from_event(event),
+            app=UniqueApp(),
+            api=UniqueApi(),
+        )
+
     @property
     def context(self) -> UniqueContext:
         """The request-level context (auth + optional chat) for this settings object."""

--- a/unique_toolkit/unique_toolkit/app/unique_settings.py
+++ b/unique_toolkit/unique_toolkit/app/unique_settings.py
@@ -622,26 +622,6 @@ class UniqueSettings:
             chat=ChatContext.from_chat_event(event),
         )
 
-    @classmethod
-    def from_event(cls, event: "BaseEvent") -> "UniqueSettings":
-        """Build an auth-only :class:`UniqueSettings` from any :class:`BaseEvent`.
-
-        No chat context is set — use :meth:`from_chat_event` when a chat
-        context is available.  App and API settings are left at their
-        default values.
-
-        Args:
-            event: Any incoming event carrying company_id and user_id.
-
-        Returns:
-            UniqueSettings with only auth context populated from the event.
-        """
-        return cls(
-            auth=AuthContext.from_event(event),
-            app=UniqueApp(),
-            api=UniqueApi(),
-        )
-
     @property
     def context(self) -> UniqueContext:
         """The request-level context (auth + optional chat) for this settings object."""
@@ -652,18 +632,6 @@ class UniqueSettings:
         # keeps working for callers that haven't migrated yet.
         self._context = UniqueContext(
             auth=UniqueAuth.from_event(event), chat=self._context.chat
-        )
-
-    # utility method to return a copy with new auth context
-    def with_auth(self, auth: AuthContextProtocol) -> Self:
-        """Return a copy of the settings with the new auth context."""
-        return self.__class__(
-            auth=auth,
-            app=self.app,
-            api=self.api,
-            chat_event_filter_options=self.chat_event_filter_options,
-            chat=self._context.chat,
-            env_file=self._env_file,
         )
 
     @property

--- a/unique_toolkit/unique_toolkit/services/knowledge_base.py
+++ b/unique_toolkit/unique_toolkit/services/knowledge_base.py
@@ -182,6 +182,53 @@ class KnowledgeBaseService:
         reranker_config: ContentRerankerConfig | None = None,
     ) -> list[ContentChunk]: ...
 
+    @overload
+    def search_content_chunks(
+        self,
+        *,
+        search_string: str,
+        search_type: ContentSearchType,
+        limit: int,
+        scope_ids: list[str],
+        score_threshold: float = _DEFAULT_SCORE_THRESHOLD,
+        search_language: str = DEFAULT_SEARCH_LANGUAGE,
+        reranker_config: ContentRerankerConfig | None = None,
+        chat_id: str | None = None,
+        chat_only: bool = False,
+    ) -> list[ContentChunk]: ...
+
+    @overload
+    def search_content_chunks(
+        self,
+        *,
+        search_string: str,
+        search_type: ContentSearchType,
+        limit: int,
+        metadata_filter: dict,
+        scope_ids: list[str] | None = None,
+        score_threshold: float = _DEFAULT_SCORE_THRESHOLD,
+        search_language: str = DEFAULT_SEARCH_LANGUAGE,
+        reranker_config: ContentRerankerConfig | None = None,
+        chat_id: str | None = None,
+        chat_only: bool = False,
+    ) -> list[ContentChunk]: ...
+
+    @overload
+    def search_content_chunks(
+        self,
+        *,
+        search_string: str,
+        search_type: ContentSearchType,
+        limit: int,
+        metadata_filter: dict,
+        content_ids: list[str],
+        score_threshold: float = _DEFAULT_SCORE_THRESHOLD,
+        search_language: str = DEFAULT_SEARCH_LANGUAGE,
+        reranker_config: ContentRerankerConfig | None = None,
+        chat_id: str | None = None,
+        chat_only: bool = False,
+    ) -> list[ContentChunk]: ...
+
     def search_content_chunks(
         self,
         *,
@@ -194,6 +241,8 @@ class KnowledgeBaseService:
         metadata_filter: dict | None = None,
         content_ids: list[str] | None = None,
         score_threshold: float | None = None,
+        chat_id: str | None = None,
+        chat_only: bool = False,
     ) -> list[ContentChunk]:
         """
         Performs a synchronous search for content chunks in the knowledge base.
@@ -208,6 +257,8 @@ class KnowledgeBaseService:
             metadata_filter (dict | None, optional): UniqueQL metadata filter. If unspecified/None, it tries to use the metadata filter from the event. Defaults to None.
             content_ids (list[str] | None, optional): The content IDs to search within. Defaults to None.
             score_threshold (float | None, optional): Sets the minimum similarity score for search results to be considered. Defaults to 0.
+            chat_id (str | None, optional): The chat ID for the search. Defaults to None.
+            chat_only (bool, optional): Whether to search only in chat-specific content. Defaults to False.
 
         Returns:
             list[ContentChunk]: The search results.
@@ -219,18 +270,21 @@ class KnowledgeBaseService:
         if metadata_filter is None:
             metadata_filter = self._metadata_filter
 
+        if chat_id is None:
+            chat_id = ""
+
         try:
             searches = search_content_chunks(
                 user_id=self._user_id,
                 company_id=self._company_id,
-                chat_id="",
+                chat_id=chat_id,
                 search_string=search_string,
                 search_type=search_type,
                 limit=limit,
                 search_language=search_language,
                 reranker_config=reranker_config,
                 scope_ids=scope_ids,
-                chat_only=False,
+                chat_only=chat_only,
                 metadata_filter=metadata_filter,
                 content_ids=content_ids,
                 score_threshold=score_threshold,
@@ -281,6 +335,53 @@ class KnowledgeBaseService:
         reranker_config: ContentRerankerConfig | None = None,
     ) -> list[ContentChunk]: ...
 
+    @overload
+    async def search_content_chunks_async(
+        self,
+        *,
+        search_string: str,
+        search_type: ContentSearchType,
+        limit: int,
+        scope_ids: list[str],
+        score_threshold: float = _DEFAULT_SCORE_THRESHOLD,
+        search_language: str = DEFAULT_SEARCH_LANGUAGE,
+        reranker_config: ContentRerankerConfig | None = None,
+        chat_id: str | None = None,
+        chat_only: bool = False,
+    ) -> list[ContentChunk]: ...
+
+    @overload
+    async def search_content_chunks_async(
+        self,
+        *,
+        search_string: str,
+        search_type: ContentSearchType,
+        limit: int,
+        metadata_filter: dict,
+        scope_ids: list[str] | None = None,
+        score_threshold: float = _DEFAULT_SCORE_THRESHOLD,
+        search_language: str = DEFAULT_SEARCH_LANGUAGE,
+        reranker_config: ContentRerankerConfig | None = None,
+        chat_id: str | None = None,
+        chat_only: bool = False,
+    ) -> list[ContentChunk]: ...
+
+    @overload
+    async def search_content_chunks_async(
+        self,
+        *,
+        search_string: str,
+        search_type: ContentSearchType,
+        limit: int,
+        metadata_filter: dict,
+        content_ids: list[str],
+        score_threshold: float = _DEFAULT_SCORE_THRESHOLD,
+        search_language: str = DEFAULT_SEARCH_LANGUAGE,
+        reranker_config: ContentRerankerConfig | None = None,
+        chat_id: str | None = None,
+        chat_only: bool = False,
+    ) -> list[ContentChunk]: ...
+
     async def search_content_chunks_async(
         self,
         *,
@@ -293,6 +394,8 @@ class KnowledgeBaseService:
         metadata_filter: dict | None = None,
         content_ids: list[str] | None = None,
         score_threshold: float | None = None,
+        chat_id: str | None = None,
+        chat_only: bool = False,
     ):
         """
         Performs an asynchronous search for content chunks in the knowledge base.
@@ -307,6 +410,8 @@ class KnowledgeBaseService:
             metadata_filter (dict | None, optional): UniqueQL metadata filter. If unspecified/None, it tries to use the metadata filter from the event. Defaults to None.
             content_ids (list[str] | None, optional): The content IDs to search within. Defaults to None.
             score_threshold (float | None, optional): Sets the minimum similarity score for search results to be considered. Defaults to 0.
+            chat_id (str | None, optional): The chat ID for the search. Defaults to None.
+            chat_only (bool, optional): Whether to search only in chat-specific content. Defaults to False.
 
         Returns:
             list[ContentChunk]: The search results.
@@ -317,18 +422,21 @@ class KnowledgeBaseService:
         if metadata_filter is None:
             metadata_filter = self._metadata_filter
 
+        if chat_id is None:
+            chat_id = ""
+
         try:
             searches = await search_content_chunks_async(
                 user_id=self._user_id,
                 company_id=self._company_id,
-                chat_id="",
+                chat_id=chat_id,
                 search_string=search_string,
                 search_type=search_type,
                 limit=limit,
                 search_language=search_language,
                 reranker_config=reranker_config,
                 scope_ids=scope_ids,
-                chat_only=False,
+                chat_only=chat_only,
                 metadata_filter=metadata_filter,
                 content_ids=content_ids,
                 score_threshold=score_threshold,

--- a/unique_toolkit/unique_toolkit/services/knowledge_base.py
+++ b/unique_toolkit/unique_toolkit/services/knowledge_base.py
@@ -64,10 +64,9 @@ class KnowledgeBaseService:
         company_id: str,
         user_id: str,
         metadata_filter: dict | None = None,
-        chat_id: str = "",
     ):
         """
-        Initialize the KnowledgeBaseService with a company_id, user_id, optional metadata_filter and chat_id.
+        Initialize the KnowledgeBaseService with a company_id, user_id and chat_id.
         """
 
         self._metadata_filter = None
@@ -75,7 +74,6 @@ class KnowledgeBaseService:
         self._company_id = company_id
         self._user_id = user_id
         self._metadata_filter = metadata_filter
-        self._chat_id = chat_id
 
     @classmethod
     @deprecated(
@@ -88,16 +86,13 @@ class KnowledgeBaseService:
         """
         metadata_filter = None
 
-        chat_id = ""
         if isinstance(event, (ChatEvent | Event)):
             metadata_filter = event.payload.metadata_filter
-            chat_id = event.payload.chat_id
 
         return cls(
             company_id=event.company_id,
             user_id=event.user_id,
             metadata_filter=metadata_filter,
-            chat_id=chat_id,
         )
 
     @classmethod
@@ -116,7 +111,6 @@ class KnowledgeBaseService:
             company_id=context.auth.get_confidential_company_id(),
             user_id=context.auth.get_confidential_user_id(),
             metadata_filter=metadata_filter,
-            chat_id=context.chat.chat_id if context.chat is not None else "",
         )
 
     @classmethod
@@ -142,9 +136,6 @@ class KnowledgeBaseService:
             company_id=settings.authcontext.get_confidential_company_id(),
             user_id=settings.authcontext.get_confidential_user_id(),
             metadata_filter=metadata_filter,
-            chat_id=settings.context.chat.chat_id
-            if settings.context.chat is not None
-            else "",
         )
 
     # Content Search
@@ -203,8 +194,6 @@ class KnowledgeBaseService:
         metadata_filter: dict | None = None,
         content_ids: list[str] | None = None,
         score_threshold: float | None = None,
-        chat_id: str | None = None,
-        chat_only: bool = False,
     ) -> list[ContentChunk]:
         """
         Performs a synchronous search for content chunks in the knowledge base.
@@ -234,14 +223,14 @@ class KnowledgeBaseService:
             searches = search_content_chunks(
                 user_id=self._user_id,
                 company_id=self._company_id,
-                chat_id=chat_id if chat_id is not None else self._chat_id,
+                chat_id="",
                 search_string=search_string,
                 search_type=search_type,
                 limit=limit,
                 search_language=search_language,
                 reranker_config=reranker_config,
                 scope_ids=scope_ids,
-                chat_only=chat_only,
+                chat_only=False,
                 metadata_filter=metadata_filter,
                 content_ids=content_ids,
                 score_threshold=score_threshold,
@@ -304,8 +293,6 @@ class KnowledgeBaseService:
         metadata_filter: dict | None = None,
         content_ids: list[str] | None = None,
         score_threshold: float | None = None,
-        chat_id: str | None = None,
-        chat_only: bool = False,
     ):
         """
         Performs an asynchronous search for content chunks in the knowledge base.
@@ -334,14 +321,14 @@ class KnowledgeBaseService:
             searches = await search_content_chunks_async(
                 user_id=self._user_id,
                 company_id=self._company_id,
-                chat_id=chat_id if chat_id is not None else self._chat_id,
+                chat_id="",
                 search_string=search_string,
                 search_type=search_type,
                 limit=limit,
                 search_language=search_language,
                 reranker_config=reranker_config,
                 scope_ids=scope_ids,
-                chat_only=chat_only,
+                chat_only=False,
                 metadata_filter=metadata_filter,
                 content_ids=content_ids,
                 score_threshold=score_threshold,
@@ -371,7 +358,7 @@ class KnowledgeBaseService:
         return search_contents(
             user_id=self._user_id,
             company_id=self._company_id,
-            chat_id=self._chat_id,
+            chat_id="",
             where=where,
             include_failed_content=include_failed_content,
         )
@@ -395,7 +382,7 @@ class KnowledgeBaseService:
         return await search_contents_async(
             user_id=self._user_id,
             company_id=self._company_id,
-            chat_id=self._chat_id,
+            chat_id="",
             where=where,
             include_failed_content=include_failed_content,
         )

--- a/unique_toolkit/unique_toolkit/services/knowledge_base.py
+++ b/unique_toolkit/unique_toolkit/services/knowledge_base.py
@@ -64,9 +64,10 @@ class KnowledgeBaseService:
         company_id: str,
         user_id: str,
         metadata_filter: dict | None = None,
+        chat_id: str = "",
     ):
         """
-        Initialize the KnowledgeBaseService with a company_id, user_id and chat_id.
+        Initialize the KnowledgeBaseService with a company_id, user_id, optional metadata_filter and chat_id.
         """
 
         self._metadata_filter = None
@@ -74,6 +75,7 @@ class KnowledgeBaseService:
         self._company_id = company_id
         self._user_id = user_id
         self._metadata_filter = metadata_filter
+        self._chat_id = chat_id
 
     @classmethod
     @deprecated(
@@ -86,13 +88,16 @@ class KnowledgeBaseService:
         """
         metadata_filter = None
 
+        chat_id = ""
         if isinstance(event, (ChatEvent | Event)):
             metadata_filter = event.payload.metadata_filter
+            chat_id = event.payload.chat_id
 
         return cls(
             company_id=event.company_id,
             user_id=event.user_id,
             metadata_filter=metadata_filter,
+            chat_id=chat_id,
         )
 
     @classmethod
@@ -111,6 +116,7 @@ class KnowledgeBaseService:
             company_id=context.auth.get_confidential_company_id(),
             user_id=context.auth.get_confidential_user_id(),
             metadata_filter=metadata_filter,
+            chat_id=context.chat.chat_id if context.chat is not None else "",
         )
 
     @classmethod
@@ -136,6 +142,9 @@ class KnowledgeBaseService:
             company_id=settings.authcontext.get_confidential_company_id(),
             user_id=settings.authcontext.get_confidential_user_id(),
             metadata_filter=metadata_filter,
+            chat_id=settings.context.chat.chat_id
+            if settings.context.chat is not None
+            else "",
         )
 
     # Content Search
@@ -194,6 +203,8 @@ class KnowledgeBaseService:
         metadata_filter: dict | None = None,
         content_ids: list[str] | None = None,
         score_threshold: float | None = None,
+        chat_id: str | None = None,
+        chat_only: bool = False,
     ) -> list[ContentChunk]:
         """
         Performs a synchronous search for content chunks in the knowledge base.
@@ -223,14 +234,14 @@ class KnowledgeBaseService:
             searches = search_content_chunks(
                 user_id=self._user_id,
                 company_id=self._company_id,
-                chat_id="",
+                chat_id=chat_id if chat_id is not None else self._chat_id,
                 search_string=search_string,
                 search_type=search_type,
                 limit=limit,
                 search_language=search_language,
                 reranker_config=reranker_config,
                 scope_ids=scope_ids,
-                chat_only=False,
+                chat_only=chat_only,
                 metadata_filter=metadata_filter,
                 content_ids=content_ids,
                 score_threshold=score_threshold,
@@ -293,6 +304,8 @@ class KnowledgeBaseService:
         metadata_filter: dict | None = None,
         content_ids: list[str] | None = None,
         score_threshold: float | None = None,
+        chat_id: str | None = None,
+        chat_only: bool = False,
     ):
         """
         Performs an asynchronous search for content chunks in the knowledge base.
@@ -321,14 +334,14 @@ class KnowledgeBaseService:
             searches = await search_content_chunks_async(
                 user_id=self._user_id,
                 company_id=self._company_id,
-                chat_id="",
+                chat_id=chat_id if chat_id is not None else self._chat_id,
                 search_string=search_string,
                 search_type=search_type,
                 limit=limit,
                 search_language=search_language,
                 reranker_config=reranker_config,
                 scope_ids=scope_ids,
-                chat_only=False,
+                chat_only=chat_only,
                 metadata_filter=metadata_filter,
                 content_ids=content_ids,
                 score_threshold=score_threshold,
@@ -358,7 +371,7 @@ class KnowledgeBaseService:
         return search_contents(
             user_id=self._user_id,
             company_id=self._company_id,
-            chat_id="",
+            chat_id=self._chat_id,
             where=where,
             include_failed_content=include_failed_content,
         )
@@ -382,7 +395,7 @@ class KnowledgeBaseService:
         return await search_contents_async(
             user_id=self._user_id,
             company_id=self._company_id,
-            chat_id="",
+            chat_id=self._chat_id,
             where=where,
             include_failed_content=include_failed_content,
         )


### PR DESCRIPTION
## Summary

- **`InternalSearchTool`**: both `ChatEvent` and `BaseEvent` branches now build a `KnowledgeBaseService` through `UniqueSettings` + `UniqueServiceFactory.create(KnowledgeBaseService, settings=settings)` — no more direct `company_id`/`user_id` constructor calls
- **`_metadata_filter` mutation fix**: `InternalSearchService` captures the filter at `__init__` time; passes `{}` (not `None`) when `chat_only=True` to prevent the `KBService` fallback without mutating service internals
- **Rename**: `content_service` → `kb_service` throughout `InternalSearchService` and fixtures
- **Tests**: `mock_kb_service` fixture now owns `UniqueServiceFactory.override` so all tests exercise the real factory code path; removed ad-hoc `@patch("...KnowledgeBaseService")` decorators from `TestInternalSearchTool`
- Bump `unique_internal_search` `1.2.34` → `1.2.35`; update `unique-toolkit` constraint to `>=1.63.2`

## Merge order

**⚠️ Requires #1294 to be merged first.**
This branch needs `unique-toolkit>=1.63.2` (for `UniqueSettings.from_event` and the `KnowledgeBaseService` `chat_id` extension).

## Test plan

- [ ] `pytest tool_packages/unique_internal_search/` passes fully
- [ ] `InternalSearchTool` initialises correctly for both `ChatEvent` and plain `BaseEvent`
- [ ] `mock_kb_service` fixture override wires through for all tool-level tests