### PR TITLE
fix: resolve CodeQL alerts and fix gitignore negation for uv.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,7 +109,7 @@ poetry.lock
 # Tutorials and examples keep their own lockfiles locally but they are
 # not tracked in git to avoid Dependabot noise for non-production code.
 **/uv.lock
-!uv.lock
+!/uv.lock
 **/package-lock.json
 
 # pdm

--- a/tutorials/self-host/aks/1-code/market_vendor/src/market_vendor/app.py
+++ b/tutorials/self-host/aks/1-code/market_vendor/src/market_vendor/app.py
@@ -112,9 +112,9 @@ def webhook():
 
         chat_service.modify_assistant_message(set_completed_at=True)
 
-    except Exception as e:
+    except Exception:
         error_message = "Error generating response"
-        _LOGGER.error(f"{error_message}: {e}")
+        _LOGGER.exception(error_message)
         chat_service.modify_assistant_message(
             content=error_message, set_completed_at=True
         )

--- a/tutorials/self-host/aks/1-code/market_vendor/src/market_vendor/app.py
+++ b/tutorials/self-host/aks/1-code/market_vendor/src/market_vendor/app.py
@@ -56,9 +56,10 @@ if env_path:
     except Exception as e:
         raise EnvironmentError(f"Error loading environment file: {str(e)}")
 
-    logger.info(f"API Key starts with: -{os.environ.get('API_KEY', '')[:5]}****-")
+    logger.info("API_KEY is %s", "set" if os.environ.get("API_KEY") else "NOT set")
     logger.info(
-        f"ENDPOINT Secret starts with: -{os.environ.get('ENDPOINT_SECRET', '')[:5]}****-"
+        "ENDPOINT_SECRET is %s",
+        "set" if os.environ.get("ENDPOINT_SECRET") else "NOT set",
     )
 
 init_sdk()

--- a/tutorials/self-host/aks/1-code/market_vendor/src/market_vendor/app.py
+++ b/tutorials/self-host/aks/1-code/market_vendor/src/market_vendor/app.py
@@ -31,12 +31,12 @@ from .config import MarketVendorConfig
 
 APP_NAME = get_app_name()
 init_logging()
-logger = logging.getLogger(f"{APP_NAME}.{__name__}")
+_LOGGER = logging.getLogger(f"{APP_NAME}.{__name__}")
 
 # On Kubernetes, we can not write onto the containers native filesystem, the env file was decrypted from the Dockerfile and mounted as a volume
 # The load_dotenv must load the decrypted file from the volume
 env_path = os.environ.get("DECRYPTED_ENV_FILE_ABSOLUTE")
-logger.info("DECRYPTED_ENV_FILE_ABSOLUTE: %s", env_path)
+_LOGGER.info("DECRYPTED_ENV_FILE_ABSOLUTE: %s", env_path)
 if env_path:
     if not os.path.exists(env_path):
         raise FileNotFoundError(f"Environment file not found at path: {env_path}")
@@ -56,8 +56,8 @@ if env_path:
     except Exception as e:
         raise EnvironmentError(f"Error loading environment file: {str(e)}")
 
-    logger.info("API_KEY is %s", "set" if os.environ.get("API_KEY") else "NOT set")
-    logger.info(
+    _LOGGER.info("API_KEY is %s", "set" if os.environ.get("API_KEY") else "NOT set")
+    _LOGGER.info(
         "ENDPOINT_SECRET is %s",
         "set" if os.environ.get("ENDPOINT_SECRET") else "NOT set",
     )
@@ -69,7 +69,7 @@ app = Flask(__name__)
 
 @app.route("/webhook", methods=["POST"])
 def webhook():
-    logger.info(f"{APP_NAME} - received webhook request")
+    _LOGGER.info(f"{APP_NAME} - received webhook request")
 
     event, status_code = verify_request_and_construct_event(
         assistant_name=APP_NAME,
@@ -114,7 +114,7 @@ def webhook():
 
     except Exception as e:
         error_message = "Error generating response"
-        logger.error(f"{error_message}: {e}")
+        _LOGGER.error(f"{error_message}: {e}")
         chat_service.modify_assistant_message(
             content=error_message, set_completed_at=True
         )

--- a/unique_sdk/CHANGELOG.md
+++ b/unique_sdk/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), 
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.1] - 2026-04-09
+- Fix stack trace exposure in custom-assistant example: return generic error messages instead of `str(e)` in HTTP responses
+
 ## [0.11.0] - 2026-04-09
 - Widen `openai` dependency upper bound from `<2` to `<3` to allow openai SDK v2.x (required for litellm security fix)
 

--- a/unique_sdk/examples/custom-assistant/src/custom_assistant/app.py
+++ b/unique_sdk/examples/custom-assistant/src/custom_assistant/app.py
@@ -33,7 +33,7 @@ dictConfig(
 )
 
 app = Flask(__name__)
-logger = logging.getLogger(__name__)
+_LOGGER = logging.getLogger(__name__)
 
 
 @app.route("/")
@@ -60,9 +60,10 @@ def search():
             jsonify({"message": "Invalid request", "params": e.params}), e.http_status
         )
     except unique_sdk.UniqueError as e:
+        _LOGGER.exception("UniqueError in search")
         return make_response(jsonify({"error": "Service error"}), e.http_status)
     except Exception:
-        logger.exception("Unexpected error in search")
+        _LOGGER.exception("Unexpected error in search")
         return jsonify(
             {"error": "Internal server error"}
         ), HTTPStatus.INTERNAL_SERVER_ERROR
@@ -85,9 +86,10 @@ def search_string():
             jsonify({"message": "Invalid request", "params": e.params}), e.http_status
         )
     except unique_sdk.UniqueError as e:
+        _LOGGER.exception("UniqueError in search_string")
         return make_response(jsonify({"error": "Service error"}), e.http_status)
     except Exception:
-        logger.exception("Unexpected error in search_string")
+        _LOGGER.exception("Unexpected error in search_string")
         return jsonify(
             {"error": "Internal server error"}
         ), HTTPStatus.INTERNAL_SERVER_ERROR
@@ -111,9 +113,10 @@ def azure_openai_chat_completion():
             jsonify({"message": "Invalid request", "params": e.params}), e.http_status
         )
     except unique_sdk.UniqueError as e:
+        _LOGGER.exception("UniqueError in azure_openai_chat_completion")
         return make_response(jsonify({"error": "Service error"}), e.http_status)
     except Exception:
-        logger.exception("Unexpected error in azure_openai_chat_completion")
+        _LOGGER.exception("Unexpected error in azure_openai_chat_completion")
         return jsonify(
             {"error": "Internal server error"}
         ), HTTPStatus.INTERNAL_SERVER_ERROR
@@ -137,9 +140,10 @@ def litellm_chat_completion():
             jsonify({"message": "Invalid request", "params": e.params}), e.http_status
         )
     except unique_sdk.UniqueError as e:
+        _LOGGER.exception("UniqueError in litellm_chat_completion")
         return make_response(jsonify({"error": "Service error"}), e.http_status)
     except Exception:
-        logger.exception("Unexpected error in litellm_chat_completion")
+        _LOGGER.exception("Unexpected error in litellm_chat_completion")
         return jsonify(
             {"error": "Internal server error"}
         ), HTTPStatus.INTERNAL_SERVER_ERROR
@@ -156,9 +160,10 @@ def chat_messages(chat_id: str):
 
         return jsonify(messages)
     except unique_sdk.UniqueError as e:
+        _LOGGER.exception("UniqueError in chat_messages")
         return make_response(jsonify({"error": "Service error"}), e.http_status)
     except Exception:
-        logger.exception("Unexpected error in chat_messages")
+        _LOGGER.exception("Unexpected error in chat_messages")
         return jsonify(
             {"error": "Internal server error"}
         ), HTTPStatus.INTERNAL_SERVER_ERROR
@@ -224,7 +229,7 @@ def webhook():
     event = None
     payload = request.data
 
-    app.logger.info("Received webhook request.")
+    app._LOGGER.info("Received webhook request.")
 
     try:
         event = json.loads(payload)
@@ -250,7 +255,7 @@ def webhook():
             print("⚠️  Webhook signature verification failed. " + str(e))
             return jsonify(success=False), HTTPStatus.BAD_REQUEST
 
-    app.logger.debug("Request headers: %s", request.headers)
+    app._LOGGER.debug("Request headers: %s", request.headers)
     pprint(event)
 
     if event and event["event"] == "unique.chat.user-message.created":
@@ -261,6 +266,6 @@ def webhook():
         handle_module_message(event["payload"], event["userId"], event["companyId"])
     else:
         # Unexpected event type
-        app.logger.error("Unhandled event type {}".format(event["type"]))
+        app._LOGGER.error("Unhandled event type {}".format(event["type"]))
 
     return jsonify(success=True)

--- a/unique_sdk/examples/custom-assistant/src/custom_assistant/app.py
+++ b/unique_sdk/examples/custom-assistant/src/custom_assistant/app.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 from http import HTTPStatus
 from logging.config import dictConfig
@@ -32,6 +33,7 @@ dictConfig(
 )
 
 app = Flask(__name__)
+logger = logging.getLogger(__name__)
 
 
 @app.route("/")
@@ -54,15 +56,16 @@ def search():
 
         return jsonify(search)
     except unique_sdk.InvalidRequestError as e:
-        message = str(e)
-        params = e.params
         return make_response(
-            jsonify({"message": message, "params": params}), e.http_status
+            jsonify({"message": "Invalid request", "params": e.params}), e.http_status
         )
     except unique_sdk.UniqueError as e:
-        return make_response(jsonify(str(e)), e.http_status)
-    except Exception as e:
-        return jsonify(str(e)), HTTPStatus.INTERNAL_SERVER_ERROR
+        return make_response(jsonify({"error": "Service error"}), e.http_status)
+    except Exception:
+        logger.exception("Unexpected error in search")
+        return jsonify(
+            {"error": "Internal server error"}
+        ), HTTPStatus.INTERNAL_SERVER_ERROR
 
 
 @app.route("/search/string", methods=["POST"])
@@ -78,15 +81,16 @@ def search_string():
 
         return jsonify(search_string)
     except unique_sdk.InvalidRequestError as e:
-        message = str(e)
-        params = e.params
         return make_response(
-            jsonify({"message": message, "params": params}), e.http_status
+            jsonify({"message": "Invalid request", "params": e.params}), e.http_status
         )
     except unique_sdk.UniqueError as e:
-        return make_response(jsonify(str(e)), e.http_status)
-    except Exception as e:
-        return jsonify(str(e)), HTTPStatus.INTERNAL_SERVER_ERROR
+        return make_response(jsonify({"error": "Service error"}), e.http_status)
+    except Exception:
+        logger.exception("Unexpected error in search_string")
+        return jsonify(
+            {"error": "Internal server error"}
+        ), HTTPStatus.INTERNAL_SERVER_ERROR
 
 
 @app.route("/azure-openai/chat/completion", methods=["POST"])
@@ -103,15 +107,16 @@ def azure_openai_chat_completion():
 
         return jsonify(chat_completion)
     except unique_sdk.InvalidRequestError as e:
-        message = str(e)
-        params = e.params
         return make_response(
-            jsonify({"message": message, "params": params}), e.http_status
+            jsonify({"message": "Invalid request", "params": e.params}), e.http_status
         )
     except unique_sdk.UniqueError as e:
-        return make_response(jsonify(str(e)), e.http_status)
-    except Exception as e:
-        return jsonify(str(e)), HTTPStatus.INTERNAL_SERVER_ERROR
+        return make_response(jsonify({"error": "Service error"}), e.http_status)
+    except Exception:
+        logger.exception("Unexpected error in azure_openai_chat_completion")
+        return jsonify(
+            {"error": "Internal server error"}
+        ), HTTPStatus.INTERNAL_SERVER_ERROR
 
 
 @app.route("/litellm/chat/completion", methods=["POST"])
@@ -128,15 +133,16 @@ def litellm_chat_completion():
 
         return jsonify(chat_completion)
     except unique_sdk.InvalidRequestError as e:
-        message = str(e)
-        params = e.params
         return make_response(
-            jsonify({"message": message, "params": params}), e.http_status
+            jsonify({"message": "Invalid request", "params": e.params}), e.http_status
         )
     except unique_sdk.UniqueError as e:
-        return make_response(jsonify(str(e)), e.http_status)
-    except Exception as e:
-        return jsonify(str(e)), HTTPStatus.INTERNAL_SERVER_ERROR
+        return make_response(jsonify({"error": "Service error"}), e.http_status)
+    except Exception:
+        logger.exception("Unexpected error in litellm_chat_completion")
+        return jsonify(
+            {"error": "Internal server error"}
+        ), HTTPStatus.INTERNAL_SERVER_ERROR
 
 
 @app.route("/chat/<chat_id>/messages")
@@ -150,9 +156,12 @@ def chat_messages(chat_id: str):
 
         return jsonify(messages)
     except unique_sdk.UniqueError as e:
-        return make_response(jsonify(str(e)), e.http_status)
-    except Exception as e:
-        return jsonify(e), HTTPStatus.INTERNAL_SERVER_ERROR
+        return make_response(jsonify({"error": "Service error"}), e.http_status)
+    except Exception:
+        logger.exception("Unexpected error in chat_messages")
+        return jsonify(
+            {"error": "Internal server error"}
+        ), HTTPStatus.INTERNAL_SERVER_ERROR
 
 
 @app.route("/chat/<chat_id>/messages/<message_id>")

--- a/unique_sdk/examples/custom-assistant/src/custom_assistant/app.py
+++ b/unique_sdk/examples/custom-assistant/src/custom_assistant/app.py
@@ -229,7 +229,7 @@ def webhook():
     event = None
     payload = request.data
 
-    app._LOGGER.info("Received webhook request.")
+    app.logger.info("Received webhook request.")
 
     try:
         event = json.loads(payload)
@@ -255,7 +255,7 @@ def webhook():
             print("⚠️  Webhook signature verification failed. " + str(e))
             return jsonify(success=False), HTTPStatus.BAD_REQUEST
 
-    app._LOGGER.debug("Request headers: %s", request.headers)
+    app.logger.debug("Request headers: %s", request.headers)
     pprint(event)
 
     if event and event["event"] == "unique.chat.user-message.created":
@@ -266,6 +266,6 @@ def webhook():
         handle_module_message(event["payload"], event["userId"], event["companyId"])
     else:
         # Unexpected event type
-        app._LOGGER.error("Unhandled event type {}".format(event["type"]))
+        app.logger.error("Unhandled event type {}".format(event["type"]))
 
     return jsonify(success=True)

--- a/unique_sdk/pyproject.toml
+++ b/unique_sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "unique_sdk"
-version = "0.11.0"
+version = "0.11.1"
 description = ""
 readme = "README.md"
 license = { text = "MIT" }

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-03-26T12:37:05.352434Z"
+exclude-newer = "2026-03-26T13:17:48.092093Z"
 exclude-newer-span = "P2W"
 
 [options.exclude-newer-package]
@@ -5353,7 +5353,7 @@ dev = []
 
 [[package]]
 name = "unique-sdk"
-version = "0.11.0"
+version = "0.11.1"
 source = { editable = "unique_sdk" }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- Fix 14 `py/stack-trace-exposure` CodeQL alerts in `unique_sdk/examples/custom-assistant/` by replacing `str(e)` responses with generic error messages and logging exceptions server-side
- Fix 2 `py/clear-text-logging-sensitive-data` CodeQL alerts in `tutorials/self-host/aks/` by replacing partial secret logging with set/not-set confirmation
- Fix `!uv.lock` gitignore negation pattern from PR #1406 — the unanchored pattern was un-ignoring all nested `uv.lock` files; changed to `!/uv.lock` to only preserve the root lockfile
- Dismiss remaining Dependabot alert for `@azure/identity` in tutorial code as tolerable risk

Refs: UN-18305

Made with [Cursor](https://cursor.com)