### PR TITLE
fix(ci): exempt workspace packages from uv exclude-newer cutoff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,19 @@ constraint-dependencies = [
 ]
 
 [tool.uv.exclude-newer-package]
+"unique-sdk" = false
 "unique-toolkit" = false
+"unique-mcp" = false
+"unique-orchestrator" = false
+"unique-web-search" = false
+"unique-internal-search" = false
+"unique-swot" = false
+"unique-deep-research" = false
+"unique-stock-ticker" = false
+"unique-follow-up-questions" = false
+"unique-six" = false
+"unique-search-proxy" = false
+"unique-quartr" = false
 "cryptography" = "2026-04-09"
 "langchain-core" = "2026-04-09"
 "langsmith" = "2026-04-15"

--- a/tutorials/mcp/mcp_sql_demo/pyproject.toml
+++ b/tutorials/mcp/mcp_sql_demo/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-sql-demo"
-version = "0.1.1"
+version = "0.1.2"
 description = "Add your description here"
 readme = "README.md"
 authors = [{ name = "Cedric Klinkert", email = "cedric@unique.ch" }]

--- a/tutorials/mcp/mcp_sql_demo/pyproject.toml
+++ b/tutorials/mcp/mcp_sql_demo/pyproject.toml
@@ -30,3 +30,4 @@ exclude-newer = "2 weeks"
 
 [tool.uv.exclude-newer-package]
 "unique-toolkit" = false
+"unique-mcp" = false

--- a/tutorials/mcp/mcp_sql_demo/pyproject.toml
+++ b/tutorials/mcp/mcp_sql_demo/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-sql-demo"
-version = "0.1.2"
+version = "0.1.1"
 description = "Add your description here"
 readme = "README.md"
 authors = [{ name = "Cedric Klinkert", email = "cedric@unique.ch" }]

--- a/tutorials/mcp/mcp_sql_demo/pyproject.toml
+++ b/tutorials/mcp/mcp_sql_demo/pyproject.toml
@@ -31,3 +31,4 @@ exclude-newer = "2 weeks"
 [tool.uv.exclude-newer-package]
 "unique-toolkit" = false
 "unique-mcp" = false
+"unique-sdk" = false

--- a/unique_mcp/CHANGELOG.md
+++ b/unique_mcp/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), 
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2] - 2026-04-20
+- Add `[tool.uv.exclude-newer-package]` entry exempting `unique-toolkit` from the root workspace `exclude-newer` cutoff so recent workspace releases resolve correctly under `UV_NO_SOURCES=1`
+
 ## [0.3.1] - 2026-04-16
 - Remove stale per-package `[tool.uv]` config and tracked `uv.lock` — unique_mcp uses the workspace root lockfile
 - Move `lxml>=5.0.0` constraint to root `pyproject.toml`

--- a/unique_mcp/pyproject.toml
+++ b/unique_mcp/pyproject.toml
@@ -26,6 +26,9 @@ dev = []
 [tool.uv.sources]
 unique-toolkit = { workspace = true }
 
+[tool.uv.exclude-newer-package]
+"unique-toolkit" = false
+
 [tool.pytest.ini_options]
 addopts = "--strict-markers --import-mode=importlib"
 asyncio_mode = "auto"

--- a/unique_mcp/pyproject.toml
+++ b/unique_mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "unique-mcp"
-version = "0.3.1"
+version = "0.3.2"
 description = "Add your description here"
 readme = "README.md"
 authors = [

--- a/unique_sdk/CHANGELOG.md
+++ b/unique_sdk/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), 
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.7] - 2026-04-20
+- Chore: exempt `unique-sdk` from the workspace root `exclude-newer` cutoff so recent SDK releases resolve correctly under `UV_NO_SOURCES=1`
+
 ## [0.11.6] - 2026-04-20
 - Add `mimeType` field to `Content`
 

--- a/unique_sdk/examples/custom-assistant/pyproject.toml
+++ b/unique_sdk/examples/custom-assistant/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "custom-assistant"
-version = "0.1.0"
+version = "0.1.1"
 description = ""
 authors = [{ name = "Konstantin Krauss", email = "konsti@users.noreply.github.com" }]
 readme = "README.md"

--- a/unique_sdk/examples/custom-assistant/pyproject.toml
+++ b/unique_sdk/examples/custom-assistant/pyproject.toml
@@ -22,3 +22,6 @@ build-backend = "uv_build"
 
 [tool.uv.sources]
 unique-sdk = { path = "../..", editable = true }
+
+[tool.uv.exclude-newer-package]
+"unique-sdk" = false

--- a/unique_sdk/examples/custom-assistant/pyproject.toml
+++ b/unique_sdk/examples/custom-assistant/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "custom-assistant"
-version = "0.1.1"
+version = "0.1.0"
 description = ""
 authors = [{ name = "Konstantin Krauss", email = "konsti@users.noreply.github.com" }]
 readme = "README.md"

--- a/unique_sdk/pyproject.toml
+++ b/unique_sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "unique_sdk"
-version = "0.11.6"
+version = "0.11.7"
 description = ""
 readme = "README.md"
 license = { text = "MIT" }

--- a/uv.lock
+++ b/uv.lock
@@ -8,16 +8,28 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-06T13:36:52.810466Z"
+exclude-newer = "2026-04-06T16:41:56.874931Z"
 exclude-newer-span = "P2W"
 
 [options.exclude-newer-package]
 unique-toolkit = false
-langsmith = "2026-04-15T22:00:00Z"
-cryptography = "2026-04-09T22:00:00Z"
-langchain-core = "2026-04-09T22:00:00Z"
+unique-internal-search = false
 pytest = "2026-04-08T22:00:00Z"
+langchain-core = "2026-04-09T22:00:00Z"
+unique-swot = false
+unique-sdk = false
+unique-mcp = false
+cryptography = "2026-04-09T22:00:00Z"
+unique-orchestrator = false
+unique-follow-up-questions = false
+langsmith = "2026-04-15T22:00:00Z"
+unique-six = false
 python-multipart = "2026-04-11T22:00:00Z"
+unique-stock-ticker = false
+unique-web-search = false
+unique-deep-research = false
+unique-search-proxy = false
+unique-quartr = false
 
 [manifest]
 members = [
@@ -5296,7 +5308,7 @@ dev = []
 
 [[package]]
 name = "unique-mcp"
-version = "0.3.1"
+version = "0.3.2"
 source = { editable = "unique_mcp" }
 dependencies = [
     { name = "fastmcp" },

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-06T16:41:56.874931Z"
+exclude-newer = "2026-04-06T16:51:03.047704Z"
 exclude-newer-span = "P2W"
 
 [options.exclude-newer-package]
@@ -5396,7 +5396,7 @@ dev = []
 
 [[package]]
 name = "unique-sdk"
-version = "0.11.6"
+version = "0.11.7"
 source = { editable = "unique_sdk" }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Under `UV_NO_SOURCES=1` (used by `.github/actions/run-coverage-check`), `uv` resolves workspace dependencies from PyPI rather than local paths. The root `pyproject.toml`'s `exclude-newer = "2 weeks"` then filters out recently-published workspace releases, breaking resolution. Concretely, this manifested as:

\`\`\`
unique-toolkit==1.77.2 depends on unique-sdk>=0.11.6,<0.12
but only unique-sdk<=0.10.100 is available
\`\`\`

## Changes

- Mirror every workspace package name under \`[tool.uv.exclude-newer-package]\` in the root \`pyproject.toml\` with \`= false\`, so they always resolve against the full PyPI history regardless of whether they appear as direct or transitive deps.
- Add missing \`exclude-newer-package\` entries to member projects that depend on workspace packages:
  - \`unique_mcp\` → \`unique-toolkit\`
  - \`tutorials/mcp/mcp_sql_demo\` → \`unique-mcp\`
  - \`unique_sdk/examples/custom-assistant\` → \`unique-sdk\`

## Test plan

- [ ] CI resolves \`unique-sdk>=0.11.x\` successfully under \`UV_NO_SOURCES=1\`
- [ ] Coverage check job (\`run-coverage-check\`) passes on this branch
- [ ] No regressions in local \`uv sync\` for affected members


Made with [Cursor](https://cursor.com)