### PR TITLE
feat(toolkit): surface unreferenced code-interpreter files (1.70.4)

### DIFF
--- a/unique_toolkit/CHANGELOG.md
+++ b/unique_toolkit/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.70.4] - 2026-04-10
+- Code interpreter postprocessing: when the model generates a file but omits `sandbox:/mnt/data/...` in the assistant message, append a fallback line `📎 [filename](unique://content/<content_id>)` instead of silently dropping the file (image, HTML, and document paths)
+- `_warn_unmatched_code_blocks` now returns `{filename: content_id}` for files with no code-block match; `apply_postprocessing_to_response` logs them when the code-execution fence feature flag is on
+
 ## [1.70.3] - 2026-04-10
 - Add optional `default_string_empty_value` to `ui_schema_for_model` so bare `str` fields (and `str` items, dict values, union branches, nested models) can get `ui:emptyValue` without `Annotated[..., RJSFMetaTag]`
 - Fix `RJSFMetaTag.StringWidget.textarea`: emit `ui:emptyValue` under the correct key (was `ui:emtpyValue`)

--- a/unique_toolkit/CHANGELOG.md
+++ b/unique_toolkit/CHANGELOG.md
@@ -5,9 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.70.4] - 2026-04-10
+## [1.70.5] - 2026-04-10
 - Code interpreter postprocessing: when the model generates a file but omits `sandbox:/mnt/data/...` in the assistant message, append a fallback line `📎 [filename](unique://content/<content_id>)` instead of silently dropping the file (image, HTML, and document paths)
 - `_warn_unmatched_code_blocks` now returns `{filename: content_id}` for files with no code-block match; `apply_postprocessing_to_response` logs them when the code-execution fence feature flag is on
+- Fix: prevent orphaned `ContentReference` when fallback document links have no matching `<sup>` tag
+
+## [1.70.4] - 2026-04-10
 - Fix: wrap code-interpreter `_upload_files_to_container` download and `containers.files.create` with tenacity exponential backoff (same pattern as generated-files postprocessor) so transient network or throttling does not leave the container without chat-uploaded files; log retries at WARNING and success at INFO
 
 ## [1.70.3] - 2026-04-10

--- a/unique_toolkit/pyproject.toml
+++ b/unique_toolkit/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "unique_toolkit"
-version = "1.70.4"
+version = "1.70.5"
 description = ""
 readme = "README.md"
 requires-python = ">=3.12"

--- a/unique_toolkit/pyproject.toml
+++ b/unique_toolkit/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "unique_toolkit"
-version = "1.70.3"
+version = "1.70.4"
 description = ""
 readme = "README.md"
 requires-python = ">=3.12"

--- a/unique_toolkit/tests/agentic/tools/test_code_interpreter_postprocessors_generated_files.py
+++ b/unique_toolkit/tests/agentic/tools/test_code_interpreter_postprocessors_generated_files.py
@@ -1235,16 +1235,17 @@ def test_replace_container_image_citation__logs_warning__when_no_sandbox_link(
     caplog,
 ) -> None:
     """
-    Purpose: Verify a WARNING is emitted by _replace_container_image_citation when no
-    sandbox link is present for the filename.
-    Why this matters: Makes it visible in production that the LLM omitted the link.
+    Purpose: Verify a WARNING is emitted and a fallback download link is appended when
+    no sandbox link is present for the filename.
+    Why this matters: Without the fallback link the user would never see the file.
     """
     with caplog.at_level(logging.WARNING, logger="unique_toolkit"):
-        _, replaced = gen_mod._replace_container_image_citation(
+        new_text, replaced = gen_mod._replace_container_image_citation(
             text="No link here.", filename="plot.png", content_id="cont_x"
         )
 
-    assert replaced is False
+    assert replaced is True
+    assert "📎 [plot.png](unique://content/cont_x)" in new_text
     assert any(
         "plot.png" in r.message and r.levelno == logging.WARNING for r in caplog.records
     )
@@ -1255,11 +1256,11 @@ def test_replace_container_file_citation__logs_warning__when_no_sandbox_link(
     caplog,
 ) -> None:
     """
-    Purpose: Verify a WARNING is emitted by _replace_container_file_citation when no
-    sandbox link is present for the filename.
+    Purpose: Verify a WARNING is emitted and a fallback download link is appended when
+    no sandbox link is present for the filename.
     """
     with caplog.at_level(logging.WARNING, logger="unique_toolkit"):
-        _, replaced = gen_mod._replace_container_file_citation(
+        new_text, replaced = gen_mod._replace_container_file_citation(
             text="No link here.",
             filename="data.csv",
             content_id="cont_y",
@@ -1267,7 +1268,8 @@ def test_replace_container_file_citation__logs_warning__when_no_sandbox_link(
             use_content_link=False,
         )
 
-    assert replaced is False
+    assert replaced is True
+    assert "📎 [data.csv](unique://content/cont_y)" in new_text
     assert any(
         "data.csv" in r.message and r.levelno == logging.WARNING for r in caplog.records
     )
@@ -1278,15 +1280,16 @@ def test_replace_container_html_citation__logs_warning__when_no_sandbox_link(
     caplog,
 ) -> None:
     """
-    Purpose: Verify a WARNING is emitted by _replace_container_html_citation when no
-    sandbox link is present for the filename.
+    Purpose: Verify a WARNING is emitted and a fallback download link is appended when
+    no sandbox link is present for the filename.
     """
     with caplog.at_level(logging.WARNING, logger="unique_toolkit"):
-        _, replaced = gen_mod._replace_container_html_citation(
+        new_text, replaced = gen_mod._replace_container_html_citation(
             text="No link here.", filename="report.html", content_id="cont_z"
         )
 
-    assert replaced is False
+    assert replaced is True
+    assert "📎 [report.html](unique://content/cont_z)" in new_text
     assert any(
         "report.html" in r.message and r.levelno == logging.WARNING
         for r in caplog.records
@@ -1620,19 +1623,21 @@ def test_warn_unmatched_code_blocks__logs_warning__when_file_not_in_any_block(
     caplog,
 ) -> None:
     """
-    Purpose: Verify a WARNING is emitted when an uploaded file (with a valid content_id)
-    is not present in any code block.
+    Purpose: Verify a WARNING is emitted and the unmatched file is returned when an
+    uploaded file (with a valid content_id) is not present in any code block.
     Why this matters: This means the file won't receive a fence when FF=on.  It will
     appear as a plain download link and the frontend artifact UI won't be shown.
     The warning tells the operator the query should be re-run.
-    Setup summary: content_map has one file; code_blocks is empty; assert warning.
+    Setup summary: content_map has one file; code_blocks is empty; assert warning and
+    returned dict contains the unmatched entry.
     """
     content_map: dict[str, str | None] = {"report.xlsx": "cont_abc"}
     code_blocks: list[CodeInterpreterBlock] = []
 
     with caplog.at_level(logging.WARNING, logger="unique_toolkit"):
-        _warn_unmatched_code_blocks(content_map, code_blocks)
+        unmatched = _warn_unmatched_code_blocks(content_map, code_blocks)
 
+    assert unmatched == {"report.xlsx": "cont_abc"}
     assert any(
         "report.xlsx" in r.message and r.levelno == logging.WARNING
         for r in caplog.records
@@ -1644,7 +1649,8 @@ def test_warn_unmatched_code_blocks__no_warning__when_file_is_in_block(
     caplog,
 ) -> None:
     """
-    Purpose: Verify no WARNING when the file is correctly matched to a code block.
+    Purpose: Verify no WARNING and an empty dict returned when the file is correctly
+    matched to a code block.
     """
     content_map: dict[str, str | None] = {"chart.png": "cont_img1"}
     code_blocks = [
@@ -1659,23 +1665,26 @@ def test_warn_unmatched_code_blocks__no_warning__when_file_is_in_block(
     ]
 
     with caplog.at_level(logging.WARNING, logger="unique_toolkit"):
-        _warn_unmatched_code_blocks(content_map, code_blocks)
+        unmatched = _warn_unmatched_code_blocks(content_map, code_blocks)
 
+    assert unmatched == {}
     assert not any(r.levelno == logging.WARNING for r in caplog.records)
 
 
 @pytest.mark.ai
 def test_warn_unmatched_code_blocks__skips_none_content_ids(caplog) -> None:
     """
-    Purpose: Verify files whose upload failed (content_id=None) are silently skipped.
+    Purpose: Verify files whose upload failed (content_id=None) are silently skipped
+    and not included in the returned dict.
     Why this matters: Upload failures are already handled upstream; no double warning.
     """
     content_map: dict[str, str | None] = {"broken.xlsx": None}
     code_blocks: list[CodeInterpreterBlock] = []
 
     with caplog.at_level(logging.WARNING, logger="unique_toolkit"):
-        _warn_unmatched_code_blocks(content_map, code_blocks)
+        unmatched = _warn_unmatched_code_blocks(content_map, code_blocks)
 
+    assert unmatched == {}
     assert not any(r.levelno == logging.WARNING for r in caplog.records)
 
 

--- a/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/postprocessors/generated_files.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/postprocessors/generated_files.py
@@ -613,7 +613,16 @@ class DisplayCodeInterpreterFilesPostProcessor(
                 len(code_blocks),
                 [f.filename for b in code_blocks for f in b.files],
             )
-            _warn_unmatched_code_blocks(self._content_map, code_blocks)
+            unmatched_blocks = _warn_unmatched_code_blocks(
+                self._content_map, code_blocks
+            )
+            if unmatched_blocks:
+                self._log.info(
+                    "Fence path: %d file(s) have no code-block match and will appear "
+                    "as plain download links: %s",
+                    len(unmatched_blocks),
+                    list(unmatched_blocks),
+                )
             text_before = loop_response.message.text
             loop_response.message.text = _inject_code_execution_fences(
                 loop_response.message.text,
@@ -1409,7 +1418,7 @@ def _replace_dangling_sandbox_links(text: str, error_message: str) -> tuple[str,
 def _warn_unmatched_code_blocks(
     content_map: dict[str, str | None],
     code_blocks: list[CodeInterpreterBlock],
-) -> None:
+) -> dict[str, str]:
     """Warn for files that were uploaded but could not be matched to any code block.
 
     When the fence feature flag is on, every uploaded file should map to a code block
@@ -1417,8 +1426,13 @@ def _warn_unmatched_code_blocks(
     matched (e.g. the LLM used a variable for the output path rather than a literal
     string) it falls back to a plain unique://content/ link with no code context.
     The user can still download it, but the frontend artifact UI will not be shown.
+
+    Returns:
+        Mapping of filename → content_id for every file that could not be matched
+        to a code block.  Callers may use this to inject additional fallback links.
     """
     fenced_filenames = {f.filename for block in code_blocks for f in block.files}
+    unmatched: dict[str, str] = {}
     for filename, content_id in content_map.items():
         if content_id is None:
             continue
@@ -1434,6 +1448,8 @@ def _warn_unmatched_code_blocks(
                 content_id,
                 filename,
             )
+            unmatched[filename] = content_id
+    return unmatched
 
 
 def _get_next_ref_number(references: list[ContentReference] | None) -> int:
@@ -1474,11 +1490,12 @@ def _replace_container_image_citation(
     if not re.search(image_markdown, text):
         logger.warning(
             "No sandbox link found for image '%s' (content_id=%s); "
-            "file was uploaded but the LLM did not reference it — it will not be displayed.",
+            "file was uploaded but the LLM did not reference it — appending fallback link.",
             filename,
             content_id,
         )
-        return text, False
+        fallback = f"\n\n📎 [{filename}](unique://content/{content_id})"
+        return text + fallback, True
 
     logger.info("Inserting image citation for '%s'", filename)
     return re.sub(
@@ -1497,11 +1514,12 @@ def _replace_container_html_citation(
     if not re.search(html_markdown, text):
         logger.warning(
             "No sandbox link found for HTML file '%s' (content_id=%s); "
-            "file was uploaded but the LLM did not reference it — it will not be displayed.",
+            "file was uploaded but the LLM did not reference it — appending fallback link.",
             filename,
             content_id,
         )
-        return text, False
+        fallback = f"\n\n📎 [{filename}](unique://content/{content_id})"
+        return text + fallback, True
 
     logger.info("Inserting HTML rendering block for '%s'", filename)
     block = f"```HtmlRendering\n800px\n600px\n\nunique://content/{content_id}\n\n```"
@@ -1554,11 +1572,12 @@ def _replace_container_file_citation(
     if not re.search(file_markdown, text):
         logger.warning(
             "No sandbox link found for file '%s' (content_id=%s); "
-            "file was uploaded but the LLM did not reference it — it will not be displayed.",
+            "file was uploaded but the LLM did not reference it — appending fallback link.",
             filename,
             content_id,
         )
-        return text, False
+        fallback = f"\n\n📎 [{filename}](unique://content/{content_id})"
+        return text + fallback, True
 
     logger.info("Displaying file %s", filename)
     replacement = (

--- a/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/postprocessors/generated_files.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/postprocessors/generated_files.py
@@ -588,7 +588,11 @@ class DisplayCodeInterpreterFilesPostProcessor(
 
             is_html_rendered = is_html
             has_superscript = f"<sup>{ref_number}</sup>" in loop_response.message.text
-            if replaced and has_superscript and not (is_image or is_html_rendered or fence_ff_on):
+            if (
+                replaced
+                and has_superscript
+                and not (is_image or is_html_rendered or fence_ff_on)
+            ):
                 loop_response.message.references.append(
                     ContentReference(
                         sequence_number=ref_number,

--- a/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/postprocessors/generated_files.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/postprocessors/generated_files.py
@@ -587,7 +587,8 @@ class DisplayCodeInterpreterFilesPostProcessor(
                 missed_files.append(filename)
 
             is_html_rendered = is_html
-            if replaced and not (is_image or is_html_rendered or fence_ff_on):
+            has_superscript = f"<sup>{ref_number}</sup>" in loop_response.message.text
+            if replaced and has_superscript and not (is_image or is_html_rendered or fence_ff_on):
                 loop_response.message.references.append(
                     ContentReference(
                         sequence_number=ref_number,

--- a/uv.lock
+++ b/uv.lock
@@ -8,20 +8,20 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-03-27T14:58:21.495643Z"
+exclude-newer = "2026-03-27T16:23:14.123736Z"
 exclude-newer-span = "P2W"
 
 [options.exclude-newer-package]
 unique-toolkit = false
-copier = "2026-04-09T22:00:00Z"
-langchain-core = "2026-04-09T22:00:00Z"
-openai = "2026-04-09T22:00:00Z"
-deepdiff = "2026-04-08T22:00:00Z"
-fastmcp = "2026-04-08T22:00:00Z"
-aiohttp = "2026-04-08T22:00:00Z"
-cryptography = "2026-04-08T22:00:00Z"
-litellm = "2026-04-09T22:00:00Z"
-requests = "2026-04-08T22:00:00Z"
+copier = "2026-04-10T04:00:00Z"
+langchain-core = "2026-04-10T04:00:00Z"
+openai = "2026-04-10T04:00:00Z"
+deepdiff = "2026-04-09T04:00:00Z"
+fastmcp = "2026-04-09T04:00:00Z"
+aiohttp = "2026-04-09T04:00:00Z"
+cryptography = "2026-04-09T04:00:00Z"
+litellm = "2026-04-10T04:00:00Z"
+requests = "2026-04-09T04:00:00Z"
 
 [manifest]
 members = [
@@ -5483,7 +5483,7 @@ dev = []
 
 [[package]]
 name = "unique-toolkit"
-version = "1.70.4"
+version = "1.70.5"
 source = { editable = "unique_toolkit" }
 dependencies = [
     { name = "aiohttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-03-27T11:59:49.126947Z"
+exclude-newer = "2026-03-27T15:41:34.259872Z"
 exclude-newer-span = "P2W"
 
 [options.exclude-newer-package]
@@ -5483,7 +5483,7 @@ dev = []
 
 [[package]]
 name = "unique-toolkit"
-version = "1.70.3"
+version = "1.70.4"
 source = { editable = "unique_toolkit" }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## 🚀 Summary

Refs: _UN-17927 / code interpreter citations (related); no single ticket linked_

When the code interpreter uploads a generated file but the model omits a `sandbox:/mnt/data/<filename>` reference in the assistant message, postprocessing used to log a warning and **drop** the file from the user-visible output. This PR appends a **fallback** markdown line so the content is still addressable:

`📎 [filename](unique://content/<content_id>)`

for **image**, **HTML**, and **document** paths (`_replace_container_image_citation`, `_replace_container_html_citation`, `_replace_container_file_citation`). `_warn_unmatched_code_blocks` now returns `{filename: content_id}` for files that cannot be matched to a code block when the code-execution fence feature flag is on; `apply_postprocessing_to_response` logs that set for operators.

**Release:** `unique_toolkit` **1.70.4** (`pyproject.toml`, `CHANGELOG.md`, root **`uv.lock`** refreshed for CI `uv sync --locked`).

## ✅ Changes

- [x] Added feature / fixed bug / updated docs — fallback links for unreferenced uploads; `_warn_unmatched_code_blocks` return value + logging
- [ ] Refactored code / cleaned up
- [x] Other (describe below)

**Other / limitations (manual UI findings — not all fixable in this PR):**

1. **Happy path unchanged:** If the model includes a sandbox link (e.g. placeholder text linking to `/mnt/data/...`), Stage-1 replacement and fence injection behave as before; the file can appear in `fileWithSource` / iframe-style UI (validated in a CSV scenario).

2. **Fallback link may not be clickable in the chat UI:** In a scenario where the model described a chart in prose only (no sandbox link), the fallback line appeared in stored `text` as `📎 […](unique://content/…)`, but the product UI did **not** treat it as a normal clickable download link. **Likely a frontend gap:** markdown renderer or link handler may not register `unique://content/…` outside dedicated widgets (fences, references). Follow-up may belong in the web client, or we could explore adding **`references`** / superscript flow for these cases in a follow-up PR.

3. **Cross-turn `content_map` / wrong filename in fallback:** In the same chat, a **previous** turn’s uploaded file (e.g. `silent_output.csv`) can still be present in the map when a **new** turn runs. If the model omits links for multiple generations, the appended fallback can surface **another** turn’s file next to the new reply. That is largely **lifecycle / state** of the postprocessor’s `content_map`, not introduced by the fallback line itself, but it affects how “correct” the appended line looks to the user.

4. **No fallback if the file never enters `content_map`:** In an Excel scenario where the assistant text was only “Done.” and the expected `.xlsx` did not appear as a user-facing artifact, the visible output was dominated by a **code** `fileWithSource`-style block, not the spreadsheet. If the binary never gets a `content_id` in the map, **no** backend postprocessing step can invent a `unique://content/…` link — that points to **upload / tracking** upstream of `apply_postprocessing`, not this diff.

5. **`_replace_container_file_error` (upload failed, `content_id is None`):** Still cannot append a content link; behaviour unchanged by design.

## 🧪 Testing

- **Automated:** `poetry run pytest tests/agentic/tools/test_code_interpreter_postprocessors_generated_files.py` — full file, 125 tests (includes updated expectations for “no sandbox link” and `_warn_unmatched_code_blocks` return dict).
- **Manual (local UI):** Three scenarios were exercised; outcomes are summarized in **Other / limitations** above (clickability, cross-turn map, missing `content_map` entry for output file).
