### PR TITLE
fix(web-search): validate parallel parameter to prevent silent data loss

### DIFF
--- a/tool_packages/unique_web_search/CHANGELOG.md
+++ b/tool_packages/unique_web_search/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.16.1] - 2026-04-12
+### Fixed
+- Validate `--parallel` crawl option to reject zero and negative values that caused silent data loss or cryptic `range()` errors
+
 ## [1.16.0] - 2026-04-11
 ### Added
 - **`unique-websearch` CLI** with two-phase architecture for AI-assisted web search:

--- a/tool_packages/unique_web_search/pyproject.toml
+++ b/tool_packages/unique_web_search/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "unique_web_search"
-version = "1.16.0"
+version = "1.16.1"
 description = ""
 readme = "README.md"
 requires-python = ">=3.12,<4.0"

--- a/tool_packages/unique_web_search/src/unique_web_search/cli/cli.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/cli/cli.py
@@ -130,7 +130,7 @@ Examples:
     "--parallel",
     "-p",
     default=10,
-    type=int,
+    type=click.IntRange(min=1),
     show_default=True,
     help="Number of URLs to crawl in parallel.",
 )

--- a/tool_packages/unique_web_search/src/unique_web_search/cli/commands/crawl.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/cli/commands/crawl.py
@@ -22,6 +22,8 @@ async def _crawl_with_parallelism(
     parallel: int,
 ) -> list[tuple[str, str, str | None]]:
     """Crawl URLs in batches of *parallel*, returning (url, content, error) triples."""
+    if parallel < 1:
+        raise ValueError(f"parallel must be >= 1, got {parallel}")
     crawler = get_crawler_service(crawler_config)
     results: list[tuple[str, str, str | None]] = []
     for i in range(0, len(urls), parallel):

--- a/tool_packages/unique_web_search/tests/test_cli.py
+++ b/tool_packages/unique_web_search/tests/test_cli.py
@@ -6,7 +6,6 @@ import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-
 from click.testing import CliRunner
 
 from unique_web_search.cli.cli import main

--- a/tool_packages/unique_web_search/tests/test_cli.py
+++ b/tool_packages/unique_web_search/tests/test_cli.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 from click.testing import CliRunner
 
 from unique_web_search.cli.cli import main
@@ -292,6 +294,14 @@ class TestCmdCrawl:
         assert len(parsed) == 1
         assert parsed[0]["content"] == "content"
         assert parsed[0]["error"] is None
+
+    def test_crawl_rejects_zero_parallel(self) -> None:
+        with pytest.raises(ValueError, match="parallel must be >= 1"):
+            cmd_crawl(MagicMock(), ["https://example.com"], parallel=0)
+
+    def test_crawl_rejects_negative_parallel(self) -> None:
+        with pytest.raises(ValueError, match="parallel must be >= 1"):
+            cmd_crawl(MagicMock(), ["https://example.com"], parallel=-1)
 
     @patch("unique_web_search.cli.commands.crawl.get_crawler_service")
     def test_crawl_batch_error(self, mock_get: MagicMock) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-03-29T12:04:19.244301Z"
+exclude-newer = "2026-03-29T12:41:52.760324Z"
 exclude-newer-span = "P2W"
 
 [options.exclude-newer-package]
@@ -5574,7 +5574,7 @@ dev = []
 
 [[package]]
 name = "unique-web-search"
-version = "1.16.0"
+version = "1.16.1"
 source = { editable = "tool_packages/unique_web_search" }
 dependencies = [
     { name = "azure-ai-projects" },


### PR DESCRIPTION
## Summary
- Validate the `--parallel` CLI option to reject zero and negative values that cause silent data loss or cryptic errors

## Changes
- **`cli.py`**: Change `--parallel` Click option from `type=int` to `type=click.IntRange(min=1)` so Click rejects invalid values at the CLI level with a clear error message
- **`commands/crawl.py`**: Add defensive `ValueError` in `_crawl_with_parallelism` for callers bypassing Click (e.g. `cmd_crawl()` invoked programmatically)

## Test plan
- [ ] `unique-websearch crawl --parallel 0 https://example.com` → Click error "0 is not in the range x>=1"
- [ ] `unique-websearch crawl --parallel -1 https://example.com` → Click error "-1 is not in the range x>=1"
- [ ] `unique-websearch crawl --parallel 5 https://example.com` → works as before

## Risk / rollout
- Low risk — only rejects previously-broken inputs (0 raised `ValueError`, negative silently dropped URLs)

Refs: Cursor Bugbot finding on PR #1347

Made with [Cursor](https://cursor.com)