### PR TITLE
fix(sdk): make UNIQUE_API_KEY and UNIQUE_APP_ID optional in unique-cli

### DIFF
--- a/unique_sdk/CHANGELOG.md
+++ b/unique_sdk/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), 
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.3] - 2026-04-14
+- Make `UNIQUE_API_KEY` and `UNIQUE_APP_ID` optional in the CLI — not needed on localhost or in a secured cluster
+
 ## [0.11.2] - 2026-04-14
 - Chore: add `importlib` import mode to pytest config to prevent namespace collisions
 - Chore: update `exclude-newer-package` timestamps and lockfile refresh

--- a/unique_sdk/CLAUDE.md
+++ b/unique_sdk/CLAUDE.md
@@ -78,10 +78,15 @@ The SDK ships an interactive file explorer CLI accessible via `unique-cli` or `p
 **Required environment variables:**
 
 ```bash
-export UNIQUE_API_KEY="ukey_..."
-export UNIQUE_APP_ID="app_..."
 export UNIQUE_USER_ID="user_..."
 export UNIQUE_COMPANY_ID="company_..."
+```
+
+**Optional environment variables** (not needed on localhost or in a secured cluster):
+
+```bash
+export UNIQUE_API_KEY="ukey_..."
+export UNIQUE_APP_ID="app_..."
 ```
 
 **CLI commands:**

--- a/unique_sdk/docs/cli/configuration.md
+++ b/unique_sdk/docs/cli/configuration.md
@@ -9,8 +9,6 @@ Unique CLI reads all configuration from environment variables. No config files a
 
 | Variable | Description | Example |
 |----------|-------------|---------|
-| `UNIQUE_API_KEY` | API key for authenticating with the Unique platform | `ukey_abc123...` |
-| `UNIQUE_APP_ID` | Application identifier | `app_xyz789...` |
 | `UNIQUE_USER_ID` | User ID used for all API requests | `user_12345` |
 | `UNIQUE_COMPANY_ID` | Company ID used for all API requests | `company_67890` |
 
@@ -18,6 +16,8 @@ Unique CLI reads all configuration from environment variables. No config files a
 
 | Variable | Description | Default |
 |----------|-------------|---------|
+| `UNIQUE_API_KEY` | API key for authenticating with the Unique platform. Not needed on localhost or in a secured cluster. | *(empty)* |
+| `UNIQUE_APP_ID` | Application identifier. Not needed on localhost or in a secured cluster. | *(empty)* |
 | `UNIQUE_API_BASE` | Base URL for the Unique API | `https://gateway.unique.app/public/chat-gen2` |
 
 ## Setup
@@ -25,10 +25,13 @@ Unique CLI reads all configuration from environment variables. No config files a
 ### Using export
 
 ```bash
-export UNIQUE_API_KEY="ukey_..."
-export UNIQUE_APP_ID="app_..."
+# Required
 export UNIQUE_USER_ID="user_..."
 export UNIQUE_COMPANY_ID="company_..."
+
+# Optional (not needed on localhost or in a secured cluster)
+export UNIQUE_API_KEY="ukey_..."
+export UNIQUE_APP_ID="app_..."
 ```
 
 ### Using a .env file
@@ -37,10 +40,11 @@ Create a `.env` file and source it before running the CLI:
 
 ```bash
 # .env
-UNIQUE_API_KEY=ukey_...
-UNIQUE_APP_ID=app_...
 UNIQUE_USER_ID=user_...
 UNIQUE_COMPANY_ID=company_...
+# Optional — only needed when connecting to an external Unique platform
+# UNIQUE_API_KEY=ukey_...
+# UNIQUE_APP_ID=app_...
 ```
 
 ```bash
@@ -54,10 +58,11 @@ If you use [direnv](https://direnv.net/), create a `.envrc` file:
 
 ```bash
 # .envrc
-export UNIQUE_API_KEY=ukey_...
-export UNIQUE_APP_ID=app_...
 export UNIQUE_USER_ID=user_...
 export UNIQUE_COMPANY_ID=company_...
+# Optional — only needed when connecting to an external Unique platform
+# export UNIQUE_API_KEY=ukey_...
+# export UNIQUE_APP_ID=app_...
 ```
 
 ## Error Handling
@@ -66,15 +71,16 @@ If any required variable is missing, the CLI exits immediately with a clear erro
 
 ```
 $ unique-cli ls
-Error: missing required environment variables: UNIQUE_API_KEY, UNIQUE_APP_ID
+Error: missing required environment variables: UNIQUE_USER_ID, UNIQUE_COMPANY_ID
 ```
 
 ## How Configuration is Wired
 
 The CLI calls `load_config()` at startup, which:
 
-1. Reads the four required environment variables
-2. Sets `unique_sdk.api_key`, `unique_sdk.app_id`, and `unique_sdk.api_base` globally
-3. Returns a `Config` object that carries `user_id` and `company_id` for every API call
+1. Reads the two required environment variables (`UNIQUE_USER_ID`, `UNIQUE_COMPANY_ID`)
+2. Reads optional `UNIQUE_API_KEY`, `UNIQUE_APP_ID`, and `UNIQUE_API_BASE`
+3. Sets `unique_sdk.api_key`, `unique_sdk.app_id`, and `unique_sdk.api_base` globally
+4. Returns a `Config` object that carries `user_id` and `company_id` for every API call
 
 This means the underlying `unique_sdk` is fully configured before any command executes.

--- a/unique_sdk/pyproject.toml
+++ b/unique_sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "unique_sdk"
-version = "0.11.2"
+version = "0.11.3"
 description = ""
 readme = "README.md"
 license = { text = "MIT" }

--- a/unique_sdk/tests/cli/test_config.py
+++ b/unique_sdk/tests/cli/test_config.py
@@ -65,6 +65,21 @@ class TestLoadConfig:
 
     @patch.dict(
         os.environ,
+        {
+            "UNIQUE_USER_ID": "user_test",
+            "UNIQUE_COMPANY_ID": "company_test",
+        },
+        clear=True,
+    )
+    def test_api_key_and_app_id_optional(self) -> None:
+        config = load_config()
+        assert config.api_key == ""
+        assert config.app_id == ""
+        assert config.user_id == "user_test"
+        assert config.company_id == "company_test"
+
+    @patch.dict(
+        os.environ,
         {"UNIQUE_API_KEY": "ukey_test"},
         clear=True,
     )

--- a/unique_sdk/unique_sdk/cli/cli.py
+++ b/unique_sdk/unique_sdk/cli/cli.py
@@ -35,13 +35,13 @@ Modes:
 
 \b
 Required environment variables:
-  UNIQUE_API_KEY      API key for the Unique platform
-  UNIQUE_APP_ID       Application identifier
   UNIQUE_USER_ID      User ID for API requests
   UNIQUE_COMPANY_ID   Company ID for API requests
 
 \b
 Optional:
+  UNIQUE_API_KEY      API key (not needed on localhost / secured cluster)
+  UNIQUE_APP_ID       Application identifier (not needed on localhost / secured cluster)
   UNIQUE_API_BASE     API base URL (default: https://gateway.unique.app/public/chat-gen2)
 
 \b

--- a/unique_sdk/unique_sdk/cli/config.py
+++ b/unique_sdk/unique_sdk/cli/config.py
@@ -36,13 +36,12 @@ class Config:
 def load_config() -> Config:
     """Load configuration from environment variables and wire into unique_sdk.
 
-    Required env vars: UNIQUE_API_KEY, UNIQUE_APP_ID, UNIQUE_USER_ID, UNIQUE_COMPANY_ID.
-    Optional: UNIQUE_API_BASE (defaults to the SDK default).
+    Required env vars: UNIQUE_USER_ID, UNIQUE_COMPANY_ID.
+    Optional: UNIQUE_API_KEY, UNIQUE_APP_ID (not needed on localhost or in a
+    secured cluster), UNIQUE_API_BASE (defaults to the SDK default).
     """
     missing: list[str] = []
     for var in (
-        "UNIQUE_API_KEY",
-        "UNIQUE_APP_ID",
         "UNIQUE_USER_ID",
         "UNIQUE_COMPANY_ID",
     ):
@@ -56,8 +55,8 @@ def load_config() -> Config:
         )
         sys.exit(1)
 
-    api_key = os.environ["UNIQUE_API_KEY"]
-    app_id = os.environ["UNIQUE_APP_ID"]
+    api_key = os.environ.get("UNIQUE_API_KEY", "")
+    app_id = os.environ.get("UNIQUE_APP_ID", "")
     user_id = os.environ["UNIQUE_USER_ID"]
     company_id = os.environ["UNIQUE_COMPANY_ID"]
     api_base = os.environ.get("UNIQUE_API_BASE", unique_sdk.api_base)

--- a/unique_sdk/unique_sdk/cli/skills/unique-cli-file-management/SKILL.md
+++ b/unique_sdk/unique_sdk/cli/skills/unique-cli-file-management/SKILL.md
@@ -20,10 +20,10 @@ description: >-
 It is installed via `pip install unique-sdk` and requires these environment variables:
 
 ```bash
-UNIQUE_API_KEY    # API key (ukey_...)
-UNIQUE_APP_ID     # App ID (app_...)
-UNIQUE_USER_ID    # User ID
-UNIQUE_COMPANY_ID # Company ID
+UNIQUE_USER_ID    # User ID (required)
+UNIQUE_COMPANY_ID # Company ID (required)
+UNIQUE_API_KEY    # API key — optional on localhost / secured cluster
+UNIQUE_APP_ID     # App ID — optional on localhost / secured cluster
 ```
 
 ## One-Shot Commands

--- a/unique_sdk/unique_sdk/cli/skills/unique-cli-mcp/SKILL.md
+++ b/unique_sdk/unique_sdk/cli/skills/unique-cli-mcp/SKILL.md
@@ -135,10 +135,10 @@ python generate_payload.py | unique-cli mcp -c chat_123 -m msg_456 --stdin
 Requires these environment variables:
 
 ```bash
-UNIQUE_API_KEY    # API key (ukey_...)
-UNIQUE_APP_ID     # App ID (app_...)
-UNIQUE_USER_ID    # User ID
-UNIQUE_COMPANY_ID # Company ID
+UNIQUE_USER_ID    # User ID (required)
+UNIQUE_COMPANY_ID # Company ID (required)
+UNIQUE_API_KEY    # API key — optional on localhost / secured cluster
+UNIQUE_APP_ID     # App ID — optional on localhost / secured cluster
 ```
 
 Install: `pip install unique-sdk`

--- a/unique_sdk/unique_sdk/cli/skills/unique-cli-scheduled-tasks/SKILL.md
+++ b/unique_sdk/unique_sdk/cli/skills/unique-cli-scheduled-tasks/SKILL.md
@@ -343,10 +343,10 @@ All methods have `*_async` variants for async usage.
 Requires these environment variables:
 
 ```bash
-UNIQUE_API_KEY    # API key (ukey_...)
-UNIQUE_APP_ID     # App ID (app_...)
-UNIQUE_USER_ID    # User ID
-UNIQUE_COMPANY_ID # Company ID
+UNIQUE_USER_ID    # User ID (required)
+UNIQUE_COMPANY_ID # Company ID (required)
+UNIQUE_API_KEY    # API key — optional on localhost / secured cluster
+UNIQUE_APP_ID     # App ID — optional on localhost / secured cluster
 ```
 
 Install: `pip install unique-sdk`

--- a/unique_sdk/unique_sdk/cli/skills/unique-cli-search/SKILL.md
+++ b/unique_sdk/unique_sdk/cli/skills/unique-cli-search/SKILL.md
@@ -106,10 +106,10 @@ unique-cli search "Q4 earnings" \
 Requires these environment variables:
 
 ```bash
-UNIQUE_API_KEY    # API key (ukey_...)
-UNIQUE_APP_ID     # App ID (app_...)
-UNIQUE_USER_ID    # User ID
-UNIQUE_COMPANY_ID # Company ID
+UNIQUE_USER_ID    # User ID (required)
+UNIQUE_COMPANY_ID # Company ID (required)
+UNIQUE_API_KEY    # API key — optional on localhost / secured cluster
+UNIQUE_APP_ID     # App ID — optional on localhost / secured cluster
 ```
 
 Install: `pip install unique-sdk`

--- a/uv.lock
+++ b/uv.lock
@@ -8,19 +8,19 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-03-31T13:47:31.94675Z"
+exclude-newer = "2026-03-31T20:31:11.886395Z"
 exclude-newer-span = "P2W"
 
 [options.exclude-newer-package]
 unique-toolkit = false
-copier = "2026-04-01T22:00:00Z"
-langchain-core = "2026-04-09T22:00:00Z"
-deepdiff = "2026-03-19T23:00:00Z"
-fastmcp = "2026-03-31T22:00:00Z"
-aiohttp = "2026-03-29T22:00:00Z"
-cryptography = "2026-04-09T22:00:00Z"
-litellm = "2026-04-01T22:00:00Z"
-requests = "2026-03-26T23:00:00Z"
+copier = "2026-04-02T04:00:00Z"
+langchain-core = "2026-04-10T04:00:00Z"
+deepdiff = "2026-03-20T04:00:00Z"
+fastmcp = "2026-04-01T04:00:00Z"
+aiohttp = "2026-03-30T04:00:00Z"
+cryptography = "2026-04-10T04:00:00Z"
+litellm = "2026-04-02T04:00:00Z"
+requests = "2026-03-27T04:00:00Z"
 
 [manifest]
 members = [
@@ -5354,7 +5354,7 @@ dev = []
 
 [[package]]
 name = "unique-sdk"
-version = "0.11.2"
+version = "0.11.3"
 source = { editable = "unique_sdk" }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Make `UNIQUE_API_KEY` and `UNIQUE_APP_ID` optional in the `unique-cli` — on localhost or in a secured cluster these are not needed
- Only `UNIQUE_USER_ID` and `UNIQUE_COMPANY_ID` remain required
- The `unique-websearch` CLI was verified to have no such checks — it's already fine

## Changes
- **`unique_sdk/cli/config.py`**: Remove `UNIQUE_API_KEY` and `UNIQUE_APP_ID` from the required env var check; default to empty strings via `os.environ.get()`
- **`unique_sdk/cli/cli.py`**: Move API_KEY / APP_ID from "Required" to "Optional" in the help text
- **`unique_sdk/docs/cli/configuration.md`**: Update docs to reflect the new optional status
- **`unique_sdk/CLAUDE.md`**: Update CLI env var documentation
- **`unique_sdk/cli/skills/`**: Update all 4 skill files (file-management, search, mcp, scheduled-tasks)
- **`unique_sdk/tests/cli/test_config.py`**: Add `test_api_key_and_app_id_optional` test
- **`unique_sdk/pyproject.toml`** + **CHANGELOG**: Bump to `0.11.3`

## Test plan
- [ ] `test_api_key_and_app_id_optional` — verifies CLI loads successfully without API_KEY / APP_ID
- [ ] Existing tests (`test_loads_from_env`, `test_missing_vars_exits`, `test_all_vars_missing_exits`) still pass
- [ ] `unique-cli --help` shows the updated help text

Made with [Cursor](https://cursor.com)