### PR TITLE
docs(skills): split security-maintenance skill into references/

### DIFF
--- a/.claude/skills/security-maintenance/SKILL.md
+++ b/.claude/skills/security-maintenance/SKILL.md
@@ -4,7 +4,7 @@ description: Triage and fix Dependabot alerts and CodeQL findings in the ai repo
 license: MIT
 compatibility: claude cursor opencode
 metadata:
-  version: "1.0.0"
+  version: "1.1.0"
   languages: python
   audience: developers
   workflow: automation

--- a/.claude/skills/security-maintenance/SKILL.md
+++ b/.claude/skills/security-maintenance/SKILL.md
@@ -18,192 +18,48 @@ I drive the security maintenance workflow for the `ai` repository to keep both d
 - **Dependabot** — https://github.com/Unique-AG/ai/security/dependabot
 - **CodeQL** — https://github.com/Unique-AG/ai/security/code-scanning
 
-For Dependabot alerts I persist fixes through `constraint-dependencies` and `exclude-newer-package` in the root `pyproject.toml`, then relock. For CodeQL findings I fix the flagged code directly. Both result in a PR.
-
 ## When to use me
 
-- User says "fix dependabot", "security maintenance", "fix vulnerabilities", "dependabot alerts", "CodeQL findings", etc.
+- "fix dependabot", "security maintenance", "fix vulnerabilities", "dependabot alerts", "CodeQL findings"
 - Periodic security maintenance sessions
 - After Dependabot auto-opens PRs (we do **not** merge those directly)
 
-## Use Instead [if available]
-
-- Use `ci-fix` for general CI failures unrelated to security
-- Use `uv` for dependency management tasks that are not security-related
-
 ---
 
-## Part 1: Dependabot Alerts
+## Dependabot workflow
 
-### Key principle
+**Never merge Dependabot auto-PRs.** Use `constraint-dependencies` in the root `pyproject.toml` instead.
 
-Dependabot auto-opens PRs that patch `pyproject.toml` / `uv.lock` directly. **Do not merge those PRs.** Instead, use the root workspace's `constraint-dependencies` section to enforce security floors, then relock. This ensures every package in the workspace picks up the fix and the constraint survives future relocks.
+1. **List alerts** — see [gh commands reference](references/gh-commands.md)
+2. **Find fix version** from the alert JSON
+3. **Add/bump `constraint-dependencies`** in root `pyproject.toml` with `"<package>>=<fixed-version>"`
+4. **Handle `exclude-newer` conflicts** — if the fix version is within the 2-week rolling window, add an `exclude-newer-package` timestamp (day after latest PyPI upload). See [exclude-newer reference](references/exclude-newer.md)
+5. **Prune stale `exclude-newer-package` entries** — remove any timestamp older than 2 weeks (redundant, global window already covers it). Keep `= false` entries.
+6. **Relock** — `uv lock --refresh`. If resolution fails, bump the timestamp and retry.
+7. **Version bump all packages** — changelog entry + patch bump for each workspace package (CI enforces this). Use the `changelog-pyproject` skill.
+8. **Branch and PR** — branch `fix/dependabot-<pkg>-<ver>` or `fix/security-<date>` for batches. Close Dependabot auto-PRs after merge.
 
-### Step 1: List open alerts
+## CodeQL workflow
 
-```bash
-gh api repos/Unique-AG/ai/dependabot/alerts --jq '.[] | select(.state=="open") | "\(.number) \(.security_advisory.severity) \(.dependency.package.ecosystem):\(.dependency.package.name) — \(.security_advisory.summary)"'
-```
+1. **List findings** — see [gh commands reference](references/gh-commands.md)
+2. **Read the rule and flagged code** in context
+3. **Fix the code** — see [common CodeQL patterns](references/codeql-patterns.md)
+4. **Version bump, branch, PR** — same as Dependabot
 
-If there are no open alerts, move on to Part 2 (CodeQL).
-
-### Step 2: For each alert, find the fix version
-
-The alert JSON contains the fixed version:
-
-```bash
-gh api repos/Unique-AG/ai/dependabot/alerts/<NUMBER> --jq '.security_vulnerability.first_patched_version.identifier'
-```
-
-Record the package name and minimum fixed version.
-
-### Step 3: Add or update constraint-dependencies
-
-Open the root `pyproject.toml`. In `[tool.uv] constraint-dependencies`, add or bump the entry:
-
-```toml
-[tool.uv]
-constraint-dependencies = [
-    # ... existing entries ...
-    "<package>>=<fixed-version>",
-]
-```
-
-If the package is already listed, bump the version floor to the fixed version.
-
-### Step 4: Handle exclude-newer conflicts
-
-The workspace uses `exclude-newer = "2 weeks"` which may hide the fixed version if it was published recently. To check:
-
-1. Look up the package's release date on PyPI:
-   ```bash
-   uv pip index versions <package> 2>&1 | head -5
-   ```
-   Or check PyPI directly: `https://pypi.org/project/<package>/<version>/`
-
-2. If the fixed version was published within the last 2 weeks (or if `uv lock` fails to resolve it), add an `exclude-newer-package` override in the root `pyproject.toml`:
-   ```toml
-   [tool.uv.exclude-newer-package]
-   "<package>" = "YYYY-MM-DD"
-   ```
-   The date must be the **day after** the latest artifact upload time for that version. Round up, not down. For example, if the latest wheel was uploaded on `2026-04-08T23:45:00Z`, use `"2026-04-09"`.
-
-3. To find the exact upload time, check the PyPI JSON API:
-   ```bash
-   curl -s https://pypi.org/pypi/<package>/<version>/json | python3 -c "import sys,json; d=json.load(sys.stdin)['urls']; print(max(u['upload_time_iso_8601'] for u in d))"
-   ```
-   Then round up to the next day.
-
-### Step 4b: Clean up stale exclude-newer-package entries
-
-Any `exclude-newer-package` timestamp that is older than the configured `exclude-newer` window (currently 2 weeks) is redundant — the global window already allows that version through. Remove these stale entries to keep the section minimal.
-
-```bash
-TODAY=$(date +%s)
-WINDOW_DAYS=14
-```
-
-For each entry in `[tool.uv.exclude-newer-package]`, check whether the timestamp is more than 14 days in the past. If it is, delete the line. Keep entries that are:
-- Set to `false` (permanent overrides, e.g. `unique-toolkit`)
-- Still within the 2-week window (the version would be hidden without the override)
-
-### Step 5: Relock
-
-```bash
-uv lock --refresh
-```
-
-If resolution fails, the `exclude-newer-package` timestamp is likely too tight. Bump it to the next day and retry.
-
-### Step 6: Version bump all packages
-
-Every workspace package needs a changelog entry and patch version bump. The CI enforces this via the `Changelog and Version Bump` workflow. For each package:
-
-1. Add a changelog entry in `<package>/CHANGELOG.md` (newest-first, today's date)
-2. Bump the `version` field in `<package>/pyproject.toml`
-3. Relock again after bumping: `uv lock --refresh`
-
-Use the `changelog-pyproject` skill for format guidance.
-
-### Step 7: Create a branch and PR
-
-- Branch naming: `fix/dependabot-<package>-<version>` or `fix/security-<date>` for batch fixes
-- Do **not** merge the Dependabot auto-PRs. Close them after your fix PR is merged.
-- Use the `pr-create` skill for PR creation
-
----
-
-## Part 2: CodeQL Findings
-
-### Step 1: List open findings
-
-Visit https://github.com/Unique-AG/ai/security/code-scanning or use:
-
-```bash
-gh api repos/Unique-AG/ai/code-scanning/alerts --jq '.[] | select(.state=="open") | "\(.number) \(.rule.severity) \(.rule.id) — \(.most_recent_instance.location.path):\(.most_recent_instance.location.start_line)"'
-```
-
-### Step 2: Understand the finding
-
-For each alert, read the rule description and the flagged code:
-
-```bash
-gh api repos/Unique-AG/ai/code-scanning/alerts/<NUMBER> --jq '{rule: .rule.id, severity: .rule.severity, description: .rule.description, path: .most_recent_instance.location.path, start_line: .most_recent_instance.location.start_line, end_line: .most_recent_instance.location.end_line}'
-```
-
-Read the flagged file and understand the vulnerability in context.
-
-### Step 3: Fix the code
-
-CodeQL fixes are code changes — there is no shortcut. Common patterns:
-
-- **SQL injection**: Use parameterized queries instead of string interpolation
-- **Path traversal**: Validate and sanitize file paths
-- **Hardcoded credentials**: Move to environment variables or secret managers
-- **Unsafe deserialization**: Use safe loaders or validate input
-- **Command injection**: Use subprocess with argument lists, not shell strings
-
-### Step 4: Version bump, branch, and PR
-
-Same as Dependabot: changelog entry, version bump, relock, create PR.
-
----
-
-## Batch workflow
-
-When doing a full security maintenance session:
+## Batch session
 
 1. List all Dependabot alerts and CodeQL findings
-2. Remove stale `exclude-newer-package` entries (older than 2 weeks)
-3. Fix all Dependabot alerts first (they're usually mechanical)
-4. Fix CodeQL findings (these require code changes)
-5. Put everything on a single branch if the fixes are related, or separate branches for unrelated fixes
-6. Bump all affected packages once at the end
-7. Create PR(s)
-8. After merge, close any Dependabot auto-PRs that are now resolved
-
----
-
-## Quick reference: root pyproject.toml sections
-
-```toml
-[tool.uv]
-exclude-newer = "2 weeks"                    # global rolling window
-constraint-dependencies = [                   # security version floors
-    "cryptography>=46.0.7",
-]
-
-[tool.uv.exclude-newer-package]
-"cryptography" = "2026-04-09"                # override for packages hidden by exclude-newer
-```
-
-- `constraint-dependencies` — enforces minimum versions across the entire workspace
-- `exclude-newer-package` — per-package override of the 2-week rolling window; set to the day after the latest PyPI artifact upload for the required version
+2. Prune stale `exclude-newer-package` entries
+3. Fix Dependabot alerts (mechanical)
+4. Fix CodeQL findings (code changes)
+5. Single branch for related fixes, separate for unrelated
+6. Bump all packages once at the end
+7. Create PR(s), close resolved Dependabot auto-PRs after merge
 
 ## Tips
 
-- **Never merge Dependabot auto-PRs** — always use `constraint-dependencies` so the fix persists across relocks
-- **Round timestamps up** — `exclude-newer-package` dates should be the day *after* the latest artifact upload, because `uv` uses a strict `<` comparison on individual wheel upload times
-- **Batch when possible** — fixing multiple alerts in one PR reduces version bump noise
-- **Prune stale timestamps** — `exclude-newer-package` entries older than the 2-week window are redundant; remove them during every maintenance session to keep the config clean
-- **Check both dashboards** — Dependabot and CodeQL are independent; zero on one doesn't mean zero on the other
+- **Never merge Dependabot auto-PRs** — `constraint-dependencies` persists across relocks
+- **Round timestamps up** — day *after* latest artifact upload (`uv` uses strict `<` on individual wheel upload times)
+- **Batch when possible** — one PR reduces version bump noise
+- **Prune stale timestamps** — entries older than the 2-week window are redundant
+- **Check both dashboards** — Dependabot and CodeQL are independent

--- a/.claude/skills/security-maintenance/references/codeql-patterns.md
+++ b/.claude/skills/security-maintenance/references/codeql-patterns.md
@@ -1,0 +1,97 @@
+# Common CodeQL Fix Patterns
+
+CodeQL fixes require code changes — there is no config shortcut. Below are common vulnerability classes and their remediation patterns.
+
+## SQL injection
+
+**Problem**: User input interpolated into SQL strings.
+
+**Fix**: Use parameterized queries.
+
+```python
+# Bad
+cursor.execute(f"SELECT * FROM users WHERE id = '{user_id}'")
+
+# Good
+cursor.execute("SELECT * FROM users WHERE id = %s", (user_id,))
+```
+
+## Path traversal
+
+**Problem**: User-controlled input used in file paths without validation.
+
+**Fix**: Validate and resolve paths, ensure they stay within allowed directories.
+
+```python
+# Bad
+open(os.path.join(base_dir, user_input))
+
+# Good
+resolved = os.path.realpath(os.path.join(base_dir, user_input))
+if not resolved.startswith(os.path.realpath(base_dir)):
+    raise ValueError("Path traversal detected")
+open(resolved)
+```
+
+## Hardcoded credentials
+
+**Problem**: Secrets, API keys, or passwords in source code.
+
+**Fix**: Move to environment variables or a secret manager.
+
+```python
+# Bad
+api_key = "sk-1234567890"
+
+# Good
+api_key = os.environ["API_KEY"]
+```
+
+## Unsafe deserialization
+
+**Problem**: Loading untrusted data with `pickle`, `yaml.load`, or similar.
+
+**Fix**: Use safe loaders or validate input.
+
+```python
+# Bad
+data = yaml.load(content)
+data = pickle.loads(payload)
+
+# Good
+data = yaml.safe_load(content)
+data = json.loads(payload)  # prefer JSON over pickle for untrusted data
+```
+
+## Command injection
+
+**Problem**: User input passed to shell commands via string concatenation.
+
+**Fix**: Use subprocess with argument lists, never `shell=True` with user input.
+
+```python
+# Bad
+os.system(f"grep {query} /var/log/app.log")
+subprocess.run(f"grep {query} /var/log/app.log", shell=True)
+
+# Good
+subprocess.run(["grep", query, "/var/log/app.log"], check=True)
+```
+
+## Server-side request forgery (SSRF)
+
+**Problem**: User-controlled URLs passed to HTTP requests without validation.
+
+**Fix**: Validate URLs against an allowlist, block internal/private ranges.
+
+```python
+# Bad
+response = requests.get(user_provided_url)
+
+# Good
+from urllib.parse import urlparse
+parsed = urlparse(user_provided_url)
+if parsed.hostname not in ALLOWED_HOSTS:
+    raise ValueError("URL not allowed")
+response = requests.get(user_provided_url)
+```

--- a/.claude/skills/security-maintenance/references/exclude-newer.md
+++ b/.claude/skills/security-maintenance/references/exclude-newer.md
@@ -1,0 +1,64 @@
+# exclude-newer and exclude-newer-package
+
+## How it works
+
+The root `pyproject.toml` sets a global rolling window:
+
+```toml
+[tool.uv]
+exclude-newer = "2 weeks"
+```
+
+This tells `uv` to ignore any package version whose PyPI artifacts were uploaded after the cutoff. This prevents unexpected breakage from brand-new releases but can conflict with security fixes that were published recently.
+
+## When you need an override
+
+If a security fix version was published within the last 2 weeks, `uv lock` will fail to resolve it. Add a per-package override:
+
+```toml
+[tool.uv.exclude-newer-package]
+"<package>" = "YYYY-MM-DD"
+```
+
+## Finding the correct timestamp
+
+The timestamp must be the **day after** the latest artifact (wheel/sdist) upload time for the required version. `uv` uses a strict `<` comparison on individual wheel upload times, not the version's publication date.
+
+### Step-by-step
+
+1. Query the PyPI JSON API for the latest artifact upload time:
+   ```bash
+   curl -s https://pypi.org/pypi/<package>/<version>/json | python3 -c "
+   import sys, json
+   data = json.load(sys.stdin)['urls']
+   print(max(u['upload_time_iso_8601'] for u in data))
+   "
+   ```
+
+2. Round up to the **next day**. For example:
+   - Latest upload: `2026-04-08T23:45:00Z` → use `"2026-04-09"`
+   - Latest upload: `2026-04-09T00:01:00Z` → use `"2026-04-10"`
+
+3. Never use the exact upload time or same day — some wheels for different Python versions / platforms are uploaded over several minutes or hours.
+
+## Pruning stale entries
+
+Any `exclude-newer-package` timestamp older than the `exclude-newer` window (currently 2 weeks) is **redundant** — the global window already allows that version through. Remove these during every maintenance session.
+
+Keep entries that are:
+- Set to `false` (permanent overrides, e.g. `unique-toolkit`)
+- Still within the 2-week window
+
+## Example
+
+```toml
+[tool.uv]
+exclude-newer = "2 weeks"
+constraint-dependencies = [
+    "cryptography>=46.0.7",
+]
+
+[tool.uv.exclude-newer-package]
+"unique-toolkit" = false            # permanent — always use latest workspace version
+"cryptography" = "2026-04-09"       # security fix, published 2026-04-08 — remove after 2026-04-22
+```

--- a/.claude/skills/security-maintenance/references/gh-commands.md
+++ b/.claude/skills/security-maintenance/references/gh-commands.md
@@ -1,0 +1,35 @@
+# GitHub CLI Commands for Security Alerts
+
+## Dependabot
+
+### List open alerts
+
+```bash
+gh api repos/Unique-AG/ai/dependabot/alerts --jq '.[] | select(.state=="open") | "\(.number) \(.security_advisory.severity) \(.dependency.package.ecosystem):\(.dependency.package.name) — \(.security_advisory.summary)"'
+```
+
+### Get fix version for a specific alert
+
+```bash
+gh api repos/Unique-AG/ai/dependabot/alerts/<NUMBER> --jq '.security_vulnerability.first_patched_version.identifier'
+```
+
+### Dismiss an alert (after fix is merged via your own PR)
+
+```bash
+gh api repos/Unique-AG/ai/dependabot/alerts/<NUMBER> -X PATCH -f state=dismissed -f dismissed_reason=fix_started
+```
+
+## CodeQL
+
+### List open findings
+
+```bash
+gh api repos/Unique-AG/ai/code-scanning/alerts --jq '.[] | select(.state=="open") | "\(.number) \(.rule.severity) \(.rule.id) — \(.most_recent_instance.location.path):\(.most_recent_instance.location.start_line)"'
+```
+
+### Get details for a specific finding
+
+```bash
+gh api repos/Unique-AG/ai/code-scanning/alerts/<NUMBER> --jq '{rule: .rule.id, severity: .rule.severity, description: .rule.description, path: .most_recent_instance.location.path, start_line: .most_recent_instance.location.start_line, end_line: .most_recent_instance.location.end_line}'
+```


### PR DESCRIPTION
## Summary

- Slim down `SKILL.md` for progressive disclosure (~66 lines, well under the 500-line recommendation)
- Move gh CLI commands to `references/gh-commands.md`
- Move exclude-newer documentation to `references/exclude-newer.md`
- Move CodeQL fix patterns to `references/codeql-patterns.md`

Follow-up to #1430.

## Test plan

- [ ] Skill file renders correctly, references are reachable via relative links
- [ ] Workflow steps remain accurate

Refs: UN-17719

Made with [Cursor](https://cursor.com)