### PR TITLE
fix(toolkit): stop orphan code.txt uploads for code interpreter (UN-19770)

### DIFF
--- a/unique_toolkit/CHANGELOG.md
+++ b/unique_toolkit/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.77.2] - 2026-04-21
+- Stop uploading orphan `code.txt` / `code_N.txt` artifacts when code interpreter runs without producing container files (UN-19770); inline assistant text is unchanged, real file outputs (charts, CSVs, etc.) are unchanged
+
 ## [1.77.1] - 2026-04-20
 - Add `selected_content_ids` filtering to history construction and `OpenFileToolRuntime` so only user-selected uploaded images and files are attached when the `enable_selected_uploaded_files_un_18215` feature flag is active
 - Add `get_selected_uploaded_content_ids` utility in `history_manager/utils.py`

--- a/unique_toolkit/pyproject.toml
+++ b/unique_toolkit/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "unique_toolkit"
-version = "1.77.1"
+version = "1.77.2"
 description = ""
 readme = "README.md"
 requires-python = ">=3.12"

--- a/unique_toolkit/tests/agentic/tools/test_code_interpreter_postprocessors_generated_files.py
+++ b/unique_toolkit/tests/agentic/tools/test_code_interpreter_postprocessors_generated_files.py
@@ -1679,7 +1679,7 @@ def test_warn_unmatched_code_blocks__skips_none_content_ids(caplog) -> None:
 
 
 # ============================================================================
-# Tests for orphan path and run()
+# Tests for apply_postprocessing_to_response edge cases and run()
 # ============================================================================
 
 
@@ -1703,7 +1703,6 @@ def test_apply_postprocessing__normalizes_none_message_text__to_empty_string(
         company_id="company-null-text",
     )
     proc._content_map = {}
-    proc._orphan_code_blocks = []
     msg = ChatMessage(
         id="test-msg-null-text",
         chat_id="c1",
@@ -1714,54 +1713,6 @@ def test_apply_postprocessing__normalizes_none_message_text__to_empty_string(
     loop = ResponsesLanguageModelStreamResponse(message=msg, output=[])
     proc.apply_postprocessing_to_response(loop)
     assert msg.text == ""
-
-
-@pytest.mark.ai
-@patch(GEN_FILES_FF)
-def test_apply_postprocessing__orphan_path_adds_reference_not_fence__when_ff_on(
-    mock_ff: MagicMock,
-) -> None:
-    """
-    Purpose: Orphan blocks are surfaced as ContentReference entries, NOT as fence text.
-    Why this matters: Fence injection for orphan blocks produced confusing UI artefacts;
-    the references panel is the clean canonical place for downloadable code outputs.
-    Setup summary: One orphan block with a document file, fence FF ON; assert a
-    ContentReference is added for the file and no fence syntax appears in message.text.
-    """
-    mock_ff.enable_code_execution_fence_un_17972.is_enabled.return_value = True
-    config = DisplayCodeInterpreterFilesPostProcessorConfig()
-    proc = DisplayCodeInterpreterFilesPostProcessor(
-        client=MagicMock(),
-        content_service=MagicMock(),
-        config=config,
-        chat_service=MagicMock(),
-        company_id="company-orphan",
-    )
-    proc._content_map = {}
-    orphan_file = CodeInterpreterFile(
-        filename="code.txt", content_id="cont_orphan", type="document"
-    )
-    proc._orphan_code_blocks = [
-        CodeInterpreterBlock(code="print('hi')", files=[orphan_file]),
-    ]
-    msg = ChatMessage(
-        id="test-msg-orphan",
-        chat_id="c1",
-        role=ChatMessageRole.ASSISTANT,
-        content="Hello",
-        references=None,
-    )
-    loop = ResponsesLanguageModelStreamResponse(message=msg, output=[])
-    changed = proc.apply_postprocessing_to_response(loop)
-    assert changed is True
-    assert msg.text is not None
-    assert "fileWithSource" not in msg.text
-    assert msg.references is not None
-    assert len(msg.references) == 1
-    ref = msg.references[0]
-    assert ref.source_id == "cont_orphan"
-    assert ref.name == "code.txt"
-    assert "cont_orphan" in ref.url
 
 
 @pytest.mark.ai
@@ -1786,7 +1737,6 @@ def test_apply_postprocessing__ff_on__does_not_append_reference_for_non_image_fi
         company_id="company-fence-on",
     )
     proc._content_map = {"report.pdf": "cid-pdf-1"}
-    proc._orphan_code_blocks = []
     message = SimpleNamespace(
         text="See [report.pdf](sandbox:/mnt/data/report.pdf) for details.",
         references=[],
@@ -1821,7 +1771,6 @@ def test_apply_postprocessing__ff_off__appends_reference_for_non_image_file(
         company_id="company-fence-off",
     )
     proc._content_map = {"report.pdf": "cid-pdf-1"}
-    proc._orphan_code_blocks = []
     message = SimpleNamespace(
         text="See [report.pdf](sandbox:/mnt/data/report.pdf) for details.",
         references=[],
@@ -1861,7 +1810,6 @@ def test_apply_postprocessing__ff_off__existing_citation_refs_preserved(
         company_id="company-existing-refs",
     )
     proc._content_map = {"data.xlsx": "cid-xls-1"}
-    proc._orphan_code_blocks = []
     existing_ref = ContentReference(
         name="source-doc",
         sequence_number=3,
@@ -1883,245 +1831,6 @@ def test_apply_postprocessing__ff_off__existing_citation_refs_preserved(
     source_ids = {r.source_id for r in message.references}
     assert "existing-sid" in source_ids
     assert "cid-xls-1" in source_ids
-
-
-@pytest.mark.ai
-@pytest.mark.asyncio
-@patch(GEN_FILES_FF)
-async def test_run__populates_orphan_blocks__when_ff_on_and_no_container_files(
-    mock_ff: MagicMock,
-) -> None:
-    mock_ff.enable_code_execution_fence_un_17972.is_enabled.return_value = True
-    call = ResponseCodeInterpreterToolCall(
-        id="call-1",
-        container_id="ctr",
-        status="completed",
-        type="code_interpreter_call",
-        code="print(42)",
-    )
-    msg = ChatMessage(
-        id="test-msg-orphan-pop",
-        chat_id="c1",
-        role=ChatMessageRole.ASSISTANT,
-        content="Hi",
-    )
-    loop = ResponsesLanguageModelStreamResponse(message=msg, output=[call])
-    uploaded = MagicMock()
-    uploaded.id = "cont_up"
-    chat = AsyncMock()
-    chat.upload_to_chat_from_bytes_async = AsyncMock(return_value=uploaded)
-    proc = DisplayCodeInterpreterFilesPostProcessor(
-        client=MagicMock(),
-        content_service=MagicMock(),
-        config=DisplayCodeInterpreterFilesPostProcessorConfig(),
-        chat_service=chat,
-        company_id="co1",
-    )
-    await proc.run(loop)
-    assert len(proc._orphan_code_blocks) == 1
-    assert proc._orphan_code_blocks[0].files[0].content_id == "cont_up"
-    chat.upload_to_chat_from_bytes_async.assert_awaited()
-
-
-@pytest.mark.ai
-@pytest.mark.asyncio
-@patch(GEN_FILES_FF)
-async def test_run__clears_orphan_blocks__when_fence_ff_off(mock_ff: MagicMock) -> None:
-    mock_ff.enable_code_execution_fence_un_17972.is_enabled.return_value = False
-    call = ResponseCodeInterpreterToolCall(
-        id="call-1",
-        container_id="ctr",
-        status="completed",
-        type="code_interpreter_call",
-        code="print(1)",
-    )
-    msg = ChatMessage(
-        id="test-msg-fence-off", chat_id="c1", role=ChatMessageRole.ASSISTANT, text="Hi"
-    )
-    loop = ResponsesLanguageModelStreamResponse(message=msg, output=[call])
-    proc = DisplayCodeInterpreterFilesPostProcessor(
-        client=MagicMock(),
-        content_service=MagicMock(),
-        config=DisplayCodeInterpreterFilesPostProcessorConfig(),
-        chat_service=AsyncMock(),
-        company_id="co1",
-    )
-    proc._orphan_code_blocks = [
-        CodeInterpreterBlock(code="old", files=[]),
-    ]
-    await proc.run(loop)
-    assert proc._orphan_code_blocks == []
-
-
-@pytest.mark.ai
-@pytest.mark.asyncio
-@patch(GEN_FILES_FF)
-async def test_run__orphan_upload_skips_calls_when_upload_fails(
-    mock_ff: MagicMock,
-) -> None:
-    mock_ff.enable_code_execution_fence_un_17972.is_enabled.return_value = True
-    call = ResponseCodeInterpreterToolCall(
-        id="call-1",
-        container_id="ctr",
-        status="completed",
-        type="code_interpreter_call",
-        code="print(1)",
-    )
-    msg = ChatMessage(
-        id="test-msg-upload-fail",
-        chat_id="c1",
-        role=ChatMessageRole.ASSISTANT,
-        content="Hi",
-    )
-    loop = ResponsesLanguageModelStreamResponse(message=msg, output=[call])
-    chat = AsyncMock()
-    chat.upload_to_chat_from_bytes_async = AsyncMock(
-        side_effect=RuntimeError("upload failed")
-    )
-    proc = DisplayCodeInterpreterFilesPostProcessor(
-        client=MagicMock(),
-        content_service=MagicMock(),
-        config=DisplayCodeInterpreterFilesPostProcessorConfig(),
-        chat_service=chat,
-        company_id="co1",
-    )
-    await proc.run(loop)
-    assert proc._orphan_code_blocks == []
-
-
-@pytest.mark.ai
-@pytest.mark.asyncio
-async def test_upload_orphan_code_as_txt__returns_empty_when_container_files_present() -> (
-    None
-):
-    proc = DisplayCodeInterpreterFilesPostProcessor(
-        client=MagicMock(),
-        content_service=MagicMock(),
-        config=DisplayCodeInterpreterFilesPostProcessorConfig(),
-        chat_service=MagicMock(),
-        company_id="co1",
-    )
-    lr = MagicMock(spec=ResponsesLanguageModelStreamResponse)
-    lr.container_files = [MagicMock()]
-    lr.code_interpreter_calls = []
-    assert await proc._upload_orphan_code_as_txt(lr) == []
-
-
-@pytest.mark.ai
-@pytest.mark.asyncio
-async def test_upload_orphan_code_as_txt__returns_empty_when_no_calls() -> None:
-    proc = DisplayCodeInterpreterFilesPostProcessor(
-        client=MagicMock(),
-        content_service=MagicMock(),
-        config=DisplayCodeInterpreterFilesPostProcessorConfig(),
-        chat_service=MagicMock(),
-        company_id="co1",
-    )
-    lr = MagicMock(spec=ResponsesLanguageModelStreamResponse)
-    lr.container_files = []
-    lr.code_interpreter_calls = []
-    assert await proc._upload_orphan_code_as_txt(lr) == []
-
-
-@pytest.mark.ai
-@pytest.mark.asyncio
-async def test_upload_orphan_code_as_txt__skips_call_without_code() -> None:
-    proc = DisplayCodeInterpreterFilesPostProcessor(
-        client=MagicMock(),
-        content_service=MagicMock(),
-        config=DisplayCodeInterpreterFilesPostProcessorConfig(),
-        chat_service=MagicMock(),
-        company_id="co1",
-    )
-    call_no_code = MagicMock(spec=ResponseCodeInterpreterToolCall)
-    call_no_code.code = None
-    lr = MagicMock(spec=ResponsesLanguageModelStreamResponse)
-    lr.container_files = []
-    lr.code_interpreter_calls = [call_no_code]
-    assert await proc._upload_orphan_code_as_txt(lr) == []
-
-
-@pytest.mark.ai
-@pytest.mark.asyncio
-async def test_upload_orphan_code_as_txt__uploads_source_code_not_stdout() -> None:
-    """
-    Purpose: Orphan .txt attachments must contain the executed source, not interpreter stdout.
-    Why this matters: stdout (e.g. print output) differs from code; users expect `code.txt` to
-    match what ran in the sandbox.
-    """
-    source = "x = 40 + 2\nprint(x)\n"
-    call = MagicMock(spec=ResponseCodeInterpreterToolCall)
-    call.code = source
-    stdout_output = MagicMock()
-    stdout_output.type = "logs"
-    stdout_output.logs = "42"
-    call.outputs = [stdout_output]
-    lr = MagicMock(spec=ResponsesLanguageModelStreamResponse)
-    lr.container_files = []
-    lr.code_interpreter_calls = [call]
-    chat = AsyncMock()
-    chat.upload_to_chat_from_bytes_async = AsyncMock(
-        return_value=MagicMock(id="cid-orphan-code")
-    )
-    proc = DisplayCodeInterpreterFilesPostProcessor(
-        client=MagicMock(),
-        content_service=MagicMock(),
-        config=DisplayCodeInterpreterFilesPostProcessorConfig(),
-        chat_service=chat,
-        company_id="co1",
-    )
-    blocks = await proc._upload_orphan_code_as_txt(lr)
-    assert len(blocks) == 1
-    chat.upload_to_chat_from_bytes_async.assert_awaited_once()
-    kwargs = chat.upload_to_chat_from_bytes_async.await_args.kwargs
-    assert kwargs["content"] == source.encode("utf-8")
-
-
-@pytest.mark.ai
-@pytest.mark.asyncio
-@pytest.mark.parametrize("num_calls", [1, 2])
-async def test_upload_orphan_code_as_txt__uploads_txt_uses_expected_filename(
-    num_calls: int,
-) -> None:
-    """Single call → code.txt; multiple calls → code_1.txt, code_2.txt."""
-    calls = [
-        ResponseCodeInterpreterToolCall(
-            id=f"call-{i}",
-            container_id="ctr",
-            status="completed",
-            type="code_interpreter_call",
-            code=f"print({i})",
-        )
-        for i in range(num_calls)
-    ]
-    lr = MagicMock(spec=ResponsesLanguageModelStreamResponse)
-    lr.container_files = []
-    lr.code_interpreter_calls = calls
-    chat = AsyncMock()
-
-    async def _upload(**kwargs):
-        m = MagicMock()
-        m.id = f"id-{kwargs.get('content_name', '')}"
-        return m
-
-    chat.upload_to_chat_from_bytes_async = AsyncMock(side_effect=_upload)
-    proc = DisplayCodeInterpreterFilesPostProcessor(
-        client=MagicMock(),
-        content_service=MagicMock(),
-        config=DisplayCodeInterpreterFilesPostProcessorConfig(),
-        chat_service=chat,
-        company_id="co1",
-    )
-    blocks = await proc._upload_orphan_code_as_txt(lr)
-    assert len(blocks) == num_calls
-    if num_calls == 1:
-        chat.upload_to_chat_from_bytes_async.assert_awaited_once()
-        assert blocks[0].files[0].filename == "code.txt"
-    else:
-        assert {blocks[i].files[0].filename for i in range(2)} == {
-            "code_1.txt",
-            "code_2.txt",
-        }
 
 
 @pytest.mark.ai

--- a/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/postprocessors/generated_files.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/postprocessors/generated_files.py
@@ -358,7 +358,6 @@ class DisplayCodeInterpreterFilesPostProcessor(
             logger, {"chat_id": chat_id or "n/a"}
         )
 
-        self._orphan_code_blocks: list[CodeInterpreterBlock] = []
         self._short_term_memory_manager = None
         if chat_id is not None and user_id is not None and company_id is not None:
             self._short_term_memory_manager = _init_short_term_memory_manager(
@@ -465,34 +464,11 @@ class DisplayCodeInterpreterFilesPostProcessor(
             )
         save_ms = (time.monotonic() - phase_t0) * 1000
 
-        phase_t0 = time.monotonic()
-        try:
-            if feature_flags.enable_code_execution_fence_un_17972.is_enabled(
-                self._company_id
-            ):
-                self._orphan_code_blocks = await self._upload_orphan_code_as_txt(
-                    loop_response
-                )
-                if self._orphan_code_blocks:
-                    self._log.info(
-                        "run() produced %d orphan code block(s)",
-                        len(self._orphan_code_blocks),
-                    )
-            else:
-                self._orphan_code_blocks = []
-        except Exception:
-            self._log.exception(
-                "run() failed to process orphan code blocks; "
-                "file replacement will still proceed."
-            )
-            self._orphan_code_blocks = []
-        orphan_ms = (time.monotonic() - phase_t0) * 1000
-
         total_ms = (time.monotonic() - run_t0) * 1000
         self._log.info(
             "run() finished — content_map has %d entries (%d ok, %d failed). "
             "Timing: total=%.0fms, load_stm=%.0fms, download_upload=%.0fms, "
-            "save_stm=%.0fms, orphan=%.0fms",
+            "save_stm=%.0fms",
             len(self._content_map),
             len(succeeded),
             len(failed),
@@ -500,7 +476,6 @@ class DisplayCodeInterpreterFilesPostProcessor(
             load_ms,
             download_upload_ms,
             save_ms,
-            orphan_ms,
         )
 
     @override
@@ -623,25 +598,6 @@ class DisplayCodeInterpreterFilesPostProcessor(
             changed |= fences_changed
             if fences_changed:
                 self._log.info("Fence injection modified the message text")
-
-            if self._orphan_code_blocks:
-                for block in self._orphan_code_blocks:
-                    for file in block.files:
-                        loop_response.message.references.append(
-                            ContentReference(
-                                sequence_number=ref_number,
-                                source_id=file.content_id,
-                                source="node-ingestion-chunks",
-                                url=f"unique://content/{file.content_id}",
-                                name=file.filename,
-                            )
-                        )
-                        ref_number += 1
-                changed = True
-                self._log.info(
-                    "Added %d orphan code block(s) to message references",
-                    len(self._orphan_code_blocks),
-                )
 
         _warn_missing_content_ids(loop_response.message.text or "", self._content_map)
         loop_response.message.text, dangling_replaced = _replace_dangling_sandbox_links(
@@ -962,74 +918,6 @@ class DisplayCodeInterpreterFilesPostProcessor(
             len(content_infos),
             (time.monotonic() - t0) * 1000,
         )
-
-    async def _upload_orphan_code_as_txt(
-        self, loop_response: ResponsesLanguageModelStreamResponse
-    ) -> list[CodeInterpreterBlock]:
-        """Upload source **code** from calls that produced no container files as .txt artifacts.
-
-        When code interpreter runs but generates no files or images, the response
-        text has no sandbox links for fence injection to hook onto.  This method
-        converts those "orphan" calls into downloadable .txt files (the executed
-        code, not stdout) so the postprocessor can attach a reference for download.
-
-        Called only when the fence feature flag is enabled.  Skipped entirely if
-        any container files were produced (normal fencing handles those).
-        """
-        if loop_response.container_files:
-            return []
-
-        calls = loop_response.code_interpreter_calls
-        if not calls:
-            return []
-
-        assert self._chat_service is not None  # Checked in __init__
-
-        use_numeric_suffix = len(calls) > 1
-        orphan_blocks: list[CodeInterpreterBlock] = []
-
-        for i, call in enumerate(calls):
-            if not call.code:
-                continue
-
-            # Always persist the executed source as the downloadable .txt (not stdout),
-            # so the attachment matches what ran in the sandbox.
-            txt_content = call.code
-            filename = f"code_{i + 1}.txt" if use_numeric_suffix else "code.txt"
-
-            try:
-                content = await self._build_retry()(
-                    self._chat_service.upload_to_chat_from_bytes_async,
-                    content=txt_content.encode("utf-8"),
-                    content_name=filename,
-                    mime_type="text/plain",
-                    skip_ingestion=True,
-                    hide_in_chat=True,
-                )
-            except Exception:
-                self._log.exception(
-                    "Failed to upload orphan code block as txt for call %d ('%s'); "
-                    "falling back to legacy code block display.",
-                    i,
-                    filename,
-                )
-                continue
-
-            orphan_file = CodeInterpreterFile(
-                filename=filename,
-                content_id=content.id,
-                type="document",
-            )
-            orphan_blocks.append(
-                CodeInterpreterBlock(code=call.code, files=[orphan_file])
-            )
-            self._log.info(
-                "Uploaded orphan code block as '%s' (content_id=%s)",
-                filename,
-                content.id,
-            )
-
-        return orphan_blocks
 
 
 def _get_file_type(filename: str) -> CodeInterpreterFileType:

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-06T16:51:03.047704Z"
+exclude-newer = "2026-04-07T09:12:06.062501Z"
 exclude-newer-span = "P2W"
 
 [options.exclude-newer-package]
@@ -5556,7 +5556,7 @@ dev = []
 
 [[package]]
 name = "unique-toolkit"
-version = "1.77.1"
+version = "1.77.2"
 source = { editable = "unique_toolkit" }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Refs: UN-19770


## Summary
- Removes the code-interpreter postprocessor path that uploaded executed Python as `code.txt` / `code_N.txt` when no sandbox/container files were produced (UN-19770).
- Inline assistant answers are unchanged; downloads for real artifacts (images, CSVs, etc.) are unchanged.
- Bumps `unique_toolkit` to **1.77.2** and refreshes root `uv.lock` for the workspace version.

## Changes
- `unique_toolkit/.../postprocessors/generated_files.py`: drop `_upload_orphan_code_as_txt` and related reference injection.
- `unique_toolkit/tests/.../test_code_interpreter_postprocessors_generated_files.py`: remove orphan-specific tests; adjust fixtures.
- `unique_toolkit/CHANGELOG.md`, `unique_toolkit/pyproject.toml`, `uv.lock`.

## Test plan
- [x] `cd unique_toolkit && poetry run pytest tests/agentic/tools/test_code_interpreter_postprocessors_generated_files.py -q` (133 passed)
- [x] Manual UI validation (no `.txt` when code runs without file output; charts/CSVs still attach)

## Risk / rollout
- Low risk: only removes an attachment path users found confusing. Rollback: revert commit and republish prior toolkit version.

Made with [Cursor](https://cursor.com)