### PR TITLE
feat(sdk): align Message and Space chat types with public message/chat DTOs

### DIFF
--- a/unique_sdk/tests/test_message_chat_unit.py
+++ b/unique_sdk/tests/test_message_chat_unit.py
@@ -1,0 +1,70 @@
+"""Unit tests for ``Message`` / ``Space`` chat shapes (public message & chat DTO parity)."""
+
+from __future__ import annotations
+
+import unique_sdk
+
+
+def test_AI_message_create_accepts_user_role_and_optional_payload_keys():
+    """Public create message allows USER or ASSISTANT and optional gpt/debug/completed."""
+    params: unique_sdk.Message.CreateParams = {
+        "chatId": "chat_1",
+        "assistantId": "ast_1",
+        "role": "USER",
+        "text": "hello",
+    }
+    assert params["role"] == "USER"
+
+
+def test_AI_message_reference_optional_fields():
+    """Reference DTO marks description, url, originalIndex as optional."""
+    minimal: unique_sdk.Message.Reference = {
+        "name": "doc",
+        "sequenceNumber": 0,
+        "sourceId": "s1",
+        "source": "search",
+    }
+    full: unique_sdk.Message.Reference = {
+        "name": "doc",
+        "sequenceNumber": 0,
+        "sourceId": "s1",
+        "source": "search",
+        "description": None,
+        "url": None,
+        "originalIndex": [0, 1],
+    }
+    assert "description" not in minimal
+    assert full["originalIndex"] == [0, 1]
+
+
+def test_AI_space_chat_result_allows_object_tag():
+    """Create-chat responses may include an object discriminator."""
+    chat: unique_sdk.Space.ChatResult = {
+        "id": "chat_1",
+        "title": "t",
+        "createdAt": "2025-01-01T00:00:00.000Z",
+        "object": "chat",
+    }
+    assert chat["object"] == "chat"
+
+
+def test_AI_space_message_includes_user_aborted_at():
+    """Message payloads may include userAbortedAt (public message DTO)."""
+    row: unique_sdk.Space.Message = {
+        "id": "msg_1",
+        "chatId": "chat_1",
+        "text": None,
+        "originalText": None,
+        "role": "ASSISTANT",
+        "debugInfo": None,
+        "gptRequest": None,
+        "completedAt": None,
+        "createdAt": None,
+        "updatedAt": None,
+        "startedStreamingAt": None,
+        "stoppedStreamingAt": None,
+        "userAbortedAt": None,
+        "references": None,
+        "assessment": None,
+    }
+    assert row["userAbortedAt"] is None

--- a/unique_sdk/unique_sdk/api_resources/_message.py
+++ b/unique_sdk/unique_sdk/api_resources/_message.py
@@ -27,12 +27,29 @@ class Message(APIResource["Message"]):
 
     class Reference(TypedDict):
         name: str
-        description: str | None
-        url: str | None
         sequenceNumber: int
-        originalIndex: list[int] | None
         sourceId: str
         source: str
+        description: NotRequired[str | None]
+        url: NotRequired[str | None]
+        originalIndex: NotRequired[list[int] | None]
+
+    class Assessment(TypedDict):
+        """Assessment row attached to a message."""
+
+        id: str
+        createdAt: str
+        updatedAt: str
+        messageId: str
+        status: str
+        explanation: str | None
+        label: str | None
+        type: str | None
+        title: str | None
+        companyId: str
+        userId: str
+        isVisible: bool
+        createdBy: str | None
 
     class Correlation(TypedDict):
         parentMessageId: str
@@ -42,11 +59,12 @@ class Message(APIResource["Message"]):
     class CreateParams(RequestOptions):
         chatId: str
         assistantId: str
-        role: Literal["ASSISTANT"]
+        role: Literal["ASSISTANT", "USER"]
         text: NotRequired[str | None]
-        references: list["Message.Reference"] | None
-        debugInfo: dict[str, Any] | None
-        completedAt: datetime | None
+        references: NotRequired[list["Message.Reference"] | None]
+        gptRequest: NotRequired[dict[str, Any] | None]
+        debugInfo: NotRequired[dict[str, Any] | None]
+        completedAt: NotRequired[datetime | None]
         correlation: NotRequired["Message.Correlation | None"]
 
     class ModifyParams(RequestOptions):
@@ -74,11 +92,19 @@ class Message(APIResource["Message"]):
 
     chatId: str
     text: str | None
+    originalText: str | None
     role: Literal["SYSTEM", "USER", "ASSISTANT"]
     gptRequest: dict[str, Any] | None
     debugInfo: dict[str, Any] | None
+    completedAt: datetime | None
+    createdAt: datetime | None
+    updatedAt: datetime | None
     startedStreamingAt: datetime | None
     stoppedStreamingAt: datetime | None
+    userAbortedAt: datetime | None
+    references: list["Message.Reference"] | None
+    assessment: list["Message.Assessment"] | None
+    object: str
 
     @classmethod
     def list(

--- a/unique_sdk/unique_sdk/api_resources/_space.py
+++ b/unique_sdk/unique_sdk/api_resources/_space.py
@@ -106,12 +106,12 @@ class Space(APIResource["Space"]):
         """
 
         name: str
-        description: str | None
-        url: str | None
         sequenceNumber: int
-        originalIndex: list[int] | None
         sourceId: str
         source: str
+        description: NotRequired[str | None]
+        url: NotRequired[str | None]
+        originalIndex: NotRequired[list[int] | None]
 
     class Assessment(TypedDict):
         """
@@ -149,6 +149,7 @@ class Space(APIResource["Space"]):
         updatedAt: str | None
         startedStreamingAt: str | None
         stoppedStreamingAt: str | None
+        userAbortedAt: str | None
         references: list["Space.Reference"] | None
         assessment: list["Space.Assessment"] | None
 
@@ -167,6 +168,7 @@ class Space(APIResource["Space"]):
         id: str
         title: str | None
         createdAt: str
+        object: NotRequired[str]
 
     class GetAllMessagesResponse(TypedDict):
         """


### PR DESCRIPTION
## Summary

Parity pass for **message** and **chat** public DTOs vs `unique_sdk` (`Message`, `Space` chat helpers).

## Changes

### `Message` (`_message.py`)

- **`CreateParams`**: `role` may be `USER` or `ASSISTANT` (public create body allows both). Optional fields `references`, `gptRequest`, `debugInfo`, `completedAt` are `NotRequired`, matching optional properties on the create DTO.
- **`Reference`**: `description`, `url`, `originalIndex` are optional keys (`NotRequired`), matching `ReferenceDto`.
- **`Assessment`**: new `TypedDict` for assessment rows on messages.
- **Resource** instance annotations: `originalText`, `completedAt`, `createdAt`, `updatedAt`, `userAbortedAt`, `references`, `assessment`, `object` so the typed surface matches `PublicMessageDto`.

### `Space` (`_space.py`)

- **`Reference`**: same optional-field pattern as `Message.Reference`.
- **`Message`**: `userAbortedAt` (public `PublicMessageDto`).
- **`ChatResult`**: optional `object` tag (e.g. `chat`), matching `PublicChatResultDto`.

## Tests

- `unique_sdk/tests/test_message_chat_unit.py` (`test_AI_*`)
- `uv run pytest unique_sdk/tests/ --ignore=unique_sdk/tests/api_resources/`
- `uv run poe -C unique_sdk typecheck`

## Cross-service reference

- Message resource: [public-message.dto.ts](https://github.com/Unique-AG/monorepo/blob/master/next/services/node-chat/src/public-api/2023-12-06/dtos/message/public-message.dto.ts)
- Create message: [public-create-message.dto.ts](https://github.com/Unique-AG/monorepo/blob/master/next/services/node-chat/src/public-api/2023-12-06/dtos/message/public-create-message.dto.ts)
- Reference: [reference.dto.ts](https://github.com/Unique-AG/monorepo/blob/master/next/services/node-chat/src/public-api/2023-12-06/dtos/message/reference.dto.ts)
- Chat create / result: [public-create-chat-request.dto.ts](https://github.com/Unique-AG/monorepo/blob/master/next/services/node-chat/src/public-api/2023-12-06/dtos/chat/public-create-chat-request.dto.ts), [public-chat-result.dto.ts](https://github.com/Unique-AG/monorepo/blob/master/next/services/node-chat/src/public-api/2023-12-06/dtos/chat/public-chat-result.dto.ts)
- Space chat API (SDK): `Space.create_chat` / `Space.ChatResult`


Made with [Cursor](https://cursor.com)