### PR TITLE
feat(sdk): add elicit CLI command group with UN-19815 visibility workaround

### DIFF
--- a/unique_sdk/CHANGELOG.md
+++ b/unique_sdk/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), 
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.7] - 2026-04-21
+- Workaround for UN-19815: `elicit ask` / `elicit create` now wrap the elicitation in a short-lived placeholder "thinking" timeline (a placeholder `ASSISTANT` message + a `RUNNING` `MessageLog` step) so the chat UI actually renders the elicitation while it is pending. The placeholder is torn down automatically (collapsed or deleted) when the user responds, on timeout, on API error, or on Ctrl-C
+- Add `--visible` / `--no-visible`, `--assistant-id`, `--placeholder-text`, `--cleanup` flags to `elicit ask` and `elicit create` in both the one-shot CLI and the REPL shell. The workaround is enabled by default whenever `--chat-id` is passed and `--message-id` is not; pass `--no-visible` to opt out once the UN-19815 UI fix lands
+- `elicit wait` and `elicit respond` now auto-clean any placeholder a prior `elicit create --visible` left behind, by reading the placeholder ids back from the elicitation's `metadata`
+- Serialize `completedAt` as an ISO-8601 UTC string (not a raw `datetime`) when collapsing the visibility placeholder via `Message.modify`, so the `PATCH /messages/{id}` body is accepted by the backend; without this the placeholder would stay visually "running" after the user responded
+- Update the `unique-cli-elicitation` skill and the CLI docs page with the new flags and a note on when to turn the workaround off
+
+## [0.11.6] - 2026-04-21
+- Fix `elicit pending` crashing with `AttributeError: 'list' object has no attribute 'get'` — the backend returns a raw JSON array; both list and dict shapes are now accepted
+- Fix `elicit wait` / `elicit ask` never terminating when the user answers — `ACCEPTED` and `REJECTED` are now recognised as terminal statuses alongside `RESPONDED` / `DECLINED` / `CANCELLED` / `EXPIRED` / `COMPLETED`
+- Accept `REJECT` as a valid `elicit respond --action` value (forwarded to the backend as `REJECT`)
+
 ## [0.11.5] - 2026-04-16
 - Add `elicit` CLI command group with `ask`, `create`, `pending`, `get`, `wait`, `respond` subcommands for both one-shot and interactive REPL modes, wrapping the existing `Elicitation` API resource
 - Add `elicit ask` convenience command that creates a FORM elicitation and blocks until the user responds, declines, cancels, or the request expires

--- a/unique_sdk/CHANGELOG.md
+++ b/unique_sdk/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), 
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.5] - 2026-04-16
+- Add `elicit` CLI command group with `ask`, `create`, `pending`, `get`, `wait`, `respond` subcommands for both one-shot and interactive REPL modes, wrapping the existing `Elicitation` API resource
+- Add `elicit ask` convenience command that creates a FORM elicitation and blocks until the user responds, declines, cancels, or the request expires
+- Add formatting helpers for elicitation display (detail view, pending list, response result)
+- Add agent skill for elicitation (`unique-cli-elicitation`) so agents route user-facing questions through the platform UI instead of asking in plain chat
+- Add `CLI > Elicitation` documentation page and expose it in the mkdocs nav
+
 ## [0.11.4] - 2026-04-15
 - Chore: standardize pytest configuration across workspace packages
 

--- a/unique_sdk/CLAUDE.md
+++ b/unique_sdk/CLAUDE.md
@@ -104,6 +104,10 @@ export UNIQUE_APP_ID="app_..."
 | `rm <name\|id>` | Delete file |
 | `mv <old> <new>` | Rename file |
 | `search <query> [--folder F] [--metadata K=V] [--limit N]` | Combined search |
+| `mcp -c <chat> -m <msg> <json>` | Call an MCP tool by name+arguments |
+| `schedule <list\|get\|create\|update\|delete> [opts]` | Manage cron-based scheduled tasks |
+| `elicit ask <message> [opts]` | Ask the user a question and wait for the answer |
+| `elicit <create\|pending\|get\|wait\|respond> [opts]` | Low-level elicitation operations |
 
 **Two modes:** Interactive shell (`unique-cli`) or one-shot (`unique-cli ls /Reports`).
 

--- a/unique_sdk/docs/cli/elicitation.md
+++ b/unique_sdk/docs/cli/elicitation.md
@@ -1,0 +1,329 @@
+# Elicitation
+
+!!! warning "Experimental"
+    The CLI is experimental and its interface may change in future releases.
+
+Ask the user a structured question and get a typed answer back. Elicitations are first-class user-input requests routed through the Unique AI Platform UI -- use them instead of asking in free-form chat whenever you need a clarification, a confirmation (especially before a destructive action), a choice between options, or a small structured form.
+
+The CLI exposes the full lifecycle:
+
+- `elicit ask` -- **create + wait** in a single call (the one you usually want)
+- `elicit create` -- fire-and-forget create (FORM or URL mode)
+- `elicit pending` -- list open requests for the current user
+- `elicit get` -- fetch one elicitation by ID
+- `elicit wait` -- poll an existing elicitation until it reaches a terminal state
+- `elicit respond` -- respond on behalf of the user (scripting / tests)
+
+Elicitations move through these statuses:
+
+| Status | Meaning |
+|--------|---------|
+| `PENDING` | Created, waiting for a response |
+| `RESPONDED` / `COMPLETED` | The user submitted an answer (`responseContent` is populated) |
+| `DECLINED` | The user explicitly declined |
+| `CANCELLED` | Cancelled by the user or system |
+| `EXPIRED` | Not answered before `expiresAt` |
+
+Any status other than `PENDING` is **terminal** -- `elicit wait` returns as soon as one of these is reached.
+
+---
+
+## elicit ask
+
+Create a FORM elicitation and block until the user responds, declines, cancels, expires, or the local `--timeout` elapses. This is the idiomatic way for an agent to request input from the user.
+
+**Synopsis:**
+
+```
+elicit ask <message> [options]
+```
+
+**Arguments:**
+
+| Argument | Description |
+|----------|-------------|
+| `message` | The question or instruction shown to the user |
+
+**Options:**
+
+| Option | Short | Default | Description |
+|--------|-------|---------|-------------|
+| `--tool-name` | `-t` | `agent_question` | Short tool/intent label shown in the UI (e.g. `confirm_delete`, `choose_quarter`). |
+| `--schema` | | single required `answer` string | JSON Schema for the form body. |
+| `--chat-id` | `-c` | none | Attach the elicitation to a chat. |
+| `--message-id` | `-m` | none | Attach to a specific message. |
+| `--expires-in` | | none | Seconds before the platform auto-expires the request. |
+| `--timeout` | | `300` | Max seconds to block locally while polling. |
+| `--poll-interval` | | `2.0` | Seconds between polls. |
+| `--metadata` | | none | `key=value` metadata (repeatable). |
+
+**Default schema (when `--schema` is omitted):**
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "answer": {
+      "type": "string",
+      "description": "Free-text answer to the question."
+    }
+  },
+  "required": ["answer"]
+}
+```
+
+**Examples:**
+
+```bash
+# Free-text question
+unique-cli elicit ask "Which quarter should I report on?"
+
+# Multiple choice -- use `enum` so the UI renders a selector
+unique-cli elicit ask "Pick a region" --tool-name choose_region --schema '{
+  "type": "object",
+  "properties": {
+    "region": {"type": "string", "enum": ["EU", "US", "APAC"]}
+  },
+  "required": ["region"]
+}'
+
+# Confirmation before a destructive action
+unique-cli elicit ask "Confirm permanently deleting /Archive/2024 and all its contents" \
+  --tool-name confirm_delete \
+  --timeout 120 \
+  --schema '{
+    "type": "object",
+    "properties": {"confirm": {"type": "boolean"}},
+    "required": ["confirm"]
+  }'
+```
+
+**Sample output:**
+
+```
+ID:         elicit_9a7b
+Status:     RESPONDED
+Mode:       FORM
+Source:     INTERNAL_TOOL
+Tool:       choose_region
+Message:    Pick a region
+Schema:     {"type":"object","properties":{"region":{"type":"string","enum":["EU","US","APAC"]}},"required":["region"]}
+URL:        -
+Chat:       -
+Message ID: -
+External ID: -
+Metadata:   -
+Response:   {"region": "EU"}
+Responded:  2026-04-16 14:22
+Expires:    -
+Created:    2026-04-16 14:21
+Updated:    2026-04-16 14:22
+```
+
+Agents parse the JSON after `Response:` to get the structured answer.
+
+!!! tip "Scripting"
+    Extract the response with `awk` + `jq`:
+
+    ```bash
+    out=$(unique-cli elicit ask "Pick a region" --schema '...')
+    json=$(echo "$out" | awk -F'Response:[[:space:]]*' '/^Response:/{print $2}')
+    region=$(echo "$json" | jq -r '.region')
+    ```
+
+---
+
+## elicit create
+
+Create an elicitation without waiting for the response. Useful when you want to ask several things in parallel or trigger a URL-based flow.
+
+**Synopsis:**
+
+```
+elicit create <message> --mode FORM|URL --tool-name <name> [options]
+```
+
+**Arguments:**
+
+| Argument | Description |
+|----------|-------------|
+| `message` | The question or instruction shown to the user |
+
+**Options:**
+
+| Option | Short | Required | Description |
+|--------|-------|----------|-------------|
+| `--mode` | | Yes | `FORM` (render a JSON Schema form) or `URL` (redirect to an external page) |
+| `--tool-name` | `-t` | Yes | Short tool/intent label |
+| `--schema` | | FORM | JSON Schema for the form body (required when `--mode FORM`) |
+| `--url` | | URL | External URL (required when `--mode URL`) |
+| `--chat-id` | `-c` | No | Associated chat ID |
+| `--message-id` | `-m` | No | Associated message ID |
+| `--expires-in` | | No | Auto-expire after N seconds |
+| `--external-id` | | No | External identifier for de-duplication / tracking |
+| `--metadata` | | No | `key=value` metadata (repeatable) |
+
+**Examples:**
+
+```bash
+# Fire-and-forget FORM elicitation
+unique-cli elicit create "Please rate the last answer" \
+  --mode FORM --tool-name feedback \
+  --schema '{"type":"object","properties":{"rating":{"type":"integer","minimum":1,"maximum":5}},"required":["rating"]}'
+
+# URL elicitation -- the user is redirected to an external survey
+unique-cli elicit create "Complete the onboarding survey" \
+  --mode URL --tool-name onboarding \
+  --url https://example.com/survey?user=123
+```
+
+The command prints the created elicitation (including its `ID:`), which you can then feed into `elicit wait` / `elicit get`.
+
+---
+
+## elicit pending
+
+List all pending (unanswered, unexpired) elicitations for the authenticated user.
+
+**Synopsis:**
+
+```
+elicit pending
+```
+
+**Example:**
+
+```bash
+unique-cli elicit pending
+```
+
+```
+2 pending elicitation(s):
+
+STATUS    MODE  TOOL           MESSAGE                              ID           EXPIRES
+PENDING   FORM  choose_region  Pick a region                        elicit_9a7b  2026-04-16 14:40
+PENDING   URL   onboarding     Complete the onboarding survey       elicit_42cd  -
+```
+
+---
+
+## elicit get
+
+Show the full details of a single elicitation by ID.
+
+**Synopsis:**
+
+```
+elicit get <elicitation_id>
+```
+
+**Example:**
+
+```bash
+unique-cli elicit get elicit_9a7b
+```
+
+Output is the same key-value block as `elicit ask` (minus the blocking behavior). Use this to inspect an elicitation's current `Status:` and `Response:` at any time.
+
+---
+
+## elicit wait
+
+Poll an existing elicitation until it reaches a terminal state or the local timeout elapses.
+
+**Synopsis:**
+
+```
+elicit wait <elicitation_id> [--timeout <seconds>] [--poll-interval <seconds>]
+```
+
+**Options:**
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--timeout` | `300` | Max seconds to wait for a terminal state |
+| `--poll-interval` | `2.0` | Seconds between polls |
+
+**Example:**
+
+```bash
+unique-cli elicit wait elicit_9a7b --timeout 120
+```
+
+On timeout, the CLI prints `elicit: timed out after Ns waiting for <id> (last status: PENDING)` followed by the last observed snapshot. The elicitation remains live on the platform -- call `elicit wait` again to resume.
+
+---
+
+## elicit respond
+
+Respond to an elicitation. The user normally does this via the Unique UI; the CLI path is mostly for scripting, integration tests, and declining / cancelling on behalf of the user.
+
+**Synopsis:**
+
+```
+elicit respond <elicitation_id> --action ACCEPT|DECLINE|CANCEL [--content <json>]
+```
+
+**Options:**
+
+| Option | Required | Description |
+|--------|----------|-------------|
+| `--action` | Yes | Response action: `ACCEPT`, `DECLINE`, or `CANCEL` |
+| `--content` | for `ACCEPT` | JSON object matching the elicitation's schema |
+
+**Examples:**
+
+```bash
+# Accept with content (simulate a user answer in a test)
+unique-cli elicit respond elicit_9a7b --action ACCEPT \
+  --content '{"region":"EU"}'
+
+# Decline or cancel
+unique-cli elicit respond elicit_9a7b --action DECLINE
+unique-cli elicit respond elicit_9a7b --action CANCEL
+```
+
+---
+
+## End-to-End Example
+
+```bash
+# 1. Create the question, fire-and-forget
+ID=$(unique-cli elicit create "Which quarter?" \
+       --mode FORM --tool-name choose_quarter \
+       --schema '{"type":"object","properties":{"q":{"type":"string","enum":["Q1","Q2"]}},"required":["q"]}' \
+     | awk '/^ID:/{print $2}')
+
+# 2. Block until answered (could be a different terminal or process)
+unique-cli elicit wait "$ID" --timeout 300
+```
+
+For the common case of "ask and immediately use the answer", `elicit ask` collapses steps 1 and 2 into a single command.
+
+---
+
+## Schema Guidance
+
+- Always set `"required"` on fields that must be present -- this prevents empty submissions.
+- Use `"enum"` for finite choices so the UI renders a selector instead of a free-text box.
+- Use `"type": "boolean"` for yes/no confirmations -- treat `true` as "go ahead" and anything else (including `DECLINED` / `CANCELLED` / `EXPIRED` statuses) as "stop".
+- Add short `"description"` strings -- they appear as helper text next to each field.
+- Keep schemas small. Several sequential `elicit ask` calls are usually clearer than one giant form.
+
+## Handling Non-Response Outcomes
+
+After `elicit ask` / `elicit wait` returns, always branch on the `Status:` value:
+
+| Status | Typical action |
+|--------|----------------|
+| `RESPONDED` / `COMPLETED` | Parse `Response:` JSON and proceed with the task. |
+| `DECLINED` | Stop. Acknowledge to the user that you stopped and ask what to do next. |
+| `CANCELLED` | Stop. The user (or system) aborted the flow. |
+| `EXPIRED` | The request timed out platform-side. Decide whether to re-ask. |
+| `elicit: timed out ...` (CLI only) | Local wait exceeded `--timeout`. The request is still live on the platform -- poll again with `elicit wait <id>` later. |
+
+## Related
+
+- [Elicitation API Reference](../api_resources/elicitation.md) -- Python SDK methods, return types, and async variants
+- [Command Reference](commands.md) -- All CLI commands
+- [Scheduled Tasks](scheduled_tasks.md) -- Another long-running platform workflow managed via the CLI

--- a/unique_sdk/docs/cli/elicitation.md
+++ b/unique_sdk/docs/cli/elicitation.md
@@ -56,6 +56,22 @@ elicit ask <message> [options]
 | `--timeout` | | `300` | Max seconds to block locally while polling. |
 | `--poll-interval` | | `2.0` | Seconds between polls. |
 | `--metadata` | | none | `key=value` metadata (repeatable). |
+| `--visible` / `--no-visible` | | `--visible` | Wrap the elicitation in a synthetic "thinking" timeline so the chat UI renders it (UN-19815 workaround). |
+| `--assistant-id` | | `$UNIQUE_ASSISTANT_ID`, else latest assistant in chat | Assistant id for the visibility placeholder. |
+| `--placeholder-text` | | `Waiting for your answer…` | Text on the placeholder thinking step. |
+| `--cleanup` | | `collapse` | How to tear down the placeholder afterwards (`collapse` \| `delete`). |
+
+!!! note "UN-19815 visibility workaround"
+    As of April 2026, the chat UI only renders an elicitation when its host
+    assistant message is actively in the *thinking timeline* display mode.
+    Elicitations emitted against a chat without a live streaming turn are
+    stored correctly by the backend but are silently invisible in the UI.
+    When you pass `--chat-id`, the CLI now (by default) materialises a
+    short-lived placeholder assistant message and running step so the UI
+    has somewhere to render the card; the placeholder is collapsed or
+    deleted automatically when the user responds. Pass `--no-visible` to
+    opt out once the permanent UI fix (ticket UN-19815) has landed in your
+    environment.
 
 **Default schema (when `--schema` is omitted):**
 

--- a/unique_sdk/docs/cli/index.md
+++ b/unique_sdk/docs/cli/index.md
@@ -124,7 +124,9 @@ python -m unique_sdk.cli
 | `rm` | Delete a file | `rm report.pdf` |
 | `mv` | Rename a file | `mv old.pdf new.pdf` |
 | `search` | Combined search | `search "query" --folder /Reports` |
+| `mcp` | Call an MCP server tool by name | `mcp -c chat_1 -m msg_1 '{"name":"tool","arguments":{}}'` |
 | `schedule` | Manage scheduled tasks | `schedule list`, `schedule create ...` |
+| `elicit` | Ask the user a question and read the answer | `elicit ask "Which quarter?"` |
 | `help` | Show available commands | `help`, `help search` |
 | `exit` | Exit the shell | `exit` |
 
@@ -145,5 +147,6 @@ Files can be referenced by:
 
 - [Command Reference](commands.md) -- detailed documentation for every command
 - [Scheduled Tasks](scheduled_tasks.md) -- create and manage recurring cron-based tasks
+- [Elicitation](elicitation.md) -- ask the user structured questions and read typed answers
 - [Search Guide](search.md) -- how to use combined search with metadata filters
 - [Configuration](configuration.md) -- environment variables and setup details

--- a/unique_sdk/mkdocs.yaml
+++ b/unique_sdk/mkdocs.yaml
@@ -98,6 +98,7 @@ nav:
     - Overview: cli/index.md
     - Command Reference: cli/commands.md
     - Scheduled Tasks: cli/scheduled_tasks.md
+    - Elicitation: cli/elicitation.md
     - Search Guide: cli/search.md
     - Configuration: cli/configuration.md
 

--- a/unique_sdk/pyproject.toml
+++ b/unique_sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "unique_sdk"
-version = "0.11.5"
+version = "0.11.7"
 description = ""
 readme = "README.md"
 license = { text = "MIT" }

--- a/unique_sdk/pyproject.toml
+++ b/unique_sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "unique_sdk"
-version = "0.11.4"
+version = "0.11.5"
 description = ""
 readme = "README.md"
 license = { text = "MIT" }

--- a/unique_sdk/tests/cli/test_elicitation.py
+++ b/unique_sdk/tests/cli/test_elicitation.py
@@ -16,9 +16,15 @@ import pytest
 
 import unique_sdk
 from unique_sdk.cli.commands.elicitation import (
+    META_CLEANUP_MODE,
+    META_PLACEHOLDER_CHAT_ID,
+    META_PLACEHOLDER_MESSAGE_ID,
+    META_PLACEHOLDER_STEP_ID,
     _build_create_params,
+    _extract_visibility_context,
     _parse_json_arg,
     _parse_metadata_pairs,
+    _resolve_assistant_id,
     cmd_elicit_ask,
     cmd_elicit_create,
     cmd_elicit_get,
@@ -245,6 +251,30 @@ class TestElicitPending:
         assert "elicit_abc" in out
 
     @patch("unique_sdk.Elicitation.get_pending_elicitations")
+    def test_accepts_plain_list_response(self, mock: MagicMock) -> None:
+        """Regression: backend returns a raw array, not wrapped in dict."""
+        mock.return_value = [_elicitation(eid="e1"), _elicitation(eid="e2")]
+        out = cmd_elicit_pending(_state())
+        assert "2 pending elicitation" in out
+        assert "e1" in out and "e2" in out
+
+    @patch("unique_sdk.Elicitation.get_pending_elicitations")
+    def test_accepts_empty_list_response(self, mock: MagicMock) -> None:
+        mock.return_value = []
+        assert "No pending" in cmd_elicit_pending(_state())
+
+    @patch("unique_sdk.Elicitation.get_pending_elicitations")
+    def test_accepts_wrapped_object_response(self, mock: MagicMock) -> None:
+        mock.return_value = {"elicitations": [_elicitation()]}
+        out = cmd_elicit_pending(_state())
+        assert "1 pending elicitation" in out
+
+    @patch("unique_sdk.Elicitation.get_pending_elicitations")
+    def test_handles_unexpected_response_type(self, mock: MagicMock) -> None:
+        mock.return_value = None
+        assert "No pending" in cmd_elicit_pending(_state())
+
+    @patch("unique_sdk.Elicitation.get_pending_elicitations")
     def test_error(self, mock: MagicMock) -> None:
         mock.side_effect = unique_sdk.APIError("fail")
         assert "elicit:" in cmd_elicit_pending(_state())
@@ -264,9 +294,11 @@ class TestElicitGet:
 
 
 class TestElicitRespond:
+    @patch("unique_sdk.Elicitation.get_elicitation")
     @patch("unique_sdk.Elicitation.respond_to_elicitation")
-    def test_accept(self, mock: MagicMock) -> None:
+    def test_accept(self, mock: MagicMock, mock_get: MagicMock) -> None:
         mock.return_value = {"success": True}
+        mock_get.return_value = _elicitation()
         result = cmd_elicit_respond(
             _state(),
             "elicit_abc",
@@ -276,17 +308,31 @@ class TestElicitRespond:
         assert "OK" in result
         assert mock.call_args[1]["content"] == {"answer": "yes"}
 
+    @patch("unique_sdk.Elicitation.get_elicitation")
     @patch("unique_sdk.Elicitation.respond_to_elicitation")
-    def test_decline(self, mock: MagicMock) -> None:
+    def test_decline(self, mock: MagicMock, mock_get: MagicMock) -> None:
         mock.return_value = {"success": True}
+        mock_get.return_value = _elicitation()
         result = cmd_elicit_respond(_state(), "elicit_abc", action="decline")
         assert "OK" in result
         assert mock.call_args[1]["action"] == "DECLINE"
         assert "content" not in mock.call_args[1]
 
+    @patch("unique_sdk.Elicitation.get_elicitation")
+    @patch("unique_sdk.Elicitation.respond_to_elicitation")
+    def test_reject(self, mock: MagicMock, mock_get: MagicMock) -> None:
+        """Regression: ``REJECT`` is a valid action accepted by the backend."""
+        mock.return_value = {"success": True}
+        mock_get.return_value = _elicitation()
+        result = cmd_elicit_respond(_state(), "elicit_abc", action="reject")
+        assert "OK" in result
+        assert mock.call_args[1]["action"] == "REJECT"
+        assert "content" not in mock.call_args[1]
+
     def test_invalid_action(self) -> None:
         result = cmd_elicit_respond(_state(), "x", action="FROB")
         assert "invalid action" in result
+        assert "REJECT" in result
 
     def test_accept_requires_content(self) -> None:
         result = cmd_elicit_respond(_state(), "x", action="ACCEPT")
@@ -312,6 +358,32 @@ class TestElicitWait:
         result = cmd_elicit_wait(_state(), "elicit_abc", timeout=5)
         assert "RESPONDED" in result
         assert '"answer"' in result
+
+    @patch("unique_sdk.cli.commands.elicitation.time.sleep")
+    @patch("unique_sdk.Elicitation.get_elicitation")
+    def test_terminates_on_accepted_status(
+        self, mock_get: MagicMock, mock_sleep: MagicMock
+    ) -> None:
+        """Regression: platform persists ``ACCEPTED`` when a user confirms a FORM."""
+        mock_get.return_value = _elicitation(
+            status="ACCEPTED", response_content={"answer": "yes"}
+        )
+        result = cmd_elicit_wait(_state(), "elicit_abc", timeout=30)
+        assert "ACCEPTED" in result
+        assert "timed out" not in result
+        assert mock_sleep.call_count == 0
+
+    @patch("unique_sdk.cli.commands.elicitation.time.sleep")
+    @patch("unique_sdk.Elicitation.get_elicitation")
+    def test_terminates_on_rejected_status(
+        self, mock_get: MagicMock, mock_sleep: MagicMock
+    ) -> None:
+        """Regression: platform persists ``REJECTED`` when a user rejects a FORM."""
+        mock_get.return_value = _elicitation(status="REJECTED")
+        result = cmd_elicit_wait(_state(), "elicit_abc", timeout=30)
+        assert "REJECTED" in result
+        assert "timed out" not in result
+        assert mock_sleep.call_count == 0
 
     @patch("unique_sdk.cli.commands.elicitation.time.sleep")
     @patch("unique_sdk.Elicitation.get_elicitation")
@@ -393,6 +465,544 @@ class TestElicitAsk:
         mock_create.side_effect = unique_sdk.APIError("fail")
         result = cmd_elicit_ask(_state(), message="x")
         assert "elicit:" in result
+
+
+# --- Visibility workaround (UN-19815) -----------------------------------
+
+
+def _placeholder_message(
+    eid: str = "msg_placeholder", assistant_id: str = "assistant_1"
+) -> dict[str, Any]:
+    return {
+        "id": eid,
+        "role": "ASSISTANT",
+        "assistantId": assistant_id,
+        "text": None,
+        "completedAt": None,
+        "chatId": "chat_1",
+    }
+
+
+def _step(sid: str = "step_placeholder") -> dict[str, Any]:
+    return {"id": sid, "status": "RUNNING", "text": "Waiting…", "order": 0}
+
+
+def _visible_elicitation(
+    *,
+    eid: str = "elicit_abc",
+    status: str = "PENDING",
+    response_content: Any = None,
+    chat_id: str = "chat_1",
+    placeholder_message_id: str = "msg_placeholder",
+    placeholder_step_id: str = "step_placeholder",
+    cleanup_mode: str = "collapse",
+    extra_metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    metadata: dict[str, Any] = {
+        "messageLogId": placeholder_step_id,
+        META_PLACEHOLDER_MESSAGE_ID: placeholder_message_id,
+        META_PLACEHOLDER_STEP_ID: placeholder_step_id,
+        META_PLACEHOLDER_CHAT_ID: chat_id,
+        META_CLEANUP_MODE: cleanup_mode,
+    }
+    if extra_metadata:
+        metadata.update(extra_metadata)
+    return _elicitation(
+        eid=eid,
+        status=status,
+        response_content=response_content,
+        metadata=metadata,
+    )
+
+
+class TestResolveAssistantId:
+    def test_env_var_wins(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("UNIQUE_ASSISTANT_ID", "from_env")
+        # no Message.list call should be needed
+        assert _resolve_assistant_id(_state(), "chat_1") == "from_env"
+
+    @patch("unique_sdk.Message.list")
+    def test_picks_latest_assistant_message(
+        self,
+        mock_list: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("UNIQUE_ASSISTANT_ID", raising=False)
+        mock_list.return_value = [
+            {"role": "USER", "assistantId": "should_ignore"},
+            {"role": "ASSISTANT", "assistantId": "older"},
+            {"role": "ASSISTANT", "assistantId": "newest"},
+        ]
+        assert _resolve_assistant_id(_state(), "chat_1") == "newest"
+
+    @patch("unique_sdk.Message.list")
+    def test_none_when_no_assistant(
+        self,
+        mock_list: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("UNIQUE_ASSISTANT_ID", raising=False)
+        mock_list.return_value = [{"role": "USER", "assistantId": "x"}]
+        assert _resolve_assistant_id(_state(), "chat_1") is None
+
+    @patch("unique_sdk.Message.list")
+    def test_none_when_list_raises(
+        self,
+        mock_list: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("UNIQUE_ASSISTANT_ID", raising=False)
+        mock_list.side_effect = unique_sdk.APIError("boom")
+        assert _resolve_assistant_id(_state(), "chat_1") is None
+
+    @patch("unique_sdk.Message.list")
+    def test_falls_back_to_debug_info_assistant_id(
+        self,
+        mock_list: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Public REST omits ``assistantId`` at the top level and nests it
+        under ``debugInfo.assistant.id``; the resolver must look there too,
+        otherwise the visibility workaround cannot auto-resolve the
+        assistant for chats fetched via the gateway.
+        """
+        monkeypatch.delenv("UNIQUE_ASSISTANT_ID", raising=False)
+        mock_list.return_value = [
+            {"role": "USER"},
+            {
+                "role": "ASSISTANT",
+                "debugInfo": {
+                    "assistant": {"id": "assistant_from_debug_info", "name": "X"},
+                },
+            },
+        ]
+        assert (
+            _resolve_assistant_id(_state(), "chat_1") == "assistant_from_debug_info"
+        )
+
+    @patch("unique_sdk.Message.list")
+    def test_falls_back_to_debug_info_on_user_message(
+        self,
+        mock_list: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Observed on the QA public gateway: ASSISTANT messages have
+        ``debugInfo.assistant == None`` while USER messages carry the
+        populated ``debugInfo.assistant.id``. Since the chat is bound to a
+        single assistant regardless of message role, the resolver must be
+        willing to read that field from any message.
+        """
+        monkeypatch.delenv("UNIQUE_ASSISTANT_ID", raising=False)
+        mock_list.return_value = [
+            {
+                "role": "USER",
+                "debugInfo": {"assistant": {"id": "assistant_from_user_msg"}},
+            },
+            {"role": "ASSISTANT", "debugInfo": {"assistant": None}},
+        ]
+        assert (
+            _resolve_assistant_id(_state(), "chat_1") == "assistant_from_user_msg"
+        )
+
+
+class TestExtractVisibilityContext:
+    def test_no_metadata(self) -> None:
+        assert _extract_visibility_context({"status": "PENDING"}) is None
+
+    def test_missing_markers(self) -> None:
+        assert _extract_visibility_context({"metadata": {"messageLogId": "x"}}) is None
+
+    def test_with_markers_defaults_collapse(self) -> None:
+        ctx = _extract_visibility_context(_visible_elicitation())
+        assert ctx == ("chat_1", "msg_placeholder", "step_placeholder", "collapse")
+
+    def test_with_markers_delete_mode(self) -> None:
+        ctx = _extract_visibility_context(_visible_elicitation(cleanup_mode="delete"))
+        assert ctx is not None
+        assert ctx[3] == "delete"
+
+    def test_unknown_cleanup_mode_defaults_to_collapse(self) -> None:
+        ctx = _extract_visibility_context(_visible_elicitation(cleanup_mode="garbage"))
+        assert ctx is not None
+        assert ctx[3] == "collapse"
+
+
+@patch("unique_sdk.Message.delete")
+@patch("unique_sdk.Message.modify")
+@patch("unique_sdk.Message.create")
+@patch("unique_sdk.MessageLog.update")
+@patch("unique_sdk.MessageLog.create")
+@patch("unique_sdk.Elicitation.get_elicitation")
+@patch("unique_sdk.Elicitation.create_elicitation")
+class TestVisibleAsk:
+    """``cmd_elicit_ask`` with the UN-19815 visibility workaround."""
+
+    def test_visible_default_creates_placeholder_and_collapses(
+        self,
+        mock_create_elicit: MagicMock,
+        mock_get_elicit: MagicMock,
+        mock_log_create: MagicMock,
+        mock_log_update: MagicMock,
+        mock_msg_create: MagicMock,
+        mock_msg_modify: MagicMock,
+        mock_msg_delete: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("UNIQUE_ASSISTANT_ID", "assistant_1")
+        mock_msg_create.return_value = _placeholder_message()
+        mock_log_create.return_value = _step()
+        mock_create_elicit.return_value = _visible_elicitation()
+        mock_get_elicit.return_value = _visible_elicitation(
+            status="ACCEPTED", response_content={"answer": "yes"}
+        )
+
+        result = cmd_elicit_ask(_state(), message="What?", chat_id="chat_1", timeout=5)
+
+        assert "ACCEPTED" in result
+        # Placeholder created with empty text and no completedAt
+        placeholder_kwargs = mock_msg_create.call_args[1]
+        assert placeholder_kwargs["role"] == "ASSISTANT"
+        assert placeholder_kwargs["text"] is None
+        assert placeholder_kwargs["completedAt"] is None
+        assert placeholder_kwargs["assistantId"] == "assistant_1"
+        # Step created in RUNNING state
+        step_kwargs = mock_log_create.call_args[1]
+        assert step_kwargs["messageId"] == "msg_placeholder"
+        assert step_kwargs["status"] == "RUNNING"
+        # Elicitation carries messageId + metadata.messageLogId + markers
+        elicit_kwargs = mock_create_elicit.call_args[1]
+        assert elicit_kwargs["messageId"] == "msg_placeholder"
+        meta = elicit_kwargs["metadata"]
+        assert meta["messageLogId"] == "step_placeholder"
+        assert meta[META_PLACEHOLDER_MESSAGE_ID] == "msg_placeholder"
+        assert meta[META_PLACEHOLDER_STEP_ID] == "step_placeholder"
+        assert meta[META_PLACEHOLDER_CHAT_ID] == "chat_1"
+        assert meta[META_CLEANUP_MODE] == "collapse"
+        # Cleanup: step completed, message modified (collapse), not deleted
+        assert mock_log_update.call_count == 1
+        log_update_kwargs = mock_log_update.call_args[1]
+        assert log_update_kwargs["status"] == "COMPLETED"
+        assert mock_msg_modify.call_count == 1
+        msg_modify_kwargs = mock_msg_modify.call_args[1]
+        assert msg_modify_kwargs["id"] == "msg_placeholder"
+        assert msg_modify_kwargs["chatId"] == "chat_1"
+        assert msg_modify_kwargs["completedAt"] is not None
+        assert mock_msg_delete.call_count == 0
+
+    def test_no_visible_skips_workaround(
+        self,
+        mock_create_elicit: MagicMock,
+        mock_get_elicit: MagicMock,
+        mock_log_create: MagicMock,
+        mock_log_update: MagicMock,
+        mock_msg_create: MagicMock,
+        mock_msg_modify: MagicMock,
+        mock_msg_delete: MagicMock,
+    ) -> None:
+        mock_create_elicit.return_value = _elicitation()
+        mock_get_elicit.return_value = _elicitation(
+            status="RESPONDED", response_content={"answer": "yes"}
+        )
+
+        result = cmd_elicit_ask(
+            _state(),
+            message="What?",
+            chat_id="chat_1",
+            timeout=5,
+            visible=False,
+        )
+
+        assert "RESPONDED" in result
+        assert mock_msg_create.call_count == 0
+        assert mock_log_create.call_count == 0
+        assert mock_msg_modify.call_count == 0
+        assert mock_msg_delete.call_count == 0
+        # Elicitation should not carry visibility markers
+        elicit_kwargs = mock_create_elicit.call_args[1]
+        assert "messageId" not in elicit_kwargs
+        assert elicit_kwargs.get("metadata") is None
+
+    def test_without_chat_id_skips_workaround(
+        self,
+        mock_create_elicit: MagicMock,
+        mock_get_elicit: MagicMock,
+        mock_log_create: MagicMock,
+        mock_log_update: MagicMock,
+        mock_msg_create: MagicMock,
+        mock_msg_modify: MagicMock,
+        mock_msg_delete: MagicMock,
+    ) -> None:
+        mock_create_elicit.return_value = _elicitation()
+        mock_get_elicit.return_value = _elicitation(
+            status="RESPONDED", response_content={"answer": "yes"}
+        )
+
+        result = cmd_elicit_ask(_state(), message="What?", timeout=5)
+
+        assert "RESPONDED" in result
+        assert mock_msg_create.call_count == 0
+
+    def test_explicit_message_id_skips_workaround(
+        self,
+        mock_create_elicit: MagicMock,
+        mock_get_elicit: MagicMock,
+        mock_log_create: MagicMock,
+        mock_log_update: MagicMock,
+        mock_msg_create: MagicMock,
+        mock_msg_modify: MagicMock,
+        mock_msg_delete: MagicMock,
+    ) -> None:
+        """When caller already supplies --message-id we trust them."""
+        mock_create_elicit.return_value = _elicitation()
+        mock_get_elicit.return_value = _elicitation(
+            status="RESPONDED", response_content={"answer": "yes"}
+        )
+
+        cmd_elicit_ask(
+            _state(),
+            message="What?",
+            chat_id="chat_1",
+            message_id="existing_msg",
+            timeout=5,
+        )
+
+        assert mock_msg_create.call_count == 0
+        elicit_kwargs = mock_create_elicit.call_args[1]
+        assert elicit_kwargs["messageId"] == "existing_msg"
+
+    def test_no_assistant_id_returns_error(
+        self,
+        mock_create_elicit: MagicMock,
+        mock_get_elicit: MagicMock,
+        mock_log_create: MagicMock,
+        mock_log_update: MagicMock,
+        mock_msg_create: MagicMock,
+        mock_msg_modify: MagicMock,
+        mock_msg_delete: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("UNIQUE_ASSISTANT_ID", raising=False)
+        with patch("unique_sdk.Message.list", return_value=[]):
+            result = cmd_elicit_ask(
+                _state(), message="What?", chat_id="chat_1", timeout=5
+            )
+        assert "cannot ask a visible question without an assistant id" in result
+        assert mock_msg_create.call_count == 0
+        assert mock_create_elicit.call_count == 0
+
+    def test_cleanup_mode_delete(
+        self,
+        mock_create_elicit: MagicMock,
+        mock_get_elicit: MagicMock,
+        mock_log_create: MagicMock,
+        mock_log_update: MagicMock,
+        mock_msg_create: MagicMock,
+        mock_msg_modify: MagicMock,
+        mock_msg_delete: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("UNIQUE_ASSISTANT_ID", "assistant_1")
+        mock_msg_create.return_value = _placeholder_message()
+        mock_log_create.return_value = _step()
+        mock_create_elicit.return_value = _visible_elicitation(cleanup_mode="delete")
+        mock_get_elicit.return_value = _visible_elicitation(
+            status="ACCEPTED", cleanup_mode="delete"
+        )
+
+        cmd_elicit_ask(
+            _state(),
+            message="Delete me",
+            chat_id="chat_1",
+            cleanup_mode="delete",
+            timeout=5,
+        )
+
+        assert mock_msg_delete.call_count == 1
+        assert mock_msg_delete.call_args[1]["chatId"] == "chat_1"
+        assert mock_msg_modify.call_count == 0
+
+    def test_cleanup_on_elicitation_create_failure(
+        self,
+        mock_create_elicit: MagicMock,
+        mock_get_elicit: MagicMock,
+        mock_log_create: MagicMock,
+        mock_log_update: MagicMock,
+        mock_msg_create: MagicMock,
+        mock_msg_modify: MagicMock,
+        mock_msg_delete: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("UNIQUE_ASSISTANT_ID", "assistant_1")
+        mock_msg_create.return_value = _placeholder_message()
+        mock_log_create.return_value = _step()
+        mock_create_elicit.side_effect = unique_sdk.APIError("boom")
+
+        result = cmd_elicit_ask(_state(), message="What?", chat_id="chat_1", timeout=5)
+
+        assert "elicit:" in result
+        # Placeholder was torn down even though elicit creation failed
+        assert mock_log_update.call_count == 1
+        assert mock_msg_modify.call_count == 1
+
+    def test_cleanup_on_wait_timeout(
+        self,
+        mock_create_elicit: MagicMock,
+        mock_get_elicit: MagicMock,
+        mock_log_create: MagicMock,
+        mock_log_update: MagicMock,
+        mock_msg_create: MagicMock,
+        mock_msg_modify: MagicMock,
+        mock_msg_delete: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("UNIQUE_ASSISTANT_ID", "assistant_1")
+        mock_msg_create.return_value = _placeholder_message()
+        mock_log_create.return_value = _step()
+        mock_create_elicit.return_value = _visible_elicitation()
+        mock_get_elicit.return_value = _visible_elicitation(status="PENDING")
+
+        with (
+            patch(
+                "unique_sdk.cli.commands.elicitation.time.monotonic",
+                side_effect=[0.0, 100.0, 200.0],
+            ),
+            patch("unique_sdk.cli.commands.elicitation.time.sleep"),
+        ):
+            result = cmd_elicit_ask(
+                _state(), message="What?", chat_id="chat_1", timeout=10
+            )
+
+        assert "timed out" in result
+        assert mock_msg_modify.call_count == 1
+
+
+class TestVisibleCreate:
+    @patch("unique_sdk.MessageLog.create")
+    @patch("unique_sdk.Message.create")
+    @patch("unique_sdk.Elicitation.create_elicitation")
+    def test_embeds_markers_and_prints_note(
+        self,
+        mock_elicit_create: MagicMock,
+        mock_msg_create: MagicMock,
+        mock_log_create: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("UNIQUE_ASSISTANT_ID", "assistant_1")
+        mock_msg_create.return_value = _placeholder_message()
+        mock_log_create.return_value = _step()
+        mock_elicit_create.return_value = _visible_elicitation()
+
+        result = cmd_elicit_create(
+            _state(),
+            mode="FORM",
+            message="Pick",
+            tool_name="pick",
+            schema='{"type":"object"}',
+            chat_id="chat_1",
+        )
+
+        assert "Created elicitation elicit_abc" in result
+        assert "placeholder assistant message was created" in result
+        kwargs = mock_elicit_create.call_args[1]
+        assert kwargs["messageId"] == "msg_placeholder"
+        assert kwargs["metadata"][META_PLACEHOLDER_MESSAGE_ID] == "msg_placeholder"
+
+
+class TestVisibleWaitCleanup:
+    @patch("unique_sdk.Message.modify")
+    @patch("unique_sdk.MessageLog.update")
+    @patch("unique_sdk.Elicitation.get_elicitation")
+    def test_wait_cleans_up_on_terminal(
+        self,
+        mock_get: MagicMock,
+        mock_log_update: MagicMock,
+        mock_msg_modify: MagicMock,
+    ) -> None:
+        mock_get.return_value = _visible_elicitation(
+            status="REJECTED",
+        )
+        result = cmd_elicit_wait(_state(), "elicit_abc", timeout=5)
+        assert "REJECTED" in result
+        assert mock_log_update.call_count == 1
+        assert mock_msg_modify.call_count == 1
+        # Uses the "other" (non-accepted) collapse text
+        assert mock_msg_modify.call_args[1]["text"] == "Clarifying question closed."
+
+    @patch("unique_sdk.Message.modify")
+    @patch("unique_sdk.MessageLog.update")
+    @patch("unique_sdk.Elicitation.get_elicitation")
+    def test_wait_cleanup_silent_on_failure(
+        self,
+        mock_get: MagicMock,
+        mock_log_update: MagicMock,
+        mock_msg_modify: MagicMock,
+    ) -> None:
+        """Cleanup errors must not mask the successful response."""
+        mock_get.return_value = _visible_elicitation(status="ACCEPTED")
+        mock_log_update.side_effect = unique_sdk.APIError("log boom")
+        mock_msg_modify.side_effect = unique_sdk.APIError("modify boom")
+
+        result = cmd_elicit_wait(_state(), "elicit_abc", timeout=5)
+        assert "ACCEPTED" in result
+
+
+class TestVisibleRespondCleanup:
+    @patch("unique_sdk.Message.modify")
+    @patch("unique_sdk.MessageLog.update")
+    @patch("unique_sdk.Elicitation.get_elicitation")
+    @patch("unique_sdk.Elicitation.respond_to_elicitation")
+    def test_respond_tears_down_placeholder(
+        self,
+        mock_respond: MagicMock,
+        mock_get: MagicMock,
+        mock_log_update: MagicMock,
+        mock_msg_modify: MagicMock,
+    ) -> None:
+        mock_respond.return_value = {"success": True}
+        mock_get.return_value = _visible_elicitation(status="ACCEPTED")
+
+        result = cmd_elicit_respond(
+            _state(),
+            "elicit_abc",
+            action="ACCEPT",
+            content='{"answer": "yes"}',
+        )
+
+        assert "OK" in result
+        assert mock_log_update.call_count == 1
+        assert mock_msg_modify.call_count == 1
+        modify_kwargs = mock_msg_modify.call_args[1]
+        assert modify_kwargs["text"] == "Clarifying question answered."
+        # Regression: `completedAt` must be an ISO-8601 string, not a raw
+        # datetime — the wire serializer (``json.dumps``) can't encode
+        # datetime and the backend rejected such bodies silently, leaving
+        # the placeholder visually "running" in the chat UI.
+        completed_at = modify_kwargs["completedAt"]
+        assert isinstance(completed_at, str)
+        assert completed_at.endswith("Z")
+
+    @patch("unique_sdk.Message.modify")
+    @patch("unique_sdk.MessageLog.update")
+    @patch("unique_sdk.Elicitation.get_elicitation")
+    @patch("unique_sdk.Elicitation.respond_to_elicitation")
+    def test_respond_no_cleanup_when_no_markers(
+        self,
+        mock_respond: MagicMock,
+        mock_get: MagicMock,
+        mock_log_update: MagicMock,
+        mock_msg_modify: MagicMock,
+    ) -> None:
+        mock_respond.return_value = {"success": True}
+        mock_get.return_value = _elicitation()  # no visibility metadata
+
+        cmd_elicit_respond(
+            _state(),
+            "elicit_abc",
+            action="ACCEPT",
+            content='{"answer": "yes"}',
+        )
+        assert mock_log_update.call_count == 0
+        assert mock_msg_modify.call_count == 0
 
 
 # --- Formatters ---------------------------------------------------------

--- a/unique_sdk/tests/cli/test_elicitation.py
+++ b/unique_sdk/tests/cli/test_elicitation.py
@@ -1,0 +1,597 @@
+"""Tests for the ``elicit`` CLI command group.
+
+Covers :mod:`unique_sdk.cli.commands.elicitation`, the three elicitation
+formatters in :mod:`unique_sdk.cli.formatting`, and the ``elicit`` subcommand
+dispatch in :mod:`unique_sdk.cli.shell`.
+"""
+
+from __future__ import annotations
+
+import json
+from io import StringIO
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import unique_sdk
+from unique_sdk.cli.commands.elicitation import (
+    _build_create_params,
+    _parse_json_arg,
+    _parse_metadata_pairs,
+    cmd_elicit_ask,
+    cmd_elicit_create,
+    cmd_elicit_get,
+    cmd_elicit_pending,
+    cmd_elicit_respond,
+    cmd_elicit_wait,
+)
+from unique_sdk.cli.config import Config
+from unique_sdk.cli.formatting import (
+    format_elicitation,
+    format_elicitation_response,
+    format_pending_elicitations,
+)
+from unique_sdk.cli.shell import UniqueShell
+from unique_sdk.cli.state import ShellState
+
+
+def _config() -> Config:
+    return Config(
+        user_id="u1",
+        company_id="c1",
+        api_key="key",
+        app_id="app",
+        api_base="https://example.com",
+    )
+
+
+def _state() -> ShellState:
+    return ShellState(_config())
+
+
+def _shell() -> UniqueShell:
+    return UniqueShell(_state())
+
+
+def _capture(shell: UniqueShell, command: str) -> str:
+    buf = StringIO()
+    shell._print = lambda text: buf.write(text + "\n")  # type: ignore[assignment]
+    shell.onecmd(command)
+    return buf.getvalue()
+
+
+def _elicitation(
+    *,
+    eid: str = "elicit_abc",
+    status: str = "PENDING",
+    mode: str = "FORM",
+    response_content: Any = None,
+    schema: dict[str, Any] | None = None,
+    metadata: dict[str, Any] | None = None,
+    tool_name: str | None = "agent_question",
+    message: str = "What should I do?",
+) -> dict[str, Any]:
+    return {
+        "id": eid,
+        "status": status,
+        "mode": mode,
+        "source": "AGENT",
+        "toolName": tool_name,
+        "message": message,
+        "schema": schema,
+        "url": None,
+        "chatId": "chat_1",
+        "messageId": None,
+        "externalElicitationId": None,
+        "metadata": metadata,
+        "responseContent": response_content,
+        "respondedAt": "2026-04-16T09:00:00Z" if response_content else None,
+        "expiresAt": "2026-04-16T10:00:00Z",
+        "createdAt": "2026-04-16T08:00:00Z",
+        "updatedAt": "2026-04-16T08:30:00Z",
+    }
+
+
+# --- Helper parsers -----------------------------------------------------
+
+
+class TestParseJsonArg:
+    def test_none_returns_none(self) -> None:
+        assert _parse_json_arg(None, field="--schema") is None
+
+    def test_valid_object(self) -> None:
+        assert _parse_json_arg('{"a": 1}', field="--schema") == {"a": 1}
+
+    def test_invalid_json_raises(self) -> None:
+        with pytest.raises(ValueError, match="Invalid JSON for --schema"):
+            _parse_json_arg("not-json", field="--schema")
+
+    def test_non_object_raises(self) -> None:
+        with pytest.raises(ValueError, match="must be a JSON object"):
+            _parse_json_arg("[1, 2]", field="--schema")
+
+
+class TestParseMetadataPairs:
+    def test_none(self) -> None:
+        assert _parse_metadata_pairs(None) is None
+
+    def test_empty(self) -> None:
+        assert _parse_metadata_pairs([]) is None
+
+    def test_pairs(self) -> None:
+        result = _parse_metadata_pairs([("k1", "v1"), ("k2", "v2")])
+        assert result == {"k1": "v1", "k2": "v2"}
+
+
+class TestBuildCreateParams:
+    def test_minimal(self) -> None:
+        params = _build_create_params(
+            mode="FORM",
+            message="Hi",
+            tool_name="tool",
+            schema=None,
+            url=None,
+            chat_id=None,
+            message_id=None,
+            expires_in_seconds=None,
+            external_elicitation_id=None,
+            metadata=None,
+        )
+        assert params == {"mode": "FORM", "message": "Hi", "toolName": "tool"}
+
+    def test_all_fields(self) -> None:
+        params = _build_create_params(
+            mode="URL",
+            message="Click",
+            tool_name="tool",
+            schema={"type": "object"},
+            url="https://x",
+            chat_id="c1",
+            message_id="m1",
+            expires_in_seconds=60,
+            external_elicitation_id="ext_1",
+            metadata={"foo": "bar"},
+        )
+        assert params["mode"] == "URL"
+        assert params["url"] == "https://x"
+        assert params["chatId"] == "c1"
+        assert params["messageId"] == "m1"
+        assert params["expiresInSeconds"] == 60
+        assert params["externalElicitationId"] == "ext_1"
+        assert params["metadata"] == {"foo": "bar"}
+        assert params["schema"] == {"type": "object"}
+
+
+# --- Commands -----------------------------------------------------------
+
+
+class TestElicitCreate:
+    @patch("unique_sdk.Elicitation.create_elicitation")
+    def test_form_success(self, mock: MagicMock) -> None:
+        mock.return_value = _elicitation()
+        result = cmd_elicit_create(
+            _state(),
+            mode="form",
+            message="Confirm?",
+            tool_name="confirm",
+            schema='{"type": "object"}',
+        )
+        assert "Created elicitation elicit_abc" in result
+        call_kwargs = mock.call_args[1]
+        assert call_kwargs["mode"] == "FORM"
+        assert call_kwargs["schema"] == {"type": "object"}
+
+    @patch("unique_sdk.Elicitation.create_elicitation")
+    def test_url_success(self, mock: MagicMock) -> None:
+        mock.return_value = _elicitation(mode="URL")
+        result = cmd_elicit_create(
+            _state(),
+            mode="URL",
+            message="Open",
+            tool_name="open",
+            url="https://example.com",
+            metadata=[("k", "v")],
+        )
+        assert "Created elicitation" in result
+        assert mock.call_args[1]["metadata"] == {"k": "v"}
+
+    def test_invalid_mode(self) -> None:
+        result = cmd_elicit_create(_state(), mode="BOGUS", message="x", tool_name="t")
+        assert "invalid mode" in result
+
+    def test_form_requires_schema(self) -> None:
+        result = cmd_elicit_create(_state(), mode="FORM", message="x", tool_name="t")
+        assert "--schema is required" in result
+
+    def test_url_requires_url(self) -> None:
+        result = cmd_elicit_create(_state(), mode="URL", message="x", tool_name="t")
+        assert "--url is required" in result
+
+    def test_invalid_schema_json(self) -> None:
+        result = cmd_elicit_create(
+            _state(),
+            mode="FORM",
+            message="x",
+            tool_name="t",
+            schema="not-json",
+        )
+        assert "Invalid JSON" in result
+
+    @patch("unique_sdk.Elicitation.create_elicitation")
+    def test_api_error(self, mock: MagicMock) -> None:
+        mock.side_effect = unique_sdk.APIError("boom")
+        result = cmd_elicit_create(
+            _state(),
+            mode="FORM",
+            message="x",
+            tool_name="t",
+            schema='{"type":"object"}',
+        )
+        assert "elicit:" in result
+
+
+class TestElicitPending:
+    @patch("unique_sdk.Elicitation.get_pending_elicitations")
+    def test_empty(self, mock: MagicMock) -> None:
+        mock.return_value = {"elicitations": []}
+        assert "No pending" in cmd_elicit_pending(_state())
+
+    @patch("unique_sdk.Elicitation.get_pending_elicitations")
+    def test_with_items(self, mock: MagicMock) -> None:
+        mock.return_value = {"elicitations": [_elicitation()]}
+        out = cmd_elicit_pending(_state())
+        assert "1 pending elicitation" in out
+        assert "elicit_abc" in out
+
+    @patch("unique_sdk.Elicitation.get_pending_elicitations")
+    def test_error(self, mock: MagicMock) -> None:
+        mock.side_effect = unique_sdk.APIError("fail")
+        assert "elicit:" in cmd_elicit_pending(_state())
+
+
+class TestElicitGet:
+    @patch("unique_sdk.Elicitation.get_elicitation")
+    def test_ok(self, mock: MagicMock) -> None:
+        mock.return_value = _elicitation()
+        out = cmd_elicit_get(_state(), "elicit_abc")
+        assert "elicit_abc" in out
+
+    @patch("unique_sdk.Elicitation.get_elicitation")
+    def test_error(self, mock: MagicMock) -> None:
+        mock.side_effect = unique_sdk.APIError("nope")
+        assert "elicit:" in cmd_elicit_get(_state(), "x")
+
+
+class TestElicitRespond:
+    @patch("unique_sdk.Elicitation.respond_to_elicitation")
+    def test_accept(self, mock: MagicMock) -> None:
+        mock.return_value = {"success": True}
+        result = cmd_elicit_respond(
+            _state(),
+            "elicit_abc",
+            action="ACCEPT",
+            content='{"answer": "yes"}',
+        )
+        assert "OK" in result
+        assert mock.call_args[1]["content"] == {"answer": "yes"}
+
+    @patch("unique_sdk.Elicitation.respond_to_elicitation")
+    def test_decline(self, mock: MagicMock) -> None:
+        mock.return_value = {"success": True}
+        result = cmd_elicit_respond(_state(), "elicit_abc", action="decline")
+        assert "OK" in result
+        assert mock.call_args[1]["action"] == "DECLINE"
+        assert "content" not in mock.call_args[1]
+
+    def test_invalid_action(self) -> None:
+        result = cmd_elicit_respond(_state(), "x", action="FROB")
+        assert "invalid action" in result
+
+    def test_accept_requires_content(self) -> None:
+        result = cmd_elicit_respond(_state(), "x", action="ACCEPT")
+        assert "--content" in result
+
+    def test_invalid_content_json(self) -> None:
+        result = cmd_elicit_respond(_state(), "x", action="ACCEPT", content="not-json")
+        assert "Invalid JSON" in result
+
+    @patch("unique_sdk.Elicitation.respond_to_elicitation")
+    def test_api_error(self, mock: MagicMock) -> None:
+        mock.side_effect = unique_sdk.APIError("fail")
+        result = cmd_elicit_respond(_state(), "x", action="CANCEL")
+        assert "elicit:" in result
+
+
+class TestElicitWait:
+    @patch("unique_sdk.Elicitation.get_elicitation")
+    def test_immediately_terminal(self, mock: MagicMock) -> None:
+        mock.return_value = _elicitation(
+            status="RESPONDED", response_content={"answer": "yes"}
+        )
+        result = cmd_elicit_wait(_state(), "elicit_abc", timeout=5)
+        assert "RESPONDED" in result
+        assert '"answer"' in result
+
+    @patch("unique_sdk.cli.commands.elicitation.time.sleep")
+    @patch("unique_sdk.Elicitation.get_elicitation")
+    def test_polls_until_terminal(
+        self, mock_get: MagicMock, mock_sleep: MagicMock
+    ) -> None:
+        mock_get.side_effect = [
+            _elicitation(status="PENDING"),
+            _elicitation(status="PENDING"),
+            _elicitation(status="DECLINED"),
+        ]
+        result = cmd_elicit_wait(_state(), "elicit_abc", timeout=30, poll_interval=0.01)
+        assert "DECLINED" in result
+        assert mock_sleep.call_count == 2
+
+    @patch("unique_sdk.cli.commands.elicitation.time.sleep")
+    @patch("unique_sdk.cli.commands.elicitation.time.monotonic")
+    @patch("unique_sdk.Elicitation.get_elicitation")
+    def test_timeout(
+        self,
+        mock_get: MagicMock,
+        mock_monotonic: MagicMock,
+        mock_sleep: MagicMock,
+    ) -> None:
+        mock_get.return_value = _elicitation(status="PENDING")
+        mock_monotonic.side_effect = [0.0, 100.0, 200.0]
+        result = cmd_elicit_wait(_state(), "elicit_abc", timeout=10)
+        assert "timed out after 10s" in result
+
+    @patch("unique_sdk.Elicitation.get_elicitation")
+    def test_api_error(self, mock: MagicMock) -> None:
+        mock.side_effect = unique_sdk.APIError("fail")
+        assert "elicit:" in cmd_elicit_wait(_state(), "x", timeout=1)
+
+
+class TestElicitAsk:
+    @patch("unique_sdk.Elicitation.get_elicitation")
+    @patch("unique_sdk.Elicitation.create_elicitation")
+    def test_default_schema(self, mock_create: MagicMock, mock_get: MagicMock) -> None:
+        mock_create.return_value = _elicitation()
+        mock_get.return_value = _elicitation(
+            status="RESPONDED", response_content={"answer": "hello"}
+        )
+        result = cmd_elicit_ask(_state(), message="What?")
+        assert "RESPONDED" in result
+        sent_schema = mock_create.call_args[1]["schema"]
+        assert sent_schema["required"] == ["answer"]
+
+    @patch("unique_sdk.Elicitation.get_elicitation")
+    @patch("unique_sdk.Elicitation.create_elicitation")
+    def test_custom_schema_and_metadata(
+        self, mock_create: MagicMock, mock_get: MagicMock
+    ) -> None:
+        mock_create.return_value = _elicitation()
+        mock_get.return_value = _elicitation(
+            status="RESPONDED", response_content={"choice": "A"}
+        )
+        result = cmd_elicit_ask(
+            _state(),
+            message="Pick",
+            schema='{"type": "object", "properties": {"choice": {"type": "string"}}}',
+            metadata=[("src", "cli")],
+        )
+        assert "RESPONDED" in result
+        assert mock_create.call_args[1]["metadata"] == {"src": "cli"}
+
+    def test_invalid_schema_json(self) -> None:
+        result = cmd_elicit_ask(_state(), message="x", schema="not-json")
+        assert "Invalid JSON" in result
+
+    @patch("unique_sdk.Elicitation.create_elicitation")
+    def test_missing_id_from_platform(self, mock_create: MagicMock) -> None:
+        mock_create.return_value = {}
+        result = cmd_elicit_ask(_state(), message="x")
+        assert "did not return an elicitation id" in result
+
+    @patch("unique_sdk.Elicitation.create_elicitation")
+    def test_api_error(self, mock_create: MagicMock) -> None:
+        mock_create.side_effect = unique_sdk.APIError("fail")
+        result = cmd_elicit_ask(_state(), message="x")
+        assert "elicit:" in result
+
+
+# --- Formatters ---------------------------------------------------------
+
+
+class TestFormatElicitation:
+    def test_pending_minimal(self) -> None:
+        out = format_elicitation(_elicitation())
+        assert "elicit_abc" in out
+        assert "PENDING" in out
+        assert "FORM" in out
+        assert "Response:" in out
+        assert "(none)" in out
+
+    def test_with_response_schema_metadata(self) -> None:
+        out = format_elicitation(
+            _elicitation(
+                status="RESPONDED",
+                response_content={"answer": "yes"},
+                schema={"type": "object"},
+                metadata={"k": "v"},
+            )
+        )
+        assert '"answer"' in out
+        assert '"type"' in out
+        assert '"k"' in out
+
+    def test_empty_fields(self) -> None:
+        out = format_elicitation(
+            {
+                "id": "e1",
+                "status": "PENDING",
+                "mode": "FORM",
+                "toolName": None,
+                "url": None,
+                "chatId": None,
+                "messageId": None,
+                "externalElicitationId": None,
+            }
+        )
+        assert "e1" in out
+        assert "PENDING" in out
+
+
+class TestFormatPendingElicitations:
+    def test_empty(self) -> None:
+        assert format_pending_elicitations([]) == "No pending elicitations."
+
+    def test_truncates_long_message(self) -> None:
+        long_msg = "x" * 200
+        out = format_pending_elicitations([_elicitation(message=long_msg)])
+        assert "..." in out
+
+    def test_multiple(self) -> None:
+        out = format_pending_elicitations(
+            [_elicitation(eid="e1"), _elicitation(eid="e2")]
+        )
+        assert "2 pending elicitation" in out
+        assert "e1" in out and "e2" in out
+
+
+class TestFormatElicitationResponse:
+    def test_success(self) -> None:
+        out = format_elicitation_response({"success": True}, "elicit_abc", "ACCEPT")
+        assert "OK" in out
+        assert "ACCEPT" in out
+        assert "elicit_abc" in out
+
+    def test_failure_with_detail(self) -> None:
+        out = format_elicitation_response(
+            {"success": False, "message": "nope"}, "elicit_abc", "DECLINE"
+        )
+        assert "FAILED" in out
+        assert "nope" in out
+
+
+# --- Shell dispatch -----------------------------------------------------
+
+
+class TestShellElicit:
+    def test_help_no_args(self) -> None:
+        out = _capture(_shell(), "elicit")
+        assert "Usage: elicit" in out
+
+    def test_unknown_subcommand(self) -> None:
+        out = _capture(_shell(), "elicit bogus")
+        assert "Unknown subcommand" in out
+
+    @patch("unique_sdk.cli.shell.cmd_elicit_pending")
+    def test_pending(self, mock: MagicMock) -> None:
+        mock.return_value = "PENDING_OUT"
+        out = _capture(_shell(), "elicit pending")
+        assert "PENDING_OUT" in out
+
+    def test_get_requires_id(self) -> None:
+        out = _capture(_shell(), "elicit get")
+        assert "Usage: elicit get" in out
+
+    @patch("unique_sdk.cli.shell.cmd_elicit_get")
+    def test_get_forwards(self, mock: MagicMock) -> None:
+        mock.return_value = "GOT"
+        out = _capture(_shell(), "elicit get elicit_abc")
+        assert "GOT" in out
+        assert mock.call_args[0][1] == "elicit_abc"
+
+    def test_ask_without_message(self) -> None:
+        out = _capture(_shell(), "elicit ask")
+        assert "Usage: elicit ask" in out
+
+    @patch("unique_sdk.cli.shell.cmd_elicit_ask")
+    def test_ask_forwards(self, mock: MagicMock) -> None:
+        mock.return_value = "ASKED"
+        out = _capture(
+            _shell(),
+            'elicit ask "What?" --timeout 30 --poll-interval 1.5 '
+            "--metadata src=cli --chat-id c1",
+        )
+        assert "ASKED" in out
+        kw = mock.call_args[1]
+        assert kw["message"] == "What?"
+        assert kw["timeout"] == 30
+        assert kw["poll_interval"] == 1.5
+        assert kw["chat_id"] == "c1"
+        assert kw["metadata"] == [("src", "cli")]
+
+    def test_ask_invalid_timeout(self) -> None:
+        out = _capture(_shell(), 'elicit ask "x" --timeout abc')
+        assert "Invalid --timeout" in out
+
+    def test_ask_invalid_poll_interval(self) -> None:
+        out = _capture(_shell(), 'elicit ask "x" --poll-interval abc')
+        assert "Invalid --poll-interval" in out
+
+    def test_ask_invalid_expires_in(self) -> None:
+        out = _capture(_shell(), 'elicit ask "x" --expires-in abc')
+        assert "Invalid --expires-in" in out
+
+    def test_ask_invalid_metadata(self) -> None:
+        out = _capture(_shell(), 'elicit ask "x" --metadata badformat')
+        assert "Invalid metadata format" in out
+
+    def test_create_without_message(self) -> None:
+        out = _capture(_shell(), "elicit create")
+        assert "Usage: elicit create" in out
+
+    def test_create_requires_mode(self) -> None:
+        out = _capture(_shell(), 'elicit create "msg" --tool-name t')
+        assert "--mode is required" in out
+
+    def test_create_requires_tool_name(self) -> None:
+        out = _capture(_shell(), 'elicit create "msg" --mode FORM')
+        assert "--tool-name" in out
+
+    @patch("unique_sdk.cli.shell.cmd_elicit_create")
+    def test_create_forwards(self, mock: MagicMock) -> None:
+        mock.return_value = "CREATED"
+        schema = json.dumps({"type": "object"})
+        out = _capture(
+            _shell(),
+            f'elicit create "Do it?" --mode FORM --tool-name confirm '
+            f"--schema '{schema}' --external-id ext_1 --message-id m1 "
+            f"--expires-in 60",
+        )
+        assert "CREATED" in out
+        kw = mock.call_args[1]
+        assert kw["mode"] == "FORM"
+        assert kw["tool_name"] == "confirm"
+        assert kw["external_elicitation_id"] == "ext_1"
+        assert kw["message_id"] == "m1"
+        assert kw["expires_in_seconds"] == 60
+
+    def test_wait_requires_id(self) -> None:
+        out = _capture(_shell(), "elicit wait")
+        assert "Usage: elicit wait" in out
+
+    @patch("unique_sdk.cli.shell.cmd_elicit_wait")
+    def test_wait_forwards(self, mock: MagicMock) -> None:
+        mock.return_value = "WAITED"
+        out = _capture(_shell(), "elicit wait elicit_abc --timeout 5")
+        assert "WAITED" in out
+        assert mock.call_args[0][1] == "elicit_abc"
+        assert mock.call_args[1]["timeout"] == 5
+
+    def test_respond_requires_id(self) -> None:
+        out = _capture(_shell(), "elicit respond")
+        assert "Usage: elicit respond" in out
+
+    def test_respond_requires_action(self) -> None:
+        out = _capture(_shell(), "elicit respond elicit_abc")
+        assert "--action" in out
+
+    @patch("unique_sdk.cli.shell.cmd_elicit_respond")
+    def test_respond_forwards(self, mock: MagicMock) -> None:
+        mock.return_value = "RESPONDED"
+        out = _capture(
+            _shell(),
+            "elicit respond elicit_abc --action ACCEPT --content '{\"a\":1}'",
+        )
+        assert "RESPONDED" in out
+        kw = mock.call_args[1]
+        assert kw["action"] == "ACCEPT"
+        assert kw["content"] == '{"a":1}'

--- a/unique_sdk/unique_sdk/cli/cli.py
+++ b/unique_sdk/unique_sdk/cli/cli.py
@@ -5,6 +5,14 @@ from __future__ import annotations
 import click
 
 from unique_sdk.cli import __version__
+from unique_sdk.cli.commands.elicitation import (
+    cmd_elicit_ask,
+    cmd_elicit_create,
+    cmd_elicit_get,
+    cmd_elicit_pending,
+    cmd_elicit_respond,
+    cmd_elicit_wait,
+)
 from unique_sdk.cli.commands.files import cmd_download, cmd_mv_file, cmd_rm, cmd_upload
 from unique_sdk.cli.commands.folders import cmd_mkdir, cmd_mvdir, cmd_rmdir
 from unique_sdk.cli.commands.mcp import cmd_mcp
@@ -63,6 +71,7 @@ Examples:
   unique-cli search "revenue" -l 50 Search with custom limit
   unique-cli upload ./file.pdf      Upload to current folder
   unique-cli download cont_abc123   Download by content ID
+  unique-cli elicit ask "Which?"    Ask the user a question synchronously
 """
 
 
@@ -648,3 +657,326 @@ def schedule_delete(ctx: click.Context, task_id: str) -> None:
       unique-cli schedule delete clx3ghi4f0003mnopqr345678
     """
     click.echo(cmd_schedule_delete(LazyState.get(ctx), task_id))
+
+
+# -- Elicitations ----------------------------------------------------------
+
+
+@main.group()
+def elicit() -> None:
+    """Ask the user questions via the Unique elicitation API.
+
+    \b
+    Elicitations are structured user-input requests displayed in the
+    Unique UI. Use this when an agent or tool needs the user to answer
+    a clarifying question, confirm a destructive action, or fill in a
+    form -- instead of guessing or halting the task.
+
+    \b
+    Subcommands:
+      ask       Create a form question and wait synchronously for the answer
+      create    Low-level: create a FORM or URL elicitation
+      pending   List pending elicitations for the current user
+      get       Show details of a single elicitation by ID
+      respond   Respond to an elicitation (ACCEPT / DECLINE / CANCEL)
+      wait      Poll an elicitation until it reaches a terminal state
+    """
+
+
+@elicit.command(name="ask")
+@click.argument("message")
+@click.option(
+    "--tool-name",
+    "-t",
+    default="agent_question",
+    show_default=True,
+    help="Name of the tool/agent asking the question (appears in the UI).",
+)
+@click.option(
+    "--schema",
+    default=None,
+    help=(
+        "JSON schema for the form. Defaults to a single required "
+        '"answer" string field when omitted.'
+    ),
+)
+@click.option("--chat-id", "-c", default=None, help="Associated chat ID.")
+@click.option("--message-id", "-m", default=None, help="Associated message ID.")
+@click.option(
+    "--expires-in",
+    "expires_in_seconds",
+    type=int,
+    default=None,
+    help="Expire the elicitation after N seconds if not answered.",
+)
+@click.option(
+    "--timeout",
+    type=int,
+    default=300,
+    show_default=True,
+    help="Max seconds to block waiting for the user's response.",
+)
+@click.option(
+    "--poll-interval",
+    type=float,
+    default=2.0,
+    show_default=True,
+    help="Seconds between polls while waiting.",
+)
+@click.option(
+    "--metadata",
+    multiple=True,
+    help="Metadata key=value pairs (repeatable).",
+)
+@click.pass_context
+def elicit_ask(
+    ctx: click.Context,
+    message: str,
+    tool_name: str,
+    schema: str | None,
+    chat_id: str | None,
+    message_id: str | None,
+    expires_in_seconds: int | None,
+    timeout: int,
+    poll_interval: float,
+    metadata: tuple[str, ...],
+) -> None:
+    """Ask the user a question and wait for the answer.
+
+    \b
+    Creates a FORM elicitation in the Unique UI with the given MESSAGE
+    and blocks until the user responds, the elicitation is declined /
+    cancelled / expired, or --timeout is reached.
+
+    \b
+    Examples:
+      unique-cli elicit ask "Which report should I send? (Q1 or Q2)"
+      unique-cli elicit ask "Confirm deletion of /Archive" --timeout 60
+      unique-cli elicit ask "Pick a region" \\
+        --schema '{"type":"object","properties":{"region":{"type":"string","enum":["EU","US","APAC"]}},"required":["region"]}'
+    """
+    parsed_metadata: list[tuple[str, str]] = []
+    for kv in metadata:
+        if "=" not in kv:
+            click.echo(f"Invalid metadata format: {kv} (expected key=value)")
+            return
+        k, v = kv.split("=", 1)
+        parsed_metadata.append((k, v))
+
+    click.echo(
+        cmd_elicit_ask(
+            LazyState.get(ctx),
+            message=message,
+            tool_name=tool_name,
+            schema=schema,
+            chat_id=chat_id,
+            message_id=message_id,
+            expires_in_seconds=expires_in_seconds,
+            timeout=timeout,
+            poll_interval=poll_interval,
+            metadata=parsed_metadata or None,
+        )
+    )
+
+
+@elicit.command(name="create")
+@click.argument("message")
+@click.option(
+    "--mode",
+    type=click.Choice(["FORM", "URL"], case_sensitive=False),
+    required=True,
+    help="Elicitation display mode.",
+)
+@click.option(
+    "--tool-name",
+    "-t",
+    required=True,
+    help="Name of the tool/agent requesting input.",
+)
+@click.option(
+    "--schema",
+    default=None,
+    help="JSON schema (required for --mode FORM).",
+)
+@click.option("--url", default=None, help="External URL (required for --mode URL).")
+@click.option("--chat-id", "-c", default=None, help="Associated chat ID.")
+@click.option("--message-id", "-m", default=None, help="Associated message ID.")
+@click.option(
+    "--expires-in",
+    "expires_in_seconds",
+    type=int,
+    default=None,
+    help="Expire the elicitation after N seconds.",
+)
+@click.option(
+    "--external-id",
+    "external_elicitation_id",
+    default=None,
+    help="External identifier for de-duplication / tracking.",
+)
+@click.option(
+    "--metadata",
+    multiple=True,
+    help="Metadata key=value pairs (repeatable).",
+)
+@click.pass_context
+def elicit_create(
+    ctx: click.Context,
+    message: str,
+    mode: str,
+    tool_name: str,
+    schema: str | None,
+    url: str | None,
+    chat_id: str | None,
+    message_id: str | None,
+    expires_in_seconds: int | None,
+    external_elicitation_id: str | None,
+    metadata: tuple[str, ...],
+) -> None:
+    """Create an elicitation without waiting for the response.
+
+    \b
+    Use this when you want to fire-and-forget, then poll later with
+    `elicit wait <id>` or `elicit get <id>`. For interactive question /
+    answer flows prefer `elicit ask` which does both in one call.
+
+    \b
+    Examples:
+      unique-cli elicit create "Please provide feedback" \\
+        --mode FORM --tool-name feedback \\
+        --schema '{"type":"object","properties":{"rating":{"type":"integer"}},"required":["rating"]}'
+
+      unique-cli elicit create "Complete the survey" \\
+        --mode URL --tool-name survey --url https://example.com/s/123
+    """
+    parsed_metadata: list[tuple[str, str]] = []
+    for kv in metadata:
+        if "=" not in kv:
+            click.echo(f"Invalid metadata format: {kv} (expected key=value)")
+            return
+        k, v = kv.split("=", 1)
+        parsed_metadata.append((k, v))
+
+    click.echo(
+        cmd_elicit_create(
+            LazyState.get(ctx),
+            mode=mode,
+            message=message,
+            tool_name=tool_name,
+            schema=schema,
+            url=url,
+            chat_id=chat_id,
+            message_id=message_id,
+            expires_in_seconds=expires_in_seconds,
+            external_elicitation_id=external_elicitation_id,
+            metadata=parsed_metadata or None,
+        )
+    )
+
+
+@elicit.command(name="pending")
+@click.pass_context
+def elicit_pending(ctx: click.Context) -> None:
+    """List all pending elicitations for the current user.
+
+    \b
+    Examples:
+      unique-cli elicit pending
+    """
+    click.echo(cmd_elicit_pending(LazyState.get(ctx)))
+
+
+@elicit.command(name="get")
+@click.argument("elicitation_id")
+@click.pass_context
+def elicit_get(ctx: click.Context, elicitation_id: str) -> None:
+    """Show details of a single elicitation by ID.
+
+    \b
+    Examples:
+      unique-cli elicit get elicit_abc123
+    """
+    click.echo(cmd_elicit_get(LazyState.get(ctx), elicitation_id))
+
+
+@elicit.command(name="wait")
+@click.argument("elicitation_id")
+@click.option(
+    "--timeout",
+    type=int,
+    default=300,
+    show_default=True,
+    help="Max seconds to wait for a terminal state.",
+)
+@click.option(
+    "--poll-interval",
+    type=float,
+    default=2.0,
+    show_default=True,
+    help="Seconds between polls.",
+)
+@click.pass_context
+def elicit_wait(
+    ctx: click.Context,
+    elicitation_id: str,
+    timeout: int,
+    poll_interval: float,
+) -> None:
+    """Poll an elicitation until it is answered, declined, cancelled, or expires.
+
+    \b
+    Examples:
+      unique-cli elicit wait elicit_abc123
+      unique-cli elicit wait elicit_abc123 --timeout 60 --poll-interval 1
+    """
+    click.echo(
+        cmd_elicit_wait(
+            LazyState.get(ctx),
+            elicitation_id,
+            timeout=timeout,
+            poll_interval=poll_interval,
+        )
+    )
+
+
+@elicit.command(name="respond")
+@click.argument("elicitation_id")
+@click.option(
+    "--action",
+    type=click.Choice(["ACCEPT", "DECLINE", "CANCEL"], case_sensitive=False),
+    required=True,
+    help="Response action.",
+)
+@click.option(
+    "--content",
+    default=None,
+    help="JSON object with response fields (required for ACCEPT).",
+)
+@click.pass_context
+def elicit_respond(
+    ctx: click.Context,
+    elicitation_id: str,
+    action: str,
+    content: str | None,
+) -> None:
+    """Respond to an elicitation (mostly for scripting / testing).
+
+    \b
+    The user normally answers via the Unique UI. Use this to script
+    declines / cancels, or to simulate a user response in tests.
+
+    \b
+    Examples:
+      unique-cli elicit respond elicit_abc123 --action ACCEPT \\
+        --content '{"answer":"yes"}'
+      unique-cli elicit respond elicit_abc123 --action DECLINE
+      unique-cli elicit respond elicit_abc123 --action CANCEL
+    """
+    click.echo(
+        cmd_elicit_respond(
+            LazyState.get(ctx),
+            elicitation_id,
+            action=action,
+            content=content,
+        )
+    )

--- a/unique_sdk/unique_sdk/cli/cli.py
+++ b/unique_sdk/unique_sdk/cli/cli.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import click
 
 from unique_sdk.cli import __version__
@@ -728,6 +730,43 @@ def elicit() -> None:
     multiple=True,
     help="Metadata key=value pairs (repeatable).",
 )
+@click.option(
+    "--visible/--no-visible",
+    "visible",
+    default=True,
+    show_default=True,
+    help=(
+        "Wrap the elicitation in a placeholder 'thinking' timeline so the "
+        "chat UI renders it (UN-19815 workaround). Requires --chat-id; the "
+        "placeholder is collapsed or deleted automatically after the user "
+        "responds."
+    ),
+)
+@click.option(
+    "--assistant-id",
+    default=None,
+    help=(
+        "Assistant id to use when creating the visibility placeholder. "
+        "Defaults to $UNIQUE_ASSISTANT_ID, else the latest assistant in the "
+        "chat."
+    ),
+)
+@click.option(
+    "--placeholder-text",
+    default=None,
+    help="Text shown on the placeholder 'thinking' step while waiting.",
+)
+@click.option(
+    "--cleanup",
+    "cleanup_mode",
+    type=click.Choice(["collapse", "delete"], case_sensitive=False),
+    default=None,
+    help=(
+        "How to tear down the visibility placeholder after the user "
+        "responds. 'collapse' (default) sets completedAt + a short note; "
+        "'delete' removes the placeholder message entirely."
+    ),
+)
 @click.pass_context
 def elicit_ask(
     ctx: click.Context,
@@ -740,6 +779,10 @@ def elicit_ask(
     timeout: int,
     poll_interval: float,
     metadata: tuple[str, ...],
+    visible: bool,
+    assistant_id: str | None,
+    placeholder_text: str | None,
+    cleanup_mode: str | None,
 ) -> None:
     """Ask the user a question and wait for the answer.
 
@@ -763,20 +806,24 @@ def elicit_ask(
         k, v = kv.split("=", 1)
         parsed_metadata.append((k, v))
 
-    click.echo(
-        cmd_elicit_ask(
-            LazyState.get(ctx),
-            message=message,
-            tool_name=tool_name,
-            schema=schema,
-            chat_id=chat_id,
-            message_id=message_id,
-            expires_in_seconds=expires_in_seconds,
-            timeout=timeout,
-            poll_interval=poll_interval,
-            metadata=parsed_metadata or None,
-        )
-    )
+    ask_kwargs: dict[str, Any] = {
+        "message": message,
+        "tool_name": tool_name,
+        "schema": schema,
+        "chat_id": chat_id,
+        "message_id": message_id,
+        "expires_in_seconds": expires_in_seconds,
+        "timeout": timeout,
+        "poll_interval": poll_interval,
+        "metadata": parsed_metadata or None,
+        "visible": visible,
+        "assistant_id": assistant_id,
+    }
+    if placeholder_text is not None:
+        ask_kwargs["placeholder_text"] = placeholder_text
+    if cleanup_mode is not None:
+        ask_kwargs["cleanup_mode"] = cleanup_mode.lower()
+    click.echo(cmd_elicit_ask(LazyState.get(ctx), **ask_kwargs))
 
 
 @elicit.command(name="create")
@@ -819,6 +866,43 @@ def elicit_ask(
     multiple=True,
     help="Metadata key=value pairs (repeatable).",
 )
+@click.option(
+    "--visible/--no-visible",
+    "visible",
+    default=True,
+    show_default=True,
+    help=(
+        "Wrap the elicitation in a placeholder 'thinking' timeline so the "
+        "chat UI renders it (UN-19815 workaround). Requires --chat-id; the "
+        "placeholder is collapsed or deleted automatically when the user "
+        "responds or when you call `elicit wait` on the returned id."
+    ),
+)
+@click.option(
+    "--assistant-id",
+    default=None,
+    help=(
+        "Assistant id to use when creating the visibility placeholder. "
+        "Defaults to $UNIQUE_ASSISTANT_ID, else the latest assistant in the "
+        "chat."
+    ),
+)
+@click.option(
+    "--placeholder-text",
+    default=None,
+    help="Text shown on the placeholder 'thinking' step while pending.",
+)
+@click.option(
+    "--cleanup",
+    "cleanup_mode",
+    type=click.Choice(["collapse", "delete"], case_sensitive=False),
+    default=None,
+    help=(
+        "How to tear down the visibility placeholder after the user "
+        "responds. 'collapse' (default) sets completedAt + a short note; "
+        "'delete' removes the placeholder message entirely."
+    ),
+)
 @click.pass_context
 def elicit_create(
     ctx: click.Context,
@@ -832,6 +916,10 @@ def elicit_create(
     expires_in_seconds: int | None,
     external_elicitation_id: str | None,
     metadata: tuple[str, ...],
+    visible: bool,
+    assistant_id: str | None,
+    placeholder_text: str | None,
+    cleanup_mode: str | None,
 ) -> None:
     """Create an elicitation without waiting for the response.
 
@@ -857,21 +945,25 @@ def elicit_create(
         k, v = kv.split("=", 1)
         parsed_metadata.append((k, v))
 
-    click.echo(
-        cmd_elicit_create(
-            LazyState.get(ctx),
-            mode=mode,
-            message=message,
-            tool_name=tool_name,
-            schema=schema,
-            url=url,
-            chat_id=chat_id,
-            message_id=message_id,
-            expires_in_seconds=expires_in_seconds,
-            external_elicitation_id=external_elicitation_id,
-            metadata=parsed_metadata or None,
-        )
-    )
+    create_kwargs: dict[str, Any] = {
+        "mode": mode,
+        "message": message,
+        "tool_name": tool_name,
+        "schema": schema,
+        "url": url,
+        "chat_id": chat_id,
+        "message_id": message_id,
+        "expires_in_seconds": expires_in_seconds,
+        "external_elicitation_id": external_elicitation_id,
+        "metadata": parsed_metadata or None,
+        "visible": visible,
+        "assistant_id": assistant_id,
+    }
+    if placeholder_text is not None:
+        create_kwargs["placeholder_text"] = placeholder_text
+    if cleanup_mode is not None:
+        create_kwargs["cleanup_mode"] = cleanup_mode.lower()
+    click.echo(cmd_elicit_create(LazyState.get(ctx), **create_kwargs))
 
 
 @elicit.command(name="pending")

--- a/unique_sdk/unique_sdk/cli/commands/elicitation.py
+++ b/unique_sdk/unique_sdk/cli/commands/elicitation.py
@@ -12,8 +12,10 @@ blocks until the user responds or the request expires/times out.
 from __future__ import annotations
 
 import json
+import os
 import time
-from typing import Any
+from datetime import datetime, timezone
+from typing import Any, Literal, cast
 
 import unique_sdk
 from unique_sdk.cli.formatting import (
@@ -25,7 +27,60 @@ from unique_sdk.cli.state import ShellState
 
 DEFAULT_POLL_INTERVAL_SECONDS = 2.0
 DEFAULT_WAIT_TIMEOUT_SECONDS = 300
-TERMINAL_STATUSES = {"RESPONDED", "DECLINED", "CANCELLED", "EXPIRED", "COMPLETED"}
+TERMINAL_STATUSES = {
+    "RESPONDED",
+    "ACCEPTED",
+    "REJECTED",
+    "DECLINED",
+    "CANCELLED",
+    "EXPIRED",
+    "COMPLETED",
+}
+
+# --- Visibility workaround for UN-19815 ---------------------------------
+#
+# The chat UI (as of 2026-04-21) only renders an elicitation when the host
+# assistant message is actively in ``ThinkingTimeline`` display mode *and*
+# the elicitation's ``metadata.messageLogId`` matches a step inside that
+# timeline. Elicitations created via the public API / CLI against a chat
+# without a currently-streaming assistant turn are therefore silently
+# invisible in the UI, even though the backend stores them correctly.
+#
+# As a workaround we synthesise a minimal thinking timeline around the
+# elicitation:
+#
+# 1. Create a placeholder assistant message with no text and no
+#    ``completedAt`` — this satisfies the UI's ``ThinkingTimeline`` gate.
+# 2. Create a ``message_log`` step under it in ``RUNNING`` status — the
+#    elicitation will reference this step via ``metadata.messageLogId``.
+# 3. Create the elicitation with ``messageId`` pointing at the placeholder
+#    and the step id wired into ``metadata.messageLogId``.
+#
+# After the user responds we either collapse the placeholder (set
+# ``completedAt`` + a short explanatory text) or delete it entirely, based
+# on ``cleanup_mode``. Cleanup runs in a ``finally`` so a Ctrl-C or API
+# error doesn't leave a dangling thinking bubble in the chat.
+#
+# This entire workaround is obsolete once UN-19815 lands in the UI; at
+# that point the ``visible`` flag can be marked as a no-op.
+
+CleanupMode = Literal["collapse", "delete"]
+
+DEFAULT_PLACEHOLDER_TEXT = "Waiting for your answer…"
+DEFAULT_CLEANUP_MODE: CleanupMode = "collapse"
+COLLAPSED_MESSAGE_TEXT_ACCEPTED = "Clarifying question answered."
+COLLAPSED_MESSAGE_TEXT_OTHER = "Clarifying question closed."
+COMPLETED_STEP_TEXT_ACCEPTED = "Answered."
+COMPLETED_STEP_TEXT_OTHER = "Closed."
+
+# Metadata keys used to mark an elicitation as carrying a synthetic
+# placeholder so ``cmd_elicit_wait`` knows what to tear down when the
+# elicitation reaches a terminal state. Prefixed with ``_uniqueSdk`` to
+# stay clearly namespaced from any caller-provided metadata.
+META_PLACEHOLDER_MESSAGE_ID = "_uniqueSdkPlaceholderMessageId"
+META_PLACEHOLDER_STEP_ID = "_uniqueSdkPlaceholderStepId"
+META_PLACEHOLDER_CHAT_ID = "_uniqueSdkPlaceholderChatId"
+META_CLEANUP_MODE = "_uniqueSdkCleanupMode"
 
 
 def _parse_json_arg(value: str | None, *, field: str) -> dict[str, Any] | None:
@@ -90,6 +145,240 @@ def _build_create_params(
     return params
 
 
+def _resolve_assistant_id(state: ShellState, chat_id: str) -> str | None:
+    """Return an ``assistantId`` usable for ``Message.create`` in this chat.
+
+    Resolution order:
+
+    1. ``$UNIQUE_ASSISTANT_ID`` environment variable.
+    2. The most recent ``ASSISTANT``-role message in the chat (via
+       ``Message.list``) — pick up its ``assistantId`` field.
+
+    Returns ``None`` if neither source yields a usable id. Callers are
+    expected to surface a descriptive error in that case because the chat
+    has no assistant context (e.g. a brand-new empty chat).
+    """
+    env_id = os.environ.get("UNIQUE_ASSISTANT_ID")
+    if env_id:
+        return env_id
+
+    try:
+        listing = unique_sdk.Message.list(
+            user_id=state.config.user_id,
+            company_id=state.config.company_id,
+            chatId=chat_id,
+        )
+    except unique_sdk.APIError:
+        return None
+
+    # ``Message`` objects are dict subclasses at runtime, but the static
+    # type advertises them as typed resources without ``assistantId`` on
+    # the instance. Fall back to ``dict`` access to keep both the type
+    # checker and the runtime happy.
+    #
+    # Resolution strategy:
+    #   (a) Preferred: most recent ASSISTANT message's top-level
+    #       ``assistantId`` — what internal/admin APIs expose.
+    #   (b) Fallback: any message's ``debugInfo.assistant.id`` — the public
+    #       gateway exposes the assistant only here, and populates it on
+    #       USER messages (not ASSISTANT ones) because it reflects the
+    #       assistant that handled the request, not the author of the
+    #       message. Since the whole chat is bound to a single assistant,
+    #       any message that carries this field gives us the right answer.
+    messages = list(listing)
+
+    for msg in reversed(messages):
+        msg_dict = cast(dict[str, Any], cast(object, msg))
+        if str(msg_dict.get("role", "")).upper() != "ASSISTANT":
+            continue
+        assistant_id = msg_dict.get("assistantId")
+        if isinstance(assistant_id, str) and assistant_id:
+            return assistant_id
+
+    for msg in reversed(messages):
+        msg_dict = cast(dict[str, Any], cast(object, msg))
+        debug_info = msg_dict.get("debugInfo")
+        if not isinstance(debug_info, dict):
+            continue
+        assistant_obj = debug_info.get("assistant")
+        if not isinstance(assistant_obj, dict):
+            continue
+        nested_id = assistant_obj.get("id")
+        if isinstance(nested_id, str) and nested_id:
+            return nested_id
+
+    return None
+
+
+def _create_visibility_context(
+    state: ShellState,
+    *,
+    chat_id: str,
+    assistant_id: str,
+    placeholder_text: str,
+) -> tuple[str, str]:
+    """Create a placeholder assistant message + running step for visibility.
+
+    Returns ``(placeholder_message_id, step_id)``. Raises ``unique_sdk.APIError``
+    (or ``ValueError`` if the platform returns malformed data) so the caller
+    can fall back or surface a user-facing error.
+    """
+    placeholder = unique_sdk.Message.create(
+        user_id=state.config.user_id,
+        company_id=state.config.company_id,
+        chatId=chat_id,
+        assistantId=assistant_id,
+        role="ASSISTANT",
+        text=None,
+        references=None,
+        debugInfo=None,
+        completedAt=None,
+    )
+    placeholder_id = cast(dict[str, Any], placeholder).get("id")
+    if not isinstance(placeholder_id, str) or not placeholder_id:
+        raise ValueError("platform did not return a placeholder message id")
+
+    step = unique_sdk.MessageLog.create(
+        user_id=state.config.user_id,
+        company_id=state.config.company_id,
+        messageId=placeholder_id,
+        text=placeholder_text,
+        status="RUNNING",
+        order=0,
+    )
+    step_id = cast(dict[str, Any], step).get("id")
+    if not isinstance(step_id, str) or not step_id:
+        raise ValueError("platform did not return a step id for the placeholder")
+
+    return placeholder_id, step_id
+
+
+def _cleanup_visibility_context(
+    state: ShellState,
+    *,
+    chat_id: str,
+    placeholder_message_id: str,
+    placeholder_step_id: str,
+    cleanup_mode: CleanupMode,
+    terminal_status: str | None,
+) -> None:
+    """Best-effort teardown of the synthetic thinking-timeline placeholder.
+
+    This runs in ``finally`` paths, so it must never raise. API failures are
+    swallowed — a dangling placeholder is preferable to masking the real
+    error from the caller.
+    """
+    # Treat both the synchronous respond-action ("ACCEPT") and the backend's
+    # persisted terminal status ("ACCEPTED" / "RESPONDED") as "the user
+    # answered positively" for the purpose of the cleanup text.
+    is_accepted = (terminal_status or "").upper() in {
+        "ACCEPT",
+        "ACCEPTED",
+        "RESPONDED",
+    }
+    step_text = (
+        COMPLETED_STEP_TEXT_ACCEPTED if is_accepted else COMPLETED_STEP_TEXT_OTHER
+    )
+    try:
+        unique_sdk.MessageLog.update(
+            user_id=state.config.user_id,
+            company_id=state.config.company_id,
+            message_log_id=placeholder_step_id,
+            status="COMPLETED",
+            text=step_text,
+        )
+    except unique_sdk.APIError:
+        pass
+
+    try:
+        if cleanup_mode == "delete":
+            unique_sdk.Message.delete(
+                placeholder_message_id,
+                state.config.user_id,
+                state.config.company_id,
+                chatId=chat_id,
+            )
+        else:
+            collapse_text = (
+                COLLAPSED_MESSAGE_TEXT_ACCEPTED
+                if is_accepted
+                else COLLAPSED_MESSAGE_TEXT_OTHER
+            )
+            # The public API expects ISO-8601 for ``completedAt`` in PATCH
+            # bodies; serializing a raw ``datetime`` via ``json.dumps`` would
+            # either raise or encode it in a way the backend rejects. Emit
+            # the canonical millisecond-precision UTC Z form. The
+            # ``ModifyParams`` TypedDict annotates this as ``datetime``, so
+            # we cast to appease the type checker — the wire format is the
+            # source of truth here.
+            completed_at_iso = (
+                datetime.now(tz=timezone.utc)
+                .isoformat(timespec="milliseconds")
+                .replace("+00:00", "Z")
+            )
+            unique_sdk.Message.modify(
+                user_id=state.config.user_id,
+                company_id=state.config.company_id,
+                id=placeholder_message_id,
+                chatId=chat_id,
+                text=collapse_text,
+                completedAt=cast(Any, completed_at_iso),
+            )
+    except unique_sdk.APIError:
+        pass
+
+
+def _merge_visibility_metadata(
+    user_metadata: dict[str, Any] | None,
+    *,
+    chat_id: str,
+    placeholder_message_id: str,
+    placeholder_step_id: str,
+    cleanup_mode: CleanupMode,
+) -> dict[str, Any]:
+    """Merge SDK-owned visibility markers into caller-supplied metadata.
+
+    SDK keys win over caller keys on collision — the caller should not use
+    the ``_uniqueSdk...`` namespace, and if they do, we refuse to let them
+    break the cleanup contract.
+    """
+    merged: dict[str, Any] = dict(user_metadata or {})
+    merged["messageLogId"] = placeholder_step_id
+    merged[META_PLACEHOLDER_MESSAGE_ID] = placeholder_message_id
+    merged[META_PLACEHOLDER_STEP_ID] = placeholder_step_id
+    merged[META_PLACEHOLDER_CHAT_ID] = chat_id
+    merged[META_CLEANUP_MODE] = cleanup_mode
+    return merged
+
+
+def _extract_visibility_context(
+    elicitation: dict[str, Any] | None,
+) -> tuple[str, str, str, CleanupMode] | None:
+    """Return ``(chat_id, message_id, step_id, cleanup_mode)`` if markers set.
+
+    Looks at ``metadata`` on a fetched elicitation to decide whether the
+    SDK created a synthetic placeholder for this elicitation and therefore
+    owns its teardown.
+    """
+    if not elicitation:
+        return None
+    metadata = elicitation.get("metadata")
+    if not isinstance(metadata, dict):
+        return None
+    message_id = metadata.get(META_PLACEHOLDER_MESSAGE_ID)
+    step_id = metadata.get(META_PLACEHOLDER_STEP_ID)
+    chat_id = metadata.get(META_PLACEHOLDER_CHAT_ID)
+    mode_raw = metadata.get(META_CLEANUP_MODE) or DEFAULT_CLEANUP_MODE
+    if not (
+        isinstance(message_id, str)
+        and isinstance(step_id, str)
+        and isinstance(chat_id, str)
+    ):
+        return None
+    mode: CleanupMode = "delete" if str(mode_raw).lower() == "delete" else "collapse"
+    return chat_id, message_id, step_id, mode
+
+
 def cmd_elicit_create(
     state: ShellState,
     *,
@@ -103,8 +392,23 @@ def cmd_elicit_create(
     expires_in_seconds: int | None = None,
     external_elicitation_id: str | None = None,
     metadata: list[tuple[str, str]] | None = None,
+    visible: bool = True,
+    assistant_id: str | None = None,
+    placeholder_text: str = DEFAULT_PLACEHOLDER_TEXT,
+    cleanup_mode: CleanupMode = DEFAULT_CLEANUP_MODE,
 ) -> str:
-    """Create an elicitation request (FORM or URL mode)."""
+    """Create an elicitation request (FORM or URL mode).
+
+    When ``chat_id`` is set and ``visible`` is ``True`` (the default), the
+    SDK materialises a placeholder assistant message + running step so the
+    chat UI will actually render the elicitation — see the module-level
+    "Visibility workaround for UN-19815" note. The placeholder stays in the
+    chat's thinking state until the elicitation reaches a terminal status,
+    at which point ``cmd_elicit_wait`` will collapse or delete it. Pass
+    ``visible=False`` to skip this and create a bare elicitation (useful
+    once the UI fix in UN-19815 ships, or for scripted flows that don't
+    need a visible prompt).
+    """
     try:
         mode_upper = mode.upper()
         if mode_upper not in ("FORM", "URL"):
@@ -116,6 +420,35 @@ def cmd_elicit_create(
         if mode_upper == "URL" and not url:
             return "elicit: --url is required when --mode URL"
 
+        user_metadata = _parse_metadata_pairs(metadata)
+        effective_message_id = message_id
+        placeholder_message_id: str | None = None
+        placeholder_step_id: str | None = None
+
+        if visible and chat_id and not message_id:
+            resolved_assistant = assistant_id or _resolve_assistant_id(state, chat_id)
+            if not resolved_assistant:
+                return (
+                    "elicit: cannot create a visible elicitation without an "
+                    "assistant id; pass --assistant-id or set "
+                    "UNIQUE_ASSISTANT_ID, or pass --no-visible to skip the "
+                    "visibility workaround"
+                )
+            placeholder_message_id, placeholder_step_id = _create_visibility_context(
+                state,
+                chat_id=chat_id,
+                assistant_id=resolved_assistant,
+                placeholder_text=placeholder_text,
+            )
+            effective_message_id = placeholder_message_id
+            user_metadata = _merge_visibility_metadata(
+                user_metadata,
+                chat_id=chat_id,
+                placeholder_message_id=placeholder_message_id,
+                placeholder_step_id=placeholder_step_id,
+                cleanup_mode=cleanup_mode,
+            )
+
         params = _build_create_params(
             mode=mode_upper,
             message=message,
@@ -123,33 +456,76 @@ def cmd_elicit_create(
             schema=parsed_schema,
             url=url,
             chat_id=chat_id,
-            message_id=message_id,
+            message_id=effective_message_id,
             expires_in_seconds=expires_in_seconds,
             external_elicitation_id=external_elicitation_id,
-            metadata=_parse_metadata_pairs(metadata),
+            metadata=user_metadata,
         )
 
-        elicitation = unique_sdk.Elicitation.create_elicitation(
-            user_id=state.config.user_id,
-            company_id=state.config.company_id,
-            **params,
-        )
+        try:
+            elicitation = unique_sdk.Elicitation.create_elicitation(
+                user_id=state.config.user_id,
+                company_id=state.config.company_id,
+                **params,
+            )
+        except unique_sdk.APIError:
+            # Creation failed after we materialised a placeholder; tear it
+            # down so the chat doesn't keep spinning forever.
+            if placeholder_message_id and placeholder_step_id and chat_id:
+                _cleanup_visibility_context(
+                    state,
+                    chat_id=chat_id,
+                    placeholder_message_id=placeholder_message_id,
+                    placeholder_step_id=placeholder_step_id,
+                    cleanup_mode=cleanup_mode,
+                    terminal_status=None,
+                )
+            raise
+
+        suffix = ""
+        if placeholder_message_id:
+            suffix = (
+                "\n\nNote: a placeholder assistant message was created to make "
+                "the elicitation visible in the chat UI. It will be "
+                f"{'deleted' if cleanup_mode == 'delete' else 'collapsed'} "
+                "automatically when you call `elicit wait` or when the user "
+                "responds via `elicit respond`."
+            )
         return (
             f"Created elicitation {elicitation.get('id', '?')}\n\n"
-            f"{format_elicitation(elicitation)}"
+            f"{format_elicitation(elicitation)}{suffix}"
         )
     except (ValueError, unique_sdk.APIError) as exc:
         return f"elicit: {exc}"
 
 
 def cmd_elicit_pending(state: ShellState) -> str:
-    """List all pending elicitation requests for the current user."""
+    """List all pending elicitation requests for the current user.
+
+    The backend ``GET /elicitation/pending`` endpoint returns a raw JSON array
+    of elicitations. Older SDKs (and some intermediate proxies) wrap the
+    payload in ``{"elicitations": [...]}``; both shapes are handled here so
+    the command stays compatible across platform versions.
+    """
     try:
-        response = unique_sdk.Elicitation.get_pending_elicitations(
-            user_id=state.config.user_id,
-            company_id=state.config.company_id,
+        # The SDK typing claims ``Elicitations`` (a dict with an
+        # ``elicitations`` key), but the backend actually returns a raw JSON
+        # array of elicitations. Cast to ``Any`` so the runtime checks below
+        # compile without an "unnecessary isinstance" warning.
+        response = cast(
+            Any,
+            unique_sdk.Elicitation.get_pending_elicitations(
+                user_id=state.config.user_id,
+                company_id=state.config.company_id,
+            ),
         )
-        return format_pending_elicitations(response.get("elicitations", []))
+        if isinstance(response, list):
+            elicitations = response
+        elif isinstance(response, dict):
+            elicitations = response.get("elicitations", []) or []
+        else:
+            elicitations = []
+        return format_pending_elicitations(elicitations)
     except unique_sdk.APIError as exc:
         return f"elicit: {exc}"
 
@@ -179,13 +555,18 @@ def cmd_elicit_respond(
     Typically the *user* responds via the Unique UI; this command is primarily
     useful for scripted workflows, tests, or declining / cancelling requests
     on their behalf.
+
+    If the elicitation was created with the visibility workaround (see
+    ``cmd_elicit_create``), the placeholder message + step are cleaned up
+    after the backend accepts the response so the chat doesn't keep
+    spinning in a fake thinking state.
     """
     try:
         action_upper = action.upper()
-        if action_upper not in ("ACCEPT", "DECLINE", "CANCEL"):
+        if action_upper not in ("ACCEPT", "DECLINE", "CANCEL", "REJECT"):
             return (
                 f"elicit: invalid action '{action}' "
-                "(expected ACCEPT, DECLINE, or CANCEL)"
+                "(expected ACCEPT, DECLINE, CANCEL, or REJECT)"
             )
 
         parsed_content = _parse_json_arg(content, field="--content")
@@ -204,6 +585,31 @@ def cmd_elicit_respond(
             company_id=state.config.company_id,
             **params,
         )
+
+        # If the elicitation was created with the visibility workaround,
+        # fetch it once to read the placeholder ids out of its metadata
+        # and tear the placeholder down. Best-effort — never lets a
+        # cleanup failure hide a successful response.
+        try:
+            elicitation = unique_sdk.Elicitation.get_elicitation(
+                user_id=state.config.user_id,
+                company_id=state.config.company_id,
+                elicitation_id=elicitation_id,
+            )
+        except unique_sdk.APIError:
+            elicitation = None
+        ctx = _extract_visibility_context(dict(elicitation) if elicitation else None)
+        if ctx is not None:
+            vis_chat_id, placeholder_id, step_id, cleanup_mode = ctx
+            _cleanup_visibility_context(
+                state,
+                chat_id=vis_chat_id,
+                placeholder_message_id=placeholder_id,
+                placeholder_step_id=step_id,
+                cleanup_mode=cleanup_mode,
+                terminal_status=action_upper,
+            )
+
         return format_elicitation_response(result, elicitation_id, action_upper)
     except (ValueError, unique_sdk.APIError) as exc:
         return f"elicit: {exc}"
@@ -219,12 +625,21 @@ def cmd_elicit_wait(
     """Block until an elicitation transitions to a terminal state.
 
     Polls ``get_elicitation`` at ``poll_interval`` intervals and returns the
-    formatted elicitation once its ``status`` is RESPONDED / DECLINED /
-    CANCELLED / EXPIRED / COMPLETED, or when ``timeout`` seconds elapse.
+    formatted elicitation once its ``status`` is terminal (RESPONDED /
+    ACCEPTED / REJECTED / DECLINED / CANCELLED / EXPIRED / COMPLETED), or
+    when ``timeout`` seconds elapse.
+
+    If the elicitation carries the SDK's visibility markers (see the
+    "Visibility workaround for UN-19815" note at the top of this module),
+    the synthetic placeholder message + step are cleaned up in a ``finally``
+    once the wait returns — regardless of whether it terminated normally,
+    timed out, or the backend started returning errors mid-poll. Cleanup
+    is best-effort and silent.
     """
+    last: dict[str, Any] | None = None
+    terminal_status: str | None = None
     try:
         deadline = time.monotonic() + max(1, timeout)
-        last: dict[str, Any] | None = None
         while True:
             elicitation = unique_sdk.Elicitation.get_elicitation(
                 user_id=state.config.user_id,
@@ -234,6 +649,7 @@ def cmd_elicit_wait(
             last = dict(elicitation)
             status = str(elicitation.get("status", "")).upper()
             if status in TERMINAL_STATUSES:
+                terminal_status = status
                 return format_elicitation(elicitation)
             if time.monotonic() >= deadline:
                 return (
@@ -244,6 +660,18 @@ def cmd_elicit_wait(
             time.sleep(poll_interval)
     except unique_sdk.APIError as exc:
         return f"elicit: {exc}"
+    finally:
+        ctx = _extract_visibility_context(last)
+        if ctx is not None:
+            vis_chat_id, placeholder_id, step_id, cleanup_mode = ctx
+            _cleanup_visibility_context(
+                state,
+                chat_id=vis_chat_id,
+                placeholder_message_id=placeholder_id,
+                placeholder_step_id=step_id,
+                cleanup_mode=cleanup_mode,
+                terminal_status=terminal_status,
+            )
 
 
 def cmd_elicit_ask(
@@ -258,12 +686,23 @@ def cmd_elicit_ask(
     timeout: int = DEFAULT_WAIT_TIMEOUT_SECONDS,
     poll_interval: float = DEFAULT_POLL_INTERVAL_SECONDS,
     metadata: list[tuple[str, str]] | None = None,
+    visible: bool = True,
+    assistant_id: str | None = None,
+    placeholder_text: str = DEFAULT_PLACEHOLDER_TEXT,
+    cleanup_mode: CleanupMode = DEFAULT_CLEANUP_MODE,
 ) -> str:
     """Create a FORM elicitation and wait for the user's reply.
 
     When no ``--schema`` is passed, a minimal single-field form asking for a
     free-text ``answer`` is used. This is the preferred entry point when an
     agent needs to ask the user a clarifying question.
+
+    When ``chat_id`` is set and ``visible`` is ``True`` (the default), the
+    elicitation is wrapped in a placeholder thinking timeline so the chat UI
+    actually renders it — see the "Visibility workaround for UN-19815" note
+    at the top of this module. The placeholder is collapsed or deleted
+    automatically after the user responds. Pass ``visible=False`` to skip
+    this and emit a bare elicitation.
     """
     try:
         parsed_schema = _parse_json_arg(schema, field="--schema")
@@ -279,6 +718,45 @@ def cmd_elicit_ask(
                 "required": ["answer"],
             }
 
+        user_metadata = _parse_metadata_pairs(metadata)
+        effective_message_id = message_id
+        placeholder_message_id: str | None = None
+        placeholder_step_id: str | None = None
+
+        if visible and chat_id and not message_id:
+            resolved_assistant = assistant_id or _resolve_assistant_id(state, chat_id)
+            if not resolved_assistant:
+                return (
+                    "elicit: cannot ask a visible question without an assistant "
+                    "id; pass --assistant-id or set UNIQUE_ASSISTANT_ID, or "
+                    "pass --no-visible to skip the visibility workaround"
+                )
+            placeholder_message_id, placeholder_step_id = _create_visibility_context(
+                state,
+                chat_id=chat_id,
+                assistant_id=resolved_assistant,
+                placeholder_text=placeholder_text,
+            )
+            effective_message_id = placeholder_message_id
+            user_metadata = _merge_visibility_metadata(
+                user_metadata,
+                chat_id=chat_id,
+                placeholder_message_id=placeholder_message_id,
+                placeholder_step_id=placeholder_step_id,
+                cleanup_mode=cleanup_mode,
+            )
+
+        def _cleanup_placeholder_if_needed() -> None:
+            if placeholder_message_id and placeholder_step_id and chat_id:
+                _cleanup_visibility_context(
+                    state,
+                    chat_id=chat_id,
+                    placeholder_message_id=placeholder_message_id,
+                    placeholder_step_id=placeholder_step_id,
+                    cleanup_mode=cleanup_mode,
+                    terminal_status=None,
+                )
+
         params = _build_create_params(
             mode="FORM",
             message=message,
@@ -286,21 +764,29 @@ def cmd_elicit_ask(
             schema=parsed_schema,
             url=None,
             chat_id=chat_id,
-            message_id=message_id,
+            message_id=effective_message_id,
             expires_in_seconds=expires_in_seconds,
             external_elicitation_id=None,
-            metadata=_parse_metadata_pairs(metadata),
+            metadata=user_metadata,
         )
 
-        elicitation = unique_sdk.Elicitation.create_elicitation(
-            user_id=state.config.user_id,
-            company_id=state.config.company_id,
-            **params,
-        )
+        try:
+            elicitation = unique_sdk.Elicitation.create_elicitation(
+                user_id=state.config.user_id,
+                company_id=state.config.company_id,
+                **params,
+            )
+        except unique_sdk.APIError:
+            _cleanup_placeholder_if_needed()
+            raise
+
         elicitation_id = elicitation.get("id")
         if not elicitation_id:
+            _cleanup_placeholder_if_needed()
             return "elicit: platform did not return an elicitation id"
 
+        # ``cmd_elicit_wait`` handles its own placeholder teardown by
+        # reading the markers back from the elicitation's metadata.
         return cmd_elicit_wait(
             state,
             elicitation_id,

--- a/unique_sdk/unique_sdk/cli/commands/elicitation.py
+++ b/unique_sdk/unique_sdk/cli/commands/elicitation.py
@@ -1,0 +1,311 @@
+"""Elicitation commands: create, list, get, respond, wait, and ask the user for input.
+
+Elicitations are user-input requests routed through the Unique AI Platform.
+They are the canonical mechanism for an agent (or tool) to pose a question to
+the user and wait for a structured answer without leaving the conversation.
+
+The CLI exposes both low-level operations (create / get / respond / list /
+wait) and a high-level ``ask`` command that creates a FORM elicitation and
+blocks until the user responds or the request expires/times out.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+
+import unique_sdk
+from unique_sdk.cli.formatting import (
+    format_elicitation,
+    format_elicitation_response,
+    format_pending_elicitations,
+)
+from unique_sdk.cli.state import ShellState
+
+DEFAULT_POLL_INTERVAL_SECONDS = 2.0
+DEFAULT_WAIT_TIMEOUT_SECONDS = 300
+TERMINAL_STATUSES = {"RESPONDED", "DECLINED", "CANCELLED", "EXPIRED", "COMPLETED"}
+
+
+def _parse_json_arg(value: str | None, *, field: str) -> dict[str, Any] | None:
+    """Parse an optional JSON string argument into a dict.
+
+    Raises ``ValueError`` with a user-friendly message if the value is not
+    valid JSON or does not decode to a JSON object.
+    """
+    if value is None:
+        return None
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid JSON for {field}: {exc}") from exc
+    if not isinstance(parsed, dict):
+        raise ValueError(f"{field} must be a JSON object")
+    return parsed
+
+
+def _parse_metadata_pairs(
+    metadata: list[tuple[str, str]] | None,
+) -> dict[str, str] | None:
+    """Convert a list of ``(key, value)`` pairs into a metadata dict."""
+    if not metadata:
+        return None
+    return dict(metadata)
+
+
+def _build_create_params(
+    *,
+    mode: str,
+    message: str,
+    tool_name: str,
+    schema: dict[str, Any] | None,
+    url: str | None,
+    chat_id: str | None,
+    message_id: str | None,
+    expires_in_seconds: int | None,
+    external_elicitation_id: str | None,
+    metadata: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Assemble the ``create_elicitation`` params dict, omitting None values."""
+    params: dict[str, Any] = {
+        "mode": mode,
+        "message": message,
+        "toolName": tool_name,
+    }
+    if schema is not None:
+        params["schema"] = schema
+    if url is not None:
+        params["url"] = url
+    if chat_id is not None:
+        params["chatId"] = chat_id
+    if message_id is not None:
+        params["messageId"] = message_id
+    if expires_in_seconds is not None:
+        params["expiresInSeconds"] = expires_in_seconds
+    if external_elicitation_id is not None:
+        params["externalElicitationId"] = external_elicitation_id
+    if metadata is not None:
+        params["metadata"] = metadata
+    return params
+
+
+def cmd_elicit_create(
+    state: ShellState,
+    *,
+    mode: str,
+    message: str,
+    tool_name: str,
+    schema: str | None = None,
+    url: str | None = None,
+    chat_id: str | None = None,
+    message_id: str | None = None,
+    expires_in_seconds: int | None = None,
+    external_elicitation_id: str | None = None,
+    metadata: list[tuple[str, str]] | None = None,
+) -> str:
+    """Create an elicitation request (FORM or URL mode)."""
+    try:
+        mode_upper = mode.upper()
+        if mode_upper not in ("FORM", "URL"):
+            return f"elicit: invalid mode '{mode}' (expected FORM or URL)"
+
+        parsed_schema = _parse_json_arg(schema, field="--schema")
+        if mode_upper == "FORM" and parsed_schema is None:
+            return "elicit: --schema is required when --mode FORM"
+        if mode_upper == "URL" and not url:
+            return "elicit: --url is required when --mode URL"
+
+        params = _build_create_params(
+            mode=mode_upper,
+            message=message,
+            tool_name=tool_name,
+            schema=parsed_schema,
+            url=url,
+            chat_id=chat_id,
+            message_id=message_id,
+            expires_in_seconds=expires_in_seconds,
+            external_elicitation_id=external_elicitation_id,
+            metadata=_parse_metadata_pairs(metadata),
+        )
+
+        elicitation = unique_sdk.Elicitation.create_elicitation(
+            user_id=state.config.user_id,
+            company_id=state.config.company_id,
+            **params,
+        )
+        return (
+            f"Created elicitation {elicitation.get('id', '?')}\n\n"
+            f"{format_elicitation(elicitation)}"
+        )
+    except (ValueError, unique_sdk.APIError) as exc:
+        return f"elicit: {exc}"
+
+
+def cmd_elicit_pending(state: ShellState) -> str:
+    """List all pending elicitation requests for the current user."""
+    try:
+        response = unique_sdk.Elicitation.get_pending_elicitations(
+            user_id=state.config.user_id,
+            company_id=state.config.company_id,
+        )
+        return format_pending_elicitations(response.get("elicitations", []))
+    except unique_sdk.APIError as exc:
+        return f"elicit: {exc}"
+
+
+def cmd_elicit_get(state: ShellState, elicitation_id: str) -> str:
+    """Fetch an elicitation by ID and show its details."""
+    try:
+        elicitation = unique_sdk.Elicitation.get_elicitation(
+            user_id=state.config.user_id,
+            company_id=state.config.company_id,
+            elicitation_id=elicitation_id,
+        )
+        return format_elicitation(elicitation)
+    except unique_sdk.APIError as exc:
+        return f"elicit: {exc}"
+
+
+def cmd_elicit_respond(
+    state: ShellState,
+    elicitation_id: str,
+    *,
+    action: str,
+    content: str | None = None,
+) -> str:
+    """Respond to an elicitation on behalf of the user.
+
+    Typically the *user* responds via the Unique UI; this command is primarily
+    useful for scripted workflows, tests, or declining / cancelling requests
+    on their behalf.
+    """
+    try:
+        action_upper = action.upper()
+        if action_upper not in ("ACCEPT", "DECLINE", "CANCEL"):
+            return (
+                f"elicit: invalid action '{action}' "
+                "(expected ACCEPT, DECLINE, or CANCEL)"
+            )
+
+        parsed_content = _parse_json_arg(content, field="--content")
+        if action_upper == "ACCEPT" and parsed_content is None:
+            return "elicit: --content (JSON object) is required for ACCEPT"
+
+        params: dict[str, Any] = {
+            "elicitationId": elicitation_id,
+            "action": action_upper,
+        }
+        if parsed_content is not None:
+            params["content"] = parsed_content
+
+        result = unique_sdk.Elicitation.respond_to_elicitation(
+            user_id=state.config.user_id,
+            company_id=state.config.company_id,
+            **params,
+        )
+        return format_elicitation_response(result, elicitation_id, action_upper)
+    except (ValueError, unique_sdk.APIError) as exc:
+        return f"elicit: {exc}"
+
+
+def cmd_elicit_wait(
+    state: ShellState,
+    elicitation_id: str,
+    *,
+    timeout: int = DEFAULT_WAIT_TIMEOUT_SECONDS,
+    poll_interval: float = DEFAULT_POLL_INTERVAL_SECONDS,
+) -> str:
+    """Block until an elicitation transitions to a terminal state.
+
+    Polls ``get_elicitation`` at ``poll_interval`` intervals and returns the
+    formatted elicitation once its ``status`` is RESPONDED / DECLINED /
+    CANCELLED / EXPIRED / COMPLETED, or when ``timeout`` seconds elapse.
+    """
+    try:
+        deadline = time.monotonic() + max(1, timeout)
+        last: dict[str, Any] | None = None
+        while True:
+            elicitation = unique_sdk.Elicitation.get_elicitation(
+                user_id=state.config.user_id,
+                company_id=state.config.company_id,
+                elicitation_id=elicitation_id,
+            )
+            last = dict(elicitation)
+            status = str(elicitation.get("status", "")).upper()
+            if status in TERMINAL_STATUSES:
+                return format_elicitation(elicitation)
+            if time.monotonic() >= deadline:
+                return (
+                    f"elicit: timed out after {timeout}s waiting for "
+                    f"{elicitation_id} (last status: {status or 'UNKNOWN'})\n\n"
+                    f"{format_elicitation(last)}"
+                )
+            time.sleep(poll_interval)
+    except unique_sdk.APIError as exc:
+        return f"elicit: {exc}"
+
+
+def cmd_elicit_ask(
+    state: ShellState,
+    *,
+    message: str,
+    tool_name: str = "agent_question",
+    schema: str | None = None,
+    chat_id: str | None = None,
+    message_id: str | None = None,
+    expires_in_seconds: int | None = None,
+    timeout: int = DEFAULT_WAIT_TIMEOUT_SECONDS,
+    poll_interval: float = DEFAULT_POLL_INTERVAL_SECONDS,
+    metadata: list[tuple[str, str]] | None = None,
+) -> str:
+    """Create a FORM elicitation and wait for the user's reply.
+
+    When no ``--schema`` is passed, a minimal single-field form asking for a
+    free-text ``answer`` is used. This is the preferred entry point when an
+    agent needs to ask the user a clarifying question.
+    """
+    try:
+        parsed_schema = _parse_json_arg(schema, field="--schema")
+        if parsed_schema is None:
+            parsed_schema = {
+                "type": "object",
+                "properties": {
+                    "answer": {
+                        "type": "string",
+                        "description": "Free-text answer to the question.",
+                    },
+                },
+                "required": ["answer"],
+            }
+
+        params = _build_create_params(
+            mode="FORM",
+            message=message,
+            tool_name=tool_name,
+            schema=parsed_schema,
+            url=None,
+            chat_id=chat_id,
+            message_id=message_id,
+            expires_in_seconds=expires_in_seconds,
+            external_elicitation_id=None,
+            metadata=_parse_metadata_pairs(metadata),
+        )
+
+        elicitation = unique_sdk.Elicitation.create_elicitation(
+            user_id=state.config.user_id,
+            company_id=state.config.company_id,
+            **params,
+        )
+        elicitation_id = elicitation.get("id")
+        if not elicitation_id:
+            return "elicit: platform did not return an elicitation id"
+
+        return cmd_elicit_wait(
+            state,
+            elicitation_id,
+            timeout=timeout,
+            poll_interval=poll_interval,
+        )
+    except (ValueError, unique_sdk.APIError) as exc:
+        return f"elicit: {exc}"

--- a/unique_sdk/unique_sdk/cli/formatting.py
+++ b/unique_sdk/unique_sdk/cli/formatting.py
@@ -1,7 +1,9 @@
-"""Tabular output formatting for ls, search results, file info, scheduled tasks, and MCP responses."""
+"""Tabular output formatting for ls, search results, file info, scheduled tasks, elicitations, and MCP responses."""
 
 from __future__ import annotations
 
+import json
+from collections.abc import Mapping, Sequence
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
@@ -182,6 +184,91 @@ def format_scheduled_tasks(tasks: list[ScheduledTask]) -> str:
     all_rows = [header] + rows
     lines.extend(_pad_columns(all_rows))
     return "\n".join(lines)
+
+
+def format_elicitation(elicitation: Mapping[str, Any]) -> str:
+    """Format a single elicitation request for terminal display.
+
+    Includes the response content inline when the elicitation has been
+    answered, which is what agents primarily need when consuming the output
+    of ``elicit wait`` / ``elicit ask``.
+    """
+    response_content = elicitation.get("responseContent")
+    response_json = (
+        json.dumps(response_content, ensure_ascii=False)
+        if response_content is not None
+        else "(none)"
+    )
+    schema = elicitation.get("schema")
+    schema_json = json.dumps(schema, ensure_ascii=False) if schema is not None else "-"
+    metadata = elicitation.get("metadata")
+    metadata_json = (
+        json.dumps(metadata, ensure_ascii=False) if metadata is not None else "-"
+    )
+
+    rows = [
+        ["ID:", elicitation.get("id", "?")],
+        ["Status:", elicitation.get("status", "?")],
+        ["Mode:", elicitation.get("mode", "?")],
+        ["Source:", elicitation.get("source", "?")],
+        ["Tool:", elicitation.get("toolName") or "-"],
+        ["Message:", elicitation.get("message", "")],
+        ["Schema:", schema_json],
+        ["URL:", elicitation.get("url") or "-"],
+        ["Chat:", elicitation.get("chatId") or "-"],
+        ["Message ID:", elicitation.get("messageId") or "-"],
+        ["External ID:", elicitation.get("externalElicitationId") or "-"],
+        ["Metadata:", metadata_json],
+        ["Response:", response_json],
+        ["Responded:", _format_date(elicitation.get("respondedAt"))],
+        ["Expires:", _format_date(elicitation.get("expiresAt"))],
+        ["Created:", _format_date(elicitation.get("createdAt"))],
+        ["Updated:", _format_date(elicitation.get("updatedAt"))],
+    ]
+    return "\n".join(_pad_columns(rows))
+
+
+def format_pending_elicitations(elicitations: Sequence[Mapping[str, Any]]) -> str:
+    """Format the list of pending elicitations as a compact table."""
+    if not elicitations:
+        return "No pending elicitations."
+
+    header = ["STATUS", "MODE", "TOOL", "MESSAGE", "ID", "EXPIRES"]
+    rows: list[list[str]] = [header]
+    for item in elicitations:
+        status = str(item.get("status", "?"))
+        mode = str(item.get("mode", "?"))
+        tool = str(item.get("toolName") or "-")
+        message = str(item.get("message") or "")
+        snippet = message[:60].replace("\n", " ").strip()
+        if len(message) > 60:
+            snippet += "..."
+        elicitation_id = str(item.get("id", "?"))
+        expires = _format_date(item.get("expiresAt"))
+        rows.append([status, mode, tool, snippet, elicitation_id, expires])
+
+    lines = [f"{len(elicitations)} pending elicitation(s):\n"]
+    lines.extend(_pad_columns(rows))
+    return "\n".join(lines)
+
+
+def format_elicitation_response(
+    result: Mapping[str, Any],
+    elicitation_id: str,
+    action: str,
+) -> str:
+    """Format the result of ``respond_to_elicitation``."""
+    success = bool(result.get("success"))
+    status = "OK" if success else "FAILED"
+    rows = [
+        ["Elicitation:", elicitation_id],
+        ["Action:", action],
+        ["Result:", status],
+    ]
+    detail = result.get("message")
+    if detail:
+        rows.append(["Detail:", str(detail)])
+    return "\n".join(_pad_columns(rows))
 
 
 def format_mcp_response(response: MCP) -> str:

--- a/unique_sdk/unique_sdk/cli/shell.py
+++ b/unique_sdk/unique_sdk/cli/shell.py
@@ -5,8 +5,17 @@ from __future__ import annotations
 import cmd
 import shlex
 import textwrap
+from typing import Any
 
 from unique_sdk.cli import __version__
+from unique_sdk.cli.commands.elicitation import (
+    cmd_elicit_ask,
+    cmd_elicit_create,
+    cmd_elicit_get,
+    cmd_elicit_pending,
+    cmd_elicit_respond,
+    cmd_elicit_wait,
+)
 from unique_sdk.cli.commands.files import cmd_download, cmd_mv_file, cmd_rm, cmd_upload
 from unique_sdk.cli.commands.folders import cmd_mkdir, cmd_mvdir, cmd_rmdir
 from unique_sdk.cli.commands.mcp import cmd_mcp
@@ -56,6 +65,35 @@ OVERVIEW_HELP = textwrap.dedent("""\
         --message-id / -m <id>    Message ID (required)
         --file / -f <path>        Read JSON from file instead
         --stdin                   Read JSON from stdin
+
+    Elicitation (ask the user):
+      elicit ask <message> [opts]    Ask a question and wait for the answer
+        --tool-name / -t <name>        Tool label shown in the UI
+        --schema <json>                JSON schema (default: single 'answer' field)
+        --chat-id / -c <id>            Associated chat ID
+        --message-id / -m <id>         Associated message ID
+        --expires-in <seconds>         Auto-expire the request
+        --timeout <seconds>            Max wait time (default: 300)
+        --poll-interval <seconds>      Poll frequency (default: 2.0)
+        --metadata key=value           Metadata (repeatable)
+      elicit create <message> [opts] Fire-and-forget create
+        --mode FORM|URL                Display mode (required)
+        --tool-name / -t <name>        Tool label (required)
+        --schema <json>                JSON schema (FORM mode)
+        --url <url>                    External URL (URL mode)
+        --chat-id / -c <id>            Associated chat ID
+        --message-id / -m <id>         Associated message ID
+        --expires-in <seconds>         Auto-expire
+        --external-id <id>             External tracking ID
+        --metadata key=value           Metadata (repeatable)
+      elicit pending                 List pending elicitations
+      elicit get <id>                Show one elicitation
+      elicit wait <id> [opts]        Poll until answered / expired
+        --timeout <seconds>            Max wait (default: 300)
+        --poll-interval <seconds>      Poll frequency (default: 2.0)
+      elicit respond <id> [opts]     Respond on behalf of the user
+        --action ACCEPT|DECLINE|CANCEL Response action (required)
+        --content <json>               Response body (required for ACCEPT)
 
     Scheduled tasks:
       schedule list             List all scheduled tasks
@@ -506,6 +544,268 @@ class UniqueShell(cmd.Cmd):
                 payload=payload,
                 file=file_path,
                 stdin=use_stdin,
+            )
+        )
+
+    # -- Elicitations --
+
+    def do_elicit(self, arg: str) -> None:
+        """Ask the user a question via the Unique elicitation API.
+
+        Usage: elicit <subcommand> [options]
+
+        Subcommands:
+          ask <message> [options]      Ask and wait synchronously for the answer
+          create <message> [options]   Create without waiting
+          pending                      List pending elicitations
+          get <id>                     Show one elicitation
+          wait <id> [options]          Poll until answered / expired
+          respond <id> [options]       Respond on behalf of the user
+
+        Ask / create options:
+          --tool-name / -t <name>      Tool label shown in the UI
+          --schema <json>              JSON schema for form fields
+          --url <url>                  External URL (create with --mode URL)
+          --mode FORM|URL              Display mode (create only, required)
+          --chat-id / -c <id>          Associated chat ID
+          --message-id / -m <id>       Associated message ID
+          --expires-in <seconds>       Auto-expire the request
+          --timeout <seconds>          (ask / wait) max wait time, default 300
+          --poll-interval <seconds>    (ask / wait) poll frequency, default 2
+          --external-id <id>           External identifier (create only)
+          --metadata key=value         Metadata (repeatable)
+
+        Respond options:
+          --action ACCEPT|DECLINE|CANCEL  Action (required)
+          --content <json>                Response body (required for ACCEPT)
+
+        Examples:
+          /> elicit ask "Which quarter should I report on? (Q1 or Q2)"
+          /> elicit ask "Confirm delete" --timeout 60
+          /> elicit pending
+          /> elicit get elicit_abc123
+          /> elicit wait elicit_abc123
+          /> elicit respond elicit_abc123 --action DECLINE
+        """
+        parts = shlex.split(arg)
+        if not parts:
+            self._print(
+                "Usage: elicit <ask|create|pending|get|wait|respond> [options]\n"
+                "Type 'help elicit' for details."
+            )
+            return
+
+        subcmd = parts[0]
+        rest = parts[1:]
+
+        if subcmd == "pending":
+            self._print(cmd_elicit_pending(self.state))
+        elif subcmd == "get":
+            if not rest:
+                self._print("Usage: elicit get <elicitation_id>")
+                return
+            self._print(cmd_elicit_get(self.state, rest[0]))
+        elif subcmd == "ask":
+            self._elicit_ask(rest)
+        elif subcmd == "create":
+            self._elicit_create(rest)
+        elif subcmd == "wait":
+            if not rest:
+                self._print("Usage: elicit wait <elicitation_id> [options]")
+                return
+            self._elicit_wait(rest[0], rest[1:])
+        elif subcmd == "respond":
+            if not rest:
+                self._print("Usage: elicit respond <elicitation_id> [options]")
+                return
+            self._elicit_respond(rest[0], rest[1:])
+        else:
+            self._print(
+                f"Unknown subcommand: {subcmd}\n"
+                "Usage: elicit <ask|create|pending|get|wait|respond> [options]"
+            )
+
+    def _elicit_parse_common(
+        self,
+        parts: list[str],
+    ) -> dict[str, Any] | None:
+        """Parse options common to ask / create / wait / respond.
+
+        Returns a dict with parsed values, or None on error (already printed).
+        The caller extracts the keys it cares about.
+        """
+        out: dict[str, Any] = {
+            "message": None,
+            "tool_name": None,
+            "schema": None,
+            "url": None,
+            "mode": None,
+            "chat_id": None,
+            "message_id": None,
+            "expires_in_seconds": None,
+            "external_elicitation_id": None,
+            "timeout": 300,
+            "poll_interval": 2.0,
+            "action": None,
+            "content": None,
+            "metadata": [],
+        }
+        positional: list[str] = []
+
+        i = 0
+        while i < len(parts):
+            tok = parts[i]
+            if tok in ("--tool-name", "-t") and i + 1 < len(parts):
+                out["tool_name"] = parts[i + 1]
+                i += 2
+            elif tok == "--schema" and i + 1 < len(parts):
+                out["schema"] = parts[i + 1]
+                i += 2
+            elif tok == "--url" and i + 1 < len(parts):
+                out["url"] = parts[i + 1]
+                i += 2
+            elif tok == "--mode" and i + 1 < len(parts):
+                out["mode"] = parts[i + 1]
+                i += 2
+            elif tok in ("--chat-id", "-c") and i + 1 < len(parts):
+                out["chat_id"] = parts[i + 1]
+                i += 2
+            elif tok in ("--message-id", "-m") and i + 1 < len(parts):
+                out["message_id"] = parts[i + 1]
+                i += 2
+            elif tok == "--expires-in" and i + 1 < len(parts):
+                try:
+                    out["expires_in_seconds"] = int(parts[i + 1])
+                except ValueError:
+                    self._print(f"Invalid --expires-in: {parts[i + 1]}")
+                    return None
+                i += 2
+            elif tok == "--external-id" and i + 1 < len(parts):
+                out["external_elicitation_id"] = parts[i + 1]
+                i += 2
+            elif tok == "--timeout" and i + 1 < len(parts):
+                try:
+                    out["timeout"] = int(parts[i + 1])
+                except ValueError:
+                    self._print(f"Invalid --timeout: {parts[i + 1]}")
+                    return None
+                i += 2
+            elif tok == "--poll-interval" and i + 1 < len(parts):
+                try:
+                    out["poll_interval"] = float(parts[i + 1])
+                except ValueError:
+                    self._print(f"Invalid --poll-interval: {parts[i + 1]}")
+                    return None
+                i += 2
+            elif tok == "--action" and i + 1 < len(parts):
+                out["action"] = parts[i + 1]
+                i += 2
+            elif tok == "--content" and i + 1 < len(parts):
+                out["content"] = parts[i + 1]
+                i += 2
+            elif tok == "--metadata" and i + 1 < len(parts):
+                kv = parts[i + 1]
+                if "=" not in kv:
+                    self._print(f"Invalid metadata format: {kv} (expected key=value)")
+                    return None
+                k, v = kv.split("=", 1)
+                out["metadata"].append((k, v))
+                i += 2
+            else:
+                positional.append(tok)
+                i += 1
+
+        if positional:
+            out["message"] = " ".join(positional)
+        return out
+
+    def _elicit_ask(self, parts: list[str]) -> None:
+        """Parse and run ``elicit ask``."""
+        opts = self._elicit_parse_common(parts)
+        if opts is None:
+            return
+        message = opts["message"]
+        if not message:
+            self._print("Usage: elicit ask <message> [options]")
+            return
+
+        self._print(
+            cmd_elicit_ask(
+                self.state,
+                message=message,
+                tool_name=opts["tool_name"] or "agent_question",
+                schema=opts["schema"],
+                chat_id=opts["chat_id"],
+                message_id=opts["message_id"],
+                expires_in_seconds=opts["expires_in_seconds"],
+                timeout=opts["timeout"],
+                poll_interval=opts["poll_interval"],
+                metadata=opts["metadata"] or None,
+            )
+        )
+
+    def _elicit_create(self, parts: list[str]) -> None:
+        """Parse and run ``elicit create``."""
+        opts = self._elicit_parse_common(parts)
+        if opts is None:
+            return
+        message = opts["message"]
+        if not message:
+            self._print(
+                "Usage: elicit create <message> --mode FORM|URL --tool-name <name> [options]"
+            )
+            return
+        if not opts["mode"]:
+            self._print("Error: --mode is required (FORM or URL).")
+            return
+        if not opts["tool_name"]:
+            self._print("Error: --tool-name / -t is required.")
+            return
+
+        self._print(
+            cmd_elicit_create(
+                self.state,
+                mode=opts["mode"],
+                message=message,
+                tool_name=opts["tool_name"],
+                schema=opts["schema"],
+                url=opts["url"],
+                chat_id=opts["chat_id"],
+                message_id=opts["message_id"],
+                expires_in_seconds=opts["expires_in_seconds"],
+                external_elicitation_id=opts["external_elicitation_id"],
+                metadata=opts["metadata"] or None,
+            )
+        )
+
+    def _elicit_wait(self, elicitation_id: str, parts: list[str]) -> None:
+        """Parse and run ``elicit wait``."""
+        opts = self._elicit_parse_common(parts)
+        if opts is None:
+            return
+        self._print(
+            cmd_elicit_wait(
+                self.state,
+                elicitation_id,
+                timeout=opts["timeout"],
+                poll_interval=opts["poll_interval"],
+            )
+        )
+
+    def _elicit_respond(self, elicitation_id: str, parts: list[str]) -> None:
+        """Parse and run ``elicit respond``."""
+        opts = self._elicit_parse_common(parts)
+        if opts is None:
+            return
+        if not opts["action"]:
+            self._print("Error: --action ACCEPT|DECLINE|CANCEL is required.")
+            return
+        self._print(
+            cmd_elicit_respond(
+                self.state,
+                elicitation_id,
+                action=opts["action"],
+                content=opts["content"],
             )
         )
 

--- a/unique_sdk/unique_sdk/cli/shell.py
+++ b/unique_sdk/unique_sdk/cli/shell.py
@@ -76,6 +76,10 @@ OVERVIEW_HELP = textwrap.dedent("""\
         --timeout <seconds>            Max wait time (default: 300)
         --poll-interval <seconds>      Poll frequency (default: 2.0)
         --metadata key=value           Metadata (repeatable)
+        --no-visible                   Skip the UN-19815 visibility workaround
+        --assistant-id <id>            Assistant id for the placeholder message
+        --placeholder-text <text>      Text on the placeholder thinking step
+        --cleanup collapse|delete      How to tear down the placeholder
       elicit create <message> [opts] Fire-and-forget create
         --mode FORM|URL                Display mode (required)
         --tool-name / -t <name>        Tool label (required)
@@ -86,6 +90,10 @@ OVERVIEW_HELP = textwrap.dedent("""\
         --expires-in <seconds>         Auto-expire
         --external-id <id>             External tracking ID
         --metadata key=value           Metadata (repeatable)
+        --no-visible                   Skip the UN-19815 visibility workaround
+        --assistant-id <id>            Assistant id for the placeholder message
+        --placeholder-text <text>      Text on the placeholder thinking step
+        --cleanup collapse|delete      Placeholder teardown mode
       elicit pending                 List pending elicitations
       elicit get <id>                Show one elicitation
       elicit wait <id> [opts]        Poll until answered / expired
@@ -649,6 +657,10 @@ class UniqueShell(cmd.Cmd):
             "action": None,
             "content": None,
             "metadata": [],
+            "visible": True,
+            "assistant_id": None,
+            "placeholder_text": None,
+            "cleanup_mode": None,
         }
         positional: list[str] = []
 
@@ -711,6 +723,27 @@ class UniqueShell(cmd.Cmd):
                 k, v = kv.split("=", 1)
                 out["metadata"].append((k, v))
                 i += 2
+            elif tok == "--no-visible":
+                out["visible"] = False
+                i += 1
+            elif tok == "--visible":
+                out["visible"] = True
+                i += 1
+            elif tok == "--assistant-id" and i + 1 < len(parts):
+                out["assistant_id"] = parts[i + 1]
+                i += 2
+            elif tok == "--placeholder-text" and i + 1 < len(parts):
+                out["placeholder_text"] = parts[i + 1]
+                i += 2
+            elif tok == "--cleanup" and i + 1 < len(parts):
+                mode = parts[i + 1].lower()
+                if mode not in ("collapse", "delete"):
+                    self._print(
+                        f"Invalid --cleanup: {parts[i + 1]} (expected collapse or delete)"
+                    )
+                    return None
+                out["cleanup_mode"] = mode
+                i += 2
             else:
                 positional.append(tok)
                 i += 1
@@ -729,20 +762,24 @@ class UniqueShell(cmd.Cmd):
             self._print("Usage: elicit ask <message> [options]")
             return
 
-        self._print(
-            cmd_elicit_ask(
-                self.state,
-                message=message,
-                tool_name=opts["tool_name"] or "agent_question",
-                schema=opts["schema"],
-                chat_id=opts["chat_id"],
-                message_id=opts["message_id"],
-                expires_in_seconds=opts["expires_in_seconds"],
-                timeout=opts["timeout"],
-                poll_interval=opts["poll_interval"],
-                metadata=opts["metadata"] or None,
-            )
-        )
+        ask_kwargs: dict[str, Any] = {
+            "message": message,
+            "tool_name": opts["tool_name"] or "agent_question",
+            "schema": opts["schema"],
+            "chat_id": opts["chat_id"],
+            "message_id": opts["message_id"],
+            "expires_in_seconds": opts["expires_in_seconds"],
+            "timeout": opts["timeout"],
+            "poll_interval": opts["poll_interval"],
+            "metadata": opts["metadata"] or None,
+            "visible": opts["visible"],
+            "assistant_id": opts["assistant_id"],
+        }
+        if opts["placeholder_text"] is not None:
+            ask_kwargs["placeholder_text"] = opts["placeholder_text"]
+        if opts["cleanup_mode"] is not None:
+            ask_kwargs["cleanup_mode"] = opts["cleanup_mode"]
+        self._print(cmd_elicit_ask(self.state, **ask_kwargs))
 
     def _elicit_create(self, parts: list[str]) -> None:
         """Parse and run ``elicit create``."""
@@ -762,21 +799,25 @@ class UniqueShell(cmd.Cmd):
             self._print("Error: --tool-name / -t is required.")
             return
 
-        self._print(
-            cmd_elicit_create(
-                self.state,
-                mode=opts["mode"],
-                message=message,
-                tool_name=opts["tool_name"],
-                schema=opts["schema"],
-                url=opts["url"],
-                chat_id=opts["chat_id"],
-                message_id=opts["message_id"],
-                expires_in_seconds=opts["expires_in_seconds"],
-                external_elicitation_id=opts["external_elicitation_id"],
-                metadata=opts["metadata"] or None,
-            )
-        )
+        create_kwargs: dict[str, Any] = {
+            "mode": opts["mode"],
+            "message": message,
+            "tool_name": opts["tool_name"],
+            "schema": opts["schema"],
+            "url": opts["url"],
+            "chat_id": opts["chat_id"],
+            "message_id": opts["message_id"],
+            "expires_in_seconds": opts["expires_in_seconds"],
+            "external_elicitation_id": opts["external_elicitation_id"],
+            "metadata": opts["metadata"] or None,
+            "visible": opts["visible"],
+            "assistant_id": opts["assistant_id"],
+        }
+        if opts["placeholder_text"] is not None:
+            create_kwargs["placeholder_text"] = opts["placeholder_text"]
+        if opts["cleanup_mode"] is not None:
+            create_kwargs["cleanup_mode"] = opts["cleanup_mode"]
+        self._print(cmd_elicit_create(self.state, **create_kwargs))
 
     def _elicit_wait(self, elicitation_id: str, parts: list[str]) -> None:
         """Parse and run ``elicit wait``."""

--- a/unique_sdk/unique_sdk/cli/skills/unique-cli-elicitation/SKILL.md
+++ b/unique_sdk/unique_sdk/cli/skills/unique-cli-elicitation/SKILL.md
@@ -16,6 +16,9 @@ Use this skill **whenever you need input from the user** -- a clarifying questio
 
 > **Rule of thumb:** if you catch yourself about to write "Could you clarify…?" or "Do you want me to…?" or "Which one should I pick?" in chat, stop and call `unique-cli elicit ask` instead.
 
+!!! important "Visibility workaround is always on"
+    The UN-19815 visibility workaround (a short-lived placeholder "thinking" message that makes the elicitation visible in the chat UI) is **enabled by default** whenever you pass `--chat-id`. Always rely on it. **Do not pass `--no-visible`** unless you have independently confirmed that the UN-19815 UI fix is live in the target environment — otherwise the elicitation will be stored by the backend but invisible in the chat. See the [visibility workaround section](#un-19815-visibility-workaround--always-on-by-default) below for details.
+
 ## When to use
 
 | Situation | Use elicitation? |
@@ -118,6 +121,29 @@ unique-cli elicit ask "Please provide report settings" --schema '{
 | `--timeout` | | `300` | Max seconds to block locally before giving up. |
 | `--poll-interval` | | `2.0` | Seconds between status polls. |
 | `--metadata` | | none | `key=value` metadata (repeatable). |
+| `--visible` / `--no-visible` | | **`--visible` (always on)** | UN-19815 workaround: wrap the elicitation in a synthetic "thinking" timeline so the chat UI actually renders it. **Leave this on.** Only disable if you have verified the UN-19815 UI fix is live in your environment. |
+| `--assistant-id` | | `$UNIQUE_ASSISTANT_ID`, else latest assistant in chat | Assistant id for the placeholder message created by the visibility workaround. |
+| `--placeholder-text` | | `Waiting for your answer…` | Text shown on the placeholder thinking step. |
+| `--cleanup` | | `collapse` | How the placeholder is torn down after the user responds: `collapse` sets `completedAt` + a short note; `delete` removes the placeholder message entirely. |
+
+### UN-19815 visibility workaround — always on by default
+
+**You do not need to think about this.** Any time you call `elicit ask` / `elicit create` with `--chat-id`, the CLI automatically wraps the elicitation in a short-lived placeholder "thinking" message so the chat UI actually renders the question. This is the current supported behaviour — not an opt-in.
+
+Why it exists: as of April 2026 the chat UI only renders an elicitation when its host assistant message is actively in the *thinking timeline* display mode ([UN-19815](https://unique-ch.atlassian.net/browse/UN-19815)). Without the workaround, an elicitation created against a chat that has no currently-streaming assistant turn would be stored correctly by the backend but be silently invisible in the UI — users would assume the feature was broken.
+
+How it is kept tidy:
+
+- A placeholder `ASSISTANT` message + `RUNNING` `MessageLog` step are created just before the elicitation.
+- The placeholder is torn down automatically after the user responds (default: `collapse` — sets `completedAt` + a short note; optional: `delete`).
+- Cleanup also runs on local timeout, API error, and Ctrl-C — there is no code path that leaves a dangling thinking bubble.
+- `elicit wait` and `elicit respond` read the cleanup markers out of the elicitation's `metadata` and tear down the placeholder themselves, so scripted flows that split create and respond are safe too.
+
+Rules for agents:
+
+1. **Do not pass `--no-visible`.** It exists only for the day the UN-19815 UI fix ships in your environment; until then the visibility workaround is the only way to make elicitations appear in the chat.
+2. If the chat is brand-new with no prior assistant messages, pass `--assistant-id <id>` or export `UNIQUE_ASSISTANT_ID` so the placeholder can be created. Otherwise the CLI prints a clear error and refuses to create an invisible elicitation.
+3. If you ever need to reason about the placeholder directly, the identifiers are stored in the elicitation's `metadata` under `_uniqueSdkPlaceholderMessageId` / `_uniqueSdkPlaceholderStepId` / `_uniqueSdkPlaceholderChatId` / `_uniqueSdkCleanupMode`. These are SDK-private — do not write to them yourself.
 
 ## Reading the Response
 
@@ -220,12 +246,13 @@ unique-cli elicit respond elicit_abc123 --action CANCEL
 ## Agent Workflow Rules
 
 1. **Default to `elicit ask`.** If you need an answer from the user, use the CLI, not a chat message.
-2. **Never run destructive CLI commands without a confirmation elicitation.** This includes `rm`, `rmdir -r`, bulk renames, large uploads, schedule deletion, etc.
-3. **Pick a meaningful `--tool-name`.** `confirm_delete`, `choose_region`, `pick_report` -- short snake_case describing the intent.
-4. **Constrain answers with a schema** whenever the valid set is finite -- don't rely on parsing free text when `enum` is an option.
-5. **Handle non-ACCEPT outcomes explicitly.** If the status is `DECLINED` / `CANCELLED` / `EXPIRED`, tell the user you stopped and ask what they want to do next instead of silently proceeding.
-6. **Don't spam elicitations.** One well-designed form with several fields is better than five sequential yes/no questions.
-7. **Respect timeouts.** The default `--timeout` is 5 minutes -- raise it only if you genuinely expect the user to take longer.
+2. **Always let the visibility workaround run.** Whenever you pass `--chat-id`, the SDK wraps the elicitation in a placeholder thinking timeline by default so the chat UI renders it ([UN-19815](https://unique-ch.atlassian.net/browse/UN-19815) workaround). **Never pass `--no-visible`** unless you have independently verified the permanent UI fix is live — without the workaround the elicitation is silently invisible to the user.
+3. **Never run destructive CLI commands without a confirmation elicitation.** This includes `rm`, `rmdir -r`, bulk renames, large uploads, schedule deletion, etc.
+4. **Pick a meaningful `--tool-name`.** `confirm_delete`, `choose_region`, `pick_report` -- short snake_case describing the intent.
+5. **Constrain answers with a schema** whenever the valid set is finite -- don't rely on parsing free text when `enum` is an option.
+6. **Handle non-ACCEPT outcomes explicitly.** If the status is `DECLINED` / `CANCELLED` / `EXPIRED`, tell the user you stopped and ask what they want to do next instead of silently proceeding.
+7. **Don't spam elicitations.** One well-designed form with several fields is better than five sequential yes/no questions.
+8. **Respect timeouts.** The default `--timeout` is 5 minutes -- raise it only if you genuinely expect the user to take longer.
 
 ## Prerequisites
 

--- a/unique_sdk/unique_sdk/cli/skills/unique-cli-elicitation/SKILL.md
+++ b/unique_sdk/unique_sdk/cli/skills/unique-cli-elicitation/SKILL.md
@@ -1,0 +1,280 @@
+---
+name: unique-cli-elicitation
+description: >-
+  ALWAYS use this skill whenever you would otherwise ask the user a
+  question in free-form chat -- for clarifications, confirmations
+  (especially destructive actions), missing parameters, multiple-choice
+  decisions, or structured form input. Elicitations are routed through
+  the Unique AI Platform UI via `unique-cli elicit ask` so the user gets
+  a proper structured prompt and you get a structured answer back.
+  Do NOT ask the user in plain chat when you can use this skill instead.
+---
+
+# Unique CLI -- Elicitation (Ask the User)
+
+Use this skill **whenever you need input from the user** -- a clarifying question, a confirmation before a destructive action, a choice between options, or a structured form. Elicitations create a first-class UI prompt on the Unique AI Platform and return the answer as structured JSON.
+
+> **Rule of thumb:** if you catch yourself about to write "Could you clarify…?" or "Do you want me to…?" or "Which one should I pick?" in chat, stop and call `unique-cli elicit ask` instead.
+
+## When to use
+
+| Situation | Use elicitation? |
+|-----------|------------------|
+| Clarifying an ambiguous request | Yes |
+| Confirming a destructive / irreversible action | Yes, always |
+| Picking among 2+ concrete options | Yes |
+| Gathering structured data (rating, date, options) | Yes |
+| Quick status update / "I'll start now" message | No -- just talk |
+| Purely informational output (results, summaries) | No |
+
+## Core Command: `elicit ask`
+
+This is the command you reach for 95% of the time. It creates a FORM elicitation, displays it to the user, and **blocks** until the user answers, declines, cancels, or the request expires.
+
+```bash
+unique-cli elicit ask "<question>" [options]
+```
+
+### Minimal example (free-text answer)
+
+```bash
+unique-cli elicit ask "Which quarter should I report on?"
+```
+
+Under the hood this creates a form with a single required string field `answer`. The reply you receive will look like:
+
+```
+ID:         elicit_abc123
+Status:     RESPONDED
+Mode:       FORM
+...
+Response:   {"answer": "Q1"}
+Responded:  2026-04-16 14:22
+```
+
+Parse the JSON next to `Response:` to get the user's answer.
+
+### Multiple-choice (recommended for picks / confirmations)
+
+Provide an explicit JSON schema so the user sees proper UI controls instead of a free-text box. Use `enum` for finite choices.
+
+```bash
+unique-cli elicit ask "Which report format do you want?" --schema '{
+  "type": "object",
+  "properties": {
+    "format": {
+      "type": "string",
+      "enum": ["PDF", "DOCX", "Markdown"],
+      "description": "Output format"
+    }
+  },
+  "required": ["format"]
+}'
+```
+
+### Confirmation (destructive action)
+
+Always use this before `rm`, `rmdir -r`, mass uploads, or anything irreversible.
+
+```bash
+unique-cli elicit ask "Confirm deleting /Archive/2024 and everything inside it" --schema '{
+  "type": "object",
+  "properties": {
+    "confirm": {
+      "type": "boolean",
+      "description": "Tick to permanently delete"
+    }
+  },
+  "required": ["confirm"]
+}'
+```
+
+Proceed **only** if the response contains `"confirm": true`. Treat `DECLINED`, `CANCELLED`, `EXPIRED`, or `confirm: false` all as "do not proceed" -- tell the user you stopped and return control.
+
+### Structured form (multiple fields)
+
+```bash
+unique-cli elicit ask "Please provide report settings" --schema '{
+  "type": "object",
+  "properties": {
+    "quarter":   {"type": "string", "enum": ["Q1", "Q2", "Q3", "Q4"]},
+    "year":      {"type": "integer", "minimum": 2000, "maximum": 2100},
+    "recipients":{"type": "array", "items": {"type": "string", "format": "email"}},
+    "include_appendix": {"type": "boolean"}
+  },
+  "required": ["quarter", "year"]
+}'
+```
+
+## `elicit ask` Options
+
+| Option | Short | Default | Description |
+|--------|-------|---------|-------------|
+| `--tool-name` | `-t` | `agent_question` | Label shown to the user (use a short verb like `clarify`, `confirm`, `choose_report`). |
+| `--schema` | | single `answer` string | JSON Schema for the form body. |
+| `--chat-id` | `-c` | none | Attach the elicitation to a chat. |
+| `--message-id` | `-m` | none | Attach to a specific message. |
+| `--expires-in` | | none | Seconds before the request auto-expires. |
+| `--timeout` | | `300` | Max seconds to block locally before giving up. |
+| `--poll-interval` | | `2.0` | Seconds between status polls. |
+| `--metadata` | | none | `key=value` metadata (repeatable). |
+
+## Reading the Response
+
+The command prints a key-value block terminated by:
+
+```
+Status:     <TERMINAL_STATUS>
+...
+Response:   <JSON or "(none)">
+```
+
+Terminal statuses:
+
+| Status | Meaning | What to do |
+|--------|---------|------------|
+| `RESPONDED` / `COMPLETED` | User answered | Parse `Response:` JSON and proceed. |
+| `DECLINED` | User explicitly declined | Do not proceed. Acknowledge and stop. |
+| `CANCELLED` | Cancelled (by user or system) | Do not proceed. |
+| `EXPIRED` | Timed out on the platform (via `--expires-in`) | Ask again only if the task still needs it. |
+
+If the CLI itself times out locally (`elicit: timed out after Ns ...`), the request is still live on the platform -- you can poll later with `elicit wait <id>` or `elicit get <id>`.
+
+## Scripting Pattern
+
+In a shell script or agent tool wrapper, capture the output and pull out the `Response:` line:
+
+```bash
+result=$(unique-cli elicit ask "Which region?" --schema '{
+  "type":"object",
+  "properties":{"region":{"type":"string","enum":["EU","US","APAC"]}},
+  "required":["region"]
+}')
+
+answer=$(echo "$result" | awk -F'Response:[[:space:]]*' '/^Response:/{print $2}')
+region=$(echo "$answer" | jq -r '.region')
+
+case "$region" in
+  EU|US|APAC) echo "Proceeding with region=$region";;
+  *)          echo "No valid answer ($region); aborting"; exit 1;;
+esac
+```
+
+## Other Subcommands
+
+These are secondary -- reach for `elicit ask` first.
+
+### `elicit create` -- fire-and-forget
+
+Create without blocking. Useful when you want to ask several things in parallel, or trigger a URL flow.
+
+```bash
+# FORM mode
+unique-cli elicit create "Please rate the last answer" \
+  --mode FORM --tool-name feedback \
+  --schema '{"type":"object","properties":{"rating":{"type":"integer","minimum":1,"maximum":5}},"required":["rating"]}'
+
+# URL mode (redirect the user to an external form)
+unique-cli elicit create "Complete the onboarding survey" \
+  --mode URL --tool-name onboarding --url https://example.com/survey
+```
+
+### `elicit pending` -- list open requests
+
+```bash
+unique-cli elicit pending
+```
+
+### `elicit get <id>` -- snapshot one elicitation
+
+```bash
+unique-cli elicit get elicit_abc123
+```
+
+### `elicit wait <id>` -- poll until terminal
+
+```bash
+unique-cli elicit wait elicit_abc123 --timeout 120
+```
+
+### `elicit respond <id>` -- respond programmatically
+
+Mostly for tests / automation. The human user normally responds via the UI.
+
+```bash
+unique-cli elicit respond elicit_abc123 --action ACCEPT \
+  --content '{"answer":"yes"}'
+
+unique-cli elicit respond elicit_abc123 --action DECLINE
+unique-cli elicit respond elicit_abc123 --action CANCEL
+```
+
+## Schema Tips
+
+- Always set `"required"` for fields you actually need -- this guarantees the user cannot submit an empty form.
+- Use `enum` for closed choices so the UI can render a selector.
+- Use `"type": "boolean"` for confirmations; treat `true` as "go ahead", everything else as "stop".
+- Add short `description` strings -- they are shown as help text next to each field.
+- Keep schemas small. Break long flows into several sequential `elicit ask` calls instead of one giant form.
+
+## Agent Workflow Rules
+
+1. **Default to `elicit ask`.** If you need an answer from the user, use the CLI, not a chat message.
+2. **Never run destructive CLI commands without a confirmation elicitation.** This includes `rm`, `rmdir -r`, bulk renames, large uploads, schedule deletion, etc.
+3. **Pick a meaningful `--tool-name`.** `confirm_delete`, `choose_region`, `pick_report` -- short snake_case describing the intent.
+4. **Constrain answers with a schema** whenever the valid set is finite -- don't rely on parsing free text when `enum` is an option.
+5. **Handle non-ACCEPT outcomes explicitly.** If the status is `DECLINED` / `CANCELLED` / `EXPIRED`, tell the user you stopped and ask what they want to do next instead of silently proceeding.
+6. **Don't spam elicitations.** One well-designed form with several fields is better than five sequential yes/no questions.
+7. **Respect timeouts.** The default `--timeout` is 5 minutes -- raise it only if you genuinely expect the user to take longer.
+
+## Prerequisites
+
+Requires these environment variables:
+
+```bash
+UNIQUE_USER_ID    # User ID (required)
+UNIQUE_COMPANY_ID # Company ID (required)
+UNIQUE_API_KEY    # API key -- optional on localhost / secured cluster
+UNIQUE_APP_ID     # App ID -- optional on localhost / secured cluster
+```
+
+Install: `pip install unique-sdk`
+
+## SDK Usage (Python)
+
+The CLI is backed by the `unique_sdk.Elicitation` API resource. When scripting from Python you can call it directly instead of shelling out:
+
+```python
+import unique_sdk
+
+elicitation = unique_sdk.Elicitation.create_elicitation(
+    user_id="user_123",
+    company_id="company_456",
+    mode="FORM",
+    message="Which quarter should I report on?",
+    toolName="choose_quarter",
+    schema={
+        "type": "object",
+        "properties": {
+            "quarter": {"type": "string", "enum": ["Q1", "Q2", "Q3", "Q4"]}
+        },
+        "required": ["quarter"],
+    },
+    expiresInSeconds=600,
+)
+
+# Poll until answered
+import time
+while elicitation["status"] not in {"RESPONDED", "DECLINED", "CANCELLED", "EXPIRED"}:
+    time.sleep(2)
+    elicitation = unique_sdk.Elicitation.get_elicitation(
+        user_id="user_123",
+        company_id="company_456",
+        elicitation_id=elicitation["id"],
+    )
+
+if elicitation["status"] == "RESPONDED":
+    print("User picked:", elicitation["responseContent"]["quarter"])
+```
+
+All methods have `*_async` variants for async usage.

--- a/uv.lock
+++ b/uv.lock
@@ -8,16 +8,16 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-02T19:32:54.505366Z"
+exclude-newer = "2026-04-02T20:33:30.870065Z"
 exclude-newer-span = "P2W"
 
 [options.exclude-newer-package]
 unique-toolkit = false
-langsmith = "2026-04-15T22:00:00Z"
-cryptography = "2026-04-09T22:00:00Z"
-langchain-core = "2026-04-09T22:00:00Z"
-pytest = "2026-04-08T22:00:00Z"
-python-multipart = "2026-04-11T22:00:00Z"
+langsmith = "2026-04-16T04:00:00Z"
+cryptography = "2026-04-10T04:00:00Z"
+langchain-core = "2026-04-10T04:00:00Z"
+pytest = "2026-04-09T04:00:00Z"
+python-multipart = "2026-04-12T04:00:00Z"
 
 [manifest]
 members = [
@@ -5384,7 +5384,7 @@ dev = []
 
 [[package]]
 name = "unique-sdk"
-version = "0.11.4"
+version = "0.11.5"
 source = { editable = "unique_sdk" }
 dependencies = [
     { name = "aiohttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-02T20:33:30.870065Z"
+exclude-newer = "2026-04-07T12:04:06.632499Z"
 exclude-newer-span = "P2W"
 
 [options.exclude-newer-package]
@@ -5384,7 +5384,7 @@ dev = []
 
 [[package]]
 name = "unique-sdk"
-version = "0.11.5"
+version = "0.11.7"
 source = { editable = "unique_sdk" }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Add a new `elicit` CLI command group to `unique-cli` (one-shot + REPL) wrapping the `Elicitation` API with `ask`, `create`, `pending`, `get`, `wait`, `respond` subcommands.
- Work around UN-19815 (chat UI only renders elicitations on messages in `ThinkingTimeline` mode) by transparently hosting the elicitation on a short-lived placeholder `ASSISTANT` message + `RUNNING` `MessageLog` step, torn down automatically on response / timeout / error / Ctrl-C.
- Ship the accompanying `unique-cli-elicitation` agent skill and CLI docs page, plus unit test coverage for the command group and the workaround.

## Changes
- `unique_sdk/unique_sdk/cli/commands/elicitation.py`: new command implementations, placeholder/step lifecycle, cleanup hooks read back from elicitation `metadata`.
- `unique_sdk/unique_sdk/cli/cli.py`, `unique_sdk/unique_sdk/cli/shell.py`: register the `elicit` group and its REPL equivalents; add `--visible/--no-visible`, `--assistant-id`, `--placeholder-text`, `--cleanup` flags on `ask` / `create`.
- `unique_sdk/tests/cli/test_elicitation.py`: full unit-test suite for every subcommand, terminal-status recognition, list/dict response shapes, and the visibility workaround teardown paths.
- `unique_sdk/docs/cli/elicitation.md`, `unique_sdk/unique_sdk/cli/skills/unique-cli-elicitation/SKILL.md`: document the new flags and when to turn the workaround off once UN-19815 is fixed upstream.
- `unique_sdk/CHANGELOG.md`, `unique_sdk/pyproject.toml`, `uv.lock`: bump `unique_sdk` to `0.11.7` and record the changes.

## Bug fixes rolled in (0.11.6 / 0.11.7)
- `elicit pending` no longer crashes with `AttributeError: 'list' object has no attribute 'get'` — both list and dict response shapes are handled.
- `elicit wait` / `elicit ask` now terminate when the user answers: `ACCEPTED` / `REJECTED` are treated as terminal alongside `RESPONDED` / `DECLINED` / `CANCELLED` / `EXPIRED` / `COMPLETED`.
- `elicit respond --action REJECT` is now accepted and forwarded correctly.
- `completedAt` is serialized as an ISO-8601 UTC string (not a raw `datetime`) when collapsing the visibility placeholder via `Message.modify`, so the `PATCH /messages/{id}` body is accepted by the backend.

## Test plan
- [x] `uv run pytest unique_sdk/tests/cli/test_elicitation.py`
- [x] Manual end-to-end via `stream_modify_demo.py` streaming 800 words with a pause every 40 — elicitations created, polled, terminal status recognised, placeholder torn down, no dangling assistant messages.
- [ ] Reviewer: run `unique-cli elicit ask --chat-id <id> --message "continue?"` against a dev environment and confirm the UI renders the widget.

## Risk / rollout
- The visibility workaround is opt-out (`--no-visible`) so callers that already pass `--message-id` keep the previous behaviour. Once UN-19815 is fixed upstream we can flip the default and eventually remove the placeholder path.
- No public API changes in the SDK resource layer; only CLI surface is extended.

Refs: UN-19815

Made with [Cursor](https://cursor.com)