### PR TITLE
feat(toolkit): user-friendly message if content filter blocks response

### DIFF
--- a/unique_toolkit/CHANGELOG.md
+++ b/unique_toolkit/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.70.9] - 2026-04-13
+### Added
+- Responses API loop: when Azure (or compatible) content filtering rejects a request (`content_filter` / ResponsibleAI-style errors), return a clear assistant message with retry hints instead of surfacing a raw API error (UN-19304)
+
 ## [1.70.8] - 2026-04-13
 ### Fixed
 - Code interpreter generated-files postprocessor (`generated_files.py`): coerce container-file uploads to KB-safe MIME types (e.g. `.py` as `text/plain`) so Unique GraphQL no longer rejects uploads with `Invalid file type` (UN-19267)

--- a/unique_toolkit/CHANGELOG.md
+++ b/unique_toolkit/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.70.9] - 2026-04-13
 ### Added
 - Responses API loop: when Azure (or compatible) content filtering rejects a request (`content_filter` / ResponsibleAI-style errors), return a clear assistant message with retry hints instead of surfacing a raw API error (UN-19304)
+### Fixed
+- Apply the same content-filter handling in `handle_responses_forced_tools_iteration` (was missing vs normal/last iteration)
+### Changed
+- User-facing copy: domain-neutral wording (no “financial terminology” assumption) for the content-filter message
 
 ## [1.70.8] - 2026-04-13
 ### Fixed

--- a/unique_toolkit/pyproject.toml
+++ b/unique_toolkit/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "unique_toolkit"
-version = "1.70.8"
+version = "1.70.9"
 description = ""
 readme = "README.md"
 requires-python = ">=3.12"

--- a/unique_toolkit/tests/agentic/test_refusal_handler.py
+++ b/unique_toolkit/tests/agentic/test_refusal_handler.py
@@ -1,0 +1,254 @@
+"""Tests for the content-filter error handler."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import unique_sdk
+
+from unique_toolkit.agentic.loop_runner._refusal_handler import (
+    CONTENT_FILTER_MESSAGE,
+    is_content_filter_error,
+    make_content_filter_response,
+)
+
+# ---------------------------------------------------------------------------
+# is_content_filter_error
+# ---------------------------------------------------------------------------
+
+
+def _unique_error(
+    code: str | None = None, message: str = "error"
+) -> unique_sdk.UniqueError:
+    err = unique_sdk.UniqueError(message=message, http_status=400, code=code)
+    return err
+
+
+class TestIsContentFilterError:
+    def test_unique_sdk_error_with_content_filter_code(self):
+        assert is_content_filter_error(_unique_error(code="content_filter")) is True
+
+    def test_unique_sdk_error_with_content_filter_in_message(self):
+        assert (
+            is_content_filter_error(_unique_error(message="content_filter triggered"))
+            is True
+        )
+
+    def test_unique_sdk_error_with_responsibleai_in_message(self):
+        assert (
+            is_content_filter_error(
+                _unique_error(message="ResponsibleAI policy violation")
+            )
+            is True
+        )
+
+    def test_unique_sdk_error_unrelated_code(self):
+        assert (
+            is_content_filter_error(
+                _unique_error(code="rate_limit", message="too many requests")
+            )
+            is False
+        )
+
+    def test_generic_exception_returns_false(self):
+        assert is_content_filter_error(ValueError("something went wrong")) is False
+
+    def test_runtime_error_returns_false(self):
+        assert is_content_filter_error(RuntimeError("unexpected")) is False
+
+    def test_openai_bad_request_with_content_filter_code(self):
+        try:
+            import httpx
+            from openai import BadRequestError
+
+            response = httpx.Response(
+                400, request=httpx.Request("POST", "https://api.openai.com")
+            )
+            exc = BadRequestError(
+                message="content filter triggered",
+                response=response,
+                body={"code": "content_filter"},
+            )
+            assert is_content_filter_error(exc) is True
+        except ImportError:
+            pytest.skip("openai not installed")
+
+    def test_openai_bad_request_without_content_filter_code(self):
+        try:
+            import httpx
+            from openai import BadRequestError
+
+            response = httpx.Response(
+                400, request=httpx.Request("POST", "https://api.openai.com")
+            )
+            exc = BadRequestError(
+                message="invalid request",
+                response=response,
+                body={"code": "invalid_request_error"},
+            )
+            assert is_content_filter_error(exc) is False
+        except ImportError:
+            pytest.skip("openai not installed")
+
+
+# ---------------------------------------------------------------------------
+# make_content_filter_response
+# ---------------------------------------------------------------------------
+
+
+class TestMakeContentFilterResponse:
+    def test_returns_response_with_friendly_message(self):
+        response = make_content_filter_response()
+        assert response.message.text == CONTENT_FILTER_MESSAGE
+        assert "flagged" in (response.message.text or "")
+        assert "rephrase" in (response.message.text or "").lower()
+
+    def test_no_tool_calls(self):
+        response = make_content_filter_response()
+        assert response.tool_calls is None
+
+    def test_empty_output(self):
+        response = make_content_filter_response()
+        assert response.output == []
+
+    def test_is_not_empty(self):
+        """Orchestrator must not treat this as an empty response."""
+        response = make_content_filter_response()
+        assert response.message.text  # truthy — has content
+
+
+# ---------------------------------------------------------------------------
+# Integration: iteration handlers surface friendly message on content filter
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_response():
+    from unique_toolkit.chat.schemas import ChatMessage, ChatMessageRole
+    from unique_toolkit.language_model.schemas import (
+        ResponsesLanguageModelStreamResponse,
+    )
+
+    message = ChatMessage(
+        id="msg_ok",
+        chat_id="chat_1",
+        role=ChatMessageRole.ASSISTANT,
+        text="Here is your analysis.",
+        original_text="Here is your analysis.",
+        references=[],
+    )
+    return ResponsesLanguageModelStreamResponse(
+        message=message, tool_calls=None, output=[]
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_responses_normal_iteration_content_filter():
+    from unique_toolkit.agentic.loop_runner._responses_iteration_handler_utils import (
+        handle_responses_normal_iteration,
+    )
+
+    content_filter_exc = _unique_error(code="content_filter")
+
+    with patch(
+        "unique_toolkit.agentic.loop_runner._responses_iteration_handler_utils.responses_stream_response",
+        new=AsyncMock(side_effect=content_filter_exc),
+    ):
+        result = await handle_responses_normal_iteration(
+            iteration_index=0,
+            model_name="gpt-4o",
+            instructions=None,
+            messages=[],
+            tools=None,
+            tool_choice=None,
+            tool_choices=None,
+            other_options={},
+            event=None,  # type: ignore[arg-type]
+            on_rate_limit_retry=None,
+        )
+
+    assert result.message.text == CONTENT_FILTER_MESSAGE
+    assert result.tool_calls is None
+
+
+@pytest.mark.asyncio
+async def test_handle_responses_normal_iteration_reraises_unrelated_error():
+    from unique_toolkit.agentic.loop_runner._responses_iteration_handler_utils import (
+        handle_responses_normal_iteration,
+    )
+
+    unrelated_exc = RuntimeError("something totally different")
+
+    with patch(
+        "unique_toolkit.agentic.loop_runner._responses_iteration_handler_utils.responses_stream_response",
+        new=AsyncMock(side_effect=unrelated_exc),
+    ):
+        with pytest.raises(RuntimeError, match="something totally different"):
+            await handle_responses_normal_iteration(
+                iteration_index=0,
+                model_name="gpt-4o",
+                instructions=None,
+                messages=[],
+                tools=None,
+                tool_choice=None,
+                tool_choices=None,
+                other_options={},
+                event=None,  # type: ignore[arg-type]
+                on_rate_limit_retry=None,
+            )
+
+
+@pytest.mark.asyncio
+async def test_handle_responses_last_iteration_content_filter():
+    from unique_toolkit.agentic.loop_runner._responses_iteration_handler_utils import (
+        handle_responses_last_iteration,
+    )
+
+    content_filter_exc = _unique_error(code="content_filter")
+
+    with patch(
+        "unique_toolkit.agentic.loop_runner._responses_iteration_handler_utils.responses_stream_response",
+        new=AsyncMock(side_effect=content_filter_exc),
+    ):
+        result = await handle_responses_last_iteration(
+            iteration_index=0,
+            model_name="gpt-4o",
+            instructions=None,
+            messages=[],
+            tools=None,
+            tool_choice=None,
+            tool_choices=None,
+            other_options={},
+            event=None,  # type: ignore[arg-type]
+            on_rate_limit_retry=None,
+        )
+
+    assert result.message.text == CONTENT_FILTER_MESSAGE
+
+
+@pytest.mark.asyncio
+async def test_handle_responses_normal_iteration_passes_through_on_success():
+    from unique_toolkit.agentic.loop_runner._responses_iteration_handler_utils import (
+        handle_responses_normal_iteration,
+    )
+
+    ok_response = _make_mock_response()
+
+    with patch(
+        "unique_toolkit.agentic.loop_runner._responses_iteration_handler_utils.responses_stream_response",
+        new=AsyncMock(return_value=ok_response),
+    ):
+        result = await handle_responses_normal_iteration(
+            iteration_index=0,
+            model_name="gpt-4o",
+            instructions=None,
+            messages=[],
+            tools=None,
+            tool_choice=None,
+            tool_choices=None,
+            other_options={},
+            event=None,  # type: ignore[arg-type]
+            on_rate_limit_retry=None,
+        )
+
+    assert result.message.text == "Here is your analysis."

--- a/unique_toolkit/tests/agentic/test_refusal_handler.py
+++ b/unique_toolkit/tests/agentic/test_refusal_handler.py
@@ -103,6 +103,7 @@ class TestMakeContentFilterResponse:
         assert response.message.text == CONTENT_FILTER_MESSAGE
         assert "flagged" in (response.message.text or "")
         assert "rephrase" in (response.message.text or "").lower()
+        assert "financial" not in (response.message.text or "").lower()
 
     def test_no_tool_calls(self):
         response = make_content_filter_response()
@@ -252,3 +253,35 @@ async def test_handle_responses_normal_iteration_passes_through_on_success():
         )
 
     assert result.message.text == "Here is your analysis."
+
+
+@pytest.mark.asyncio
+async def test_handle_responses_forced_tools_iteration_content_filter():
+    from unique_toolkit.agentic.loop_runner._responses_iteration_handler_utils import (
+        handle_responses_forced_tools_iteration,
+    )
+
+    content_filter_exc = _unique_error(code="content_filter")
+    ok_response = _make_mock_response()
+
+    mock_stream = AsyncMock(side_effect=[ok_response, content_filter_exc])
+
+    with patch(
+        "unique_toolkit.agentic.loop_runner._responses_iteration_handler_utils.responses_stream_response",
+        new=mock_stream,
+    ):
+        result = await handle_responses_forced_tools_iteration(
+            iteration_index=0,
+            model_name="gpt-4o",
+            instructions=None,
+            messages=[],
+            tools=None,
+            tool_choice=None,
+            tool_choices=["required", "auto"],
+            other_options={},
+            event=None,  # type: ignore[arg-type]
+            on_rate_limit_retry=None,
+        )
+
+    assert result.message.text == CONTENT_FILTER_MESSAGE
+    assert mock_stream.await_count == 2

--- a/unique_toolkit/unique_toolkit/agentic/loop_runner/_refusal_handler.py
+++ b/unique_toolkit/unique_toolkit/agentic/loop_runner/_refusal_handler.py
@@ -23,7 +23,7 @@ _LOGGER = logging.getLogger(__name__)
 # Shown to the user when Azure's content-safety filter blocks a request.
 CONTENT_FILTER_MESSAGE = (
     "Your request was flagged by the platform's safety system and couldn't be processed. "
-    "This sometimes happens with financial terminology.\n\n"
+    "That can happen with certain wording, even when the request is legitimate.\n\n"
     "A few things that usually help:\n"
     "- **Rephrase or break the request into smaller steps**\n"
     "- **Try again** — transient flags occasionally clear on retry\n"

--- a/unique_toolkit/unique_toolkit/agentic/loop_runner/_refusal_handler.py
+++ b/unique_toolkit/unique_toolkit/agentic/loop_runner/_refusal_handler.py
@@ -1,0 +1,111 @@
+"""Utilities for handling platform-level content-filter blocks.
+
+When Azure's content-safety filter rejects a request it raises an HTTP 400
+error with ``code="content_filter"`` *before* the model ever responds.  We
+catch that exception in the iteration handlers and surface a clear,
+actionable message to the user instead of letting a raw API error propagate.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import unique_sdk
+
+if TYPE_CHECKING:
+    from unique_toolkit.language_model.schemas import (
+        ResponsesLanguageModelStreamResponse,
+    )
+
+_LOGGER = logging.getLogger(__name__)
+
+# Shown to the user when Azure's content-safety filter blocks a request.
+CONTENT_FILTER_MESSAGE = (
+    "Your request was flagged by the platform's safety system and couldn't be processed. "
+    "This sometimes happens with financial terminology.\n\n"
+    "A few things that usually help:\n"
+    "- **Rephrase or break the request into smaller steps**\n"
+    "- **Try again** — transient flags occasionally clear on retry\n"
+    "- If it keeps happening, let your administrator know so they can adjust the content filter settings"
+)
+
+# Azure sets code="content_filter" on the 400 error body.
+_CONTENT_FILTER_CODES = ("content_filter",)
+_CONTENT_FILTER_MESSAGE_FRAGMENTS = (
+    "content filter",
+    "content_filter",
+    "ResponsibleAI",
+)
+
+
+def is_content_filter_error(exc: BaseException) -> bool:
+    """Return ``True`` when *exc* is an Azure content-filter block.
+
+    Checks:
+    1. OpenAI SDK's typed ``ContentFilterFinishReasonError`` / ``BadRequestError``
+       with ``code="content_filter"``.
+    2. ``unique_sdk.UniqueError`` with ``code="content_filter"``.
+    3. String-pattern fallback on the exception message.
+    """
+    try:
+        from openai import BadRequestError, ContentFilterFinishReasonError
+
+        if isinstance(exc, ContentFilterFinishReasonError):
+            _LOGGER.warning("ContentFilterFinishReasonError detected")
+            return True
+
+        if (
+            isinstance(exc, BadRequestError)
+            and getattr(exc, "code", None) in _CONTENT_FILTER_CODES
+        ):
+            _LOGGER.warning("OpenAI BadRequestError with content_filter code detected")
+            return True
+    except ImportError:
+        pass
+
+    if isinstance(exc, unique_sdk.UniqueError):
+        if getattr(exc, "code", None) in _CONTENT_FILTER_CODES:
+            _LOGGER.warning(
+                "Content filter block detected via unique_sdk error code: %s",
+                exc.code,
+            )
+            return True
+
+        msg = str(exc).lower()
+        if any(
+            fragment.lower() in msg for fragment in _CONTENT_FILTER_MESSAGE_FRAGMENTS
+        ):
+            _LOGGER.warning(
+                "Content filter block detected via message fragment: %s",
+                str(exc)[:200],
+            )
+            return True
+
+    return False
+
+
+def make_content_filter_response() -> ResponsesLanguageModelStreamResponse:
+    """Build a synthetic response carrying the content-filter user message.
+
+    The orchestrator treats this like a normal final response (no tool calls,
+    text present) and writes the text back to the assistant message.
+    """
+    from unique_toolkit.chat.schemas import ChatMessage, ChatMessageRole
+    from unique_toolkit.language_model.schemas import (
+        ResponsesLanguageModelStreamResponse,
+    )
+
+    message = ChatMessage(
+        id="content_filter_error",
+        chat_id="",
+        role=ChatMessageRole.ASSISTANT,
+        text=CONTENT_FILTER_MESSAGE,
+        original_text=CONTENT_FILTER_MESSAGE,
+        references=[],
+    )
+    return ResponsesLanguageModelStreamResponse(
+        message=message,
+        tool_calls=None,
+        output=[],
+    )

--- a/unique_toolkit/unique_toolkit/agentic/loop_runner/_responses_iteration_handler_utils.py
+++ b/unique_toolkit/unique_toolkit/agentic/loop_runner/_responses_iteration_handler_utils.py
@@ -1,6 +1,10 @@
 import logging
 from typing import Unpack
 
+from unique_toolkit.agentic.loop_runner._refusal_handler import (
+    is_content_filter_error,
+    make_content_filter_response,
+)
 from unique_toolkit.agentic.loop_runner._responses_stream_handler_utils import (
     responses_stream_response,
 )
@@ -17,10 +21,19 @@ async def handle_responses_last_iteration(
 ) -> ResponsesLanguageModelStreamResponse:
     _LOGGER.info("Reached last iteration, removing tools and producing final response")
 
-    return await responses_stream_response(
-        loop_runner_kwargs=kwargs,
-        tools=None,
-    )
+    try:
+        return await responses_stream_response(
+            loop_runner_kwargs=kwargs,
+            tools=None,
+        )
+    except Exception as exc:
+        if is_content_filter_error(exc):
+            _LOGGER.warning(
+                "Azure content filter block on last iteration — "
+                "returning user-friendly error message"
+            )
+            return make_content_filter_response()
+        raise
 
 
 async def handle_responses_normal_iteration(
@@ -28,7 +41,17 @@ async def handle_responses_normal_iteration(
 ) -> ResponsesLanguageModelStreamResponse:
     _LOGGER.info("Running loop iteration %d", kwargs["iteration_index"])
 
-    return await responses_stream_response(loop_runner_kwargs=kwargs)
+    try:
+        return await responses_stream_response(loop_runner_kwargs=kwargs)
+    except Exception as exc:
+        if is_content_filter_error(exc):
+            _LOGGER.warning(
+                "Azure content filter block on iteration %d — "
+                "returning user-friendly error message",
+                kwargs["iteration_index"],
+            )
+            return make_content_filter_response()
+        raise
 
 
 async def handle_responses_forced_tools_iteration(

--- a/unique_toolkit/unique_toolkit/agentic/loop_runner/_responses_iteration_handler_utils.py
+++ b/unique_toolkit/unique_toolkit/agentic/loop_runner/_responses_iteration_handler_utils.py
@@ -67,9 +67,20 @@ async def handle_responses_forced_tools_iteration(
     responses: list[ResponsesLanguageModelStreamResponse] = []
 
     for opt in tool_choices:
-        responses.append(
-            await responses_stream_response(loop_runner_kwargs=kwargs, tool_choice=opt)
-        )
+        try:
+            responses.append(
+                await responses_stream_response(
+                    loop_runner_kwargs=kwargs, tool_choice=opt
+                )
+            )
+        except Exception as exc:
+            if is_content_filter_error(exc):
+                _LOGGER.warning(
+                    "Azure content filter block on forced tools iteration — "
+                    "returning user-friendly error message"
+                )
+                return make_content_filter_response()
+            raise
 
     # Merge responses and refs:
     tool_calls = []

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-03-30T08:21:16.370035Z"
+exclude-newer = "2026-03-30T13:27:06.704315Z"
 exclude-newer-span = "P2W"
 
 [options.exclude-newer-package]
@@ -5506,7 +5506,7 @@ dev = []
 
 [[package]]
 name = "unique-toolkit"
-version = "1.70.8"
+version = "1.70.9"
 source = { editable = "unique_toolkit" }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

**Refs:** [UN-19304](https://unique-ch.atlassian.net/browse/UN-19304)

When a deployment uses strict platform content filtering (e.g. Azure AI Foundry / Responsible AI), the Responses stream can fail with a `content_filter`-style error before the model returns a normal assistant message. Users previously saw a raw or opaque failure.

This PR detects those errors in the Responses API loop (`handle_responses_normal_iteration` / `handle_responses_last_iteration`), and returns a single synthetic assistant response with a short, helpful message: explain what likely happened, suggest rephrasing / smaller steps / retry, and point admins at content-filter settings if it keeps happening.

No prompt softening or automatic retries—UX-only handling for this failure mode.

## Changes

- [x] Added feature / fixed bug / updated docs
- [ ] Refactored code / cleaned up
- [ ] Other (describe below)

**Details**

- New `unique_toolkit/agentic/loop_runner/_refusal_handler.py`: `is_content_filter_error()` (typed `unique_sdk.UniqueError` + OpenAI SDK signals + narrow message fragments), `make_content_filter_response()`.
- `unique_toolkit/agentic/loop_runner/_responses_iteration_handler_utils.py`: try/except around `responses_stream_response`; unrelated exceptions are re-raised unchanged.
- Tests: `unique_toolkit/tests/agentic/test_refusal_handler.py` (detection, synthetic response shape, handler integration, non-filter errors still propagate).
- Version **1.70.9** + `CHANGELOG.md`; root **`uv.lock`** updated for workspace `unique-toolkit`.

## Testing

- **Automated:** `poetry run pytest unique_toolkit/tests/agentic/test_refusal_handler.py` — all tests pass (16).
- **Local / E2E:** **Limited.** Typical dev environments do not enable the same Azure (or equivalent) content filters as customer tenants, so reproducing a real `content_filter` block locally is often **not possible**. Validation is expected on a **staging or tenant** where content filtering is active (e.g. scenarios similar to the hedge-fund multi-turn stress prompts on UN-19304).
- **Regression:** Normal chats without a filter error should be unchanged (handler only runs when the exception matches the narrow detector).

[UN-19304]: https://unique-ch.atlassian.net/browse/UN-19304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ