### PR TITLE
feat(skills): add model deployment skill [UN-17994]

### DIFF
--- a/.claude/skills/model-deployment/SKILL.md
+++ b/.claude/skills/model-deployment/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: model-deployment
+description: Deploy a new LLM model via LiteLLM (GitOps) and/or Azure (Terraform + node backend), add it to the ai toolkit, and verify end-to-end. Use when rolling out a model to any environment, adding a model to the toolkit, troubleshooting "model not available" errors, or finding pricing/token limits/model ids for any provider.
+license: MIT
+compatibility: claude cursor opencode
+metadata:
+  version: "3.0.0"
+  languages: all
+  audience: developers operators
+  workflow: operations
+  since: "2026-04-15"
+---
+
+# Model deployment (LLM — any provider)
+
+This skill guides the full lifecycle of deploying a new LLM model across the Unique platform:
+
+- **monorepo** — LiteLLM proxy config (GitOps), node-chat backend (Azure track), Terraform
+- **ai repo** — toolkit language model registry (`LanguageModelInfo`)
+
+**Cardinal rule:** never guess token limits, capabilities, pricing, or provider strings. Always cite the source (model card URL, LiteLLM registry, Jira ticket, or PR). If no authoritative source exists, ask the user.
+
+## When to use this skill
+
+- Deploying a new model to Dev, QA, UAT, or Prod (any provider).
+- Adding a model to the LiteLLM proxy and/or Azure OpenAI.
+- Adding a model to the ai toolkit language model registry.
+- Troubleshooting "model not available on cluster" or config-sync issues.
+- Finding pricing, token window sizes, or model identifiers for any provider.
+
+---
+
+## Step 0 — Gather information before touching any file
+
+| Question | Why |
+|----------|-----|
+| **Track:** `azure`, `litellm`, or `both` | Determines which repos/files to touch |
+| **Environments** and **rollout order** (e.g. qa → uat01 → prod) | Controls which overlay files are edited and in what sequence |
+| **Model identifiers** — For LiteLLM: user-facing `model_name` + provider model string. For Azure: model name, version, deployment names, API version, capacity | Required for config entries |
+| **Token limits / capabilities** — with a cited source | Required for toolkit `LanguageModelInfo` |
+| **Toolkit:** already merged / has open PR / needs to be done now? | Avoids duplicate work |
+| **Allowlist / exposure constraints** | Determines selectability — see [MODEL-SELECTABILITY.md](references/MODEL-SELECTABILITY.md) |
+
+### Where to find model facts
+
+| Fact | Where to look |
+|------|---------------|
+| **Azure model deployments** | [Azure AI Foundry](https://ai.azure.com/) — Deployments page (single source of truth for Azure) |
+| **Token window** | Vendor model card: [OpenAI](https://platform.openai.com/docs/models), [Anthropic](https://docs.anthropic.com/en/docs/about-claude/models), [Google](https://deepmind.google/models/), [LiteLLM registry](https://models.litellm.ai/) |
+| **Pricing** | [Azure AI Foundry](https://ai.azure.com/) Quota page, [OpenAI](https://openai.com/api/pricing/), [Anthropic](https://www.anthropic.com/pricing), [Google Cloud](https://cloud.google.com/vertex-ai/generative-ai/pricing) |
+| **Model identifiers / provider prefix** | [LiteLLM model registry](https://models.litellm.ai/) |
+| **API version (Azure)** | [Azure AI Foundry](https://ai.azure.com/) Deployments page or Azure REST API changelog |
+| **Capabilities** | Vendor model cards, release blog posts, changelogs |
+
+---
+
+## Repo and file map
+
+| Repo | What you touch |
+|------|----------------|
+| **monorepo** | LiteLLM overlay: `gitops-resources/argocd/clusters/<cluster>/<env>/value-overlays/litellm.yaml`. Node-chat: language-model enum + Azure factory config. Terraform: `azurerm_cognitive_deployment`, Key Vault secret. |
+| **ai repo** | Toolkit: `LanguageModelName` enum + `LanguageModelInfo.from_name()` case + tests in `unique_toolkit/unique_toolkit/language_model/infos.py`. |
+
+```
+gitops-resources/argocd/clusters/
+├── unique/          # multi-tenant: qa/, uat01/, prod/, us01/
+├── <single-tenant>/ # e.g. tree, burger, cat, ...
+```
+
+---
+
+## Track A — LiteLLM (GitOps)
+
+### A1) Validate model id and provider prefix
+
+1. Search [LiteLLM model registry](https://models.litellm.ai/) for the model.
+2. Document the two strings: **user-facing key** (`model_name`, no prefix, hyphens) and **provider model** (`litellm_params.model`, with prefix).
+
+See [LITELLM-CONFIG.md](references/LITELLM-CONFIG.md) for config examples and provider prefix conventions.
+
+### A2) Update ArgoCD overlay(s)
+
+Edit `monorepo/gitops-resources/argocd/clusters/<cluster>/<env>/value-overlays/litellm.yaml`. Add a new entry under `proxy_config.model_list`, following the existing alphabetical grouping style.
+
+### A3) Monorepo PR
+
+- **Branch:** `feat/litellm-<model-name>`
+- **Commit:** `feat(litellm): add <model_name> model to <envs>`
+- PR body: env overlays changed, model names, source links, verification steps.
+
+### A4) After merge — sync + restart
+
+1. In ArgoCD, sync the LiteLLM application for the target environment.
+2. **Roll the LiteLLM Deployment** (not HPA — restarting HPA does not reload pods).
+
+### A5) Verify
+
+1. Confirm model appears in LiteLLM dashboard.
+2. Smoke test with the exact model id users will request (e.g. `litellm:<model_name>`).
+
+---
+
+## Track B — Azure (Terraform + node backend)
+
+### B1) Gather Azure deployment details
+
+Check [Azure AI Foundry](https://ai.azure.com/) first — the Deployments page lists all active model deployments with name, version, capacity, rate limits, and retirement dates.
+
+Confirm: Azure OpenAI account, model name + version, deployment names, capacity, API version.
+
+### B2) Terraform changes
+
+Add `azurerm_cognitive_deployment` resource(s) in the **infrastructure** repo. See [AZURE-NODE-CHAT.md](references/AZURE-NODE-CHAT.md) for Terraform patterns.
+
+### B3) Node backend registration
+
+Three files in `next/services/node-chat/src/openai/`: `language-model.enum.ts`, `azure-sdk-openai.service.factory.ts`, `azure-sdk-openai.service.ts`. See [AZURE-NODE-CHAT.md](references/AZURE-NODE-CHAT.md) for code examples.
+
+### B4) PR + apply workflow
+
+1. Create PR; link to Jira ticket and source docs.
+2. Review Terraform plan — stop if unexpected drift appears.
+3. Apply via Atlantis, one workspace at a time.
+
+### B5) Verify
+
+1. Confirm deployments exist in [Azure AI Foundry](https://ai.azure.com/).
+2. **Roll the node-chat Deployment** (not HPA).
+3. Smoke test **both** plain chat (node-chat) **and** agentic assistant space (assistants-core) — bugs can hide in one path. See [LESSONS-LEARNED.md](references/LESSONS-LEARNED.md) for why.
+
+---
+
+## Model selectability
+
+Two layers control whether a model is available and user-selectable. See [MODEL-SELECTABILITY.md](references/MODEL-SELECTABILITY.md) for full details.
+
+Quick decision matrix:
+
+| Want the model to... | `UNIQUEAI_SUPPORTED_MODELS` | `UNIQUEAI_ALLOWED_MODELS` |
+|---|---|---|
+| Be available and selectable by users | Add | Add |
+| Be available but only for internal use | Add | Do **not** add |
+| Not be available at all | Do **not** add | N/A |
+
+---
+
+## Track C — AI toolkit
+
+### C1) Check existing state
+
+Check whether the model already exists in `unique_toolkit/unique_toolkit/language_model/infos.py` (merged, open PR, or needs to be added).
+
+### C2) Add model to toolkit
+
+Add `LanguageModelName` enum entry and `LanguageModelInfo.from_name()` case. See [TOOLKIT-REGISTRY.md](references/TOOLKIT-REGISTRY.md) for code examples and field reference.
+
+**Critical:** for `default_options`, use the string `"none"` — never Python `None`. See [LESSONS-LEARNED.md](references/LESSONS-LEARNED.md).
+
+### C3) Release
+
+- **Branch:** `feat/toolkit-<model-slug>`
+- **Commit:** `feat(toolkit): add <model_name> model info`
+- Follow the normal toolkit release process (version bump + CHANGELOG).
+
+For early exposure before the toolkit release, use the `LANGUAGE_MODEL_INFOS` env override — see [TOOLKIT-REGISTRY.md](references/TOOLKIT-REGISTRY.md).
+
+---
+
+## Multi-cluster rollouts
+
+1. **One monorepo PR** touching multiple cluster overlays.
+2. After merge, rollout **per cluster**: ArgoCD sync → roll Deployment → verify + smoke test.
+3. Repeat in the agreed rollout order.
+
+---
+
+## Final checklist (every track)
+
+- [ ] Correct environment(s) targeted and rollout order followed (qa → uat → prod)
+- [ ] Config synced in ArgoCD where applicable
+- [ ] Correct **Deployment** rolled (not HPA)
+- [ ] Smoke test succeeded using the exact model id users will request
+- [ ] Sources cited for token limits, capabilities, and model identifiers
+- [ ] **Model selectability decided:** added to `UNIQUEAI_SUPPORTED_MODELS` (cluster-available) and, if user-facing, to `UNIQUEAI_ALLOWED_MODELS` env var
+- [ ] Rollout notes captured (Jira comment + links + timestamps)
+
+---
+
+## Rollback and safety
+
+- **Explicit approvals required** before editing committed code, suggesting Atlantis apply, or anything affecting production.
+- If Terraform drift or "model not discoverable" looks wrong: **stop**, explain what you see, propose the smallest safe next action.
+- For incident patterns and past mistakes, see [LESSONS-LEARNED.md](references/LESSONS-LEARNED.md).

--- a/.claude/skills/model-deployment/references/AZURE-NODE-CHAT.md
+++ b/.claude/skills/model-deployment/references/AZURE-NODE-CHAT.md
@@ -1,0 +1,63 @@
+# Track B — Azure + node-chat details
+
+## Terraform (infrastructure repo)
+
+Terraform lives in the **infrastructure** repo. Look for existing `azurerm_cognitive_deployment` resources for the same Azure OpenAI account and copy the pattern:
+
+1. Add or update `azurerm_cognitive_deployment` resource(s) for the new model — one per deployment (e.g. base + chat variants). Key properties: `model.name`, `model.version`, `sku.capacity`.
+2. Update the Key Vault secret holding endpoint definitions (commonly `azure-openai-endpoint-definitions`) so node-chat can discover the new deployment at startup.
+3. If the model requires a new API key or endpoint, add a corresponding Key Vault secret reference.
+
+**Tip:** search the infrastructure repo for an existing model deployment (e.g. `gpt-5.4`) to find the exact Terraform module and variable pattern to replicate.
+
+## Node-chat registration — code examples
+
+Three files in `next/services/node-chat/src/openai/`:
+
+### 1. `language-model.enum.ts`
+
+Add to `LanguageModel` enum and `LanguageModelNameKey`:
+
+```typescript
+// In LanguageModel enum:
+AZURE_GPT_55_2026_0901 = 'AZURE_GPT_55_2026_0901',
+
+// In LanguageModelNameKey:
+AZURE_GPT_55_2026_0901: 'gpt-5.5-2026-09-01', // EU, US ✅
+```
+
+### 2. `azure-sdk-openai.service.factory.ts`
+
+Add a `case` in the factory `switch` and add the model to `UNIQUEAI_SUPPORTED_MODELS`:
+
+```typescript
+// In UNIQUEAI_SUPPORTED_MODELS array:
+LanguageModelNameKey.AZURE_GPT_55_2026_0901,
+
+// In the factory switch:
+case LanguageModel.AZURE_GPT_55_2026_0901:
+  return new AzureSdkOpenAIService(
+    enableV1,
+    this.getConfigOfModel({
+      modelKey: 'gpt-5.5-2026-09-01',
+      maxToken: 1000000,
+      apiVersion: '2024-10-21',
+    }),
+    this.azureSdkOpenAICommonService.getTokenCount,
+    this.authTokenService,
+    openAIClientOptions,
+  );
+```
+
+### 3. `azure-sdk-openai.service.ts`
+
+If the model needs special parameter handling (e.g. reasoning params), update the `getDeploymentName()` switch to map the `modelKey` to the Azure deployment name.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---------|-------------|
+| `reasoning_effort does not support null` | `default_options` in `LanguageModelInfo` uses Python `None` instead of string `"none"`. See [LESSONS-LEARNED.md](LESSONS-LEARNED.md). |
+| Works in plain chat but fails in agentic space | Bug in the Python toolkit's parameter construction — check `responses_api.py` reasoning handling and the toolkit version pinned in `assistants-core`. |
+| Works in agentic space but fails in plain chat | Bug in node-chat TypeScript Azure SDK service — check `azure-sdk-openai.service.ts` option spreading. |
+| Model works on master but not on release branch | Cherry-pick was incomplete — check that `assistants-core` toolkit version was bumped alongside node-chat changes. |

--- a/.claude/skills/model-deployment/references/LESSONS-LEARNED.md
+++ b/.claude/skills/model-deployment/references/LESSONS-LEARNED.md
@@ -1,0 +1,57 @@
+# Lessons learned
+
+These come from real deployment experience and real incidents — refer back to them when something looks off.
+
+## `default_options` pitfall: `None` vs `"none"` (caused production incident)
+
+When defining `default_options` for a reasoning model, **never** use Python `None` for `reasoning_effort`:
+
+```python
+# BAD — caused reasoning_effort=null sent to Azure, which rejects it
+default_options={"reasoning_effort": None}
+
+# GOOD — explicit string value, accepted by Azure
+default_options={"reasoning_effort": "none"}
+
+# ALSO GOOD — omit the key entirely if no default is needed
+default_options={}
+```
+
+**What happened:** `AZURE_GPT_51_2025_1113` was defined with `"reasoning_effort": None` in `default_options`. The toolkit's `_prepare_responses_params_util` checked `"reasoning_effort" in model_info.default_options` (key existence), found the key, and constructed `Reasoning(effort=None)`. This serialized to `reasoning_effort: null` in the Azure API request. Azure rejected it: *"reasoning_effort does not support null. Supported values are: none, low, medium, high."*
+
+The guard only checked if the key was present, not whether the value was non-null. The fix (v1.57.0) added `resolve_temp_and_reasoning()` which explicitly substitutes `None` with the model's declared default.
+
+## Dual code paths: node-chat vs assistants-core
+
+Azure models are called through **two independent paths**:
+
+1. **node-chat (TypeScript)** — Chat Completions and Responses API via the Azure SDK. Used by plain chat spaces.
+2. **assistants-core (Python)** — Responses API via `unique_toolkit`. Used by agentic spaces with Python modules.
+
+These paths have different handling for parameters like `reasoning_effort`. A bug in the toolkit Python path may not reproduce in node-chat, and vice versa. **Always test both paths** when deploying or updating a model: send a message in a plain chat space (node-chat) AND in an agentic assistant space (assistants-core).
+
+## Cherry-pick completeness across repos
+
+When cherry-picking model support into a release branch, **all cross-repo dependencies must be bumped together**. In a past incident, GPT-5.4 was cherry-picked into the release branch (node-chat TypeScript changes) but the `unique_toolkit` version bump in `assistants-core` was forgotten. This left the buggy toolkit version in place for gpt-5.1, causing the `reasoning_effort: null` production error.
+
+Checklist for cherry-picks:
+- [ ] Node-chat TypeScript changes (language-model enum, factory, service)
+- [ ] `assistants-core` `pyproject.toml` toolkit version bump
+- [ ] LiteLLM overlay changes (if applicable)
+- [ ] Terraform changes (if applicable)
+
+## Responses API is stricter than Chat Completions API
+
+- The Responses API (used by the Python toolkit in `assistants-core`) sends parameters directly to Azure and rejects invalid values like `reasoning_effort: null`.
+- The Chat Completions API (used by node-chat via the Azure SDK) may silently drop or ignore malformed optional parameters in some cases.
+- This means a model definition bug can cause errors in agentic Python spaces but not in plain chat spaces. When investigating "model X works in chat but fails in assistants," look at the toolkit's parameter construction.
+
+## Restart the right thing
+
+- To reload config/secrets: roll the **Kubernetes Deployment**.
+- Restarting an **HPA** does not reload running pods (it only adjusts autoscaling).
+
+## Never guess model facts
+
+- Token limits, capabilities, model identifiers: use authoritative sources only.
+- If no source is available, ask the user to provide a link or confirm explicitly.

--- a/.claude/skills/model-deployment/references/LITELLM-CONFIG.md
+++ b/.claude/skills/model-deployment/references/LITELLM-CONFIG.md
@@ -1,0 +1,68 @@
+# Track A — LiteLLM config details
+
+## Config entry examples
+
+From our actual ArgoCD overlays:
+
+```yaml
+# Standard model
+- model_name: anthropic-claude-opus-4-6
+  litellm_params:
+    model: anthropic/claude-opus-4-6
+    api_key: os.environ/ANTHROPIC_API_KEY
+    max_tokens: 20000
+
+# Gemini model
+- model_name: gemini-2-5-flash
+  litellm_params:
+    model: gemini/gemini-2.5-flash
+    api_key: os.environ/GEMINI_API_KEY
+
+# Model with thinking/reasoning enabled
+- model_name: anthropic-claude-3-7-sonnet-thinking
+  litellm_params:
+    model: anthropic/claude-3-7-sonnet-20250219
+    api_key: os.environ/ANTHROPIC_API_KEY
+    temperature: 1.0
+    max_tokens: 64000
+    thinking:
+      type: enabled
+      budget_tokens: 20000
+    additional_drop_params: ["top_p"]
+```
+
+### Notes
+
+- `api_key` uses `os.environ/<KEY_NAME>` syntax — LiteLLM resolves this at runtime from pod environment.
+- `max_tokens` is the **output** token limit for the proxy; set it conservatively to avoid exceeding context limits.
+- For thinking/reasoning models, set `temperature: 1.0` (required by the provider) and configure the `thinking` block.
+
+## Provider prefix conventions
+
+- Gemini API key auth: `gemini/<model>` with `GEMINI_API_KEY`
+- Anthropic: `anthropic/<model>` with `ANTHROPIC_API_KEY`
+- OpenAI via LiteLLM: `openai/<model>` with `OPENAI_API_KEY`
+- If the LiteLLM registry shows a different prefix for a new provider, confirm with the team first.
+
+## model_name vs litellm_params.model
+
+- `model_name` = user-facing key (no provider prefix): `gemini-2-5-flash`
+- `litellm_params.model` = provider model string (with prefix): `gemini/gemini-2.5-flash`
+- Common mistake: putting a provider string as `model_name`. If `model_name` contains `/`, it is almost certainly wrong.
+
+## Preview naming
+
+If the upstream model uses `-preview` in its name, keep `-preview` in the exposed `model_name` too.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---------|-------------|
+| Model not visible in LiteLLM UI | ArgoCD app not synced, Deployment not rolled, or YAML syntax error |
+| "Model not available on cluster" | Config not applied, pods running old config, or model name mismatch |
+| Wrong responses / unexpected model | Wrong provider prefix (e.g. missing `gemini/` prefix with `GEMINI_API_KEY`) |
+
+## ArgoCD vs LiteLLM dashboard
+
+- **ArgoCD** is the source of truth for config sync ("sync from git" happens here).
+- **LiteLLM dashboard** is for inspecting proxy state (model list, logs) — you cannot deploy or sync from it.

--- a/.claude/skills/model-deployment/references/MODEL-SELECTABILITY.md
+++ b/.claude/skills/model-deployment/references/MODEL-SELECTABILITY.md
@@ -1,0 +1,46 @@
+# Model selectability
+
+There are **two gatekeeping layers** that control whether a model is available and selectable on uniqueai.
+
+## Layer 1: `UNIQUEAI_SUPPORTED_MODELS` (hardcoded in code)
+
+This is a hardcoded array in `azure-sdk-openai.service.factory.ts` that defines which models are **available on the cluster**. If a model is not in this list, it cannot be used at all — even if it has an enum entry and factory case.
+
+```typescript
+export const UNIQUEAI_SUPPORTED_MODELS = [
+  LanguageModelNameKey.AZURE_GPT_4o_2024_1120,
+  LanguageModelNameKey.AZURE_GPT_54_2026_0305,
+  'litellm:gemini-2-5-pro',
+  // ... add your new model here
+] as const;
+```
+
+You **must** add your model to this array (done in B3) for it to be cluster-available.
+
+## Layer 2: `UNIQUEAI_ALLOWED_MODELS` (env var, per-company)
+
+This environment variable on node-chat controls which of the cluster-available models are **selectable by end users** in the UI model picker. If a model should not appear in the user-facing dropdown, do not add it here.
+
+- **Env var:** `UNIQUEAI_ALLOWED_MODELS` in the node-chat Helm chart / deployment config.
+- **Format:** `companyId:MODEL_NAME,MODEL_NAME2;companyId2:MODEL_NAME3` — semicolon-separated company entries, colon-separated company ID and comma-separated model names.
+- **Wildcard:** `*:MODEL_NAME` makes a model selectable for all companies.
+- **Unset / empty:** when the env var is unset, the default model selection logic applies (all cluster models are available).
+
+## Decision matrix
+
+| Want the model to... | `UNIQUEAI_SUPPORTED_MODELS` | `UNIQUEAI_ALLOWED_MODELS` |
+|---|---|---|
+| Be available and selectable by users | Add | Add |
+| Be available but only for internal/orchestrator use | Add | Do **not** add |
+| Not be available at all | Do **not** add | N/A |
+
+## Where to configure `UNIQUEAI_ALLOWED_MODELS`
+
+- **Per-environment overlays:** `next/services/node-chat/deploy/<Env>/values.yaml` — production example at `next/services/node-chat/deploy/Prod/values.yaml`.
+- **Helm chart default:** `next/services/node-chat/deploy/helm-chart/values.yaml` has the env var commented out by default.
+- **Code:** parsed by `OpenAiconfigSchema` in `next/services/node-chat/src/openai/config-schema.ts`, used by the Azure SDK service factory to filter available models per company.
+
+## Important notes
+
+- The model names in `UNIQUEAI_ALLOWED_MODELS` must match the `LanguageModel` enum values (e.g. `AZURE_GPT_4o_2024_1120`), **not** the Azure deployment name or the LiteLLM `model_name`.
+- If a model is listed in `UNIQUEAI_ALLOWED_MODELS` but is not in `UNIQUEAI_SUPPORTED_MODELS` or not deployed on the cluster, node-chat logs a warning: *"Model X is listed in UNIQUEAI_ALLOWED_MODELS but not found in the cluster list of models"*.

--- a/.claude/skills/model-deployment/references/TOOLKIT-REGISTRY.md
+++ b/.claude/skills/model-deployment/references/TOOLKIT-REGISTRY.md
@@ -1,0 +1,69 @@
+# Track C — AI toolkit details
+
+## LanguageModelInfo code example
+
+In `unique_toolkit/unique_toolkit/language_model/infos.py`:
+
+### 1. Enum entry
+
+Convention:
+- Azure models: `AZURE_GPT_54_2026_0305 = "AZURE_GPT_54_2026_0305"`
+- LiteLLM models: `OPENAI_GPT_54 = "litellm:openai-gpt-5-4"`
+
+### 2. `LanguageModelInfo.from_name()` case
+
+```python
+case LanguageModelName.OPENAI_GPT_54:
+    return LanguageModelInfo(
+        name=model_name,
+        provider=LanguageModelProvider.LITELLM,
+        version="2026-03-05",
+        token_limits=LanguageModelTokenLimits(
+            token_limit_input=200_000,
+            token_limit_output=100_000,
+        ),
+        capabilities=[
+            ModelCapabilities.FUNCTION_CALLING,
+            ModelCapabilities.STREAMING,
+        ],
+        temperature_bounds=TemperatureBounds(
+            min_temperature=0.0, max_temperature=1.0
+        ),
+        supported_reasoning_efforts=[
+            "low", "medium", "high", "xhigh",
+        ],
+        default_options={"reasoning_effort": "medium"},
+    )
+```
+
+## Field reference
+
+| Field | Description |
+|-------|-------------|
+| `token_limits` | Input and output token limits — cite the model card |
+| `capabilities` | `FUNCTION_CALLING`, `STREAMING`, `VISION`, etc. |
+| `temperature_bounds` | Min/max temperature — reasoning models typically use `(0.0, 1.0)`. Never use `(1.0, 1.0)` — this was a past mistake that locked temperature to 1.0 regardless of reasoning state. |
+| `supported_reasoning_efforts` | `None` = unknown (pass-through), `[]` = no reasoning, `["low", "medium", "high"]` = validated list |
+| `default_options` | Default `reasoning_effort` and other defaults. **Critical: use the string `"none"` — never Python `None`.** See [LESSONS-LEARNED.md](LESSONS-LEARNED.md). |
+
+## LANGUAGE_MODEL_INFOS env override (early exposure)
+
+Before a toolkit release is published, you can expose a model immediately by setting the `LANGUAGE_MODEL_INFOS` environment variable on the relevant service. Useful for smoke-testing a model in QA before the toolkit PR is merged.
+
+### Format
+
+JSON dict where each key is a model identifier and each value is a `LanguageModelInfo`-compatible dict:
+
+```bash
+LANGUAGE_MODEL_INFOS='{"MY_NEW_MODEL": {"name": "litellm:my-new-model", "provider": "LITELLM", "version": "2026-01-01", "capabilities": ["function_calling", "streaming"], "token_limits": {"token_limit_input": 128000, "token_limit_output": 16384}}}'
+```
+
+### Where to set it
+
+Set the env var in the service's app configuration or Helm values overlay for the target environment. The toolkit parses this at startup and merges it with the hardcoded model registry.
+
+### Caveats
+
+- This is a **temporary** measure — always follow up with a proper toolkit PR.
+- Models loaded via env have `supported_reasoning_efforts=None` (unknown / pass-through) unless explicitly set in the JSON.
+- If `default_options.reasoning_effort` is set but `supported_reasoning_efforts` is empty, the model's default effort will not be validated.


### PR DESCRIPTION
## Summary

- Adds a model deployment skill (`.claude/skills/model-deployment/`) that centralizes guidance for deploying LLM models across the Unique platform
- Covers three deployment tracks: LiteLLM (GitOps), Azure OpenAI (Terraform + node backend), and AI toolkit (`LanguageModelInfo`)
- Includes hard-won lessons from the `reasoning_effort: null` production incident and other real deployment issues

## Structure

Follows progressive disclosure — slim core SKILL.md (~190 lines) with five focused reference files loaded on demand:

| File | Content |
|------|---------|
| `SKILL.md` | Core workflow steps, decision points, checklists |
| `references/LITELLM-CONFIG.md` | Config examples, provider prefixes, troubleshooting |
| `references/AZURE-NODE-CHAT.md` | Terraform patterns, node-chat code examples, troubleshooting |
| `references/TOOLKIT-REGISTRY.md` | LanguageModelInfo examples, field reference, env override |
| `references/LESSONS-LEARNED.md` | Production incidents, dual code paths, cherry-pick checklist |
| `references/MODEL-SELECTABILITY.md` | UNIQUEAI_SUPPORTED_MODELS vs UNIQUEAI_ALLOWED_MODELS |

## Test plan

- [x] YAML frontmatter validates correctly
- [x] No broken markdown links between SKILL.md and references
- [x] Cross-referenced with real deployment files (litellm.yaml overlays, infos.py, azure-sdk-openai.service.ts)
- [x] Lessons learned section verified against actual incident timeline (2026.12.0 → 2026.12.1)

Refs: UN-17994