### PR TITLE
fix(toolkit): add tenacity retry to _upload_files_to_container

### DIFF
--- a/unique_toolkit/CHANGELOG.md
+++ b/unique_toolkit/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.70.4] - 2026-04-10
+- Fix: wrap code-interpreter `_upload_files_to_container` download and `containers.files.create` with tenacity exponential backoff (same pattern as generated-files postprocessor) so transient network or throttling does not leave the container without chat-uploaded files; log retries at WARNING and success at INFO
+
 ## [1.70.3] - 2026-04-10
 - Add optional `default_string_empty_value` to `ui_schema_for_model` so bare `str` fields (and `str` items, dict values, union branches, nested models) can get `ui:emptyValue` without `Annotated[..., RJSFMetaTag]`
 - Fix `RJSFMetaTag.StringWidget.textarea`: emit `ui:emptyValue` under the correct key (was `ui:emtpyValue`)

--- a/unique_toolkit/pyproject.toml
+++ b/unique_toolkit/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "unique_toolkit"
-version = "1.70.3"
+version = "1.70.4"
 description = ""
 readme = "README.md"
 requires-python = ">=3.12"

--- a/unique_toolkit/tests/agentic/tools/test_code_interpreter_service.py
+++ b/unique_toolkit/tests/agentic/tools/test_code_interpreter_service.py
@@ -1,7 +1,7 @@
 """Tests for OpenAICodeInterpreterTool (get_debug_info, get_required_include_params, get_tool_prompts)."""
 
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from openai.types.responses import ResponseCodeInterpreterToolCall
@@ -11,8 +11,11 @@ from unique_toolkit.agentic.tools.openai_builtin.code_interpreter.config import 
     OpenAICodeInterpreterConfig,
 )
 from unique_toolkit.agentic.tools.openai_builtin.code_interpreter.service import (
+    CodeExecutionShortTermMemorySchema,
     OpenAICodeInterpreterTool,
+    _upload_files_to_container,
 )
+from unique_toolkit.content.schemas import Content
 
 
 @pytest.fixture
@@ -244,3 +247,88 @@ def test_get_required_include_params__returns_empty_list__when_ff_off() -> None:
         result = tool.get_required_include_params()
 
     assert result == []
+
+
+# ============================================================================
+# Tests for _upload_files_to_container (retry-wrapped download + create)
+# ============================================================================
+
+
+@pytest.mark.ai
+@pytest.mark.asyncio
+async def test_upload_files_to_container__downloads_and_creates__when_file_not_in_memory() -> (
+    None
+):
+    """
+    Purpose: Exercise the upload branch: download bytes from ContentService and
+    ``containers.files.create`` so diff coverage includes retry-wrapped I/O.
+    Why this matters: CI requires ≥60% coverage on changed lines in service.py.
+    """
+    memory = CodeExecutionShortTermMemorySchema(
+        container_id="ctr_test",
+        file_ids={},
+    )
+    uploaded = Content(id="cont_upload_1", key="data.csv")
+    content_service = MagicMock()
+    content_service.download_content_to_bytes_async = AsyncMock(
+        return_value=b"a,b\n1,2\n",
+    )
+    openai_file = MagicMock()
+    openai_file.id = "file_openai_1"
+    files_create = AsyncMock(return_value=openai_file)
+    client = MagicMock()
+    client.containers.files.create = files_create
+
+    result = await _upload_files_to_container(
+        client=client,
+        uploaded_files=[uploaded],
+        memory=memory,
+        content_service=content_service,
+        chat_id="chat_1",
+    )
+
+    assert result.file_ids["cont_upload_1"] == "file_openai_1"
+    content_service.download_content_to_bytes_async.assert_awaited_once_with(
+        content_id="cont_upload_1",
+        chat_id="chat_1",
+    )
+    files_create.assert_awaited_once()
+    assert files_create.await_args.kwargs["container_id"] == "ctr_test"
+    assert files_create.await_args.kwargs["file"] == ("data.csv", b"a,b\n1,2\n")
+
+
+@pytest.mark.ai
+@pytest.mark.asyncio
+async def test_upload_files_to_container__retries_download__after_transient_error() -> (
+    None
+):
+    """
+    Purpose: Confirm tenacity retries ``download_content_to_bytes_async`` after a
+    transient failure before calling ``containers.files.create``.
+    """
+    memory = CodeExecutionShortTermMemorySchema(
+        container_id="ctr_retry",
+        file_ids={},
+    )
+    uploaded = Content(id="cont_retry_1", key="f.bin")
+    content_service = MagicMock()
+    content_service.download_content_to_bytes_async = AsyncMock(
+        side_effect=[ConnectionError("blip"), b"payload"],
+    )
+    openai_file = MagicMock()
+    openai_file.id = "file_after_retry"
+    files_create = AsyncMock(return_value=openai_file)
+    client = MagicMock()
+    client.containers.files.create = files_create
+
+    result = await _upload_files_to_container(
+        client=client,
+        uploaded_files=[uploaded],
+        memory=memory,
+        content_service=content_service,
+        chat_id="chat_retry",
+    )
+
+    assert result.file_ids["cont_retry_1"] == "file_after_retry"
+    assert content_service.download_content_to_bytes_async.await_count == 2
+    files_create.assert_awaited_once()

--- a/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/service.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/service.py
@@ -6,6 +6,12 @@ from typing import Any, override
 from openai import AsyncOpenAI, BaseModel, NotFoundError
 from openai.types.responses import ResponseCodeInterpreterToolCall, ResponseIncludable
 from openai.types.responses.tool_param import CodeInterpreter
+from tenacity import (
+    AsyncRetrying,
+    before_sleep_log,
+    stop_after_attempt,
+    wait_exponential,
+)
 
 from unique_toolkit import ContentService, ShortTermMemoryService
 from unique_toolkit.agentic.feature_flags.feature_flags import feature_flags
@@ -25,6 +31,25 @@ from unique_toolkit.content.schemas import (
 )
 
 logger = logging.getLogger(__name__)
+
+_UPLOAD_MAX_RETRIES = 2
+_UPLOAD_RETRY_BASE_DELAY = 0.5
+
+
+def _build_upload_retry() -> AsyncRetrying:
+    """Exponential-backoff retry policy for transient upload/download failures.
+
+    Matches the pattern used in the ``DisplayCodeInterpreterFilesPostProcessor``
+    so that every outbound I/O call gets the same behaviour: up to
+    ``_UPLOAD_MAX_RETRIES`` extra attempts, doubling the wait each time,
+    with a WARNING log before each sleep.
+    """
+    return AsyncRetrying(
+        stop=stop_after_attempt(1 + _UPLOAD_MAX_RETRIES),
+        wait=wait_exponential(multiplier=_UPLOAD_RETRY_BASE_DELAY),
+        before_sleep=before_sleep_log(logger, logging.WARNING),
+        reraise=True,
+    )
 
 
 _SHORT_TERM_MEMORY_NAME = "container_code_execution"
@@ -127,17 +152,34 @@ async def _upload_files_to_container(
 
         if upload:
             logger.info(
-                "Uploding file %s to container %s", file.id, memory.container_id
+                "Uploading file %s (%s) to container %s",
+                file.id,
+                file.key,
+                memory.container_id,
             )
-            file_content = await content_service.download_content_to_bytes_async(
-                content_id=file.id, chat_id=chat_id
+            file_content = await _build_upload_retry()(
+                content_service.download_content_to_bytes_async,
+                content_id=file.id,
+                chat_id=chat_id,
             )
-
-            openai_file = await client.containers.files.create(
+            logger.info(
+                "Downloaded %d bytes for file %s; uploading to container %s",
+                len(file_content),
+                file.id,
+                container_id,
+            )
+            openai_file = await _build_upload_retry()(
+                client.containers.files.create,
                 container_id=container_id,
                 file=(file.key, file_content),
             )
             memory.file_ids[file.id] = openai_file.id
+            logger.info(
+                "File %s successfully uploaded as OpenAI file %s in container %s",
+                file.id,
+                openai_file.id,
+                container_id,
+            )
 
     return memory
 

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-03-27T11:59:49.126947Z"
+exclude-newer = "2026-03-27T14:58:21.495643Z"
 exclude-newer-span = "P2W"
 
 [options.exclude-newer-package]
@@ -5483,7 +5483,7 @@ dev = []
 
 [[package]]
 name = "unique-toolkit"
-version = "1.70.3"
+version = "1.70.4"
 source = { editable = "unique_toolkit" }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Refs: _ticket / issue id if applicable_

Code interpreter already retries **heavy** I/O on the **outbound** path (`generated_files.py`): streaming download from the OpenAI container and upload back to chat use a manual download loop plus tenacity-backed chat uploads.

The **inbound** path—download chat attachments via `ContentService.download_content_to_bytes_async` and push them into the sandbox with `client.containers.files.create`—had **no** retries. Transient network errors or throttling could leave the file missing while execution continued, with weak observability.

This PR **completes retry hardening for those heavy operations** by wrapping both calls with the same tenacity pattern as the postprocessor (`AsyncRetrying`, exponential backoff, `before_sleep_log` at WARNING, `reraise=True`) and clearer INFO logs (byte count after download, OpenAI file id after upload).

**Release:** `unique_toolkit` **1.70.4** — `CHANGELOG.md`, `unique_toolkit/pyproject.toml`, root `uv.lock`.

## Changes

- [x] Fixed bug / hardened reliability (inbound code-interpreter file pipeline)
- [ ] Refactored code / cleaned up
- [ ] Other (describe below)

## Testing

- Manual: chat with code interpreter + uploaded file; confirm analysis runs and logs show upload path.
- Second message in same chat: confirm “already in container” path still behaves (no duplicate upload when file metadata still valid).
- Optional: parallel sends from two tabs on the same chat to stress upload ordering; failures should surface after retries instead of silent missing files.
- CI: lint / tests / types as usual on the PR.