### PR TITLE
fix(unique-toolkit): filter uploaded images and files by user selection

### DIFF
--- a/unique_toolkit/CHANGELOG.md
+++ b/unique_toolkit/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.77.1] - 2026-04-20
 - Add `selected_content_ids` filtering to history construction and `OpenFileToolRuntime` so only user-selected uploaded images and files are attached when the `enable_selected_uploaded_files_un_18215` feature flag is active
-- Add `compute_selected_uploaded_content_ids` utility in `history_manager/utils.py`
+- Add `get_selected_uploaded_content_ids` utility in `history_manager/utils.py`
 - Thread `selected_content_ids` through `LoopTokenReducer`, `get_full_history_with_contents*`, and `_append_element_to_builder_async`
 - Store `company_id` as instance attribute on `ShowExecutedCodePostprocessor`
 

--- a/unique_toolkit/CHANGELOG.md
+++ b/unique_toolkit/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.77.1] - 2026-04-20
+- Add `selected_content_ids` filtering to history construction and `OpenFileToolRuntime` so only user-selected uploaded images and files are attached when the `enable_selected_uploaded_files_un_18215` feature flag is active
+- Add `compute_selected_uploaded_content_ids` utility in `history_manager/utils.py`
+- Thread `selected_content_ids` through `LoopTokenReducer`, `get_full_history_with_contents*`, and `_append_element_to_builder_async`
+- Store `company_id` as instance attribute on `ShowExecutedCodePostprocessor`
+
 ## [1.77.0] - 2026-04-20
 - Add experimental `TodoWriteTool` for agent-side task tracking with persistent short-term memory, configurable Jinja prompts (RJSF-tagged for admin UI), sequential-first execution mode with optional parallel, `active_form` for live status display, verification nudge, and Steps panel logging with status icons
 

--- a/unique_toolkit/pyproject.toml
+++ b/unique_toolkit/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "unique_toolkit"
-version = "1.77.0"
+version = "1.77.1"
 description = ""
 readme = "README.md"
 requires-python = ">=3.12"

--- a/unique_toolkit/tests/agentic/test_history_construction_async.py
+++ b/unique_toolkit/tests/agentic/test_history_construction_async.py
@@ -664,3 +664,156 @@ async def test_tool_calls_async_multiple_rounds():
 
     assert isinstance(result, LanguageModelMessages)
     assert len(result.root) >= 4
+
+
+# ---------------------------------------------------------------------------
+# _append_element_to_builder_async — selected_content_ids filtering
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.ai
+@pytest.mark.asyncio
+async def test_append_element_to_builder_async_selected_content_ids_filters_images():
+    """When selected_content_ids is set, only matching images should be attached."""
+    from unique_toolkit.agentic.history_manager.history_construction_with_contents import (
+        ChatMessageWithContents,
+        FileContentSerialization,
+    )
+
+    img_selected = _make_image_content(key="selected.png", content_id="img_sel")
+    img_excluded = _make_image_content(key="excluded.png", content_id="img_exc")
+    content_service = MagicMock()
+    content_service.download_content_to_bytes_async = AsyncMock(return_value=b"\x89PNG")
+    builder = MagicMock()
+
+    msg = ChatMessageWithContents(
+        id="m1",
+        chat_id="c1",
+        text="two images",
+        role=ChatRole.USER,
+        gpt_request=None,
+        created_at=datetime(2026, 1, 1, 12, 0),
+        contents=[img_selected, img_excluded],
+    )
+
+    with (
+        patch(
+            "unique_toolkit.agentic.history_manager.history_construction_with_contents.FileUtils.is_file_content",
+            return_value=False,
+        ),
+        patch(
+            "unique_toolkit.agentic.history_manager.history_construction_with_contents.FileUtils.is_image_content",
+            return_value=True,
+        ),
+    ):
+        await _append_element_to_builder_async(
+            builder=builder,
+            c=msg,
+            text="two images",
+            include_images=ImageContentInclusion.ALL,
+            file_content_serialization_type=FileContentSerialization.NONE,
+            content_service=content_service,
+            chat_id="c1",
+            selected_content_ids={"img_sel"},
+        )
+
+    builder.image_message_append.assert_called_once()
+    download_call_args = content_service.download_content_to_bytes_async.call_args_list
+    downloaded_ids = [call.kwargs.get("content_id") for call in download_call_args]
+    assert "img_sel" in downloaded_ids
+    assert "img_exc" not in downloaded_ids
+
+
+@pytest.mark.ai
+@pytest.mark.asyncio
+async def test_append_element_to_builder_async_selected_content_ids_empty_excludes_all():
+    """When selected_content_ids is an empty set, no images should be attached."""
+    from unique_toolkit.agentic.history_manager.history_construction_with_contents import (
+        ChatMessageWithContents,
+        FileContentSerialization,
+    )
+
+    img = _make_image_content(key="photo.png", content_id="img_1")
+    builder = MagicMock()
+
+    msg = ChatMessageWithContents(
+        id="m1",
+        chat_id="c1",
+        text="one image",
+        role=ChatRole.USER,
+        gpt_request=None,
+        created_at=datetime(2026, 1, 1, 12, 0),
+        contents=[img],
+    )
+
+    with (
+        patch(
+            "unique_toolkit.agentic.history_manager.history_construction_with_contents.FileUtils.is_file_content",
+            return_value=False,
+        ),
+        patch(
+            "unique_toolkit.agentic.history_manager.history_construction_with_contents.FileUtils.is_image_content",
+            return_value=True,
+        ),
+    ):
+        await _append_element_to_builder_async(
+            builder=builder,
+            c=msg,
+            text="one image",
+            include_images=ImageContentInclusion.ALL,
+            file_content_serialization_type=FileContentSerialization.NONE,
+            content_service=MagicMock(),
+            chat_id="c1",
+            selected_content_ids=set(),
+        )
+
+    builder.image_message_append.assert_not_called()
+    builder.message_append.assert_called_once()
+
+
+@pytest.mark.ai
+@pytest.mark.asyncio
+async def test_append_element_to_builder_async_selected_content_ids_none_includes_all():
+    """When selected_content_ids is None (FF disabled), all images are included."""
+    from unique_toolkit.agentic.history_manager.history_construction_with_contents import (
+        ChatMessageWithContents,
+        FileContentSerialization,
+    )
+
+    img = _make_image_content(key="photo.png", content_id="img_1")
+    content_service = MagicMock()
+    content_service.download_content_to_bytes_async = AsyncMock(return_value=b"\x89PNG")
+    builder = MagicMock()
+
+    msg = ChatMessageWithContents(
+        id="m1",
+        chat_id="c1",
+        text="one image",
+        role=ChatRole.USER,
+        gpt_request=None,
+        created_at=datetime(2026, 1, 1, 12, 0),
+        contents=[img],
+    )
+
+    with (
+        patch(
+            "unique_toolkit.agentic.history_manager.history_construction_with_contents.FileUtils.is_file_content",
+            return_value=False,
+        ),
+        patch(
+            "unique_toolkit.agentic.history_manager.history_construction_with_contents.FileUtils.is_image_content",
+            return_value=True,
+        ),
+    ):
+        await _append_element_to_builder_async(
+            builder=builder,
+            c=msg,
+            text="one image",
+            include_images=ImageContentInclusion.ALL,
+            file_content_serialization_type=FileContentSerialization.NONE,
+            content_service=content_service,
+            chat_id="c1",
+            selected_content_ids=None,
+        )
+
+    builder.image_message_append.assert_called_once()

--- a/unique_toolkit/tests/agentic/test_loop_token_reducer.py
+++ b/unique_toolkit/tests/agentic/test_loop_token_reducer.py
@@ -1350,28 +1350,28 @@ async def test_get_history_from_db__calls_with_tool_calls__when_persistence_enab
 
 
 # ---------------------------------------------------------------------------
-# compute_selected_uploaded_content_ids (shared utility)
+# get_selected_uploaded_content_ids (shared utility)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.ai
-def test_compute_selected_uploaded_content_ids_ff_disabled(test_event):
+def test_get_selected_uploaded_content_ids_ff_disabled(test_event):
     """When the feature flag is disabled, should return None."""
     from unique_toolkit.agentic.history_manager.utils import (
-        compute_selected_uploaded_content_ids,
+        get_selected_uploaded_content_ids,
     )
 
     with patch("unique_toolkit.agentic.history_manager.utils.feature_flags") as ff:
         ff.enable_selected_uploaded_files_un_18215.is_enabled.return_value = False
-        result = compute_selected_uploaded_content_ids(test_event)
+        result = get_selected_uploaded_content_ids(test_event)
     assert result is None
 
 
 @pytest.mark.ai
-def test_compute_selected_uploaded_content_ids_ff_enabled_with_selection(test_event):
+def test_get_selected_uploaded_content_ids_ff_enabled_with_selection(test_event):
     """When FF is enabled and files are selected, should return the selected IDs."""
     from unique_toolkit.agentic.history_manager.utils import (
-        compute_selected_uploaded_content_ids,
+        get_selected_uploaded_content_ids,
     )
 
     additional = MagicMock()
@@ -1380,32 +1380,32 @@ def test_compute_selected_uploaded_content_ids_ff_enabled_with_selection(test_ev
 
     with patch("unique_toolkit.agentic.history_manager.utils.feature_flags") as ff:
         ff.enable_selected_uploaded_files_un_18215.is_enabled.return_value = True
-        result = compute_selected_uploaded_content_ids(test_event)
+        result = get_selected_uploaded_content_ids(test_event)
     assert result == {"file_1", "file_2"}
 
 
 @pytest.mark.ai
-def test_compute_selected_uploaded_content_ids_ff_enabled_no_additional_params(
+def test_get_selected_uploaded_content_ids_ff_enabled_no_additional_params(
     test_event,
 ):
     """When FF is enabled but additional_parameters is None, should return None."""
     from unique_toolkit.agentic.history_manager.utils import (
-        compute_selected_uploaded_content_ids,
+        get_selected_uploaded_content_ids,
     )
 
     test_event.payload.additional_parameters = None
 
     with patch("unique_toolkit.agentic.history_manager.utils.feature_flags") as ff:
         ff.enable_selected_uploaded_files_un_18215.is_enabled.return_value = True
-        result = compute_selected_uploaded_content_ids(test_event)
+        result = get_selected_uploaded_content_ids(test_event)
     assert result is None
 
 
 @pytest.mark.ai
-def test_compute_selected_uploaded_content_ids_ff_enabled_empty_selection(test_event):
+def test_get_selected_uploaded_content_ids_ff_enabled_empty_selection(test_event):
     """When FF is enabled but no files selected, should return empty set."""
     from unique_toolkit.agentic.history_manager.utils import (
-        compute_selected_uploaded_content_ids,
+        get_selected_uploaded_content_ids,
     )
 
     additional = MagicMock()
@@ -1414,5 +1414,5 @@ def test_compute_selected_uploaded_content_ids_ff_enabled_empty_selection(test_e
 
     with patch("unique_toolkit.agentic.history_manager.utils.feature_flags") as ff:
         ff.enable_selected_uploaded_files_un_18215.is_enabled.return_value = True
-        result = compute_selected_uploaded_content_ids(test_event)
+        result = get_selected_uploaded_content_ids(test_event)
     assert result == set()

--- a/unique_toolkit/tests/agentic/test_loop_token_reducer.py
+++ b/unique_toolkit/tests/agentic/test_loop_token_reducer.py
@@ -1347,3 +1347,72 @@ async def test_get_history_from_db__calls_with_tool_calls__when_persistence_enab
 
     mock_get_history.assert_called_once()
     assert reducer.max_db_source_number == 5
+
+
+# ---------------------------------------------------------------------------
+# compute_selected_uploaded_content_ids (shared utility)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.ai
+def test_compute_selected_uploaded_content_ids_ff_disabled(test_event):
+    """When the feature flag is disabled, should return None."""
+    from unique_toolkit.agentic.history_manager.utils import (
+        compute_selected_uploaded_content_ids,
+    )
+
+    with patch("unique_toolkit.agentic.history_manager.utils.feature_flags") as ff:
+        ff.enable_selected_uploaded_files_un_18215.is_enabled.return_value = False
+        result = compute_selected_uploaded_content_ids(test_event)
+    assert result is None
+
+
+@pytest.mark.ai
+def test_compute_selected_uploaded_content_ids_ff_enabled_with_selection(test_event):
+    """When FF is enabled and files are selected, should return the selected IDs."""
+    from unique_toolkit.agentic.history_manager.utils import (
+        compute_selected_uploaded_content_ids,
+    )
+
+    additional = MagicMock()
+    additional.selected_uploaded_file_ids = ["file_1", "file_2"]
+    test_event.payload.additional_parameters = additional
+
+    with patch("unique_toolkit.agentic.history_manager.utils.feature_flags") as ff:
+        ff.enable_selected_uploaded_files_un_18215.is_enabled.return_value = True
+        result = compute_selected_uploaded_content_ids(test_event)
+    assert result == {"file_1", "file_2"}
+
+
+@pytest.mark.ai
+def test_compute_selected_uploaded_content_ids_ff_enabled_no_additional_params(
+    test_event,
+):
+    """When FF is enabled but additional_parameters is None, should return None."""
+    from unique_toolkit.agentic.history_manager.utils import (
+        compute_selected_uploaded_content_ids,
+    )
+
+    test_event.payload.additional_parameters = None
+
+    with patch("unique_toolkit.agentic.history_manager.utils.feature_flags") as ff:
+        ff.enable_selected_uploaded_files_un_18215.is_enabled.return_value = True
+        result = compute_selected_uploaded_content_ids(test_event)
+    assert result is None
+
+
+@pytest.mark.ai
+def test_compute_selected_uploaded_content_ids_ff_enabled_empty_selection(test_event):
+    """When FF is enabled but no files selected, should return empty set."""
+    from unique_toolkit.agentic.history_manager.utils import (
+        compute_selected_uploaded_content_ids,
+    )
+
+    additional = MagicMock()
+    additional.selected_uploaded_file_ids = []
+    test_event.payload.additional_parameters = additional
+
+    with patch("unique_toolkit.agentic.history_manager.utils.feature_flags") as ff:
+        ff.enable_selected_uploaded_files_un_18215.is_enabled.return_value = True
+        result = compute_selected_uploaded_content_ids(test_event)
+    assert result == set()

--- a/unique_toolkit/tests/agentic/tools/test_open_file_tool_runtime.py
+++ b/unique_toolkit/tests/agentic/tools/test_open_file_tool_runtime.py
@@ -54,12 +54,14 @@ def _make_config(
     send_files_in_payload: bool = False,
     send_uploaded_files_in_payload: bool = False,
     use_responses_api: bool = True,
+    selected_content_ids: frozenset[str] | None = None,
 ) -> OpenFileToolRuntimeConfig:
     return OpenFileToolRuntimeConfig(
         enabled=enabled,
         send_files_in_payload=send_files_in_payload,
         send_uploaded_files_in_payload=send_uploaded_files_in_payload,
         use_responses_api=use_responses_api,
+        selected_content_ids=selected_content_ids,
     )
 
 
@@ -134,6 +136,7 @@ class TestOpenFileToolRuntimeConfig:
         assert cfg.send_files_in_payload is False
         assert cfg.send_uploaded_files_in_payload is False
         assert cfg.use_responses_api is False
+        assert cfg.selected_content_ids is None
 
     def test__frozen__cannot_mutate(self):
         """
@@ -1420,6 +1423,82 @@ class TestGetUploadedDocuments:
 
         assert result[0].id == "cont_old"
         assert result[1].id == "cont_new"
+
+    def test__selected_content_ids__filters_to_selected(
+        self, logger, content_service, tool_manager, message_step_logger
+    ):
+        """
+        Purpose: Only documents whose ID is in selected_content_ids are returned.
+        Why this matters: Unselected uploaded files must not be injected into the payload.
+        Setup summary: Two PDFs, only one ID in selected_content_ids, verify only it is returned.
+        """
+        doc_a = _make_content(id="cont_a", key="a.pdf")
+        doc_b = _make_content(id="cont_b", key="b.pdf")
+        content_service.get_documents_uploaded_to_chat.return_value = [doc_a, doc_b]
+
+        rt = OpenFileToolRuntime(
+            logger=logger,
+            config=_make_config(selected_content_ids=frozenset({"cont_a"})),
+            content_service=content_service,
+            tool_manager=tool_manager,
+            message_step_logger=message_step_logger,
+            agent_file_registry=[],
+        )
+
+        result = rt.get_uploaded_documents()
+
+        assert len(result) == 1
+        assert result[0].id == "cont_a"
+
+    def test__selected_content_ids__empty_excludes_all(
+        self, logger, content_service, tool_manager, message_step_logger
+    ):
+        """
+        Purpose: An empty selected_content_ids set excludes all uploaded documents.
+        Why this matters: When the user has deselected everything, nothing should be attached.
+        Setup summary: Two PDFs, empty frozenset for selected_content_ids, verify empty result.
+        """
+        doc_a = _make_content(id="cont_a", key="a.pdf")
+        doc_b = _make_content(id="cont_b", key="b.pdf")
+        content_service.get_documents_uploaded_to_chat.return_value = [doc_a, doc_b]
+
+        rt = OpenFileToolRuntime(
+            logger=logger,
+            config=_make_config(selected_content_ids=frozenset()),
+            content_service=content_service,
+            tool_manager=tool_manager,
+            message_step_logger=message_step_logger,
+            agent_file_registry=[],
+        )
+
+        result = rt.get_uploaded_documents()
+
+        assert result == []
+
+    def test__selected_content_ids__none_includes_all(
+        self, logger, content_service, tool_manager, message_step_logger
+    ):
+        """
+        Purpose: When selected_content_ids is None, no filtering is applied.
+        Why this matters: None means the feature flag is disabled, so all documents are included.
+        Setup summary: Two PDFs, selected_content_ids=None, verify both returned.
+        """
+        doc_a = _make_content(id="cont_a", key="a.pdf")
+        doc_b = _make_content(id="cont_b", key="b.pdf")
+        content_service.get_documents_uploaded_to_chat.return_value = [doc_a, doc_b]
+
+        rt = OpenFileToolRuntime(
+            logger=logger,
+            config=_make_config(selected_content_ids=None),
+            content_service=content_service,
+            tool_manager=tool_manager,
+            message_step_logger=message_step_logger,
+            agent_file_registry=[],
+        )
+
+        result = rt.get_uploaded_documents()
+
+        assert len(result) == 2
 
 
 # ===================================================================

--- a/unique_toolkit/unique_toolkit/agentic/history_manager/history_construction_with_contents.py
+++ b/unique_toolkit/unique_toolkit/agentic/history_manager/history_construction_with_contents.py
@@ -237,10 +237,18 @@ def _append_element_to_builder(
     file_content_serialization_type: FileContentSerialization,
     content_service: ContentService,
     chat_id: str,
+    selected_content_ids: set[str] | None = None,
 ) -> None:
     if len(c.contents) > 0:
         file_contents = [co for co in c.contents if FileUtils.is_file_content(co.key)]
         image_contents = [co for co in c.contents if FileUtils.is_image_content(co.key)]
+        if selected_content_ids is not None:
+            file_contents = [
+                co for co in file_contents if co.id in selected_content_ids
+            ]
+            image_contents = [
+                co for co in image_contents if co.id in selected_content_ids
+            ]
         content = (
             text
             + "\n\n"
@@ -280,10 +288,18 @@ async def _append_element_to_builder_async(
     file_content_serialization_type: FileContentSerialization,
     content_service: ContentService,
     chat_id: str,
+    selected_content_ids: set[str] | None = None,
 ) -> None:
     if len(c.contents) > 0:
         file_contents = [co for co in c.contents if FileUtils.is_file_content(co.key)]
         image_contents = [co for co in c.contents if FileUtils.is_image_content(co.key)]
+        if selected_content_ids is not None:
+            file_contents = [
+                co for co in file_contents if co.id in selected_content_ids
+            ]
+            image_contents = [
+                co for co in image_contents if co.id in selected_content_ids
+            ]
         content = (
             text
             + "\n\n"
@@ -321,6 +337,7 @@ def get_full_history_with_contents(
     content_service: ContentService,
     include_images: ImageContentInclusion = ImageContentInclusion.ALL,
     file_content_serialization_type: FileContentSerialization = FileContentSerialization.FILE_NAME,
+    selected_content_ids: set[str] | None = None,
 ) -> LanguageModelMessages:
     grouped_elements = get_chat_history_with_contents(
         user_message=user_message,
@@ -347,6 +364,7 @@ def get_full_history_with_contents(
             file_content_serialization_type=file_content_serialization_type,
             content_service=content_service,
             chat_id=chat_id,
+            selected_content_ids=selected_content_ids,
         )
     return builder.build()
 
@@ -359,6 +377,7 @@ async def get_full_history_with_contents_async(
     content_service: ContentService,
     include_images: ImageContentInclusion = ImageContentInclusion.ALL,
     file_content_serialization_type: FileContentSerialization = FileContentSerialization.FILE_NAME,
+    selected_content_ids: set[str] | None = None,
 ) -> LanguageModelMessages:
     grouped_elements = await get_chat_history_with_contents_async(
         user_message=user_message,
@@ -384,6 +403,7 @@ async def get_full_history_with_contents_async(
             file_content_serialization_type=file_content_serialization_type,
             content_service=content_service,
             chat_id=chat_id,
+            selected_content_ids=selected_content_ids,
         )
     return builder.build()
 
@@ -396,6 +416,7 @@ def get_full_history_with_contents_and_tool_calls(
     content_service: ContentService,
     include_images: ImageContentInclusion = ImageContentInclusion.ALL,
     file_content_serialization_type: FileContentSerialization = FileContentSerialization.FILE_NAME,
+    selected_content_ids: set[str] | None = None,
 ) -> tuple[LanguageModelMessages, int, dict[int, "ContentChunk"]]:
     """Build the full LLM message history, including persisted tool call rounds.
 
@@ -526,6 +547,7 @@ def get_full_history_with_contents_and_tool_calls(
             file_content_serialization_type=file_content_serialization_type,
             content_service=content_service,
             chat_id=chat_id,
+            selected_content_ids=selected_content_ids,
         )
     return builder.build(), max_source_number, source_map
 
@@ -538,6 +560,7 @@ async def get_full_history_with_contents_and_tool_calls_async(
     content_service: ContentService,
     include_images: ImageContentInclusion = ImageContentInclusion.ALL,
     file_content_serialization_type: FileContentSerialization = FileContentSerialization.FILE_NAME,
+    selected_content_ids: set[str] | None = None,
 ) -> tuple[LanguageModelMessages, int, dict[int, "ContentChunk"]]:
     """Async version of get_full_history_with_contents_and_tool_calls."""
     from unique_toolkit.agentic.history_manager.utils import (
@@ -642,6 +665,7 @@ async def get_full_history_with_contents_and_tool_calls_async(
             file_content_serialization_type=file_content_serialization_type,
             content_service=content_service,
             chat_id=chat_id,
+            selected_content_ids=selected_content_ids,
         )
     return builder.build(), max_source_number, source_map
 

--- a/unique_toolkit/unique_toolkit/agentic/history_manager/loop_token_reducer.py
+++ b/unique_toolkit/unique_toolkit/agentic/history_manager/loop_token_reducer.py
@@ -13,7 +13,10 @@ from unique_toolkit.agentic.history_manager.history_construction_with_contents i
     get_full_history_with_contents_and_tool_calls_async,
     get_full_history_with_contents_async,
 )
-from unique_toolkit.agentic.history_manager.utils import serialize_tool_content_json
+from unique_toolkit.agentic.history_manager.utils import (
+    compute_selected_uploaded_content_ids,
+    serialize_tool_content_json,
+)
 from unique_toolkit.agentic.reference_manager.reference_manager import ReferenceManager
 from unique_toolkit.app.schemas import ChatEvent
 from unique_toolkit.app.unique_settings import UniqueSettings
@@ -76,6 +79,7 @@ class LoopTokenReducer:
         self._max_db_source_number: int = -1
         self._db_source_map: dict[int, ContentChunk] = {}
         self._enable_tool_call_persistence = enable_tool_call_persistence
+        self._selected_content_ids = compute_selected_uploaded_content_ids(event)
 
     @property
     def max_db_source_number(self) -> int:
@@ -322,6 +326,7 @@ class LoopTokenReducer:
                 chat_service=self._chat_service,
                 content_service=self._content_service,
                 file_content_serialization_type=file_content_serialization_type,
+                selected_content_ids=self._selected_content_ids,
             )
             self._max_db_source_number = max_src
             self._db_source_map = src_map
@@ -332,6 +337,7 @@ class LoopTokenReducer:
                 chat_service=self._chat_service,
                 content_service=self._content_service,
                 file_content_serialization_type=file_content_serialization_type,
+                selected_content_ids=self._selected_content_ids,
             )
 
         if remove_from_text is not None:

--- a/unique_toolkit/unique_toolkit/agentic/history_manager/loop_token_reducer.py
+++ b/unique_toolkit/unique_toolkit/agentic/history_manager/loop_token_reducer.py
@@ -14,7 +14,7 @@ from unique_toolkit.agentic.history_manager.history_construction_with_contents i
     get_full_history_with_contents_async,
 )
 from unique_toolkit.agentic.history_manager.utils import (
-    compute_selected_uploaded_content_ids,
+    get_selected_uploaded_content_ids,
     serialize_tool_content_json,
 )
 from unique_toolkit.agentic.reference_manager.reference_manager import ReferenceManager
@@ -79,7 +79,7 @@ class LoopTokenReducer:
         self._max_db_source_number: int = -1
         self._db_source_map: dict[int, ContentChunk] = {}
         self._enable_tool_call_persistence = enable_tool_call_persistence
-        self._selected_content_ids = compute_selected_uploaded_content_ids(event)
+        self._selected_content_ids = get_selected_uploaded_content_ids(event)
 
     @property
     def max_db_source_number(self) -> int:

--- a/unique_toolkit/unique_toolkit/agentic/history_manager/utils.py
+++ b/unique_toolkit/unique_toolkit/agentic/history_manager/utils.py
@@ -3,7 +3,9 @@ import logging
 from copy import deepcopy
 from typing import Any
 
+from unique_toolkit.agentic.feature_flags import feature_flags
 from unique_toolkit.agentic.tools.schemas import Source
+from unique_toolkit.app.schemas import ChatEvent
 from unique_toolkit.content.schemas import ContentChunk
 from unique_toolkit.language_model.schemas import (
     LanguageModelAssistantMessage,
@@ -12,6 +14,27 @@ from unique_toolkit.language_model.schemas import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def compute_selected_uploaded_content_ids(event: ChatEvent) -> set[str] | None:
+    """Derive the set of content IDs the user explicitly selected.
+
+    Returns ``None`` when the feature flag is disabled (meaning *all*
+    uploaded images should be included), or a ``set[str]`` of IDs when
+    only a subset should be attached.
+    """
+    if not feature_flags.enable_selected_uploaded_files_un_18215.is_enabled(
+        event.company_id
+    ):
+        return None
+
+    if not (
+        hasattr(event.payload, "additional_parameters")
+        and event.payload.additional_parameters
+    ):
+        return None
+
+    return set(event.payload.additional_parameters.selected_uploaded_file_ids)
 
 
 def serialize_tool_content_json(value: Any) -> str:

--- a/unique_toolkit/unique_toolkit/agentic/history_manager/utils.py
+++ b/unique_toolkit/unique_toolkit/agentic/history_manager/utils.py
@@ -16,7 +16,7 @@ from unique_toolkit.language_model.schemas import (
 logger = logging.getLogger(__name__)
 
 
-def compute_selected_uploaded_content_ids(event: ChatEvent) -> set[str] | None:
+def get_selected_uploaded_content_ids(event: ChatEvent) -> set[str] | None:
     """Derive the set of content IDs the user explicitly selected.
 
     Returns ``None`` when the feature flag is disabled (meaning *all*

--- a/unique_toolkit/unique_toolkit/agentic/tools/experimental/open_file_tool/runtime.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/experimental/open_file_tool/runtime.py
@@ -34,6 +34,7 @@ class OpenFileToolRuntimeConfig:
     send_files_in_payload: bool = False
     send_uploaded_files_in_payload: bool = False
     use_responses_api: bool = False
+    selected_content_ids: frozenset[str] | None = None
 
 
 class OpenFileToolRuntime:
@@ -256,6 +257,12 @@ class OpenFileToolRuntime:
                 if (document.expired_at is None or document.expired_at > now)
                 and document.key.lower().endswith(".pdf")
             ]
+            if self._config.selected_content_ids is not None:
+                uploaded_documents = [
+                    doc
+                    for doc in uploaded_documents
+                    if doc.id in self._config.selected_content_ids
+                ]
             self._cached_uploaded_documents = sorted(
                 uploaded_documents,
                 key=lambda document: (

--- a/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/postprocessors/code_display.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/postprocessors/code_display.py
@@ -55,6 +55,7 @@ class ShowExecutedCodePostprocessor(ResponsesApiPostprocessor):
     ):
         super().__init__(self.__class__.__name__)
         self._config = config
+        self._company_id = company_id
         self._is_enabled = (
             self._config.enable
             and not feature_flags.enable_code_execution_fence_un_17972.is_enabled(

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-06T10:00:12.368923Z"
+exclude-newer = "2026-04-06T12:22:35.949784Z"
 exclude-newer-span = "P2W"
 
 [options.exclude-newer-package]
@@ -5544,7 +5544,7 @@ dev = []
 
 [[package]]
 name = "unique-toolkit"
-version = "1.77.0"
+version = "1.77.1"
 source = { editable = "unique_toolkit" }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Add `selected_content_ids` filtering so only user-selected uploaded images and files are attached when the
`enable_selected_uploaded_files_un_18215` feature flag is active.

- Add `compute_selected_uploaded_content_ids` utility in `history_manager/utils.py`
- Thread `selected_content_ids` through `LoopTokenReducer`, `get_full_history_with_contents*`, and `_append_element_to_builder_async`
- Support `selected_content_ids` in `OpenFileToolRuntimeConfig` to filter uploaded PDFs
- Store `company_id` as instance attribute on `ShowExecutedCodePostprocessor`

Made-with: Cursor

## 🚀 Summary
Refs: https://github.com/Unique-AG/ai/pull/1452

Briefly describe the changes introduced in this PR.

## ✅ Changes

- [ ] Added feature / fixed bug / updated docs
- [ ] Refactored code / cleaned up
- [ ] Other (describe below)

## 🧪 Testing

Explain what has been tested and how.
