### PR TITLE
fix(toolkit): add powerpoint to fileWithSource type mapping

### DIFF
--- a/unique_toolkit/CHANGELOG.md
+++ b/unique_toolkit/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.70.2] - 2026-04-10
+- Fix: add `powerpoint` type mapping for `.pptx` / `.ppt` in `_file_frontend_type`; previously these emitted `type="document"` in `fileWithSource` fences instead of `type="powerpoint"`
+
 ## [1.70.1] - 2026-04-09
 - Add three-state `supported_reasoning_efforts` per model: `None` (unknown — pass-through), `[]` (no reasoning), `[...]` (validated list incl. `xhigh`)
 - Add `resolve_temp_and_reasoning` instance method centralising validation, defaults, and clamping for both API paths

--- a/unique_toolkit/CHANGELOG.md
+++ b/unique_toolkit/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.70.2] - 2026-04-10
-- Fix: add `powerpoint` type mapping for `.pptx` / `.ppt` in `_file_frontend_type`; previously these emitted `type="document"` in `fileWithSource` fences instead of `type="powerpoint"`
+- Fix (UN-17927): add `powerpoint` type mapping for `.pptx` / `.ppt` in `_file_frontend_type`; previously these emitted `type="document"` in `fileWithSource` fences instead of `type="powerpoint"`
 
 ## [1.70.1] - 2026-04-09
 - Add three-state `supported_reasoning_efforts` per model: `None` (unknown — pass-through), `[]` (no reasoning), `[...]` (validated list incl. `xhigh`)

--- a/unique_toolkit/pyproject.toml
+++ b/unique_toolkit/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "unique_toolkit"
-version = "1.70.1"
+version = "1.70.2"
 description = ""
 readme = "README.md"
 requires-python = ">=3.12"

--- a/unique_toolkit/tests/agentic/tools/test_code_interpreter_postprocessors_generated_files.py
+++ b/unique_toolkit/tests/agentic/tools/test_code_interpreter_postprocessors_generated_files.py
@@ -874,6 +874,26 @@ def test_file_frontend_type__returns_pdf__for_pdf() -> None:
 
 
 @pytest.mark.ai
+def test_file_frontend_type__returns_word__for_docx() -> None:
+    assert _file_frontend_type("report.docx") == "word"
+
+
+@pytest.mark.ai
+def test_file_frontend_type__returns_word__for_doc() -> None:
+    assert _file_frontend_type("report.doc") == "word"
+
+
+@pytest.mark.ai
+def test_file_frontend_type__returns_powerpoint__for_pptx() -> None:
+    assert _file_frontend_type("slides.pptx") == "powerpoint"
+
+
+@pytest.mark.ai
+def test_file_frontend_type__returns_powerpoint__for_ppt() -> None:
+    assert _file_frontend_type("slides.ppt") == "powerpoint"
+
+
+@pytest.mark.ai
 def test_file_frontend_type__returns_document__for_unknown() -> None:
     assert _file_frontend_type("output.xyz") == "document"
 

--- a/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/postprocessors/generated_files.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/postprocessors/generated_files.py
@@ -1075,13 +1075,14 @@ def _file_frontend_type(filename: str) -> str:
     """Map filename to the type token the frontend expects in fileWithSource.
 
     Assumed enum (to be confirmed with frontend):
-      excel   → .xlsx / .xls
-      csv     → .csv
-      word    → .docx / .doc
-      pdf     → .pdf
-      html    → .html / .htm
-      image   → image/* MIME
-      document → fallback
+      excel       → .xlsx / .xls
+      csv         → .csv
+      word        → .docx / .doc
+      powerpoint  → .pptx / .ppt
+      pdf         → .pdf
+      html        → .html / .htm
+      image       → image/* MIME
+      document    → fallback
     """
     ext = filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
     mime = guess_type(filename)[0] or ""
@@ -1093,6 +1094,8 @@ def _file_frontend_type(filename: str) -> str:
         "csv": "csv",
         "docx": "word",
         "doc": "word",
+        "pptx": "powerpoint",
+        "ppt": "powerpoint",
         "pdf": "pdf",
         "html": "html",
         "htm": "html",

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-03-26T14:27:08.973922Z"
+exclude-newer = "2026-03-27T06:21:38.237291Z"
 exclude-newer-span = "P2W"
 
 [options.exclude-newer-package]
@@ -5483,7 +5483,7 @@ dev = []
 
 [[package]]
 name = "unique-toolkit"
-version = "1.70.1"
+version = "1.70.2"
 source = { editable = "unique_toolkit" }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

**Refs:** UN-17927

Code interpreter postprocessing now maps `.pptx` and `.ppt` to the frontend token `powerpoint` in `fileWithSource` fences. Before this change those files fell through to `type="document"`, so the UI could not show a PowerPoint-specific treatment.

## Changes

- [x] Added feature / fixed bug / updated docs
- [ ] Refactored code / cleaned up
- [ ] Other (describe below)

- Extend `_file_frontend_type` with `pptx` / `ppt` → `powerpoint` (docstring table updated).
- Add unit tests for `word`, `doc`, `powerpoint` (`pptx` / `ppt`).
- Bump `unique_toolkit` to **1.70.2** and add **CHANGELOG** entry (UN-17927).

## Testing

- `poetry run pytest unique_toolkit/tests/agentic/tools/test_code_interpreter_postprocessors_generated_files.py -q -k "frontend_type"`
- Manual (code-execution fence FF on): run a prompt that produces a `.pptx` and confirm stored `message.text` contains `fileWithSource(..., type="powerpoint", ...)`.

## Toolkit verification (Python / persisted message)

- **PowerPoint:** Stored assistant `message.text` includes a `fileWithSource` fence with `type="powerpoint"` and the real `contentId`. `originalText` still shows `sandbox:/mnt/data/...pptx`; the postprocessor replaces that with the fence, so the emitted string is what the UI should parse.
- **Word:** Still emits `type="word"` for `.docx` / `.doc`; behaviour unchanged aside from the new ppt mapping.
- **Images:** Still use `imgWithSource` (not `fileWithSource`), so image/chart output is unchanged.

## UI / follow-up

Until the frontend maps `type="powerpoint"` to the PPTX icon/widget, the new token may still look like a generic file even though the payload is correct. That work stays on the UI side.