### PR TITLE
feat(sdk): align Content search and ContentInfo types with public content DTOs

### DIFF
--- a/unique_sdk/tests/test_content_info_unit.py
+++ b/unique_sdk/tests/test_content_info_unit.py
@@ -1,0 +1,47 @@
+"""Unit tests for ``Content`` search / content-info TypedDict shapes."""
+
+from __future__ import annotations
+
+import unique_sdk
+
+
+def test_AI_content_where_input_accepts_parent_id_filter():
+    """Public ContentWhereInput includes parentId (StringNullableFilter)."""
+    where: unique_sdk.Content.ContentWhereInput = {
+        "parentId": {"equals": "scope_123"},
+    }
+    assert where["parentId"] == {"equals": "scope_123"}
+
+
+def test_AI_content_info_matches_nullable_metric_fields():
+    """Content info payloads may null byteSize, mimeType, ownerId, ingestionState."""
+    row: unique_sdk.Content.ContentInfo = {
+        "id": "cont_1",
+        "key": "doc.pdf",
+        "url": None,
+        "title": None,
+        "description": None,
+        "metadata": {"k": "v"},
+        "byteSize": None,
+        "mimeType": None,
+        "ownerId": None,
+        "ingestionState": None,
+        "createdAt": "2021-01-01T00:00:00.000Z",
+        "updatedAt": "2021-01-01T00:00:00.000Z",
+        "expiresAt": None,
+        "deletedAt": None,
+        "expiredAt": None,
+        "object": "content-info",
+    }
+    assert row["byteSize"] is None
+    assert row.get("object") == "content-info"
+
+
+def test_AI_paginated_content_infos_optional_object_discriminator():
+    """List endpoints may include an object tag (e.g. content-infos)."""
+    page: unique_sdk.Content.PaginatedContentInfos = {
+        "contentInfos": [],
+        "totalCount": 0,
+        "object": "content-infos",
+    }
+    assert page["object"] == "content-infos"

--- a/unique_sdk/unique_sdk/api_resources/_content.py
+++ b/unique_sdk/unique_sdk/api_resources/_content.py
@@ -23,6 +23,9 @@ class Content(APIResource["Content"]):
     key: str
     url: str | None
     title: str | None
+    description: str | None
+    mimeType: str | None
+    createdAt: str
     updatedAt: str
     chunks: list["Content.Chunk"] | None
     metadata: dict[str, Any] | None
@@ -30,6 +33,8 @@ class Content(APIResource["Content"]):
     readUrl: str | None
     expiredAt: str | None
     appliedIngestionConfig: dict[str, Any] | None
+    ingestionState: str
+    object: str
 
     class QueryMode(Enum):
         Default = "default"
@@ -79,6 +84,7 @@ class Content(APIResource["Content"]):
         ownerId: "Content.StringFilter | None"
         title: "Content.StringNullableFilter | None"
         url: "Content.StringNullableFilter | None"
+        parentId: "Content.StringNullableFilter | None"
 
     class SearchParams(RequestOptions):
         where: "Content.ContentWhereInput"
@@ -184,24 +190,28 @@ class Content(APIResource["Content"]):
         key: str
         url: str | None
         title: str | None
-        metadata: dict[str, Any] | None
-        mimeType: str
         description: str | None
-        byteSize: int
-        ownerId: str
+        metadata: dict[str, Any] | None
+        byteSize: int | None
+        mimeType: str | None
+        ownerId: str | None
+        ingestionState: str | None
         createdAt: str
         updatedAt: str
         expiresAt: str | None
         deletedAt: str | None
         expiredAt: str | None
+        object: NotRequired[str]
 
     class PaginatedContentInfo(TypedDict):
         contentInfo: list["Content.ContentInfo"]
         totalCount: int
+        object: NotRequired[str]
 
     class PaginatedContentInfos(TypedDict):
         contentInfos: list["Content.ContentInfo"]
         totalCount: int
+        object: NotRequired[str]
 
     class DeleteParams(RequestOptions):
         contentId: NotRequired[str]

--- a/unique_sdk/unique_sdk/cli/formatting.py
+++ b/unique_sdk/unique_sdk/cli/formatting.py
@@ -114,12 +114,12 @@ def format_search_results(results: list[Any]) -> str:
 
 def format_content_info(info: Content.ContentInfo) -> str:
     """Format a single content info record."""
-    rows = [
+    rows: list[list[str]] = [
         ["ID:", info.get("id", "?")],
         ["Title:", info.get("title") or info.get("key") or "?"],
-        ["MIME:", info.get("mimeType", "?")],
+        ["MIME:", info.get("mimeType") or "?"],
         ["Size:", _format_size(info.get("byteSize"))],
-        ["Owner:", info.get("ownerId", "?")],
+        ["Owner:", info.get("ownerId") or "?"],
         ["Created:", _format_date(info.get("createdAt"))],
         ["Updated:", _format_date(info.get("updatedAt"))],
     ]


### PR DESCRIPTION
## Summary

Second slice of the public API ↔ `unique_sdk` parity pass (**content**): search filters, content search row shape, and content-info payloads.

## SDK changes

- **`Content` resource (search results)**: document `description`, `mimeType`, `createdAt`, `ingestionState`, and `object` alongside existing fields so the typed surface matches `PublicContentDto` / GraphQL content search.
- **`ContentWhereInput`**: add `parentId` (`StringNullableFilter`) for hierarchical filters (was present in node-chat `ContentWhereInput` but missing in the SDK).
- **`ContentInfo`**: nullable `byteSize`, `mimeType`, `ownerId`; add `ingestionState`; optional `object` discriminator for content-info responses.
- **`PaginatedContentInfo` / `PaginatedContentInfos`**: optional `object` tag on list responses.
- **CLI** `format_content_info`: handle nullable `mimeType` / `ownerId` and satisfy typing for `_pad_columns`.

## Tests

- `uv run pytest unique_sdk/tests/test_content_info_unit.py`
- `uv run poe -C unique_sdk typecheck`
- `uv run pytest unique_sdk/tests/ --ignore=unique_sdk/tests/api_resources/`

## Cross-service reference

- Content search `where` clause: [content-where-input.ts](https://github.com/Unique-AG/monorepo/blob/master/next/services/node-chat/src/public-api/2023-12-06/dtos/content/content-where-input.ts)
- Search POST body: [search.dto.ts](https://github.com/Unique-AG/monorepo/blob/master/next/services/node-chat/src/public-api/2023-12-06/dtos/content/search.dto.ts)
- Content info row: [public-content-info-result.dto.ts](https://github.com/Unique-AG/monorepo/blob/master/next/services/node-chat/src/public-api/2023-12-06/dtos/content/public-content-info-result.dto.ts)
- Content search row: [public-content.dto.ts](https://github.com/Unique-AG/monorepo/blob/master/next/services/node-chat/src/public-api/2023-12-06/dtos/content/public-content.dto.ts)
- HTTP routes: [public-content.controller.ts](https://github.com/Unique-AG/monorepo/blob/master/next/services/node-chat/src/public-api/2023-12-06/content/public-content.controller.ts)


Made with [Cursor](https://cursor.com)