### PR TITLE
feat(toolkit): add ContentChunk.to_reference() and None-safe page postfix

### DIFF
--- a/unique_toolkit/CHANGELOG.md
+++ b/unique_toolkit/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.75.0] - 2026-04-16
+- Add `ContentChunk.to_reference()` method to convert a chunk into a `ContentReference` with page-number info, matching the backend streaming-path format for use with `modify_assistant_message`
+- Harden `_generate_pages_postfix` to accept `None` page values (`start_page`/`end_page` are optional on `ContentChunk`), preventing `TypeError` on real API chunks
+- Fix page-postfix dedup check to handle non-contiguous page sets after `merge_content_chunks`
+
 ## [1.74.2] - 2026-04-16
 - Adding model `litellm:anthropic-claude-opus-4-7` to `language_model/info.py`
 

--- a/unique_toolkit/pyproject.toml
+++ b/unique_toolkit/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "unique_toolkit"
-version = "1.74.2"
+version = "1.75.0"
 description = ""
 readme = "README.md"
 requires-python = ">=3.12"

--- a/unique_toolkit/tests/content/test_content_schemas_unit.py
+++ b/unique_toolkit/tests/content/test_content_schemas_unit.py
@@ -1,6 +1,8 @@
+from datetime import datetime
+
 import pytest
 
-from unique_toolkit.content.schemas import Content
+from unique_toolkit.content.schemas import Content, ContentChunk, ContentReference
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -147,3 +149,207 @@ class TestContentIsIngested:
 
         with pytest.raises(TypeError):
             content.is_ingested(False)  # type: ignore[call-arg]
+
+
+# ---------------------------------------------------------------------------
+# ContentChunk.to_reference
+# ---------------------------------------------------------------------------
+
+
+class TestContentChunkToReference:
+    def test_basic_reference_with_pages(self):
+        chunk = ContentChunk(
+            id="cont_123",
+            chunk_id="chunk_abc",
+            title="Report.pdf",
+            text="some text",
+            order=1,
+            start_page=3,
+            end_page=5,
+        )
+
+        ref = chunk.to_reference(sequence_number=1)
+
+        assert isinstance(ref, ContentReference)
+        assert ref.id == "cont_123"
+        assert ref.message_id == ""
+        assert ref.name == "Report.pdf : 3,4,5"
+        assert ref.sequence_number == 1
+        assert ref.source_id == "cont_123_chunk_abc"
+        assert ref.source == "node-ingestion-chunks"
+        assert ref.url == "unique://content/cont_123"
+        assert ref.original_index == []
+
+    def test_none_pages_do_not_crash(self):
+        chunk = ContentChunk(
+            id="cont_456",
+            chunk_id="chunk_def",
+            title="NoPagesDoc.pdf",
+            text="text",
+            order=1,
+            start_page=None,
+            end_page=None,
+        )
+
+        ref = chunk.to_reference(sequence_number=2)
+
+        assert ref.name == "NoPagesDoc.pdf"
+
+    def test_none_start_page_with_valid_end_page(self):
+        chunk = ContentChunk(
+            id="cont_789",
+            chunk_id="chunk_ghi",
+            title="Partial.pdf",
+            text="text",
+            order=1,
+            start_page=None,
+            end_page=5,
+        )
+
+        ref = chunk.to_reference(sequence_number=1)
+
+        assert ref.name == "Partial.pdf"
+
+    def test_valid_start_page_with_none_end_page(self):
+        chunk = ContentChunk(
+            id="cont_aaa",
+            chunk_id="chunk_bbb",
+            title="HalfPage.pdf",
+            text="text",
+            order=1,
+            start_page=3,
+            end_page=None,
+        )
+
+        ref = chunk.to_reference(sequence_number=1)
+
+        assert ref.name == "HalfPage.pdf : 3"
+
+    def test_url_uses_chunk_url_when_not_internally_stored(self):
+        chunk = ContentChunk(
+            id="cont_ext",
+            chunk_id="chunk_ext",
+            title="Web Page",
+            text="text",
+            order=1,
+            url="https://example.com/page",
+            internally_stored_at=None,
+        )
+
+        ref = chunk.to_reference(sequence_number=1)
+
+        assert ref.url == "https://example.com/page"
+
+    def test_url_falls_back_to_unique_when_internally_stored(self):
+        chunk = ContentChunk(
+            id="cont_int",
+            chunk_id="chunk_int",
+            title="Stored Doc",
+            text="text",
+            order=1,
+            url="https://example.com/stored",
+            internally_stored_at=datetime(2024, 7, 22, 11, 51, 40),
+        )
+
+        ref = chunk.to_reference(sequence_number=1)
+
+        assert ref.url == "unique://content/cont_int"
+
+    def test_url_falls_back_when_no_url(self):
+        chunk = ContentChunk(
+            id="cont_no_url",
+            chunk_id="chunk_no",
+            title="No URL",
+            text="text",
+            order=1,
+            url=None,
+        )
+
+        ref = chunk.to_reference(sequence_number=1)
+
+        assert ref.url == "unique://content/cont_no_url"
+
+    def test_source_id_without_chunk_id(self):
+        chunk = ContentChunk(
+            id="cont_only",
+            title="Doc",
+            text="text",
+            order=1,
+        )
+
+        ref = chunk.to_reference(sequence_number=1)
+
+        assert ref.source_id == "cont_only"
+
+    def test_original_index_passed_through(self):
+        chunk = ContentChunk(
+            id="cont_idx",
+            chunk_id="chunk_idx",
+            title="Doc",
+            text="text",
+            order=1,
+        )
+
+        ref = chunk.to_reference(sequence_number=3, original_index=[1, 4])
+
+        assert ref.original_index == [1, 4]
+        assert ref.sequence_number == 3
+
+    def test_falls_back_to_key_when_no_title(self):
+        chunk = ContentChunk(
+            id="cont_key",
+            chunk_id="chunk_key",
+            key="document.pdf",
+            text="text",
+            order=1,
+            start_page=1,
+            end_page=1,
+        )
+
+        ref = chunk.to_reference(sequence_number=1)
+
+        assert ref.name == "document.pdf : 1"
+
+    def test_sets_message_id_when_provided(self):
+        chunk = ContentChunk(
+            id="cont_msg",
+            chunk_id="chunk_msg",
+            title="Doc",
+            text="text",
+            order=1,
+        )
+
+        ref = chunk.to_reference(sequence_number=1, message_id="msg_abc")
+
+        assert ref.id == "cont_msg"
+        assert ref.message_id == "msg_abc"
+
+    def test_falls_back_to_content_id_when_no_title_or_key(self):
+        chunk = ContentChunk(
+            id="cont_noname",
+            chunk_id="chunk_x",
+            text="text",
+            order=1,
+            start_page=2,
+            end_page=2,
+        )
+
+        ref = chunk.to_reference(sequence_number=1)
+
+        assert ref.name == "Content cont_noname : 2"
+
+    def test_does_not_double_pages_postfix_when_title_already_includes_it(self):
+        chunk = ContentChunk(
+            id="cont_sorted",
+            chunk_id="chunk_s",
+            title="Annual Report : 1,2,3",
+            text="text",
+            order=1,
+            start_page=1,
+            end_page=3,
+        )
+
+        ref = chunk.to_reference(sequence_number=1)
+
+        assert ref.name == "Annual Report : 1,2,3"
+        assert ref.name.count(" : 1,2,3") == 1

--- a/unique_toolkit/tests/content/test_content_schemas_unit.py
+++ b/unique_toolkit/tests/content/test_content_schemas_unit.py
@@ -353,3 +353,22 @@ class TestContentChunkToReference:
 
         assert ref.name == "Annual Report : 1,2,3"
         assert ref.name.count(" : 1,2,3") == 1
+
+    def test_does_not_double_postfix_after_merge_with_non_contiguous_pages(self):
+        """After merge_content_chunks, title may carry a non-contiguous postfix
+        (e.g. " : 1,2,5,8,9") while start_page/end_page span a contiguous
+        range (1..9). The dedup check must still prevent a second postfix."""
+        chunk = ContentChunk(
+            id="cont_merged",
+            chunk_id="chunk_m",
+            title="Report : 1,2,5,8,9",
+            text="text",
+            order=1,
+            start_page=1,
+            end_page=9,
+        )
+
+        ref = chunk.to_reference(sequence_number=1)
+
+        assert " : " not in ref.name.replace("Report : 1,2,5,8,9", "", 1)
+        assert ref.name == "Report : 1,2,5,8,9"

--- a/unique_toolkit/tests/content/test_content_utils_unit.py
+++ b/unique_toolkit/tests/content/test_content_utils_unit.py
@@ -5,6 +5,7 @@ import pytest
 from unique_toolkit.content.schemas import ContentChunk
 from unique_toolkit.content.utils import (
     _apply_ingestion_upload_url_override,
+    _generate_pages_postfix,
     count_tokens,
     map_content,
     map_content_chunk,
@@ -269,3 +270,58 @@ class TestApplyIngestionUploadUrlOverride:
         ):
             result = _apply_ingestion_upload_url_override(write_url)
         assert result == "https://internal/upload?key=xyz"
+
+
+class TestGeneratePagesPostfix:
+    def test_single_chunk_with_page_range(self):
+        chunks = [ContentChunk(id="1", text="t", order=1, start_page=3, end_page=5)]
+
+        assert _generate_pages_postfix(chunks) == " : 3,4,5"
+
+    def test_single_chunk_single_page(self):
+        chunks = [ContentChunk(id="1", text="t", order=1, start_page=2, end_page=2)]
+
+        assert _generate_pages_postfix(chunks) == " : 2"
+
+    def test_none_start_and_end_returns_empty(self):
+        chunks = [
+            ContentChunk(id="1", text="t", order=1, start_page=None, end_page=None)
+        ]
+
+        assert _generate_pages_postfix(chunks) == ""
+
+    def test_none_start_with_valid_end_returns_empty(self):
+        chunks = [ContentChunk(id="1", text="t", order=1, start_page=None, end_page=5)]
+
+        assert _generate_pages_postfix(chunks) == ""
+
+    def test_valid_start_with_none_end_returns_single_page(self):
+        chunks = [ContentChunk(id="1", text="t", order=1, start_page=3, end_page=None)]
+
+        assert _generate_pages_postfix(chunks) == " : 3"
+
+    def test_sentinel_minus_one_start_and_end_returns_empty(self):
+        chunks = [ContentChunk(id="1", text="t", order=1, start_page=-1, end_page=-1)]
+
+        assert _generate_pages_postfix(chunks) == ""
+
+    def test_valid_start_with_minus_one_end_returns_single_page(self):
+        chunks = [ContentChunk(id="1", text="t", order=1, start_page=4, end_page=-1)]
+
+        assert _generate_pages_postfix(chunks) == " : 4"
+
+    def test_multiple_chunks_deduplicates_and_sorts(self):
+        chunks = [
+            ContentChunk(id="1", text="t", order=1, start_page=3, end_page=5),
+            ContentChunk(id="1", text="t", order=2, start_page=4, end_page=7),
+        ]
+
+        assert _generate_pages_postfix(chunks) == " : 3,4,5,6,7"
+
+    def test_zero_pages_are_filtered_out(self):
+        chunks = [ContentChunk(id="1", text="t", order=1, start_page=0, end_page=2)]
+
+        assert _generate_pages_postfix(chunks) == " : 1,2"
+
+    def test_empty_chunks_list_returns_empty(self):
+        assert _generate_pages_postfix([]) == ""

--- a/unique_toolkit/unique_toolkit/content/schemas.py
+++ b/unique_toolkit/unique_toolkit/content/schemas.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime
 from enum import StrEnum
 from typing import Any, Optional
@@ -71,6 +73,56 @@ class ContentChunk(BaseModel):
     internally_stored_at: datetime | None = None
     created_at: datetime | None = None
     updated_at: datetime | None = None
+
+    def to_reference(
+        self,
+        sequence_number: int,
+        original_index: list[int] | None = None,
+        *,
+        message_id: str = "",
+    ) -> ContentReference:
+        """Convert this chunk into a ``ContentReference`` with page-number info.
+
+        When using ``modify_assistant_message`` (the message-update path) instead of
+        streaming via ``complete_with_references``, the backend does **not**
+        automatically create references from ``searchContext``. This method replicates
+        the reference format the backend streaming path produces so page numbers
+        appear in the frontend reference chips.
+
+        Args:
+            sequence_number: The 1-based sequence number shown in the ``<sup>``
+                tag in the message text.
+            original_index: Optional list of bracket indices (``[N]``) in the
+                message text that this reference corresponds to.
+            message_id: The chat message id this reference belongs to, if any.
+
+        Returns:
+            A ``ContentReference`` ready to pass to ``modify_assistant_message``.
+        """
+        from unique_toolkit.content.utils import _generate_pages_postfix
+
+        name = self.title or self.key or f"Content {self.id}"
+        pages_postfix = _generate_pages_postfix([self])
+        if pages_postfix and not name.endswith(pages_postfix):
+            name = f"{name}{pages_postfix}"
+
+        source_id = f"{self.id}_{self.chunk_id}" if self.chunk_id else self.id
+        url = (
+            self.url
+            if self.url and not self.internally_stored_at
+            else f"unique://content/{self.id}"
+        )
+
+        return ContentReference(
+            id=self.id,
+            message_id=message_id,
+            name=name,
+            sequence_number=sequence_number,
+            source_id=source_id,
+            source="node-ingestion-chunks",
+            url=url,
+            original_index=original_index or [],
+        )
 
 
 class Content(BaseModel):

--- a/unique_toolkit/unique_toolkit/content/schemas.py
+++ b/unique_toolkit/unique_toolkit/content/schemas.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from datetime import datetime
 from enum import StrEnum
 from typing import Any, Optional
@@ -103,7 +104,7 @@ class ContentChunk(BaseModel):
 
         name = self.title or self.key or f"Content {self.id}"
         pages_postfix = _generate_pages_postfix([self])
-        if pages_postfix and not name.endswith(pages_postfix):
+        if pages_postfix and not re.search(r" : [\d,]+$", name):
             name = f"{name}{pages_postfix}"
 
         source_id = f"{self.id}_{self.chunk_id}" if self.chunk_id else self.id

--- a/unique_toolkit/unique_toolkit/content/utils.py
+++ b/unique_toolkit/unique_toolkit/content/utils.py
@@ -10,12 +10,7 @@ import tiktoken
 import unique_sdk
 from typing_extensions import deprecated
 
-from unique_toolkit.content.schemas import (
-    Content,
-    ContentChunk,
-    ContentMetadata,
-    ContentReference,
-)
+from unique_toolkit.content.schemas import Content, ContentChunk, ContentMetadata
 
 logger = logging.getLogger(__name__)
 
@@ -133,7 +128,7 @@ def _generate_pages_postfix(chunks: list[ContentChunk]) -> str:
     returns the empty string when there are no valid pages.
 
     **Usage:** Called from ``sort_content_chunks``, ``merge_content_chunks``, and
-    ``content_chunk_to_reference`` so list presentation and reference names stay
+    ``ContentChunk.to_reference`` so list presentation and reference names stay
     consistent with the backend's page postfix convention.
 
     **Why pages may be missing:** ``ContentChunk.start_page`` and ``end_page`` are
@@ -149,26 +144,6 @@ def _generate_pages_postfix(chunks: list[ContentChunk]) -> str:
     """
 
     def gen_all_numbers_in_between(start: int | None, end: int | None) -> list[int]:
-        """Expand a single start/end page pair into a list of inclusive page numbers.
-
-        ``ContentChunk`` exposes optional page fields; ``None`` must be handled like
-        "no page data" so ``_generate_pages_postfix`` (and thus
-        ``content_chunk_to_reference``) stay safe for production chunks.
-
-        **Rules:**
-            * ``start`` is ``None`` or ``-1``: return ``[]`` (no range; avoids
-              ``TypeError`` from ``range`` or ``end + 1`` when ``end`` is ``None``).
-            * ``start`` valid but ``end`` is ``None`` or ``-1``: return ``[start]``
-              (single known page, same as legacy ``-1`` end semantics).
-            * Otherwise: return every integer from ``start`` through ``end`` inclusive.
-
-        Args:
-            start: First page, or ``None`` / ``-1`` if unknown.
-            end: Last page, or ``None`` / ``-1`` if only ``start`` is known.
-
-        Returns:
-            List of page numbers for this pair (may be empty).
-        """
         if start is None or start == -1:
             return []
         if end is None or end == -1:
@@ -185,81 +160,6 @@ def _generate_pages_postfix(chunks: list[ContentChunk]) -> str:
         " : " + ",".join(str(p) for p in page_numbers) if page_numbers else ""
     )
     return pages_postfix
-
-
-def content_chunk_to_reference(
-    chunk: ContentChunk,
-    sequence_number: int,
-    original_index: list[int] | None = None,
-    *,
-    message_id: str = "",
-) -> ContentReference:
-    """Convert a ``ContentChunk`` into a ``ContentReference`` with page-number info.
-
-    Prefer :meth:`ContentChunk.to_reference <unique_toolkit.content.schemas.ContentChunk.to_reference>`
-    on the chunk instance in application code; this function remains for backward
-    compatibility and is the shared implementation both call sites use.
-
-    When using ``modify_assistant_message`` (the message-update path) instead
-    of streaming via ``complete_with_references``, the backend does **not**
-    automatically create references from ``searchContext``.  This helper
-    replicates the reference format that the backend streaming path produces
-    so that page numbers appear in the frontend reference chips.
-
-    Conventions applied:
-
-    * **id** — the chunk's content id (``chunk.id``), aligned with streaming
-      reference persistence.
-    * **message_id** — optional; set when the reference belongs to a specific
-      chat message.
-    * **source_id** — ``{content_id}_{chunk_id}`` (matches the backend
-      ``ReferenceService`` and ``ReferenceManager`` lookup).
-    * **source** — ``"node-ingestion-chunks"``.
-    * **name** — document title/key with a `` : 1,2,3`` page-number postfix
-      (same format as the backend ``generatePagesPostfix``); if neither title
-      nor key is set, ``Content {content_id}`` (matches reference dedup logic).
-      If ``title``/``key`` already end with that postfix (e.g. after
-      ``sort_content_chunks`` / ``merge_content_chunks``), it is not appended
-      twice.
-    * **url** — the chunk's own URL when it has one and is **not**
-      internally stored; otherwise ``unique://content/{content_id}``
-      (matches the ``internally_stored_at`` guard in the streaming path).
-
-    Args:
-        chunk: The content chunk to convert.
-        sequence_number: The 1-based sequence number shown in the ``<sup>``
-            tag in the message text.
-        original_index: Optional list of bracket indices (``[N]``) in the
-            message text that this reference corresponds to.
-        message_id: The chat message id this reference belongs to, if any.
-
-    Returns:
-        A ``ContentReference`` ready to pass to ``modify_assistant_message``.
-    """
-    name = chunk.title or chunk.key or f"Content {chunk.id}"
-    pages_postfix = _generate_pages_postfix([chunk])
-    # sort_content_chunks / merge_content_chunks may already have appended the same
-    # postfix to title or key; avoid "Report : 1,2 : 1,2".
-    if pages_postfix and not name.endswith(pages_postfix):
-        name = f"{name}{pages_postfix}"
-
-    source_id = f"{chunk.id}_{chunk.chunk_id}" if chunk.chunk_id else chunk.id
-    url = (
-        chunk.url
-        if chunk.url and not chunk.internally_stored_at
-        else f"unique://content/{chunk.id}"
-    )
-
-    return ContentReference(
-        id=chunk.id,
-        message_id=message_id,
-        name=name,
-        sequence_number=sequence_number,
-        source_id=source_id,
-        source="node-ingestion-chunks",
-        url=url,
-        original_index=original_index or [],
-    )
 
 
 def pick_content_chunks_for_token_window(

--- a/unique_toolkit/unique_toolkit/content/utils.py
+++ b/unique_toolkit/unique_toolkit/content/utils.py
@@ -10,7 +10,12 @@ import tiktoken
 import unique_sdk
 from typing_extensions import deprecated
 
-from unique_toolkit.content.schemas import Content, ContentChunk, ContentMetadata
+from unique_toolkit.content.schemas import (
+    Content,
+    ContentChunk,
+    ContentMetadata,
+    ContentReference,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -121,40 +126,53 @@ def merge_content_chunks(content_chunks: list[ContentChunk]):
 
 
 def _generate_pages_postfix(chunks: list[ContentChunk]) -> str:
-    """
-    Generates a postfix string of page numbers from a list of source objects.
-    Each source object contains startPage and endPage numbers. The function
-    compiles a list of all unique page numbers greater than 0 from all chunks,
-    and then returns them as a string prefixed with " : " if there are any.
+    """Build a human-readable page suffix for one or more chunks (e.g. ``" : 1,2,3"``).
 
-    Parameters:
-    - chunks (list): A list of objects with 'startPage' and 'endPage' keys.
+    Collects all page numbers greater than zero from each chunk's ``start_page`` and
+    ``end_page``, deduplicates and sorts them, then formats them as ``" : n,n,..."`` or
+    returns the empty string when there are no valid pages.
+
+    **Usage:** Called from ``sort_content_chunks``, ``merge_content_chunks``, and
+    ``content_chunk_to_reference`` so list presentation and reference names stay
+    consistent with the backend's page postfix convention.
+
+    **Why pages may be missing:** ``ContentChunk.start_page`` and ``end_page`` are
+    optional (``None`` from the API). This path must not call ``range`` with ``None``,
+    or callers would raise ``TypeError`` when building references from real chunks.
+
+    Args:
+        chunks: Chunks whose ``start_page`` / ``end_page`` may be ``None`` or ``-1``
+            (sentinel for unknown).
 
     Returns:
-    - string: A string of page numbers separated by commas, prefixed with " : ".
+        Postfix string such as ``" : 3,4,5"``, or ``""`` when no positive pages apply.
     """
 
-    def gen_all_numbers_in_between(start, end) -> list[int]:
-        """
-        Generates a list of all numbers between start and end, inclusive.
-        If start or end is -1, it behaves as follows:
-        - If both start and end are -1, it returns an empty list.
-        - If only end is -1, it returns a list containing only the start.
-        - If start is -1, it returns an empty list.
+    def gen_all_numbers_in_between(start: int | None, end: int | None) -> list[int]:
+        """Expand a single start/end page pair into a list of inclusive page numbers.
 
-        Parameters:
-        - start (int): The starting page number.
-        - end (int): The ending page number.
+        ``ContentChunk`` exposes optional page fields; ``None`` must be handled like
+        "no page data" so ``_generate_pages_postfix`` (and thus
+        ``content_chunk_to_reference``) stay safe for production chunks.
+
+        **Rules:**
+            * ``start`` is ``None`` or ``-1``: return ``[]`` (no range; avoids
+              ``TypeError`` from ``range`` or ``end + 1`` when ``end`` is ``None``).
+            * ``start`` valid but ``end`` is ``None`` or ``-1``: return ``[start]``
+              (single known page, same as legacy ``-1`` end semantics).
+            * Otherwise: return every integer from ``start`` through ``end`` inclusive.
+
+        Args:
+            start: First page, or ``None`` / ``-1`` if unknown.
+            end: Last page, or ``None`` / ``-1`` if only ``start`` is known.
 
         Returns:
-        - list: A list of numbers from start to end, inclusive.
+            List of page numbers for this pair (may be empty).
         """
-        if start == -1 and end == -1:
+        if start is None or start == -1:
             return []
-        if end == -1:
+        if end is None or end == -1:
             return [start]
-        if start == -1:
-            return []
         return list(range(start, end + 1))
 
     page_numbers_array = [
@@ -167,6 +185,81 @@ def _generate_pages_postfix(chunks: list[ContentChunk]) -> str:
         " : " + ",".join(str(p) for p in page_numbers) if page_numbers else ""
     )
     return pages_postfix
+
+
+def content_chunk_to_reference(
+    chunk: ContentChunk,
+    sequence_number: int,
+    original_index: list[int] | None = None,
+    *,
+    message_id: str = "",
+) -> ContentReference:
+    """Convert a ``ContentChunk`` into a ``ContentReference`` with page-number info.
+
+    Prefer :meth:`ContentChunk.to_reference <unique_toolkit.content.schemas.ContentChunk.to_reference>`
+    on the chunk instance in application code; this function remains for backward
+    compatibility and is the shared implementation both call sites use.
+
+    When using ``modify_assistant_message`` (the message-update path) instead
+    of streaming via ``complete_with_references``, the backend does **not**
+    automatically create references from ``searchContext``.  This helper
+    replicates the reference format that the backend streaming path produces
+    so that page numbers appear in the frontend reference chips.
+
+    Conventions applied:
+
+    * **id** — the chunk's content id (``chunk.id``), aligned with streaming
+      reference persistence.
+    * **message_id** — optional; set when the reference belongs to a specific
+      chat message.
+    * **source_id** — ``{content_id}_{chunk_id}`` (matches the backend
+      ``ReferenceService`` and ``ReferenceManager`` lookup).
+    * **source** — ``"node-ingestion-chunks"``.
+    * **name** — document title/key with a `` : 1,2,3`` page-number postfix
+      (same format as the backend ``generatePagesPostfix``); if neither title
+      nor key is set, ``Content {content_id}`` (matches reference dedup logic).
+      If ``title``/``key`` already end with that postfix (e.g. after
+      ``sort_content_chunks`` / ``merge_content_chunks``), it is not appended
+      twice.
+    * **url** — the chunk's own URL when it has one and is **not**
+      internally stored; otherwise ``unique://content/{content_id}``
+      (matches the ``internally_stored_at`` guard in the streaming path).
+
+    Args:
+        chunk: The content chunk to convert.
+        sequence_number: The 1-based sequence number shown in the ``<sup>``
+            tag in the message text.
+        original_index: Optional list of bracket indices (``[N]``) in the
+            message text that this reference corresponds to.
+        message_id: The chat message id this reference belongs to, if any.
+
+    Returns:
+        A ``ContentReference`` ready to pass to ``modify_assistant_message``.
+    """
+    name = chunk.title or chunk.key or f"Content {chunk.id}"
+    pages_postfix = _generate_pages_postfix([chunk])
+    # sort_content_chunks / merge_content_chunks may already have appended the same
+    # postfix to title or key; avoid "Report : 1,2 : 1,2".
+    if pages_postfix and not name.endswith(pages_postfix):
+        name = f"{name}{pages_postfix}"
+
+    source_id = f"{chunk.id}_{chunk.chunk_id}" if chunk.chunk_id else chunk.id
+    url = (
+        chunk.url
+        if chunk.url and not chunk.internally_stored_at
+        else f"unique://content/{chunk.id}"
+    )
+
+    return ContentReference(
+        id=chunk.id,
+        message_id=message_id,
+        name=name,
+        sequence_number=sequence_number,
+        source_id=source_id,
+        source="node-ingestion-chunks",
+        url=url,
+        original_index=original_index or [],
+    )
 
 
 def pick_content_chunks_for_token_window(

--- a/uv.lock
+++ b/uv.lock
@@ -8,16 +8,16 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-02T20:33:30.870065Z"
+exclude-newer = "2026-04-03T07:06:04.154803Z"
 exclude-newer-span = "P2W"
 
 [options.exclude-newer-package]
 unique-toolkit = false
-langsmith = "2026-04-16T04:00:00Z"
-cryptography = "2026-04-10T04:00:00Z"
-langchain-core = "2026-04-10T04:00:00Z"
-pytest = "2026-04-09T04:00:00Z"
-python-multipart = "2026-04-12T04:00:00Z"
+langsmith = "2026-04-15T22:00:00Z"
+cryptography = "2026-04-09T22:00:00Z"
+langchain-core = "2026-04-09T22:00:00Z"
+pytest = "2026-04-08T22:00:00Z"
+python-multipart = "2026-04-11T22:00:00Z"
 
 [manifest]
 members = [
@@ -5544,7 +5544,7 @@ dev = []
 
 [[package]]
 name = "unique-toolkit"
-version = "1.74.2"
+version = "1.75.0"
 source = { editable = "unique_toolkit" }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- Adds `content_chunk_to_reference()` to `unique_toolkit.content.utils` — converts a `ContentChunk` into a `ContentReference` with page-number info, matching the backend streaming-path format for use with `modify_assistant_message`.
- Hardens `_generate_pages_postfix` inner helper to accept `None` page values (`start_page`/`end_page` are optional on `ContentChunk`) instead of only handling the `-1` sentinel, preventing `TypeError` on real API chunks.

## Context

When using `modify_assistant_message` (the message-update path) instead of streaming via `complete_with_references`, the backend does not automatically create references from `searchContext`. This utility replicates the reference format the backend streaming path produces so page numbers appear in the frontend reference chips.

## Follow-up (not in this PR)

- `ContentChunk.to_reference()` convenience method on the schema
- Export from `content/__init__.py`
- Refactored `_find_references` in `language_model/reference.py` to use the new utility
- Tests and changelog/version bump

## Test plan

- [ ] Verify `content_chunk_to_reference` produces correct `ContentReference` fields
- [ ] Verify `None` page values do not raise `TypeError` in `_generate_pages_postfix`
- [ ] Verify page postfix is not doubled when title already includes it

Made with [Cursor](https://cursor.com)