### PR TITLE
fix(toolkit): revert fallback link noise from PR #1418 (1.70.7)

### DIFF
--- a/unique_toolkit/CHANGELOG.md
+++ b/unique_toolkit/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.70.7] - 2026-04-12
+- Revert fallback `📎 [filename](unique://content/...)` links from PR #1418 — when the LLM omits a sandbox reference the file is silently skipped again (warn-only) instead of appending noisy download links to the message
+- Revert `_warn_unmatched_code_blocks` return-value change; the function is fire-and-forget again
+- Revert `has_superscript` guard on `ContentReference` creation; references are added whenever a file link is replaced
+
 ## [1.70.6] - 2026-04-10
 - Code interpreter postprocessor (`generated_files.py`): dangling `sandbox:/mnt/data/...` markdown links are replaced with a per-file notice naming the file and suggesting regeneration, instead of the generic download-failure message
 - Orphan code-execution runs (no container file output, fence feature flag `enable_code_execution_fence_un_17972`): uploaded `.txt` artifacts are attached as `ContentReference` entries in `message.references` instead of appending `fileWithSource` fences to `message.text`; remove unused `_build_orphan_fences` and `_get_next_fence_id`

--- a/unique_toolkit/pyproject.toml
+++ b/unique_toolkit/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "unique_toolkit"
-version = "1.70.6"
+version = "1.70.7"
 description = ""
 readme = "README.md"
 requires-python = ">=3.12"

--- a/unique_toolkit/tests/agentic/tools/test_code_interpreter_postprocessors_generated_files.py
+++ b/unique_toolkit/tests/agentic/tools/test_code_interpreter_postprocessors_generated_files.py
@@ -1234,17 +1234,16 @@ def test_replace_container_image_citation__logs_warning__when_no_sandbox_link(
     caplog,
 ) -> None:
     """
-    Purpose: Verify a WARNING is emitted and a fallback download link is appended when
-    no sandbox link is present for the filename.
-    Why this matters: Without the fallback link the user would never see the file.
+    Purpose: Verify a WARNING is emitted by _replace_container_image_citation when no
+    sandbox link is present for the filename.
+    Why this matters: Makes it visible in production that the LLM omitted the link.
     """
     with caplog.at_level(logging.WARNING, logger="unique_toolkit"):
-        new_text, replaced = gen_mod._replace_container_image_citation(
+        _, replaced = gen_mod._replace_container_image_citation(
             text="No link here.", filename="plot.png", content_id="cont_x"
         )
 
-    assert replaced is True
-    assert "📎 [plot.png](unique://content/cont_x)" in new_text
+    assert replaced is False
     assert any(
         "plot.png" in r.message and r.levelno == logging.WARNING for r in caplog.records
     )
@@ -1255,11 +1254,11 @@ def test_replace_container_file_citation__logs_warning__when_no_sandbox_link(
     caplog,
 ) -> None:
     """
-    Purpose: Verify a WARNING is emitted and a fallback download link is appended when
-    no sandbox link is present for the filename.
+    Purpose: Verify a WARNING is emitted by _replace_container_file_citation when no
+    sandbox link is present for the filename.
     """
     with caplog.at_level(logging.WARNING, logger="unique_toolkit"):
-        new_text, replaced = gen_mod._replace_container_file_citation(
+        _, replaced = gen_mod._replace_container_file_citation(
             text="No link here.",
             filename="data.csv",
             content_id="cont_y",
@@ -1267,8 +1266,7 @@ def test_replace_container_file_citation__logs_warning__when_no_sandbox_link(
             use_content_link=False,
         )
 
-    assert replaced is True
-    assert "📎 [data.csv](unique://content/cont_y)" in new_text
+    assert replaced is False
     assert any(
         "data.csv" in r.message and r.levelno == logging.WARNING for r in caplog.records
     )
@@ -1279,16 +1277,15 @@ def test_replace_container_html_citation__logs_warning__when_no_sandbox_link(
     caplog,
 ) -> None:
     """
-    Purpose: Verify a WARNING is emitted and a fallback download link is appended when
-    no sandbox link is present for the filename.
+    Purpose: Verify a WARNING is emitted by _replace_container_html_citation when no
+    sandbox link is present for the filename.
     """
     with caplog.at_level(logging.WARNING, logger="unique_toolkit"):
-        new_text, replaced = gen_mod._replace_container_html_citation(
+        _, replaced = gen_mod._replace_container_html_citation(
             text="No link here.", filename="report.html", content_id="cont_z"
         )
 
-    assert replaced is True
-    assert "📎 [report.html](unique://content/cont_z)" in new_text
+    assert replaced is False
     assert any(
         "report.html" in r.message and r.levelno == logging.WARNING
         for r in caplog.records
@@ -1621,21 +1618,19 @@ def test_warn_unmatched_code_blocks__logs_warning__when_file_not_in_any_block(
     caplog,
 ) -> None:
     """
-    Purpose: Verify a WARNING is emitted and the unmatched file is returned when an
-    uploaded file (with a valid content_id) is not present in any code block.
+    Purpose: Verify a WARNING is emitted when an uploaded file (with a valid content_id)
+    is not present in any code block.
     Why this matters: This means the file won't receive a fence when FF=on.  It will
     appear as a plain download link and the frontend artifact UI won't be shown.
     The warning tells the operator the query should be re-run.
-    Setup summary: content_map has one file; code_blocks is empty; assert warning and
-    returned dict contains the unmatched entry.
+    Setup summary: content_map has one file; code_blocks is empty; assert warning.
     """
     content_map: dict[str, str | None] = {"report.xlsx": "cont_abc"}
     code_blocks: list[CodeInterpreterBlock] = []
 
     with caplog.at_level(logging.WARNING, logger="unique_toolkit"):
-        unmatched = _warn_unmatched_code_blocks(content_map, code_blocks)
+        _warn_unmatched_code_blocks(content_map, code_blocks)
 
-    assert unmatched == {"report.xlsx": "cont_abc"}
     assert any(
         "report.xlsx" in r.message and r.levelno == logging.WARNING
         for r in caplog.records
@@ -1647,8 +1642,7 @@ def test_warn_unmatched_code_blocks__no_warning__when_file_is_in_block(
     caplog,
 ) -> None:
     """
-    Purpose: Verify no WARNING and an empty dict returned when the file is correctly
-    matched to a code block.
+    Purpose: Verify no WARNING when the file is correctly matched to a code block.
     """
     content_map: dict[str, str | None] = {"chart.png": "cont_img1"}
     code_blocks = [
@@ -1663,26 +1657,23 @@ def test_warn_unmatched_code_blocks__no_warning__when_file_is_in_block(
     ]
 
     with caplog.at_level(logging.WARNING, logger="unique_toolkit"):
-        unmatched = _warn_unmatched_code_blocks(content_map, code_blocks)
+        _warn_unmatched_code_blocks(content_map, code_blocks)
 
-    assert unmatched == {}
     assert not any(r.levelno == logging.WARNING for r in caplog.records)
 
 
 @pytest.mark.ai
 def test_warn_unmatched_code_blocks__skips_none_content_ids(caplog) -> None:
     """
-    Purpose: Verify files whose upload failed (content_id=None) are silently skipped
-    and not included in the returned dict.
+    Purpose: Verify files whose upload failed (content_id=None) are silently skipped.
     Why this matters: Upload failures are already handled upstream; no double warning.
     """
     content_map: dict[str, str | None] = {"broken.xlsx": None}
     code_blocks: list[CodeInterpreterBlock] = []
 
     with caplog.at_level(logging.WARNING, logger="unique_toolkit"):
-        unmatched = _warn_unmatched_code_blocks(content_map, code_blocks)
+        _warn_unmatched_code_blocks(content_map, code_blocks)
 
-    assert unmatched == {}
     assert not any(r.levelno == logging.WARNING for r in caplog.records)
 
 

--- a/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/postprocessors/generated_files.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/postprocessors/generated_files.py
@@ -586,12 +586,7 @@ class DisplayCodeInterpreterFilesPostProcessor(
                 missed_files.append(filename)
 
             is_html_rendered = is_html
-            has_superscript = f"<sup>{ref_number}</sup>" in loop_response.message.text
-            if (
-                replaced
-                and has_superscript
-                and not (is_image or is_html_rendered or fence_ff_on)
-            ):
+            if replaced and not (is_image or is_html_rendered or fence_ff_on):
                 loop_response.message.references.append(
                     ContentReference(
                         sequence_number=ref_number,
@@ -617,16 +612,7 @@ class DisplayCodeInterpreterFilesPostProcessor(
                 len(code_blocks),
                 [f.filename for b in code_blocks for f in b.files],
             )
-            unmatched_blocks = _warn_unmatched_code_blocks(
-                self._content_map, code_blocks
-            )
-            if unmatched_blocks:
-                self._log.info(
-                    "Fence path: %d file(s) have no code-block match and will appear "
-                    "as plain download links: %s",
-                    len(unmatched_blocks),
-                    list(unmatched_blocks),
-                )
+            _warn_unmatched_code_blocks(self._content_map, code_blocks)
             text_before = loop_response.message.text
             loop_response.message.text = _inject_code_execution_fences(
                 loop_response.message.text,
@@ -1401,7 +1387,7 @@ def _replace_dangling_sandbox_links(text: str) -> tuple[str, bool]:
 def _warn_unmatched_code_blocks(
     content_map: dict[str, str | None],
     code_blocks: list[CodeInterpreterBlock],
-) -> dict[str, str]:
+) -> None:
     """Warn for files that were uploaded but could not be matched to any code block.
 
     When the fence feature flag is on, every uploaded file should map to a code block
@@ -1409,13 +1395,8 @@ def _warn_unmatched_code_blocks(
     matched (e.g. the LLM used a variable for the output path rather than a literal
     string) it falls back to a plain unique://content/ link with no code context.
     The user can still download it, but the frontend artifact UI will not be shown.
-
-    Returns:
-        Mapping of filename → content_id for every file that could not be matched
-        to a code block.  Callers may use this to inject additional fallback links.
     """
     fenced_filenames = {f.filename for block in code_blocks for f in block.files}
-    unmatched: dict[str, str] = {}
     for filename, content_id in content_map.items():
         if content_id is None:
             continue
@@ -1431,8 +1412,6 @@ def _warn_unmatched_code_blocks(
                 content_id,
                 filename,
             )
-            unmatched[filename] = content_id
-    return unmatched
 
 
 def _get_next_ref_number(references: list[ContentReference] | None) -> int:
@@ -1473,12 +1452,11 @@ def _replace_container_image_citation(
     if not re.search(image_markdown, text):
         logger.warning(
             "No sandbox link found for image '%s' (content_id=%s); "
-            "file was uploaded but the LLM did not reference it — appending fallback link.",
+            "file was uploaded but the LLM did not reference it — it will not be displayed.",
             filename,
             content_id,
         )
-        fallback = f"\n\n📎 [{filename}](unique://content/{content_id})"
-        return text + fallback, True
+        return text, False
 
     logger.info("Inserting image citation for '%s'", filename)
     return re.sub(
@@ -1497,12 +1475,11 @@ def _replace_container_html_citation(
     if not re.search(html_markdown, text):
         logger.warning(
             "No sandbox link found for HTML file '%s' (content_id=%s); "
-            "file was uploaded but the LLM did not reference it — appending fallback link.",
+            "file was uploaded but the LLM did not reference it — it will not be displayed.",
             filename,
             content_id,
         )
-        fallback = f"\n\n📎 [{filename}](unique://content/{content_id})"
-        return text + fallback, True
+        return text, False
 
     logger.info("Inserting HTML rendering block for '%s'", filename)
     block = f"```HtmlRendering\n800px\n600px\n\nunique://content/{content_id}\n\n```"
@@ -1555,12 +1532,11 @@ def _replace_container_file_citation(
     if not re.search(file_markdown, text):
         logger.warning(
             "No sandbox link found for file '%s' (content_id=%s); "
-            "file was uploaded but the LLM did not reference it — appending fallback link.",
+            "file was uploaded but the LLM did not reference it — it will not be displayed.",
             filename,
             content_id,
         )
-        fallback = f"\n\n📎 [{filename}](unique://content/{content_id})"
-        return text + fallback, True
+        return text, False
 
     logger.info("Displaying file %s", filename)
     replacement = (

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-03-29T12:04:19.244301Z"
+exclude-newer = "2026-03-29T12:35:48.741802Z"
 exclude-newer-span = "P2W"
 
 [options.exclude-newer-package]
@@ -5483,7 +5483,7 @@ dev = []
 
 [[package]]
 name = "unique-toolkit"
-version = "1.70.6"
+version = "1.70.7"
 source = { editable = "unique_toolkit" }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Revert the fallback `📎 [filename](unique://content/...)` links introduced in PR #1418 — these appended download links to every message where the LLM omitted a sandbox reference, creating excessive noise for end users
- Restore warn-only behaviour: log a WARNING but leave `message.text` untouched
- Bump version to 1.70.7

## Changes
- `generated_files.py`: revert `_replace_container_image_citation`, `_replace_container_html_citation`, `_replace_container_file_citation` to return `(text, False)` instead of appending a fallback link
- `generated_files.py`: revert `_warn_unmatched_code_blocks` return type from `dict[str, str]` back to `None`
- `generated_files.py`: remove `has_superscript` guard on `ContentReference` creation — references are added whenever a file link is replaced
- `test_code_interpreter_postprocessors_generated_files.py`: update 6 tests to match reverted expectations
- `CHANGELOG.md` / `pyproject.toml` / `uv.lock`: version bump 1.70.6 → 1.70.7

## Test plan
- [ ] CI passes all existing tests (including the updated test assertions)
- [ ] Manual: verify code-interpreter responses no longer contain spurious `📎` fallback lines

## Risk / rollout
- Files genuinely missed by the LLM will again be silently absent from the message (warn-only). This is the intended trade-off — the fallback noise was worse than the missing link.

Refs: #1418

Made with [Cursor](https://cursor.com)