### PR TITLE
feat(sdk): align Content.Chunk TypedDict with public chunk wire format

### DIFF
--- a/unique_sdk/tests/test_content_chunk_unit.py
+++ b/unique_sdk/tests/test_content_chunk_unit.py
@@ -1,0 +1,35 @@
+"""Unit tests for ``Content.Chunk`` TypedDict (public API / GraphQL parity)."""
+
+from __future__ import annotations
+
+import unique_sdk
+
+
+def test_AI_content_chunk_accepts_minimal_embedded_search_shape():
+    """Embedded chunk hits may only expose id, text, and page metadata."""
+    minimal: unique_sdk.Content.Chunk = {
+        "id": "chunk_1",
+        "text": "body",
+        "startPage": 1,
+        "endPage": 1,
+        "order": 0,
+    }
+    assert minimal["id"] == "chunk_1"
+
+
+def test_AI_content_chunk_accepts_full_public_chunk_shape():
+    """Full chunk records include contentId, timestamps, model, and object."""
+    full: unique_sdk.Content.Chunk = {
+        "id": "chunk_1",
+        "text": "body",
+        "contentId": "cont_1",
+        "createdAt": "2021-01-01T00:00:00.000Z",
+        "updatedAt": "2021-01-01T00:00:00.000Z",
+        "object": "chunk",
+        "startPage": 1,
+        "endPage": 2,
+        "order": 0,
+        "model": "text-embedding-3-small",
+    }
+    assert full["contentId"] == "cont_1"
+    assert full["object"] == "chunk"

--- a/unique_sdk/unique_sdk/api_resources/_content.py
+++ b/unique_sdk/unique_sdk/api_resources/_content.py
@@ -168,11 +168,24 @@ class Content(APIResource["Content"]):
         ingestionState: str
 
     class Chunk(TypedDict):
+        """Chunk on the wire (content search, chunk mutations).
+
+        Field names match the public API / GraphQL ``Chunk`` type (camelCase).
+        Embedded chunks in some search responses may omit metadata; those entries
+        are optional. Full chunk records include ``contentId``, timestamps, and
+        ``object`` (typically ``\"chunk\"``).
+        """
+
         id: str
         text: str
-        startPage: int | None
-        endPage: int | None
-        order: int | None
+        contentId: NotRequired[str]
+        createdAt: NotRequired[str]
+        updatedAt: NotRequired[str]
+        object: NotRequired[str]
+        startPage: NotRequired[int | None]
+        endPage: NotRequired[int | None]
+        order: NotRequired[int | None]
+        model: NotRequired[str | None]
 
     class ContentInfo(TypedDict):
         """


### PR DESCRIPTION
## Summary

Extends `Content.Chunk` so it matches the fields exposed by the public chunk / GraphQL `Chunk` type (camelCase keys). Slender embedded chunks from content search can still omit metadata; those keys are `NotRequired`.

## Changes

- Add optional `contentId`, `createdAt`, `updatedAt`, `object`, `model`.
- Treat `startPage`, `endPage`, and `order` as optional keys (with nullable int where present), consistent with optional fields on the TS DTOs.

## Cross-service reference

- Chunk DTO: [PublicChunkDto](https://github.com/Unique-AG/monorepo/blob/master/next/services/node-chat/src/public-api/2023-12-06/dtos/chunk/public-chunk.dto.ts)
- Routes using the create mutation DTO: [PublicChunkController](https://github.com/Unique-AG/monorepo/blob/master/next/services/node-chat/src/public-api/2023-12-06/chunk/public-chunk.controller.ts)

## Tests

- `uv run pytest unique_sdk/tests/test_content_chunk_unit.py`
- `uv run poe -C unique_sdk typecheck`


Made with [Cursor](https://cursor.com)