### PR TITLE
feat(orchestrator): Add support for planning middleware when responses api is activated

### DIFF
--- a/unique_orchestrator/CHANGELOG.md
+++ b/unique_orchestrator/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.22.0] - 2026-04-16
+- Add planning middleware support for Responses API
+
 ## [1.21.3] - 2026-04-15
 - Chore: standardize pytest configuration across workspace packages
 

--- a/unique_orchestrator/pyproject.toml
+++ b/unique_orchestrator/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "unique_orchestrator"
-version = "1.21.3"
+version = "1.22.0"
 description = ""
 readme = "README.md"
 license = { text = "Proprietary" }
@@ -12,7 +12,7 @@ dependencies = [
     "pydantic>=2.8.2,<3",
     "typing-extensions>=4.9.0,<5",
     "jinja2>=3.1.0,<4",
-    "unique-toolkit>=1.71.0,<2",
+    "unique-toolkit>=1.73.0,<2",
     "unique-stock-ticker>=1.1.1,<2",
     "unique-follow-up-questions>=1.1.2,<2",
     "unique-internal-search>=1.2.22,<2",

--- a/unique_orchestrator/unique_orchestrator/_builders/__init__.py
+++ b/unique_orchestrator/unique_orchestrator/_builders/__init__.py
@@ -1,5 +1,6 @@
 from unique_orchestrator._builders.loop_iteration_runner import (
     build_loop_iteration_runner,
+    build_responses_loop_iteration_runner,
 )
 from unique_orchestrator._builders.open_file_setup import (
     configure_file_payload,
@@ -10,4 +11,5 @@ __all__ = [
     "build_loop_iteration_runner",
     "configure_file_payload",
     "handle_uploaded_file_tool_choices",
+    "build_responses_loop_iteration_runner",
 ]

--- a/unique_orchestrator/unique_orchestrator/_builders/loop_iteration_runner.py
+++ b/unique_orchestrator/unique_orchestrator/_builders/loop_iteration_runner.py
@@ -1,5 +1,3 @@
-from typing import Literal, overload
-
 from openai import AsyncOpenAI
 from unique_toolkit import LanguageModelService
 from unique_toolkit.agentic.history_manager.history_manager import (
@@ -21,59 +19,34 @@ from unique_toolkit.chat.service import ChatService
 from unique_orchestrator.config import UniqueAIConfig, get_model_family
 
 
-@overload
-def build_loop_iteration_runner(
-    *,
+def build_responses_loop_iteration_runner(
     config: UniqueAIConfig,
     history_manager: HistoryManager,
-    chat_service: ChatService,
-    use_responses_api: Literal[True],
     openai_client: AsyncOpenAI,
-    llm_service: LanguageModelService | None = ...,
-) -> ResponsesLoopIterationRunner: ...
+) -> ResponsesLoopIterationRunner:
+    runner = ResponsesBasicLoopIterationRunner(
+        config=BasicLoopIterationRunnerConfig(
+            max_loop_iterations=config.agent.max_loop_iterations
+        )
+    )
+
+    if config.agent.experimental.loop_configuration.planning_config is not None:
+        runner = ResponsesPlanningMiddleware(
+            loop_runner=runner,
+            config=config.agent.experimental.loop_configuration.planning_config,
+            openai_client=openai_client,
+            history_manager=history_manager,
+        )
+
+    return runner
 
 
-@overload
 def build_loop_iteration_runner(
-    *,
     config: UniqueAIConfig,
     history_manager: HistoryManager,
     chat_service: ChatService,
     llm_service: LanguageModelService,
-    use_responses_api: Literal[False] = False,
-    openai_client: AsyncOpenAI | None = ...,
-) -> LoopIterationRunner: ...
-
-
-def build_loop_iteration_runner(
-    *,
-    config: UniqueAIConfig,
-    history_manager: HistoryManager,
-    chat_service: ChatService,
-    use_responses_api: bool = False,
-    llm_service: LanguageModelService | None = None,
-    openai_client: AsyncOpenAI | None = None,
-) -> LoopIterationRunner | ResponsesLoopIterationRunner:
-    if use_responses_api:
-        responses_runner: ResponsesLoopIterationRunner = (
-            ResponsesBasicLoopIterationRunner(
-                config=BasicLoopIterationRunnerConfig(
-                    max_loop_iterations=config.agent.max_loop_iterations
-                )
-            )
-        )
-        if config.agent.experimental.loop_configuration.planning_config is not None:
-            if openai_client is None:
-                raise ValueError("openai_client is required when use_responses_api is True")
-
-            responses_runner = ResponsesPlanningMiddleware(
-                loop_runner=responses_runner,
-                config=config.agent.experimental.loop_configuration.planning_config,
-                openai_client=openai_client,
-                history_manager=history_manager,
-            )
-        return responses_runner
-
+) -> LoopIterationRunner:
     base_config = BasicLoopIterationRunnerConfig(
         max_loop_iterations=config.agent.max_loop_iterations
     )
@@ -95,9 +68,6 @@ def build_loop_iteration_runner(
         runner = BasicLoopIterationRunner(config=base_config)
 
     if config.agent.experimental.loop_configuration.planning_config is not None:
-        if llm_service is None:
-            raise ValueError("llm_service is required when use_responses_api is False")
-
         runner = PlanningMiddleware(
             loop_runner=runner,
             config=config.agent.experimental.loop_configuration.planning_config,

--- a/unique_orchestrator/unique_orchestrator/_builders/loop_iteration_runner.py
+++ b/unique_orchestrator/unique_orchestrator/_builders/loop_iteration_runner.py
@@ -1,5 +1,6 @@
 from typing import Literal, overload
 
+from openai import AsyncOpenAI
 from unique_toolkit import LanguageModelService
 from unique_toolkit.agentic.history_manager.history_manager import (
     HistoryManager,
@@ -16,37 +17,42 @@ from unique_toolkit.agentic.loop_runner import (
     ResponsesPlanningMiddleware,
 )
 from unique_toolkit.chat.service import ChatService
-from unique_toolkit.framework_utilities.openai.client import get_async_openai_client
 
 from unique_orchestrator.config import UniqueAIConfig, get_model_family
 
 
 @overload
 def build_loop_iteration_runner(
+    *,
     config: UniqueAIConfig,
     history_manager: HistoryManager,
-    llm_service: LanguageModelService,
     chat_service: ChatService,
-    use_responses_api: Literal[False],
-) -> LoopIterationRunner: ...
+    use_responses_api: Literal[True],
+    openai_client: AsyncOpenAI,
+    llm_service: LanguageModelService | None = ...,
+) -> ResponsesLoopIterationRunner: ...
 
 
 @overload
 def build_loop_iteration_runner(
+    *,
     config: UniqueAIConfig,
     history_manager: HistoryManager,
-    llm_service: LanguageModelService,
     chat_service: ChatService,
-    use_responses_api: Literal[True],
-) -> ResponsesLoopIterationRunner: ...
+    llm_service: LanguageModelService,
+    use_responses_api: Literal[False] = False,
+    openai_client: AsyncOpenAI | None = ...,
+) -> LoopIterationRunner: ...
 
 
 def build_loop_iteration_runner(
+    *,
     config: UniqueAIConfig,
     history_manager: HistoryManager,
-    llm_service: LanguageModelService,
     chat_service: ChatService,
     use_responses_api: bool = False,
+    llm_service: LanguageModelService | None = None,
+    openai_client: AsyncOpenAI | None = None,
 ) -> LoopIterationRunner | ResponsesLoopIterationRunner:
     if use_responses_api:
         responses_runner: ResponsesLoopIterationRunner = (
@@ -57,10 +63,13 @@ def build_loop_iteration_runner(
             )
         )
         if config.agent.experimental.loop_configuration.planning_config is not None:
+            if openai_client is None:
+                raise ValueError("openai_client is required when use_responses_api is True")
+
             responses_runner = ResponsesPlanningMiddleware(
                 loop_runner=responses_runner,
                 config=config.agent.experimental.loop_configuration.planning_config,
-                openai_client=get_async_openai_client(),
+                openai_client=openai_client,
                 history_manager=history_manager,
             )
         return responses_runner
@@ -86,6 +95,9 @@ def build_loop_iteration_runner(
         runner = BasicLoopIterationRunner(config=base_config)
 
     if config.agent.experimental.loop_configuration.planning_config is not None:
+        if llm_service is None:
+            raise ValueError("llm_service is required when use_responses_api is False")
+
         runner = PlanningMiddleware(
             loop_runner=runner,
             config=config.agent.experimental.loop_configuration.planning_config,

--- a/unique_orchestrator/unique_orchestrator/_builders/loop_iteration_runner.py
+++ b/unique_orchestrator/unique_orchestrator/_builders/loop_iteration_runner.py
@@ -13,8 +13,10 @@ from unique_toolkit.agentic.loop_runner import (
     QwenLoopIterationRunner,
     ResponsesBasicLoopIterationRunner,
     ResponsesLoopIterationRunner,
+    ResponsesPlanningMiddleware,
 )
 from unique_toolkit.chat.service import ChatService
+from unique_toolkit.framework_utilities.openai.client import get_async_openai_client
 
 from unique_orchestrator.config import UniqueAIConfig, get_model_family
 
@@ -47,11 +49,21 @@ def build_loop_iteration_runner(
     use_responses_api: bool = False,
 ) -> LoopIterationRunner | ResponsesLoopIterationRunner:
     if use_responses_api:
-        return ResponsesBasicLoopIterationRunner(
-            config=BasicLoopIterationRunnerConfig(
-                max_loop_iterations=config.agent.max_loop_iterations
+        responses_runner: ResponsesLoopIterationRunner = (
+            ResponsesBasicLoopIterationRunner(
+                config=BasicLoopIterationRunnerConfig(
+                    max_loop_iterations=config.agent.max_loop_iterations
+                )
             )
         )
+        if config.agent.experimental.loop_configuration.planning_config is not None:
+            responses_runner = ResponsesPlanningMiddleware(
+                loop_runner=responses_runner,
+                config=config.agent.experimental.loop_configuration.planning_config,
+                openai_client=get_async_openai_client(),
+                history_manager=history_manager,
+            )
+        return responses_runner
 
     base_config = BasicLoopIterationRunnerConfig(
         max_loop_iterations=config.agent.max_loop_iterations

--- a/unique_orchestrator/unique_orchestrator/tests/test_build_loop_iteration_runner.py
+++ b/unique_orchestrator/unique_orchestrator/tests/test_build_loop_iteration_runner.py
@@ -23,6 +23,7 @@ from unique_toolkit.agentic.loop_runner import (
 
 from unique_orchestrator._builders.loop_iteration_runner import (
     build_loop_iteration_runner,
+    build_responses_loop_iteration_runner,
 )
 from unique_orchestrator.config import UniqueAIConfig, get_model_family
 
@@ -44,33 +45,29 @@ class TestGetModelFamily:
         assert get_model_family("claude-3") is None
 
 
-class TestBuildLoopIterationRunnerResponsesApi:
+class TestBuildResponsesLoopIterationRunner:
     @pytest.mark.ai
-    def test_build_loop_iteration_runner__returns_responses_runner__when_responses_api_enabled(
+    def test_build_responses_loop_iteration_runner__returns_responses_runner(
         self,
     ) -> None:
         config: UniqueAIConfig = UniqueAIConfig()
-        runner = build_loop_iteration_runner(
+        runner = build_responses_loop_iteration_runner(
             config=config,
             history_manager=MagicMock(),
-            llm_service=MagicMock(),
-            chat_service=MagicMock(),
-            use_responses_api=True,
+            openai_client=MagicMock(),
         )
         assert isinstance(runner, ResponsesBasicLoopIterationRunner)
 
     @pytest.mark.ai
-    def test_build_loop_iteration_runner__uses_agent_max_iterations__for_responses_runner(
+    def test_build_responses_loop_iteration_runner__uses_agent_max_iterations(
         self,
     ) -> None:
         config: UniqueAIConfig = UniqueAIConfig()
         config.agent.max_loop_iterations = 7
-        runner = build_loop_iteration_runner(
+        runner = build_responses_loop_iteration_runner(
             config=config,
             history_manager=MagicMock(),
-            llm_service=MagicMock(),
-            chat_service=MagicMock(),
-            use_responses_api=True,
+            openai_client=MagicMock(),
         )
         assert isinstance(runner, ResponsesBasicLoopIterationRunner)
         assert runner._config.max_loop_iterations == 7
@@ -90,9 +87,8 @@ class TestBuildLoopIterationRunnerCompletionsApi:
         runner = build_loop_iteration_runner(
             config=config,
             history_manager=MagicMock(),
-            llm_service=MagicMock(),
             chat_service=MagicMock(),
-            use_responses_api=False,
+            llm_service=MagicMock(),
         )
         assert type(runner) is BasicLoopIterationRunner
 
@@ -110,9 +106,8 @@ class TestBuildLoopIterationRunnerCompletionsApi:
         runner = build_loop_iteration_runner(
             config=config,
             history_manager=MagicMock(),
-            llm_service=MagicMock(),
             chat_service=MagicMock(),
-            use_responses_api=False,
+            llm_service=MagicMock(),
         )
         assert isinstance(runner, BasicLoopIterationRunner)
         assert runner._config.max_loop_iterations == 8
@@ -132,9 +127,8 @@ class TestBuildLoopIterationRunnerQwenModel:
         runner = build_loop_iteration_runner(
             config=config,
             history_manager=MagicMock(),
-            llm_service=MagicMock(),
             chat_service=MagicMock(),
-            use_responses_api=False,
+            llm_service=MagicMock(),
         )
         assert isinstance(runner, QwenLoopIterationRunner)
 
@@ -153,9 +147,8 @@ class TestBuildLoopIterationRunnerQwenModel:
         runner = build_loop_iteration_runner(
             config=config,
             history_manager=MagicMock(),
-            llm_service=MagicMock(),
             chat_service=MagicMock(),
-            use_responses_api=False,
+            llm_service=MagicMock(),
         )
         assert isinstance(runner, QwenLoopIterationRunner)
         assert runner._config.max_loop_iterations == 3
@@ -175,9 +168,8 @@ class TestBuildLoopIterationRunnerQwenModel:
         runner = build_loop_iteration_runner(
             config=config,
             history_manager=MagicMock(),
-            llm_service=MagicMock(),
             chat_service=MagicMock(),
-            use_responses_api=False,
+            llm_service=MagicMock(),
         )
         assert isinstance(runner, QwenLoopIterationRunner)
         assert runner._forced_tool_call_instruction == custom_instruction
@@ -197,9 +189,8 @@ class TestBuildLoopIterationRunnerQwenModel:
         runner = build_loop_iteration_runner(
             config=config,
             history_manager=MagicMock(),
-            llm_service=MagicMock(),
             chat_service=MagicMock(),
-            use_responses_api=False,
+            llm_service=MagicMock(),
         )
         assert isinstance(runner, QwenLoopIterationRunner)
         assert runner._last_iteration_instruction == custom_instruction
@@ -218,9 +209,8 @@ class TestBuildLoopIterationRunnerQwenModel:
         runner = build_loop_iteration_runner(
             config=config,
             history_manager=MagicMock(),
-            llm_service=MagicMock(),
             chat_service=chat_service,
-            use_responses_api=False,
+            llm_service=MagicMock(),
         )
         assert isinstance(runner, QwenLoopIterationRunner)
         assert runner._chat_service is chat_service
@@ -240,9 +230,8 @@ class TestBuildLoopIterationRunnerMistralModel:
         runner = build_loop_iteration_runner(
             config=config,
             history_manager=MagicMock(),
-            llm_service=MagicMock(),
             chat_service=MagicMock(),
-            use_responses_api=False,
+            llm_service=MagicMock(),
         )
         assert isinstance(runner, MistralLoopIterationRunner)
 
@@ -260,9 +249,8 @@ class TestBuildLoopIterationRunnerMistralModel:
         runner = build_loop_iteration_runner(
             config=config,
             history_manager=MagicMock(),
-            llm_service=MagicMock(),
             chat_service=MagicMock(),
-            use_responses_api=False,
+            llm_service=MagicMock(),
         )
         assert isinstance(runner, MistralLoopIterationRunner)
         assert runner._config.max_loop_iterations == 6
@@ -283,9 +271,8 @@ class TestBuildLoopIterationRunnerPlanningMiddleware:
         runner = build_loop_iteration_runner(
             config=config,
             history_manager=MagicMock(),
-            llm_service=MagicMock(),
             chat_service=MagicMock(),
-            use_responses_api=False,
+            llm_service=MagicMock(),
         )
         assert isinstance(runner, PlanningMiddleware)
 
@@ -303,9 +290,8 @@ class TestBuildLoopIterationRunnerPlanningMiddleware:
         runner = build_loop_iteration_runner(
             config=config,
             history_manager=MagicMock(),
-            llm_service=MagicMock(),
             chat_service=MagicMock(),
-            use_responses_api=False,
+            llm_service=MagicMock(),
         )
         assert isinstance(runner, PlanningMiddleware)
         assert type(runner._loop_runner) is BasicLoopIterationRunner
@@ -324,9 +310,8 @@ class TestBuildLoopIterationRunnerPlanningMiddleware:
         runner = build_loop_iteration_runner(
             config=config,
             history_manager=MagicMock(),
-            llm_service=MagicMock(),
             chat_service=MagicMock(),
-            use_responses_api=False,
+            llm_service=MagicMock(),
         )
         assert isinstance(runner, PlanningMiddleware)
         assert isinstance(runner._loop_runner, QwenLoopIterationRunner)
@@ -345,9 +330,8 @@ class TestBuildLoopIterationRunnerPlanningMiddleware:
         runner = build_loop_iteration_runner(
             config=config,
             history_manager=MagicMock(),
-            llm_service=MagicMock(),
             chat_service=MagicMock(),
-            use_responses_api=False,
+            llm_service=MagicMock(),
         )
         assert isinstance(runner, PlanningMiddleware)
         assert isinstance(runner._loop_runner, MistralLoopIterationRunner)
@@ -369,9 +353,8 @@ class TestBuildLoopIterationRunnerPlanningMiddleware:
         runner = build_loop_iteration_runner(
             config=config,
             history_manager=MagicMock(),
-            llm_service=MagicMock(),
             chat_service=MagicMock(),
-            use_responses_api=False,
+            llm_service=MagicMock(),
         )
         assert isinstance(runner, PlanningMiddleware)
         assert runner._config is planning_config
@@ -391,9 +374,8 @@ class TestBuildLoopIterationRunnerPlanningMiddleware:
         runner = build_loop_iteration_runner(
             config=config,
             history_manager=history_manager,
-            llm_service=MagicMock(),
             chat_service=MagicMock(),
-            use_responses_api=False,
+            llm_service=MagicMock(),
         )
         assert isinstance(runner, PlanningMiddleware)
         assert runner._history_manager is history_manager
@@ -413,9 +395,8 @@ class TestBuildLoopIterationRunnerPlanningMiddleware:
         runner = build_loop_iteration_runner(
             config=config,
             history_manager=MagicMock(),
-            llm_service=llm_service,
             chat_service=MagicMock(),
-            use_responses_api=False,
+            llm_service=llm_service,
         )
         assert isinstance(runner, PlanningMiddleware)
         assert runner._llm_service is llm_service
@@ -433,135 +414,97 @@ class TestBuildLoopIterationRunnerPlanningMiddleware:
         runner = build_loop_iteration_runner(
             config=config,
             history_manager=MagicMock(),
-            llm_service=MagicMock(),
             chat_service=MagicMock(),
-            use_responses_api=False,
+            llm_service=MagicMock(),
         )
         assert isinstance(runner, BasicLoopIterationRunner)
         assert not isinstance(runner, PlanningMiddleware)
 
 
-class TestBuildLoopIterationRunnerResponsesPlanningMiddleware:
+class TestBuildResponsesLoopIterationRunnerPlanningMiddleware:
     @pytest.mark.ai
-    def test_build_loop_iteration_runner__wraps_with_responses_planning__when_planning_config_set(
+    def test_build_responses_loop_iteration_runner__wraps_with_responses_planning__when_planning_config_set(
         self,
-        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        monkeypatch.setattr(
-            "unique_orchestrator._builders.loop_iteration_runner.get_async_openai_client",
-            lambda: MagicMock(),
-        )
         config: UniqueAIConfig = UniqueAIConfig()
         config.agent.experimental.loop_configuration.planning_config = PlanningConfig()
-        runner = build_loop_iteration_runner(
+        runner = build_responses_loop_iteration_runner(
             config=config,
             history_manager=MagicMock(),
-            llm_service=MagicMock(),
-            chat_service=MagicMock(),
-            use_responses_api=True,
+            openai_client=MagicMock(),
         )
         assert isinstance(runner, ResponsesPlanningMiddleware)
 
     @pytest.mark.ai
-    def test_build_loop_iteration_runner__wraps_responses_basic_runner__in_responses_planning_middleware(
+    def test_build_responses_loop_iteration_runner__wraps_responses_basic_runner__in_responses_planning_middleware(
         self,
-        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        monkeypatch.setattr(
-            "unique_orchestrator._builders.loop_iteration_runner.get_async_openai_client",
-            lambda: MagicMock(),
-        )
         config: UniqueAIConfig = UniqueAIConfig()
         config.agent.experimental.loop_configuration.planning_config = PlanningConfig()
-        runner = build_loop_iteration_runner(
+        runner = build_responses_loop_iteration_runner(
             config=config,
             history_manager=MagicMock(),
-            llm_service=MagicMock(),
-            chat_service=MagicMock(),
-            use_responses_api=True,
+            openai_client=MagicMock(),
         )
         assert isinstance(runner, ResponsesPlanningMiddleware)
         assert isinstance(runner._loop_runner, ResponsesBasicLoopIterationRunner)
 
     @pytest.mark.ai
-    def test_build_loop_iteration_runner__passes_planning_config__to_responses_middleware(
+    def test_build_responses_loop_iteration_runner__passes_planning_config__to_responses_middleware(
         self,
-        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        monkeypatch.setattr(
-            "unique_orchestrator._builders.loop_iteration_runner.get_async_openai_client",
-            lambda: MagicMock(),
-        )
         config: UniqueAIConfig = UniqueAIConfig()
         planning_config: PlanningConfig = PlanningConfig(
             ignored_options=["custom_option"]
         )
         config.agent.experimental.loop_configuration.planning_config = planning_config
-        runner = build_loop_iteration_runner(
+        runner = build_responses_loop_iteration_runner(
             config=config,
             history_manager=MagicMock(),
-            llm_service=MagicMock(),
-            chat_service=MagicMock(),
-            use_responses_api=True,
+            openai_client=MagicMock(),
         )
         assert isinstance(runner, ResponsesPlanningMiddleware)
         assert runner._config is planning_config
 
     @pytest.mark.ai
-    def test_build_loop_iteration_runner__passes_history_manager__to_responses_middleware(
+    def test_build_responses_loop_iteration_runner__passes_history_manager__to_responses_middleware(
         self,
-        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        monkeypatch.setattr(
-            "unique_orchestrator._builders.loop_iteration_runner.get_async_openai_client",
-            lambda: MagicMock(),
-        )
         config: UniqueAIConfig = UniqueAIConfig()
         config.agent.experimental.loop_configuration.planning_config = PlanningConfig()
         history_manager: MagicMock = MagicMock()
-        runner = build_loop_iteration_runner(
+        runner = build_responses_loop_iteration_runner(
             config=config,
             history_manager=history_manager,
-            llm_service=MagicMock(),
-            chat_service=MagicMock(),
-            use_responses_api=True,
+            openai_client=MagicMock(),
         )
         assert isinstance(runner, ResponsesPlanningMiddleware)
         assert runner._history_manager is history_manager
 
     @pytest.mark.ai
-    def test_build_loop_iteration_runner__passes_openai_client__to_responses_middleware(
+    def test_build_responses_loop_iteration_runner__passes_openai_client__to_responses_middleware(
         self,
-        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         mock_client: MagicMock = MagicMock()
-        monkeypatch.setattr(
-            "unique_orchestrator._builders.loop_iteration_runner.get_async_openai_client",
-            lambda: mock_client,
-        )
         config: UniqueAIConfig = UniqueAIConfig()
         config.agent.experimental.loop_configuration.planning_config = PlanningConfig()
-        runner = build_loop_iteration_runner(
+        runner = build_responses_loop_iteration_runner(
             config=config,
             history_manager=MagicMock(),
-            llm_service=MagicMock(),
-            chat_service=MagicMock(),
-            use_responses_api=True,
+            openai_client=mock_client,
         )
         assert isinstance(runner, ResponsesPlanningMiddleware)
         assert runner._openai_client is mock_client
 
     @pytest.mark.ai
-    def test_build_loop_iteration_runner__no_planning__when_planning_config_none_and_responses_api(
+    def test_build_responses_loop_iteration_runner__no_planning__when_planning_config_none(
         self,
     ) -> None:
         config: UniqueAIConfig = UniqueAIConfig()
-        runner = build_loop_iteration_runner(
+        runner = build_responses_loop_iteration_runner(
             config=config,
             history_manager=MagicMock(),
-            llm_service=MagicMock(),
-            chat_service=MagicMock(),
-            use_responses_api=True,
+            openai_client=MagicMock(),
         )
         assert isinstance(runner, ResponsesBasicLoopIterationRunner)
         assert not isinstance(runner, ResponsesPlanningMiddleware)
@@ -579,9 +522,8 @@ class TestBuildLoopIterationRunnerModelFamilyIntegration:
         runner = build_loop_iteration_runner(
             config=config,
             history_manager=MagicMock(),
-            llm_service=MagicMock(),
             chat_service=MagicMock(),
-            use_responses_api=False,
+            llm_service=MagicMock(),
         )
         assert type(runner) is BasicLoopIterationRunner
 
@@ -594,9 +536,8 @@ class TestBuildLoopIterationRunnerModelFamilyIntegration:
         runner = build_loop_iteration_runner(
             config=config,
             history_manager=MagicMock(),
-            llm_service=MagicMock(),
             chat_service=MagicMock(),
-            use_responses_api=False,
+            llm_service=MagicMock(),
         )
         assert isinstance(runner, MistralLoopIterationRunner)
 
@@ -609,8 +550,7 @@ class TestBuildLoopIterationRunnerModelFamilyIntegration:
         runner = build_loop_iteration_runner(
             config=config,
             history_manager=MagicMock(),
-            llm_service=MagicMock(),
             chat_service=MagicMock(),
-            use_responses_api=False,
+            llm_service=MagicMock(),
         )
         assert isinstance(runner, QwenLoopIterationRunner)

--- a/unique_orchestrator/unique_orchestrator/tests/test_build_loop_iteration_runner.py
+++ b/unique_orchestrator/unique_orchestrator/tests/test_build_loop_iteration_runner.py
@@ -18,6 +18,7 @@ from unique_toolkit.agentic.loop_runner import (
     PlanningMiddleware,
     QwenLoopIterationRunner,
     ResponsesBasicLoopIterationRunner,
+    ResponsesPlanningMiddleware,
 )
 
 from unique_orchestrator._builders.loop_iteration_runner import (
@@ -438,6 +439,132 @@ class TestBuildLoopIterationRunnerPlanningMiddleware:
         )
         assert isinstance(runner, BasicLoopIterationRunner)
         assert not isinstance(runner, PlanningMiddleware)
+
+
+class TestBuildLoopIterationRunnerResponsesPlanningMiddleware:
+    @pytest.mark.ai
+    def test_build_loop_iteration_runner__wraps_with_responses_planning__when_planning_config_set(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "unique_orchestrator._builders.loop_iteration_runner.get_async_openai_client",
+            lambda: MagicMock(),
+        )
+        config: UniqueAIConfig = UniqueAIConfig()
+        config.agent.experimental.loop_configuration.planning_config = PlanningConfig()
+        runner = build_loop_iteration_runner(
+            config=config,
+            history_manager=MagicMock(),
+            llm_service=MagicMock(),
+            chat_service=MagicMock(),
+            use_responses_api=True,
+        )
+        assert isinstance(runner, ResponsesPlanningMiddleware)
+
+    @pytest.mark.ai
+    def test_build_loop_iteration_runner__wraps_responses_basic_runner__in_responses_planning_middleware(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "unique_orchestrator._builders.loop_iteration_runner.get_async_openai_client",
+            lambda: MagicMock(),
+        )
+        config: UniqueAIConfig = UniqueAIConfig()
+        config.agent.experimental.loop_configuration.planning_config = PlanningConfig()
+        runner = build_loop_iteration_runner(
+            config=config,
+            history_manager=MagicMock(),
+            llm_service=MagicMock(),
+            chat_service=MagicMock(),
+            use_responses_api=True,
+        )
+        assert isinstance(runner, ResponsesPlanningMiddleware)
+        assert isinstance(runner._loop_runner, ResponsesBasicLoopIterationRunner)
+
+    @pytest.mark.ai
+    def test_build_loop_iteration_runner__passes_planning_config__to_responses_middleware(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "unique_orchestrator._builders.loop_iteration_runner.get_async_openai_client",
+            lambda: MagicMock(),
+        )
+        config: UniqueAIConfig = UniqueAIConfig()
+        planning_config: PlanningConfig = PlanningConfig(
+            ignored_options=["custom_option"]
+        )
+        config.agent.experimental.loop_configuration.planning_config = planning_config
+        runner = build_loop_iteration_runner(
+            config=config,
+            history_manager=MagicMock(),
+            llm_service=MagicMock(),
+            chat_service=MagicMock(),
+            use_responses_api=True,
+        )
+        assert isinstance(runner, ResponsesPlanningMiddleware)
+        assert runner._config is planning_config
+
+    @pytest.mark.ai
+    def test_build_loop_iteration_runner__passes_history_manager__to_responses_middleware(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "unique_orchestrator._builders.loop_iteration_runner.get_async_openai_client",
+            lambda: MagicMock(),
+        )
+        config: UniqueAIConfig = UniqueAIConfig()
+        config.agent.experimental.loop_configuration.planning_config = PlanningConfig()
+        history_manager: MagicMock = MagicMock()
+        runner = build_loop_iteration_runner(
+            config=config,
+            history_manager=history_manager,
+            llm_service=MagicMock(),
+            chat_service=MagicMock(),
+            use_responses_api=True,
+        )
+        assert isinstance(runner, ResponsesPlanningMiddleware)
+        assert runner._history_manager is history_manager
+
+    @pytest.mark.ai
+    def test_build_loop_iteration_runner__passes_openai_client__to_responses_middleware(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        mock_client: MagicMock = MagicMock()
+        monkeypatch.setattr(
+            "unique_orchestrator._builders.loop_iteration_runner.get_async_openai_client",
+            lambda: mock_client,
+        )
+        config: UniqueAIConfig = UniqueAIConfig()
+        config.agent.experimental.loop_configuration.planning_config = PlanningConfig()
+        runner = build_loop_iteration_runner(
+            config=config,
+            history_manager=MagicMock(),
+            llm_service=MagicMock(),
+            chat_service=MagicMock(),
+            use_responses_api=True,
+        )
+        assert isinstance(runner, ResponsesPlanningMiddleware)
+        assert runner._openai_client is mock_client
+
+    @pytest.mark.ai
+    def test_build_loop_iteration_runner__no_planning__when_planning_config_none_and_responses_api(
+        self,
+    ) -> None:
+        config: UniqueAIConfig = UniqueAIConfig()
+        runner = build_loop_iteration_runner(
+            config=config,
+            history_manager=MagicMock(),
+            llm_service=MagicMock(),
+            chat_service=MagicMock(),
+            use_responses_api=True,
+        )
+        assert isinstance(runner, ResponsesBasicLoopIterationRunner)
+        assert not isinstance(runner, ResponsesPlanningMiddleware)
 
 
 class TestBuildLoopIterationRunnerModelFamilyIntegration:

--- a/unique_orchestrator/unique_orchestrator/unique_ai_builder.py
+++ b/unique_orchestrator/unique_orchestrator/unique_ai_builder.py
@@ -432,7 +432,7 @@ async def _build_responses(
     loop_iteration_runner = build_loop_iteration_runner(
         config=config,
         history_manager=common_components.history_manager,
-        llm_service=common_components.llm_service,
+        openai_client = client,
         chat_service=common_components.chat_service,
         use_responses_api=True,
     )

--- a/unique_orchestrator/unique_orchestrator/unique_ai_builder.py
+++ b/unique_orchestrator/unique_orchestrator/unique_ai_builder.py
@@ -75,7 +75,10 @@ from unique_toolkit.content.service import ContentService
 from unique_toolkit.language_model.infos import ModelCapabilities
 from unique_toolkit.protocols.support import ResponsesSupportCompleteWithReferences
 
-from unique_orchestrator._builders import build_loop_iteration_runner
+from unique_orchestrator._builders import (
+    build_loop_iteration_runner,
+    build_responses_loop_iteration_runner,
+)
 from unique_orchestrator._builders.open_file_setup import (
     configure_file_payload,
     handle_uploaded_file_tool_choices,
@@ -429,12 +432,10 @@ async def _build_responses(
             history_manager=history_manager,
         )
 
-    loop_iteration_runner = build_loop_iteration_runner(
+    loop_iteration_runner = build_responses_loop_iteration_runner(
         config=config,
         history_manager=common_components.history_manager,
-        openai_client = client,
-        chat_service=common_components.chat_service,
-        use_responses_api=True,
+        openai_client=client,
     )
 
     streaming_handler = ResponsesStreamingHandler(
@@ -522,7 +523,6 @@ def _build_completions(
         history_manager=common_components.history_manager,
         llm_service=common_components.llm_service,
         chat_service=common_components.chat_service,
-        use_responses_api=False,
     )
 
     return UniqueAI(

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-02T09:08:36.127671Z"
+exclude-newer = "2026-04-02T09:22:35.354961Z"
 exclude-newer-span = "P2W"
 
 [options.exclude-newer-package]
@@ -5320,7 +5320,7 @@ dev = []
 
 [[package]]
 name = "unique-orchestrator"
-version = "1.21.3"
+version = "1.22.0"
 source = { editable = "unique_orchestrator" }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## 🚀 Summary
Refs: [UN-19510](https://unique-ch.atlassian.net/browse/UN-19510)

- Add planning middleware support for Responses API
- Cleanup loop iteration runner building logic

## ✅ Changes

- [x] Added feature / fixed bug / updated docs
- [x] Refactored code / cleaned up
- [ ] Other (describe below)

## 🧪 Testing

- Local manual tests
- AI generated unit tests


[UN-19510]: https://unique-ch.atlassian.net/browse/UN-19510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ