### PR TITLE
feat(sdk): align Search and SearchString with public search DTOs

### DIFF
--- a/unique_sdk/tests/test_search_unit.py
+++ b/unique_sdk/tests/test_search_unit.py
@@ -1,0 +1,29 @@
+"""Unit tests for ``Search`` / ``SearchString`` (public search DTO parity)."""
+
+from __future__ import annotations
+
+import unique_sdk
+
+
+def test_AI_search_create_params_allows_minimal_body():
+    """Public create search only requires searchString and searchType."""
+    params: unique_sdk.Search.CreateParams = {
+        "searchString": "query",
+        "searchType": "COMBINED",
+    }
+    assert params["searchType"] == "COMBINED"
+
+
+def test_AI_search_string_history_message_accepts_any_role_string():
+    """History entries use the same role strings as stored messages (not only lowercase)."""
+    msg: unique_sdk.SearchString.HistoryMessage = {"role": "USER", "text": "hi"}
+    assert msg["role"] == "USER"
+
+
+def test_AI_search_string_create_accepts_freeform_language_model():
+    """languageModel is an open string on the public create DTO."""
+    params: unique_sdk.SearchString.CreateParams = {
+        "prompt": "expand",
+        "languageModel": "gpt-4o-mini",
+    }
+    assert params["languageModel"] == "gpt-4o-mini"

--- a/unique_sdk/unique_sdk/api_resources/_search.py
+++ b/unique_sdk/unique_sdk/api_resources/_search.py
@@ -43,11 +43,13 @@ class Search(APIResource["Search"]):
     updatedAt: str
     url: str | None
     title: str | None
-    key: str | None
+    key: str
+    internallyStoredAt: str | None
     order: int
     startPage: int
     endPage: int
     metadata: dict[str, Any] | None
+    object: str
 
     @classmethod
     def create(

--- a/unique_sdk/unique_sdk/api_resources/_search_string.py
+++ b/unique_sdk/unique_sdk/api_resources/_search_string.py
@@ -8,7 +8,7 @@ from unique_sdk._util import classproperty
 
 
 class HistoryMessage(TypedDict):
-    role: Literal["system", "user", "assistant"]
+    role: str
     text: str
 
 
@@ -17,17 +17,14 @@ class SearchString(APIResource["SearchString"]):
     def OBJECT_NAME(cls) -> Literal["search.search-string"]:
         return "search.search-string"
 
+    searchString: str
+    object: str
+
     class CreateParams(RequestOptions):
         prompt: str
-        chatId: NotRequired["str"]
+        chatId: NotRequired[str]
         messages: NotRequired[list[HistoryMessage]]
-        languageModel: NotRequired[
-            Literal[
-                "AZURE_GPT_4_0613",
-                "AZURE_GPT_4_32K_0613",
-                "AZURE_GPT_4_TURBO_1106",
-            ]
-        ]
+        languageModel: NotRequired[str]
 
     @classmethod
     def create(


### PR DESCRIPTION
## Summary

Parity pass for **search** public DTOs vs `unique_sdk.Search` and `SearchString`.

## Changes

### `Search` (`_search.py`)

Wire fields on search hits now match [public-search.dto.ts](https://github.com/Unique-AG/monorepo/blob/master/next/services/node-chat/src/public-api/2023-12-06/dtos/search/public-search.dto.ts):

- **`key`**: required string (was `str | null`).
- **`internallyStoredAt`**: `str | null` (ISO timestamps on the wire).
- **`object`**: discriminator (e.g. `search.search`).

`Search.CreateParams` was already aligned with [public-create-search.dto.ts](https://github.com/Unique-AG/monorepo/blob/master/next/services/node-chat/src/public-api/2023-12-06/dtos/search/public-create-search.dto.ts) (search types, qdrant params, etc.).

### `SearchString` (`_search_string.py`)

- Response shape: **`searchString`** and **`object`** on the resource, matching [public-search-string.dto.ts](https://github.com/Unique-AG/monorepo/blob/master/next/services/node-chat/src/public-api/2023-12-06/dtos/search/public-search-string.dto.ts).
- **`HistoryMessage.role`**: `str` so Prisma/Gateway roles (e.g. `USER`) type-check.
- **`CreateParams`**: `languageModel` is an open optional string; `chatId` typing normalized to `NotRequired[str]`.

## Tests

- `unique_sdk/tests/test_search_unit.py` (`test_AI_*`)
- `uv run pytest unique_sdk/tests/ --ignore=unique_sdk/tests/api_resources/`
- `uv run poe -C unique_sdk typecheck`

## Cross-service reference

- Create search body: [public-create-search.dto.ts](https://github.com/Unique-AG/monorepo/blob/master/next/services/node-chat/src/public-api/2023-12-06/dtos/search/public-create-search.dto.ts)
- Search hit: [public-search.dto.ts](https://github.com/Unique-AG/monorepo/blob/master/next/services/node-chat/src/public-api/2023-12-06/dtos/search/public-search.dto.ts)
- Search string create/result: [public-create-search-string.dto.ts](https://github.com/Unique-AG/monorepo/blob/master/next/services/node-chat/src/public-api/2023-12-06/dtos/search/public-create-search-string.dto.ts), [public-search-string.dto.ts](https://github.com/Unique-AG/monorepo/blob/master/next/services/node-chat/src/public-api/2023-12-06/dtos/search/public-search-string.dto.ts)


Made with [Cursor](https://cursor.com)