### PR TITLE
feat(sdk): align Folder response TypedDicts with public folder DTOs

### DIFF
--- a/unique_sdk/tests/cli/test_cli.py
+++ b/unique_sdk/tests/cli/test_cli.py
@@ -75,10 +75,12 @@ class TestClickCLI:
         mock.return_value = {
             "id": "scope_abc",
             "name": "New",
-            "ingestionConfig": {},
+            "ingestionConfig": {"uniqueIngestionMode": "INGESTION"},
             "createdAt": "2025-01-01T00:00:00Z",
             "updatedAt": "2025-03-01T10:00:00Z",
             "parentId": "scope_root",
+            "externalId": None,
+            "scopeAccess": [],
         }
         runner = CliRunner()
         result = runner.invoke(main, ["mvdir", "scope_abc", "New"])

--- a/unique_sdk/tests/cli/test_commands.py
+++ b/unique_sdk/tests/cli/test_commands.py
@@ -59,10 +59,12 @@ def _folder_info(
     return {
         "id": fid,
         "name": name,
-        "ingestionConfig": {},
+        "ingestionConfig": {"uniqueIngestionMode": "INGESTION"},
         "createdAt": "2025-01-01T00:00:00Z",
         "updatedAt": "2025-03-01T10:00:00Z",
         "parentId": "scope_root",
+        "externalId": None,
+        "scopeAccess": [],
     }
 
 

--- a/unique_sdk/tests/cli/test_formatting.py
+++ b/unique_sdk/tests/cli/test_formatting.py
@@ -25,10 +25,12 @@ def _folder(
     return {
         "id": fid,
         "name": name,
-        "ingestionConfig": {},
+        "ingestionConfig": {"uniqueIngestionMode": "INGESTION"},
         "createdAt": "2025-01-01T00:00:00Z",
         "updatedAt": updated,
         "parentId": parent,
+        "externalId": None,
+        "scopeAccess": [],
     }
 
 

--- a/unique_sdk/tests/cli/test_shell.py
+++ b/unique_sdk/tests/cli/test_shell.py
@@ -161,10 +161,12 @@ class TestShellFolderOps:
         mock.return_value = {
             "id": "scope_abc",
             "name": "New",
-            "ingestionConfig": {},
+            "ingestionConfig": {"uniqueIngestionMode": "INGESTION"},
             "createdAt": "2025-01-01T00:00:00Z",
             "updatedAt": "2025-03-01T10:00:00Z",
             "parentId": "scope_root",
+            "externalId": None,
+            "scopeAccess": [],
         }
         out = _capture(_shell("/R", "scope_r"), "mvdir Q1 New")
         assert "Renamed" in out

--- a/unique_sdk/tests/test_folder_info_unit.py
+++ b/unique_sdk/tests/test_folder_info_unit.py
@@ -1,0 +1,58 @@
+"""Unit tests for ``Folder`` response TypedDict shapes (folder public API parity)."""
+
+from __future__ import annotations
+
+import unique_sdk
+
+
+def test_AI_folder_info_includes_scope_access_and_object_tags():
+    """Folder info lists mirror API payloads with scopeAccess and optional object."""
+    row: unique_sdk.Folder.FolderInfo = {
+        "id": "scope_1",
+        "name": "Docs",
+        "ingestionConfig": {"uniqueIngestionMode": "INGESTION"},
+        "createdAt": "2025-01-01T00:00:00Z",
+        "updatedAt": "2025-01-02T00:00:00Z",
+        "parentId": "scope_root",
+        "externalId": "ext_1",
+        "scopeAccess": [
+            {
+                "entityId": "user_1",
+                "type": "READ",
+                "entityType": "USER",
+                "object": "scopeAccess",
+            }
+        ],
+        "object": "folder-info",
+    }
+    assert row["scopeAccess"][0]["entityId"] == "user_1"
+
+
+def test_AI_folder_infos_and_delete_and_path_responses_allow_object_tag():
+    """Paginated folder list, delete batch, and path responses expose optional object."""
+    infos: unique_sdk.Folder.FolderInfos = {
+        "folderInfos": [],
+        "totalCount": 0,
+        "object": "folder-infos",
+    }
+    deleted: unique_sdk.Folder.DeleteResponse = {
+        "successFolders": [],
+        "failedFolders": [],
+        "object": "deleted-folders",
+    }
+    path: unique_sdk.Folder.FolderPathResponse = {
+        "folderPath": "/a/b",
+        "object": "folder-path",
+    }
+    assert infos["object"] == "folder-infos"
+    assert deleted["object"] == "deleted-folders"
+    assert path["object"] == "folder-path"
+
+
+def test_AI_ingestion_config_accepts_hide_in_chat():
+    """Ingestion config matches optional hideInChat from the shared ingestion DTO."""
+    cfg: unique_sdk.Folder.IngestionConfig = {
+        "uniqueIngestionMode": "INGESTION",
+        "hideInChat": True,
+    }
+    assert cfg["hideInChat"] is True

--- a/unique_sdk/unique_sdk/api_resources/_folder.py
+++ b/unique_sdk/unique_sdk/api_resources/_folder.py
@@ -28,6 +28,7 @@ class Folder(APIResource["Folder"]):
         type: Literal["READ", "WRITE"]
         entityType: Literal["USER", "GROUP"]
         createdAt: NotRequired[str]
+        object: NotRequired[str]
 
     class Children(TypedDict):
         """
@@ -59,6 +60,7 @@ class Folder(APIResource["Folder"]):
         uniqueIngestionMode: str
         vttConfig: NotRequired["Folder.VttConfig | None"]
         wordReadMode: NotRequired[str | None]
+        hideInChat: NotRequired[bool | None]
 
     class CreatedFolder(TypedDict):
         id: str
@@ -87,10 +89,13 @@ class Folder(APIResource["Folder"]):
         updatedAt: str | None
         parentId: str | None
         externalId: str | None
+        scopeAccess: list["Folder.ScopeAccess"]
+        object: NotRequired[str]
 
     class FolderInfos(TypedDict):
         folderInfos: list["Folder.FolderInfo"]
         totalCount: int
+        object: NotRequired[str]
 
     id: str
     name: str
@@ -182,6 +187,7 @@ class Folder(APIResource["Folder"]):
 
         successFolders: list["Folder.DeleteFolderResponse"]
         failedFolders: list["Folder.DeleteFolderResponse"]
+        object: NotRequired[str]
 
     class FolderPathResponse(TypedDict):
         """
@@ -189,6 +195,7 @@ class Folder(APIResource["Folder"]):
         """
 
         folderPath: str
+        object: NotRequired[str]
 
     @classmethod
     def get_folder_path(


### PR DESCRIPTION
## Summary

Third parity slice (**folder**): extend `unique_sdk.Folder` wire types so they cover fields exposed by the node-chat public folder DTOs.

## SDK changes

- **`FolderInfo`**: add required `scopeAccess` (list of `ScopeAccess`) and optional `object` discriminator, matching folder-info / folder-infos responses.
- **`ScopeAccess`**: optional `object` tag (e.g. `scopeAccess`).
- **`FolderInfos`**, **`DeleteResponse`**, **`FolderPathResponse`**: optional `object` tag.
- **`IngestionConfig`**: `hideInChat` (optional boolean), aligned with the shared ingestion-config DTO used by folder payloads.

## Tests

- `unique_sdk/tests/test_folder_info_unit.py` (`test_AI_*`)
- CLI test fixtures updated with `scopeAccess`, `externalId`, and a minimal valid `ingestionConfig` (`uniqueIngestionMode: INGESTION`).
- `uv run pytest unique_sdk/tests/ --ignore=unique_sdk/tests/api_resources/`
- `uv run poe -C unique_sdk typecheck`

## Cross-service reference

- Folder info row: [public-folder-info-result.dto.ts](https://github.com/Unique-AG/monorepo/blob/master/next/services/node-chat/src/public-api/2023-12-06/dtos/folder/public-folder-info-result.dto.ts)
- Folder infos page: [public-folder-infos-result.dto.ts](https://github.com/Unique-AG/monorepo/blob/master/next/services/node-chat/src/public-api/2023-12-06/dtos/folder/public-folder-infos-result.dto.ts)
- Scope access: [public-scope-access.dto.ts](https://github.com/Unique-AG/monorepo/blob/master/next/services/node-chat/src/public-api/2023-12-06/dtos/folder/public-scope-access.dto.ts)
- Delete batch result: [public-delete-folders-and-contents-recursively-result.dto.ts](https://github.com/Unique-AG/monorepo/blob/master/next/services/node-chat/src/public-api/2023-12-06/dtos/folder/public-delete-folders-and-contents-recursively-result.dto.ts)
- Folder path: [public-folder-path-result.dto.ts](https://github.com/Unique-AG/monorepo/blob/master/next/services/node-chat/src/public-api/2023-12-06/dtos/folder/public-folder-path-result.dto.ts)
- Ingestion config (shared): [ingestion-config.dto.ts](https://github.com/Unique-AG/monorepo/blob/master/next/services/node-chat/src/public-api/2023-12-06/dtos/ingestion-config/ingestion-config.dto.ts)
- HTTP routes: [public-folder.controller.ts](https://github.com/Unique-AG/monorepo/blob/master/next/services/node-chat/src/public-api/2023-12-06/folder/public-folder.controller.ts)


Made with [Cursor](https://cursor.com)