### PR TITLE
fix(toolkit): improve UX for dangling sandbox links and orphan code blocks

### DIFF
--- a/unique_toolkit/CHANGELOG.md
+++ b/unique_toolkit/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.70.4] - 2026-04-10
+- Code interpreter postprocessor (`generated_files.py`): dangling `sandbox:/mnt/data/...` markdown links are replaced with a per-file notice naming the file and suggesting regeneration, instead of the generic download-failure message
+- Orphan code-execution runs (no container file output, fence feature flag `enable_code_execution_fence_un_17972`): uploaded `.txt` artifacts are attached as `ContentReference` entries in `message.references` instead of appending `fileWithSource` fences to `message.text`; remove unused `_build_orphan_fences` and `_get_next_fence_id`
+
 ## [1.70.3] - 2026-04-10
 - Add optional `default_string_empty_value` to `ui_schema_for_model` so bare `str` fields (and `str` items, dict values, union branches, nested models) can get `ui:emptyValue` without `Annotated[..., RJSFMetaTag]`
 - Fix `RJSFMetaTag.StringWidget.textarea`: emit `ui:emptyValue` under the correct key (was `ui:emtpyValue`)

--- a/unique_toolkit/CHANGELOG.md
+++ b/unique_toolkit/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.70.5] - 2026-04-10
+- Code interpreter orphan `.txt` uploads (`_upload_orphan_code_as_txt`): file body is always the executed **source code**, not stdout from `code_interpreter_call.outputs`
+
 ## [1.70.4] - 2026-04-10
 - Code interpreter postprocessor (`generated_files.py`): dangling `sandbox:/mnt/data/...` markdown links are replaced with a per-file notice naming the file and suggesting regeneration, instead of the generic download-failure message
 - Orphan code-execution runs (no container file output, fence feature flag `enable_code_execution_fence_un_17972`): uploaded `.txt` artifacts are attached as `ContentReference` entries in `message.references` instead of appending `fileWithSource` fences to `message.text`; remove unused `_build_orphan_fences` and `_get_next_fence_id`

--- a/unique_toolkit/pyproject.toml
+++ b/unique_toolkit/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "unique_toolkit"
-version = "1.70.4"
+version = "1.70.5"
 description = ""
 readme = "README.md"
 requires-python = ">=3.12"

--- a/unique_toolkit/pyproject.toml
+++ b/unique_toolkit/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "unique_toolkit"
-version = "1.70.3"
+version = "1.70.4"
 description = ""
 readme = "README.md"
 requires-python = ">=3.12"

--- a/unique_toolkit/tests/agentic/tools/test_code_interpreter_postprocessors_generated_files.py
+++ b/unique_toolkit/tests/agentic/tools/test_code_interpreter_postprocessors_generated_files.py
@@ -17,7 +17,6 @@ from unique_toolkit.agentic.tools.openai_builtin.code_interpreter.postprocessors
     DisplayCodeInterpreterFilesPostProcessorConfig,
     _build_code_blocks,
     _build_file_fence,
-    _collect_stdout,
     _ensure_fences_are_standalone,
     _file_frontend_type,
     _file_title,
@@ -1688,97 +1687,6 @@ def test_warn_unmatched_code_blocks__skips_none_content_ids(caplog) -> None:
 
 
 # ============================================================================
-# Tests for _collect_stdout
-# ============================================================================
-
-
-def _make_logs_output(logs: str) -> MagicMock:
-    """Build a mock output item with type='logs' and the given logs string."""
-    output = MagicMock()
-    output.type = "logs"
-    output.logs = logs
-    return output
-
-
-def _make_image_output() -> MagicMock:
-    """Build a mock output item with type='image' (should be ignored by _collect_stdout)."""
-    output = MagicMock()
-    output.type = "image"
-    return output
-
-
-def _make_call(outputs: list | None) -> ResponseCodeInterpreterToolCall:
-    """Build a minimal ResponseCodeInterpreterToolCall with the given outputs list."""
-    call = MagicMock(spec=ResponseCodeInterpreterToolCall)
-    call.outputs = outputs
-    return call
-
-
-@pytest.mark.ai
-def test_collect_stdout__returns_empty_string__when_outputs_is_none() -> None:
-    """
-    Purpose: Verify _collect_stdout returns '' when the call has no outputs (include not set).
-    Why this matters: When the Responses API is called without include=["code_interpreter_call.outputs"],
-    call.outputs is None; we must not crash and must fall back to source code.
-    """
-    call = _make_call(outputs=None)
-    assert _collect_stdout(call) == ""
-
-
-@pytest.mark.ai
-def test_collect_stdout__returns_empty_string__when_outputs_is_empty_list() -> None:
-    """
-    Purpose: Verify _collect_stdout returns '' for an empty outputs list.
-    Why this matters: Empty list is a valid API response when code produces no stdout.
-    """
-    call = _make_call(outputs=[])
-    assert _collect_stdout(call) == ""
-
-
-@pytest.mark.ai
-def test_collect_stdout__returns_logs__when_single_logs_output() -> None:
-    """
-    Purpose: Verify _collect_stdout extracts the logs text from a single logs output item.
-    Why this matters: Core happy-path for log extraction (orphan .txt uploads use source code, not stdout).
-    """
-    call = _make_call(outputs=[_make_logs_output("Hello, world!")])
-    assert _collect_stdout(call) == "Hello, world!"
-
-
-@pytest.mark.ai
-def test_collect_stdout__joins_multiple_logs_outputs__with_newline() -> None:
-    """
-    Purpose: Verify _collect_stdout joins multiple logs outputs with newlines.
-    Why this matters: Code interpreter may emit several log chunks; they must be
-    concatenated in order so the txt file is readable.
-    """
-    call = _make_call(
-        outputs=[
-            _make_logs_output("line 1"),
-            _make_logs_output("line 2"),
-            _make_logs_output("line 3"),
-        ]
-    )
-    assert _collect_stdout(call) == "line 1\nline 2\nline 3"
-
-
-@pytest.mark.ai
-def test_collect_stdout__ignores_non_logs_outputs() -> None:
-    """
-    Purpose: Verify _collect_stdout skips image (and other non-logs) output items.
-    Why this matters: Code interpreter outputs can include images; those must not
-    be included in the stdout text.
-    """
-    call = _make_call(
-        outputs=[
-            _make_logs_output("stdout text"),
-            _make_image_output(),
-        ]
-    )
-    assert _collect_stdout(call) == "stdout text"
-
-
-# ============================================================================
 # Tests for orphan path and run()
 # ============================================================================
 
@@ -2152,7 +2060,10 @@ async def test_upload_orphan_code_as_txt__uploads_source_code_not_stdout() -> No
     source = "x = 40 + 2\nprint(x)\n"
     call = MagicMock(spec=ResponseCodeInterpreterToolCall)
     call.code = source
-    call.outputs = [_make_logs_output("42")]
+    stdout_output = MagicMock()
+    stdout_output.type = "logs"
+    stdout_output.logs = "42"
+    call.outputs = [stdout_output]
     lr = MagicMock(spec=ResponsesLanguageModelStreamResponse)
     lr.container_files = []
     lr.code_interpreter_calls = [call]

--- a/unique_toolkit/tests/agentic/tools/test_code_interpreter_postprocessors_generated_files.py
+++ b/unique_toolkit/tests/agentic/tools/test_code_interpreter_postprocessors_generated_files.py
@@ -1730,7 +1730,7 @@ def test_collect_stdout__returns_empty_string__when_outputs_is_empty_list() -> N
 def test_collect_stdout__returns_logs__when_single_logs_output() -> None:
     """
     Purpose: Verify _collect_stdout extracts the logs text from a single logs output item.
-    Why this matters: Core happy-path: stdout from a print() call should become the txt content.
+    Why this matters: Core happy-path for log extraction (orphan .txt uploads use source code, not stdout).
     """
     call = _make_call(outputs=[_make_logs_output("Hello, world!")])
     assert _collect_stdout(call) == "Hello, world!"
@@ -2130,6 +2130,39 @@ async def test_upload_orphan_code_as_txt__skips_call_without_code() -> None:
     lr.container_files = []
     lr.code_interpreter_calls = [call_no_code]
     assert await proc._upload_orphan_code_as_txt(lr) == []
+
+
+@pytest.mark.ai
+@pytest.mark.asyncio
+async def test_upload_orphan_code_as_txt__uploads_source_code_not_stdout() -> None:
+    """
+    Purpose: Orphan .txt attachments must contain the executed source, not interpreter stdout.
+    Why this matters: stdout (e.g. print output) differs from code; users expect `code.txt` to
+    match what ran in the sandbox.
+    """
+    source = "x = 40 + 2\nprint(x)\n"
+    call = MagicMock(spec=ResponseCodeInterpreterToolCall)
+    call.code = source
+    call.outputs = [_make_logs_output("42")]
+    lr = MagicMock(spec=ResponsesLanguageModelStreamResponse)
+    lr.container_files = []
+    lr.code_interpreter_calls = [call]
+    chat = AsyncMock()
+    chat.upload_to_chat_from_bytes_async = AsyncMock(
+        return_value=MagicMock(id="cid-orphan-code")
+    )
+    proc = DisplayCodeInterpreterFilesPostProcessor(
+        client=MagicMock(),
+        content_service=MagicMock(),
+        config=DisplayCodeInterpreterFilesPostProcessorConfig(),
+        chat_service=chat,
+        company_id="co1",
+    )
+    blocks = await proc._upload_orphan_code_as_txt(lr)
+    assert len(blocks) == 1
+    chat.upload_to_chat_from_bytes_async.assert_awaited_once()
+    kwargs = chat.upload_to_chat_from_bytes_async.await_args.kwargs
+    assert kwargs["content"] == source.encode("utf-8")
 
 
 @pytest.mark.ai

--- a/unique_toolkit/tests/agentic/tools/test_code_interpreter_postprocessors_generated_files.py
+++ b/unique_toolkit/tests/agentic/tools/test_code_interpreter_postprocessors_generated_files.py
@@ -1551,19 +1551,19 @@ def test_replace_dangling_sandbox_links__replaces_and_warns__when_sandbox_link_p
     caplog,
 ) -> None:
     """
-    Purpose: Verify that dangling sandbox links are replaced with the error message
-    and a WARNING is logged.
-    Why this matters: Without replacement the user sees a broken link; the warning
-    makes the incident visible in production logs.
+    Purpose: Verify that dangling sandbox links are replaced with a per-file notice
+    that names the file, and a WARNING is logged.
+    Why this matters: Without replacement the user sees a broken link; the named notice
+    gives actionable context and the warning makes the incident visible in production logs.
     """
     text = "Download: [chart](sandbox:/mnt/data/chart.png)"
-    error_msg = "⚠️ File download failed ..."
 
     with caplog.at_level(logging.WARNING, logger="unique_toolkit"):
-        result, replaced = _replace_dangling_sandbox_links(text, error_msg)
+        result, replaced = _replace_dangling_sandbox_links(text)
 
     assert replaced is True
-    assert error_msg in result
+    assert "chart.png" in result
+    assert "could not be retrieved" in result
     assert "sandbox:/mnt/data/chart.png" not in result
     assert any(
         "sandbox:/mnt/data/chart.png" in r.message and r.levelno == logging.WARNING
@@ -1580,10 +1580,9 @@ def test_replace_dangling_sandbox_links__no_change__when_no_sandbox_link(
     sandbox links.
     """
     text = "Here is your result: ````imgWithSource(contentId='cont_1')````"
-    error_msg = "⚠️ File download failed ..."
 
     with caplog.at_level(logging.WARNING, logger="unique_toolkit"):
-        result, replaced = _replace_dangling_sandbox_links(text, error_msg)
+        result, replaced = _replace_dangling_sandbox_links(text)
 
     assert replaced is False
     assert result == text
@@ -1751,29 +1750,8 @@ def test_collect_stdout__ignores_non_logs_outputs() -> None:
 
 
 # ============================================================================
-# Tests for orphan path, _get_next_fence_id, _build_orphan_fences, run()
+# Tests for orphan path and run()
 # ============================================================================
-
-
-@pytest.mark.ai
-def test_get_next_fence_id__returns_one__when_no_fences_in_text() -> None:
-    assert gen_mod._get_next_fence_id("plain text") == 1
-
-
-@pytest.mark.ai
-def test_get_next_fence_id__returns_max_plus_one__when_fences_in_text() -> None:
-    text = "x ````fileWithSource(id='2', contentId='a')```` y ````imgWithSource(id='5', contentId='b')````"
-    assert gen_mod._get_next_fence_id(text) == 6
-
-
-@pytest.mark.ai
-def test_build_orphan_fences__concatenates_file_fences() -> None:
-    f = CodeInterpreterFile(filename="code.txt", content_id="cid1", type="document")
-    block = CodeInterpreterBlock(code="print(1)", files=[f])
-    out = gen_mod._build_orphan_fences([block], start_fence_id=1)
-    assert "fileWithSource" in out
-    assert "cid1" in out
-    assert "print(1)" in out or "\\n" in out  # code may be escaped in fence
 
 
 @pytest.mark.ai
@@ -1811,15 +1789,15 @@ def test_apply_postprocessing__normalizes_none_message_text__to_empty_string(
 
 @pytest.mark.ai
 @patch(GEN_FILES_FF)
-def test_apply_postprocessing__orphan_path_appends_fence_but_not_references__when_ff_on(
+def test_apply_postprocessing__orphan_path_adds_reference_not_fence__when_ff_on(
     mock_ff: MagicMock,
 ) -> None:
     """
-    Purpose: Orphan blocks get fence text but NO ContentReference entries when fence FF is on.
-    Why this matters: Orphan artifacts are rendered via fences in message.text; adding them
-    to references would surface them as source citations, which is semantically wrong.
-    Setup summary: One orphan block with a document file, fence FF ON; assert fence text
-    added and references remain empty.
+    Purpose: Orphan blocks are surfaced as ContentReference entries, NOT as fence text.
+    Why this matters: Fence injection for orphan blocks produced confusing UI artefacts;
+    the references panel is the clean canonical place for downloadable code outputs.
+    Setup summary: One orphan block with a document file, fence FF ON; assert a
+    ContentReference is added for the file and no fence syntax appears in message.text.
     """
     mock_ff.enable_code_execution_fence_un_17972.is_enabled.return_value = True
     config = DisplayCodeInterpreterFilesPostProcessorConfig()
@@ -1848,8 +1826,13 @@ def test_apply_postprocessing__orphan_path_appends_fence_but_not_references__whe
     changed = proc.apply_postprocessing_to_response(loop)
     assert changed is True
     assert msg.text is not None
-    assert "fileWithSource" in msg.text
-    assert msg.references == []
+    assert "fileWithSource" not in msg.text
+    assert msg.references is not None
+    assert len(msg.references) == 1
+    ref = msg.references[0]
+    assert ref.source_id == "cont_orphan"
+    assert ref.name == "code.txt"
+    assert "cont_orphan" in ref.url
 
 
 @pytest.mark.ai

--- a/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/postprocessors/generated_files.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/postprocessors/generated_files.py
@@ -957,13 +957,12 @@ class DisplayCodeInterpreterFilesPostProcessor(
     async def _upload_orphan_code_as_txt(
         self, loop_response: ResponsesLanguageModelStreamResponse
     ) -> list[CodeInterpreterBlock]:
-        """Upload stdout (or code) from calls that produced no container files as .txt artifacts.
+        """Upload source **code** from calls that produced no container files as .txt artifacts.
 
         When code interpreter runs but generates no files or images, the response
         text has no sandbox links for fence injection to hook onto.  This method
-        converts those "orphan" calls into downloadable .txt files so the fence
-        postprocessor can attach a fileWithSource component and the new Code
-        Execution UI is shown instead of the legacy <details> block.
+        converts those "orphan" calls into downloadable .txt files (the executed
+        code, not stdout) so the postprocessor can attach a reference for download.
 
         Called only when the fence feature flag is enabled.  Skipped entirely if
         any container files were produced (normal fencing handles those).
@@ -984,13 +983,9 @@ class DisplayCodeInterpreterFilesPostProcessor(
             if not call.code:
                 continue
 
-            # Code interpreter logs are only present on each code_interpreter_call when
-            # the create/retrieve request sets include=["code_interpreter_call.outputs"]
-            # (see OpenAI Responses API `include` and manual examples in
-            # docs/manual_examples_for_docs/code_execution_openai_client.py).  If
-            # `outputs` is omitted, call.outputs is null and we fall back to the
-            # source code as the downloadable txt.
-            txt_content = _collect_stdout(call) or call.code
+            # Always persist the executed source as the downloadable .txt (not stdout),
+            # so the attachment matches what ran in the sandbox.
+            txt_content = call.code
             filename = f"code_{i + 1}.txt" if use_numeric_suffix else "code.txt"
 
             try:

--- a/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/postprocessors/generated_files.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/postprocessors/generated_files.py
@@ -625,19 +625,27 @@ class DisplayCodeInterpreterFilesPostProcessor(
                 self._log.info("Fence injection modified the message text")
 
             if self._orphan_code_blocks:
-                fence_id = _get_next_fence_id(loop_response.message.text)
-                orphan_fences = _build_orphan_fences(self._orphan_code_blocks, fence_id)
-                loop_response.message.text = (
-                    loop_response.message.text.rstrip() + "\n\n" + orphan_fences
-                )
+                for block in self._orphan_code_blocks:
+                    for file in block.files:
+                        loop_response.message.references.append(
+                            ContentReference(
+                                sequence_number=ref_number,
+                                source_id=file.content_id,
+                                source="node-ingestion-chunks",
+                                url=f"unique://content/{file.content_id}",
+                                name=file.filename,
+                            )
+                        )
+                        ref_number += 1
                 changed = True
                 self._log.info(
-                    "Appended %d orphan fence(s)", len(self._orphan_code_blocks)
+                    "Added %d orphan code block(s) to message references",
+                    len(self._orphan_code_blocks),
                 )
 
         _warn_missing_content_ids(loop_response.message.text, self._content_map)
         loop_response.message.text, dangling_replaced = _replace_dangling_sandbox_links(
-            loop_response.message.text, self._config.file_download_failed_message
+            loop_response.message.text
         )
         changed |= dangling_replaced
         if dangling_replaced:
@@ -1027,31 +1035,6 @@ def _collect_stdout(call: ResponseCodeInterpreterToolCall) -> str:
     return "\n".join(output.logs for output in call.outputs if output.type == "logs")
 
 
-def _get_next_fence_id(text: str) -> int:
-    """Return the next available fence id by scanning existing fences in the text."""
-    existing = re.findall(r"````(?:imgWithSource|fileWithSource)\(id='(\d+)'", text)
-    if not existing:
-        return 1
-    return max(int(fid) for fid in existing) + 1
-
-
-def _build_orphan_fences(
-    blocks: list[CodeInterpreterBlock], start_fence_id: int
-) -> str:
-    """Build concatenated fence text for orphan code blocks.
-
-    Orphan blocks have no inline ref in the message text, so their fences are
-    appended directly rather than injected via pattern replacement.
-    """
-    fence_id = start_fence_id
-    parts: list[str] = []
-    for block in blocks:
-        for file in block.files:
-            parts.append(_build_file_fence(file, block.code, fence_id))
-            fence_id += 1
-    return "\n".join(parts)
-
-
 def _get_file_type(filename: str) -> CodeInterpreterFileType:
     mime = guess_type(filename)[0] or ""
     if mime.startswith("image/"):
@@ -1380,27 +1363,35 @@ def _warn_missing_content_ids(text: str, content_map: dict[str, str | None]) -> 
 # so the entire `[label](sandbox://...)` token can be replaced rather than just the URL.
 _SANDBOX_MARKDOWN_LINK_RE = re.compile(r"!?\[.*?\]\(sandbox:/mnt/data/\S+?\)")
 
+# Extracts the bare filename from a sandbox URL like `sandbox:/mnt/data/foo.csv`.
+_SANDBOX_FILENAME_RE = re.compile(r"sandbox:/mnt/data/([^)\s]+)")
 
-def _replace_dangling_sandbox_links(text: str, error_message: str) -> tuple[str, bool]:
-    """Replace any remaining sandbox:/mnt/data/ markdown links with an error message.
+
+def _replace_dangling_sandbox_links(text: str) -> tuple[str, bool]:
+    """Replace any remaining sandbox:/mnt/data/ markdown links with a per-file notice.
 
     A dangling link means either the LLM hallucinated a file reference (the sandbox
     link appears in the text but no matching container file annotation was emitted by
     OpenAI), or the link format did not match the expected regex in stage-1.  In both
     cases the user would see a broken link; this function replaces each such link with
-    the configured error message and logs a warning so the incident is visible in logs.
+    an actionable message that names the specific file, and logs a warning so the
+    incident is visible in production logs.
     """
-    matches = _SANDBOX_MARKDOWN_LINK_RE.findall(text)
-    if not matches:
+    if not _SANDBOX_MARKDOWN_LINK_RE.search(text):
         return text, False
-    for match in matches:
+
+    def _replacement(m: re.Match[str]) -> str:
+        filename_match = _SANDBOX_FILENAME_RE.search(m.group())
+        filename = filename_match.group(1) if filename_match else "the file"
         logger.warning(
             "Dangling sandbox link found in final text: '%s'. "
             "The file was either never uploaded or the link format did not match "
-            "the expected pattern — replacing with error message.",
-            match,
+            "the expected pattern — replacing with per-file notice.",
+            m.group(),
         )
-    return _SANDBOX_MARKDOWN_LINK_RE.sub(error_message, text), True
+        return f"⚠️ The file *{filename}* could not be retrieved. You can ask me to regenerate it."
+
+    return _SANDBOX_MARKDOWN_LINK_RE.sub(_replacement, text), True
 
 
 def _warn_unmatched_code_blocks(

--- a/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/postprocessors/generated_files.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/postprocessors/generated_files.py
@@ -9,7 +9,6 @@ from typing import NamedTuple, override
 
 import httpx
 from openai import AsyncOpenAI
-from openai.types.responses import ResponseCodeInterpreterToolCall
 from openai.types.responses.response_output_text import AnnotationContainerFileCitation
 from pydantic import BaseModel, Field, RootModel
 from pydantic.json_schema import SkipJsonSchema
@@ -1035,13 +1034,6 @@ class DisplayCodeInterpreterFilesPostProcessor(
             )
 
         return orphan_blocks
-
-
-def _collect_stdout(call: ResponseCodeInterpreterToolCall) -> str:
-    """Collect all stdout logs from a code interpreter call's outputs."""
-    if not call.outputs:
-        return ""
-    return "\n".join(output.logs for output in call.outputs if output.type == "logs")
 
 
 def _get_file_type(filename: str) -> CodeInterpreterFileType:

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-03-27T14:45:01.019045Z"
+exclude-newer = "2026-03-27T15:10:58.738461Z"
 exclude-newer-span = "P2W"
 
 [options.exclude-newer-package]
@@ -5483,7 +5483,7 @@ dev = []
 
 [[package]]
 name = "unique-toolkit"
-version = "1.70.4"
+version = "1.70.5"
 source = { editable = "unique_toolkit" }
 dependencies = [
     { name = "aiohttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-03-27T11:59:49.126947Z"
+exclude-newer = "2026-03-27T14:45:01.019045Z"
 exclude-newer-span = "P2W"
 
 [options.exclude-newer-package]
@@ -5483,7 +5483,7 @@ dev = []
 
 [[package]]
 name = "unique-toolkit"
-version = "1.70.3"
+version = "1.70.4"
 source = { editable = "unique_toolkit" }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Refs: UN-17927 / code interpreter citations (related); no single ticket linked

Improves code-interpreter postprocessing UX in two places:

1. **Dangling sandbox links** — Any remaining `[label](sandbox:/mnt/data/…)` in the assistant message (no matching uploaded file / stage-1 miss) is no longer replaced with the generic “file could not be generated” string. Each link is replaced with a short notice that **names the file** and tells the user they can ask to regenerate it.

2. **Orphan code execution** — When the interpreter runs but produces **no** container files (with `enable_code_execution_fence_un_17972` on), we upload code block as `.txt` for download, but we **stop appending `fileWithSource` fences** to `message.text`. Those artifacts are added as **`ContentReference`** rows on `message.references` so they show in the references panel instead of odd inline fences.

Also: merged latest `main`, bumped **`unique_toolkit` to `1.70.4`**, updated **`unique_toolkit/CHANGELOG.md`**, and refreshed **root `uv.lock`** (`uv lock`) so CI `uv sync --locked` stays green.

## Changes

- [x] Fixed bug / improved UX (dangling links + orphan outputs)
- [x] Removed dead helpers (`_build_orphan_fences`, `_get_next_fence_id`)
- [x] Release housekeeping: `pyproject.toml` version, `CHANGELOG`, root `uv.lock`

## Testing

- `poetry run pytest` (targeted): `tests/agentic/tools/test_code_interpreter_postprocessors_generated_files.py` with `-k "dangling_sandbox or orphan_path_adds_reference"` — passes locally after merge.
- **Suggested:** full CI / broader `unique_toolkit` tests on the PR.