### PR TITLE
feat(unique_mcp): scoped MetaKeys, ContextRequirements, and injector refactor

### DIFF
--- a/unique_mcp/CHANGELOG.md
+++ b/unique_mcp/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), 
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.3] - 2026-04-21
+
+### Added
+- Add `MetaKeys` StrEnum with namespaced `unique.app/auth/*`, `unique.app/chat/*`, and `unique.app/search/*` keys for typed access to MCP `_meta` fields
+- Add `META_FLAT_ALIASES` mapping from legacy camelCase flat keys to namespaced keys for backward compatibility (gated by `enable_mcp_metadata_fallback_un_19145` FF)
+- Add `ContextRequirements` pydantic model and `merge_tool_meta` helper for tools to declare which context keys they require via `unique.app/context-requirements`
+- Add `get_request_meta` injector to expose raw `_meta` dict to MCP tool handlers
+- Refactor `get_unique_settings` to compose `AuthContext` and `ChatContext` from `_meta` using `MetaKeys`, with FF-gated flat alias fallback for pre-migration clients
+- Export `MetaKeys`, `META_FLAT_ALIASES`, `ContextRequirements`, `CONTEXT_REQUIREMENTS_META_KEY`, `merge_tool_meta`, `get_request_meta` from package root
+
 ## [0.3.2] - 2026-04-20
 - Add `[tool.uv.exclude-newer-package]` entry exempting `unique-toolkit` from the root workspace `exclude-newer` cutoff so recent workspace releases resolve correctly under `UV_NO_SOURCES=1`
 

--- a/unique_mcp/CHANGELOG.md
+++ b/unique_mcp/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.3.3] - 2026-04-22
 - Add `MetaKeys` StrEnum (`unique.app/auth/*`, `unique.app/chat/*`) and `META_FLAT_ALIASES` for FF-gated camelCase fallback
 - Add `ContextRequirements` + `merge_tool_meta` for tools to declare required `_meta` keys
-- Add `get_request_meta` injector; refactor `get_unique_settings` to compose auth/chat context from `_meta`
+- Add `get_request_meta` injector for tools that need raw `_meta` access beyond auth/chat context
+- Refactor `get_unique_settings` to compose auth/chat context from `_meta` using `MetaKeys`
 
 ## [0.3.2] - 2026-04-20
 - Add `[tool.uv.exclude-newer-package]` entry exempting `unique-toolkit` from the root workspace `exclude-newer` cutoff so recent workspace releases resolve correctly under `UV_NO_SOURCES=1`

--- a/unique_mcp/CHANGELOG.md
+++ b/unique_mcp/CHANGELOG.md
@@ -8,12 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.3.3] - 2026-04-21
 
 ### Added
-- Add `MetaKeys` StrEnum with namespaced `unique.app/auth/*`, `unique.app/chat/*`, and `unique.app/search/*` keys for typed access to MCP `_meta` fields
-- Add `META_FLAT_ALIASES` mapping from legacy camelCase flat keys to namespaced keys for backward compatibility (gated by `enable_mcp_metadata_fallback_un_19145` FF)
-- Add `ContextRequirements` pydantic model and `merge_tool_meta` helper for tools to declare which context keys they require via `unique.app/context-requirements`
-- Add `get_request_meta` injector to expose raw `_meta` dict to MCP tool handlers
-- Refactor `get_unique_settings` to compose `AuthContext` and `ChatContext` from `_meta` using `MetaKeys`, with FF-gated flat alias fallback for pre-migration clients
-- Export `MetaKeys`, `META_FLAT_ALIASES`, `ContextRequirements`, `CONTEXT_REQUIREMENTS_META_KEY`, `merge_tool_meta`, `get_request_meta` from package root
+- Add `MetaKeys` StrEnum with `unique.app/auth/*` and `unique.app/chat/*` infrastructure keys; tool-specific keys (e.g. search) are defined alongside their tool
+- Add `META_FLAT_ALIASES` for backward-compatible flat camelCase key fallback, gated by `enable_mcp_metadata_fallback_un_19145` FF
+- Add `ContextRequirements` model and `merge_tool_meta` helper so tools can declare required/optional `_meta` keys via `unique.app/context-requirements`
+- Add `get_request_meta` injector exposing raw `_meta` to tool handlers
+- Refactor `get_unique_settings` to compose auth and chat context from `_meta` using `MetaKeys`, with FF-gated flat alias fallback
 
 ## [0.3.2] - 2026-04-20
 - Add `[tool.uv.exclude-newer-package]` entry exempting `unique-toolkit` from the root workspace `exclude-newer` cutoff so recent workspace releases resolve correctly under `UV_NO_SOURCES=1`

--- a/unique_mcp/CHANGELOG.md
+++ b/unique_mcp/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), 
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.3] - 2026-04-21
+## [0.3.3] - 2026-04-22
 - Add `MetaKeys` StrEnum (`unique.app/auth/*`, `unique.app/chat/*`) and `META_FLAT_ALIASES` for FF-gated camelCase fallback
 - Add `ContextRequirements` + `merge_tool_meta` for tools to declare required `_meta` keys
 - Add `get_request_meta` injector; refactor `get_unique_settings` to compose auth/chat context from `_meta`

--- a/unique_mcp/CHANGELOG.md
+++ b/unique_mcp/CHANGELOG.md
@@ -6,13 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.3.3] - 2026-04-21
-
-### Added
-- Add `MetaKeys` StrEnum with `unique.app/auth/*` and `unique.app/chat/*` infrastructure keys; tool-specific keys (e.g. search) are defined alongside their tool
-- Add `META_FLAT_ALIASES` for backward-compatible flat camelCase key fallback, gated by `enable_mcp_metadata_fallback_un_19145` FF
-- Add `ContextRequirements` model and `merge_tool_meta` helper so tools can declare required/optional `_meta` keys via `unique.app/context-requirements`
-- Add `get_request_meta` injector exposing raw `_meta` to tool handlers
-- Refactor `get_unique_settings` to compose auth and chat context from `_meta` using `MetaKeys`, with FF-gated flat alias fallback
+- Add `MetaKeys` StrEnum (`unique.app/auth/*`, `unique.app/chat/*`) and `META_FLAT_ALIASES` for FF-gated camelCase fallback
+- Add `ContextRequirements` + `merge_tool_meta` for tools to declare required `_meta` keys
+- Add `get_request_meta` injector; refactor `get_unique_settings` to compose auth/chat context from `_meta`
 
 ## [0.3.2] - 2026-04-20
 - Add `[tool.uv.exclude-newer-package]` entry exempting `unique-toolkit` from the root workspace `exclude-newer` cutoff so recent workspace releases resolve correctly under `UV_NO_SOURCES=1`

--- a/unique_mcp/pyproject.toml
+++ b/unique_mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "unique-mcp"
-version = "0.3.2"
+version = "0.3.3"
 description = "Add your description here"
 readme = "README.md"
 authors = [
@@ -13,7 +13,7 @@ dependencies = [
     "platformdirs>=4.0.0",
     "pydantic>=2.12.5",
     "pydantic-settings>=2.0.0",
-    "unique-toolkit>=1.65.2",
+    "unique-toolkit>=1.78.1",
 ]
 
 [build-system]

--- a/unique_mcp/src/unique_mcp/__init__.py
+++ b/unique_mcp/src/unique_mcp/__init__.py
@@ -1,11 +1,24 @@
+from unique_mcp.context_requirements import (
+    CONTEXT_REQUIREMENTS_META_KEY,
+    ContextRequirements,
+    merge_tool_meta,
+)
+from unique_mcp.meta_keys import META_FLAT_ALIASES, MetaKeys
 from unique_mcp.unique_injectors import (
+    get_request_meta,
     get_unique_service_factory,
     get_unique_settings,
     get_unique_userinfo,
 )
 
 __all__ = [
+    "CONTEXT_REQUIREMENTS_META_KEY",
+    "ContextRequirements",
+    "META_FLAT_ALIASES",
+    "MetaKeys",
+    "get_request_meta",
     "get_unique_service_factory",
     "get_unique_settings",
     "get_unique_userinfo",
+    "merge_tool_meta",
 ]

--- a/unique_mcp/src/unique_mcp/context_requirements.py
+++ b/unique_mcp/src/unique_mcp/context_requirements.py
@@ -1,0 +1,77 @@
+"""Tool-level declaration of the ``_meta`` keys an MCP tool needs at call time.
+
+MCP servers publish this declaration as part of a tool's static ``meta`` (the
+dict returned by ``listTools``) under the
+:data:`CONTEXT_REQUIREMENTS_META_KEY` namespace. The host (monorepo) reads
+the cached declaration once per tool and intersects it with the per-server
+admin allow-list to decide which keys to forward in each ``callTool``
+request's ``_meta``.
+
+The declaration lives on the **tool definition** (Layer 1). It is never a
+request ``_meta`` key (Layer 3).
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+CONTEXT_REQUIREMENTS_META_KEY = "unique.app/context-requirements"
+
+
+class ContextRequirements(BaseModel):
+    """Declares which ``_meta`` keys a tool expects on every ``callTool``.
+
+    Keys should be fully-qualified ``unique.app/...`` names (see
+    :class:`unique_mcp.meta_keys.MetaKeys`). Server-specific custom keys are
+    allowed when :attr:`accepts_custom` is ``True``; whether a host forwards
+    them is still subject to the admin allow-list.
+    """
+
+    required: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Keys that MUST be present in the request `_meta` for the tool to "
+            "function correctly."
+        ),
+    )
+    optional: list[str] = Field(
+        default_factory=list,
+        description=("Keys the tool will consume when present but does not require."),
+    )
+    accepts_custom: bool = Field(
+        default=False,
+        description=(
+            "If true, the tool is prepared to consume admin-configured custom "
+            "keys in addition to `required`/`optional`."
+        ),
+    )
+
+    def to_tool_meta(self) -> dict[str, object]:
+        """Return the declaration as a ``{CONTEXT_REQUIREMENTS_META_KEY: ...}`` dict.
+
+        Suitable for passing (merged) into the ``meta`` argument of
+        ``FastMCP.tool(...)``.
+        """
+        return {CONTEXT_REQUIREMENTS_META_KEY: self.model_dump(mode="json")}
+
+
+def merge_tool_meta(
+    base: dict[str, object] | None,
+    requirements: ContextRequirements,
+) -> dict[str, object]:
+    """Merge a :class:`ContextRequirements` declaration into existing tool meta.
+
+    Existing keys in ``base`` are preserved; the
+    :data:`CONTEXT_REQUIREMENTS_META_KEY` entry is overwritten so callers can
+    rely on the returned dict reflecting the supplied ``requirements``.
+    """
+    out: dict[str, object] = dict(base or {})
+    out.update(requirements.to_tool_meta())
+    return out
+
+
+__all__ = [
+    "CONTEXT_REQUIREMENTS_META_KEY",
+    "ContextRequirements",
+    "merge_tool_meta",
+]

--- a/unique_mcp/src/unique_mcp/context_requirements.py
+++ b/unique_mcp/src/unique_mcp/context_requirements.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 CONTEXT_REQUIREMENTS_META_KEY = "unique.app/context-requirements"
 
@@ -8,8 +8,8 @@ CONTEXT_REQUIREMENTS_META_KEY = "unique.app/context-requirements"
 class ContextRequirements(BaseModel):
     """Declares which ``_meta`` keys a tool expects on every ``callTool``."""
 
-    required: list[str] = []
-    optional: list[str] = []
+    required: list[str] = Field(default_factory=list)
+    optional: list[str] = Field(default_factory=list)
     accepts_custom: bool = False
 
     def to_tool_meta(self) -> dict[str, object]:

--- a/unique_mcp/src/unique_mcp/context_requirements.py
+++ b/unique_mcp/src/unique_mcp/context_requirements.py
@@ -1,57 +1,18 @@
-"""Tool-level declaration of the ``_meta`` keys an MCP tool needs at call time.
-
-MCP servers publish this declaration as part of a tool's static ``meta`` (the
-dict returned by ``listTools``) under the
-:data:`CONTEXT_REQUIREMENTS_META_KEY` namespace. The host (monorepo) reads
-the cached declaration once per tool and intersects it with the per-server
-admin allow-list to decide which keys to forward in each ``callTool``
-request's ``_meta``.
-
-The declaration lives on the **tool definition** (Layer 1). It is never a
-request ``_meta`` key (Layer 3).
-"""
-
 from __future__ import annotations
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 CONTEXT_REQUIREMENTS_META_KEY = "unique.app/context-requirements"
 
 
 class ContextRequirements(BaseModel):
-    """Declares which ``_meta`` keys a tool expects on every ``callTool``.
+    """Declares which ``_meta`` keys a tool expects on every ``callTool``."""
 
-    Keys should be fully-qualified ``unique.app/...`` names (see
-    :class:`unique_mcp.meta_keys.MetaKeys`). Server-specific custom keys are
-    allowed when :attr:`accepts_custom` is ``True``; whether a host forwards
-    them is still subject to the admin allow-list.
-    """
-
-    required: list[str] = Field(
-        default_factory=list,
-        description=(
-            "Keys that MUST be present in the request `_meta` for the tool to "
-            "function correctly."
-        ),
-    )
-    optional: list[str] = Field(
-        default_factory=list,
-        description=("Keys the tool will consume when present but does not require."),
-    )
-    accepts_custom: bool = Field(
-        default=False,
-        description=(
-            "If true, the tool is prepared to consume admin-configured custom "
-            "keys in addition to `required`/`optional`."
-        ),
-    )
+    required: list[str] = []
+    optional: list[str] = []
+    accepts_custom: bool = False
 
     def to_tool_meta(self) -> dict[str, object]:
-        """Return the declaration as a ``{CONTEXT_REQUIREMENTS_META_KEY: ...}`` dict.
-
-        Suitable for passing (merged) into the ``meta`` argument of
-        ``FastMCP.tool(...)``.
-        """
         return {CONTEXT_REQUIREMENTS_META_KEY: self.model_dump(mode="json")}
 
 
@@ -59,12 +20,6 @@ def merge_tool_meta(
     base: dict[str, object] | None,
     requirements: ContextRequirements,
 ) -> dict[str, object]:
-    """Merge a :class:`ContextRequirements` declaration into existing tool meta.
-
-    Existing keys in ``base`` are preserved; the
-    :data:`CONTEXT_REQUIREMENTS_META_KEY` entry is overwritten so callers can
-    rely on the returned dict reflecting the supplied ``requirements``.
-    """
     out: dict[str, object] = dict(base or {})
     out.update(requirements.to_tool_meta())
     return out

--- a/unique_mcp/src/unique_mcp/meta_keys.py
+++ b/unique_mcp/src/unique_mcp/meta_keys.py
@@ -25,6 +25,5 @@ META_FLAT_ALIASES: dict[str, str] = {
     MetaKeys.CHAT_ID: "chatId",
     MetaKeys.USER_MESSAGE_ID: "messageId",
 }
-"""Flat camelCase aliases from pre-#22513 builds, used for FF-gated fallback."""
 
 __all__ = ["MetaKeys", "META_FLAT_ALIASES"]

--- a/unique_mcp/src/unique_mcp/meta_keys.py
+++ b/unique_mcp/src/unique_mcp/meta_keys.py
@@ -27,15 +27,4 @@ META_FLAT_ALIASES: dict[str, str] = {
 }
 """Flat camelCase aliases from pre-#22513 builds, used for FF-gated fallback."""
 
-_LEGACY_NAMESPACE_ALIASES: dict[str, str] = {
-    MetaKeys.USER_ID: "unique.app/user-id",
-    MetaKeys.COMPANY_ID: "unique.app/company-id",
-}
-"""Pre-scope-segment namespace keys (pre-#22513) — no ``/auth/`` segment.
-
-Clients still sending ``unique.app/user-id`` instead of
-``unique.app/auth/user-id`` are covered by this second FF-gated fallback pass.
-"""
-
-
-__all__ = ["MetaKeys", "META_FLAT_ALIASES", "_LEGACY_NAMESPACE_ALIASES"]
+__all__ = ["MetaKeys", "META_FLAT_ALIASES"]

--- a/unique_mcp/src/unique_mcp/meta_keys.py
+++ b/unique_mcp/src/unique_mcp/meta_keys.py
@@ -1,0 +1,60 @@
+"""Canonical ``_meta`` key names on the Unique MCP wire.
+
+The monorepo standard (see #22513) namespaces keys under ``unique.app/`` with
+a **scope segment** — ``auth``, ``chat``, ``search`` — so unrelated fields do
+not collide at the top level.
+
+Pre-#22513 monorepo builds still emit **flat camelCase** aliases
+(``userId``, ``companyId``, …). Those are tolerated through
+:data:`META_FLAT_ALIASES` and gated by the
+``enable_mcp_metadata_fallback_un_19145`` feature flag.
+
+:class:`MetaKeys` is a :class:`~enum.StrEnum` so every member is both a real
+enum value (iteration, reverse lookup via ``MetaKeys("unique.app/auth/user-id")``,
+typed signatures) and a plain ``str`` (dict keys, pydantic ``validation_alias``,
+JSON serialisation).
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class MetaKeys(StrEnum):
+    """Canonical namespaced ``_meta`` key names."""
+
+    # Identity (auth scope)
+    USER_ID = "unique.app/auth/user-id"
+    COMPANY_ID = "unique.app/auth/company-id"
+
+    # Chat session scope
+    CHAT_ID = "unique.app/chat/chat-id"
+    USER_MESSAGE_ID = "unique.app/chat/user-message-id"
+    ASSISTANT_ID = "unique.app/chat/assistant-id"
+    PARENT_CHAT_ID = "unique.app/chat/parent-chat-id"
+    LAST_ASSISTANT_MESSAGE_ID = "unique.app/chat/last-assistant-message-id"
+    LAST_USER_MESSAGE_TEXT = "unique.app/chat/last-user-message-text"
+
+    # Search scoping
+    CONTENT_IDS = "unique.app/search/content-ids"
+    METADATA_FILTER = "unique.app/search/metadata-filter"
+    SELECTED_UPLOADED_FILE_IDS = "unique.app/search/selected-uploaded-file-ids"
+    LANGUAGE_MODEL_MAX_INPUT_TOKENS = (
+        "unique.app/search/language-model-max-input-tokens"
+    )
+
+
+META_FLAT_ALIASES: dict[str, str] = {
+    MetaKeys.USER_ID: "userId",
+    MetaKeys.COMPANY_ID: "companyId",
+    MetaKeys.CHAT_ID: "chatId",
+    MetaKeys.USER_MESSAGE_ID: "messageId",
+}
+"""Flat camelCase aliases produced by pre-#22513 monorepo builds.
+
+Only keys present here are eligible for the camelCase fallback; anything
+else must be sent under its canonical ``unique.app/...`` name.
+"""
+
+
+__all__ = ["MetaKeys", "META_FLAT_ALIASES"]

--- a/unique_mcp/src/unique_mcp/meta_keys.py
+++ b/unique_mcp/src/unique_mcp/meta_keys.py
@@ -27,5 +27,15 @@ META_FLAT_ALIASES: dict[str, str] = {
 }
 """Flat camelCase aliases from pre-#22513 builds, used for FF-gated fallback."""
 
+_LEGACY_NAMESPACE_ALIASES: dict[str, str] = {
+    MetaKeys.USER_ID: "unique.app/user-id",
+    MetaKeys.COMPANY_ID: "unique.app/company-id",
+}
+"""Pre-scope-segment namespace keys (pre-#22513) — no ``/auth/`` segment.
 
-__all__ = ["MetaKeys", "META_FLAT_ALIASES"]
+Clients still sending ``unique.app/user-id`` instead of
+``unique.app/auth/user-id`` are covered by this second FF-gated fallback pass.
+"""
+
+
+__all__ = ["MetaKeys", "META_FLAT_ALIASES", "_LEGACY_NAMESPACE_ALIASES"]

--- a/unique_mcp/src/unique_mcp/meta_keys.py
+++ b/unique_mcp/src/unique_mcp/meta_keys.py
@@ -1,35 +1,10 @@
-"""Canonical ``_meta`` key names on the Unique MCP wire.
-
-The monorepo standard (see #22513) namespaces keys under ``unique.app/`` with
-a **scope segment** — ``auth``, ``chat`` — so unrelated fields do not collide
-at the top level.
-
-Pre-#22513 monorepo builds still emit **flat camelCase** aliases
-(``userId``, ``companyId``, …). Those are tolerated through
-:data:`META_FLAT_ALIASES` and gated by the
-``enable_mcp_metadata_fallback_un_19145`` feature flag.
-
-:class:`MetaKeys` is a :class:`~enum.StrEnum` so every member is both a real
-enum value (iteration, reverse lookup via ``MetaKeys("unique.app/auth/user-id")``,
-typed signatures) and a plain ``str`` (dict keys, pydantic ``validation_alias``,
-JSON serialisation).
-
-Tool-specific scoping keys (e.g. ``unique.app/search/*``) are defined in their
-own enum alongside the tool that consumes them — see
-``unique_mcp.internal_search.meta.SearchMetaKeys`` for an example.
-"""
-
 from __future__ import annotations
 
 from enum import StrEnum
 
 
 class MetaKeys(StrEnum):
-    """Canonical namespaced ``_meta`` key names for auth and chat context.
-
-    These are infrastructure keys consumed by :func:`get_unique_settings` for
-    every tool.  Tool-specific keys live in their own StrEnum next to the tool.
-    """
+    """Canonical ``_meta`` key names for auth and chat context shared by every tool."""
 
     # Identity (auth scope)
     USER_ID = "unique.app/auth/user-id"
@@ -50,11 +25,7 @@ META_FLAT_ALIASES: dict[str, str] = {
     MetaKeys.CHAT_ID: "chatId",
     MetaKeys.USER_MESSAGE_ID: "messageId",
 }
-"""Flat camelCase aliases produced by pre-#22513 monorepo builds.
-
-Only keys present here are eligible for the camelCase fallback; anything
-else must be sent under its canonical ``unique.app/...`` name.
-"""
+"""Flat camelCase aliases from pre-#22513 builds, used for FF-gated fallback."""
 
 
 __all__ = ["MetaKeys", "META_FLAT_ALIASES"]

--- a/unique_mcp/src/unique_mcp/meta_keys.py
+++ b/unique_mcp/src/unique_mcp/meta_keys.py
@@ -1,8 +1,8 @@
 """Canonical ``_meta`` key names on the Unique MCP wire.
 
 The monorepo standard (see #22513) namespaces keys under ``unique.app/`` with
-a **scope segment** — ``auth``, ``chat``, ``search`` — so unrelated fields do
-not collide at the top level.
+a **scope segment** — ``auth``, ``chat`` — so unrelated fields do not collide
+at the top level.
 
 Pre-#22513 monorepo builds still emit **flat camelCase** aliases
 (``userId``, ``companyId``, …). Those are tolerated through
@@ -13,6 +13,10 @@ Pre-#22513 monorepo builds still emit **flat camelCase** aliases
 enum value (iteration, reverse lookup via ``MetaKeys("unique.app/auth/user-id")``,
 typed signatures) and a plain ``str`` (dict keys, pydantic ``validation_alias``,
 JSON serialisation).
+
+Tool-specific scoping keys (e.g. ``unique.app/search/*``) are defined in their
+own enum alongside the tool that consumes them — see
+``unique_mcp.internal_search.meta.SearchMetaKeys`` for an example.
 """
 
 from __future__ import annotations
@@ -21,7 +25,11 @@ from enum import StrEnum
 
 
 class MetaKeys(StrEnum):
-    """Canonical namespaced ``_meta`` key names."""
+    """Canonical namespaced ``_meta`` key names for auth and chat context.
+
+    These are infrastructure keys consumed by :func:`get_unique_settings` for
+    every tool.  Tool-specific keys live in their own StrEnum next to the tool.
+    """
 
     # Identity (auth scope)
     USER_ID = "unique.app/auth/user-id"
@@ -34,14 +42,6 @@ class MetaKeys(StrEnum):
     PARENT_CHAT_ID = "unique.app/chat/parent-chat-id"
     LAST_ASSISTANT_MESSAGE_ID = "unique.app/chat/last-assistant-message-id"
     LAST_USER_MESSAGE_TEXT = "unique.app/chat/last-user-message-text"
-
-    # Search scoping
-    CONTENT_IDS = "unique.app/search/content-ids"
-    METADATA_FILTER = "unique.app/search/metadata-filter"
-    SELECTED_UPLOADED_FILE_IDS = "unique.app/search/selected-uploaded-file-ids"
-    LANGUAGE_MODEL_MAX_INPUT_TOKENS = (
-        "unique.app/search/language-model-max-input-tokens"
-    )
 
 
 META_FLAT_ALIASES: dict[str, str] = {

--- a/unique_mcp/src/unique_mcp/unique_injectors.py
+++ b/unique_mcp/src/unique_mcp/unique_injectors.py
@@ -181,6 +181,8 @@ def get_request_meta() -> dict[str, Any] | None:
     """Standard injector for raw ``_meta`` access.
 
     Use via ``Depends(get_request_meta)`` instead of reaching into FastMCP internals.
+    Centralising here means the meta source (FastMCP today, potentially multiple
+    sources in the future) can evolve without touching tool code.
     """
     return _fastmcp_read_meta_dict()
 
@@ -188,7 +190,7 @@ def get_request_meta() -> dict[str, Any] | None:
 def get_unique_settings() -> UniqueSettings:
     settings = _base_settings()
 
-    meta = _fastmcp_read_meta_dict()
+    meta = get_request_meta()
 
     if meta is not None:
         auth_context = _auth_from_meta(meta)

--- a/unique_mcp/src/unique_mcp/unique_injectors.py
+++ b/unique_mcp/src/unique_mcp/unique_injectors.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping
 from functools import lru_cache
+from typing import Any
 
 import httpx
 
@@ -17,25 +19,27 @@ except ImportError:
 
 
 from pydantic import BaseModel, SecretStr
+from unique_toolkit.agentic.feature_flags.feature_flags import feature_flags
 from unique_toolkit.app.unique_settings import (
     AuthContext,
+    ChatContext,
     UniqueSettings,
 )
 from unique_toolkit.services.factory import UniqueServiceFactory
 
 from unique_mcp.auth.zitadel.oauth_proxy import ZitadelOAuthProxySettings
+from unique_mcp.meta_keys import META_FLAT_ALIASES, MetaKeys
 
 _LOGGER = logging.getLogger(__name__)
 
 _CLAIM_USER_ID = "sub"
 _CLAIM_COMPANY_ID = "urn:zitadel:iam:user:resourceowner:id"
-_META_USER_ID = "unique.app/user-id"
-_META_COMPANY_ID = "unique.app/company-id"
+_MCP_CHAT_CONTEXT_SENTINEL = "mcp-unknown"
 _HTTP_CLIENT = httpx.AsyncClient(timeout=10.0)
 
 
-def _fastmcp_context_to_auth_context() -> AuthContext | None:
-    """Read ``_meta`` from the active FastMCP request, if available."""
+def _read_meta_dict() -> dict[str, Any] | None:
+    """Return the raw ``_meta`` dict of the active FastMCP request, if any."""
     try:
         ctx = get_context()
     except (RuntimeError, LookupError):
@@ -47,14 +51,68 @@ def _fastmcp_context_to_auth_context() -> AuthContext | None:
     rc = ctx.request_context
     if rc is None or rc.meta is None:
         return None
-    meta = dict(rc.meta) or None
-    if meta:
-        uid = meta.get(_META_USER_ID, None)
-        cid = meta.get(_META_COMPANY_ID, None)
-        if uid and isinstance(uid, str) and cid and isinstance(cid, str):
-            _LOGGER.debug("Auth from _meta (user=%s)", uid)
-            return AuthContext(user_id=SecretStr(uid), company_id=SecretStr(cid))
+    meta = dict(rc.meta)
+    return meta or None
+
+
+def _pick_meta(meta: Mapping[str, Any], canonical_key: str) -> str | None:
+    """Look up ``canonical_key`` in ``meta``, with optional flat-camelCase fallback.
+
+    The canonical (namespaced) key is always consulted first. The flat
+    camelCase alias from :data:`META_FLAT_ALIASES` is only tried when the
+    ``enable_mcp_metadata_fallback_un_19145`` feature flag is enabled AND
+    the canonical key is absent. Non-string values are ignored.
+    """
+    value = meta.get(canonical_key)
+    if isinstance(value, str) and value:
+        return value
+
+    if feature_flags.enable_mcp_metadata_fallback_un_19145.is_enabled():
+        flat_alias = META_FLAT_ALIASES.get(canonical_key)
+        if flat_alias is not None:
+            fallback = meta.get(flat_alias)
+            if isinstance(fallback, str) and fallback:
+                return fallback
+
     return None
+
+
+def _auth_from_meta(meta: Mapping[str, Any]) -> AuthContext | None:
+    """Build an :class:`AuthContext` from request ``_meta`` when possible."""
+    uid = _pick_meta(meta, MetaKeys.USER_ID)
+    cid = _pick_meta(meta, MetaKeys.COMPANY_ID)
+    if uid and cid:
+        _LOGGER.debug("Auth from _meta (user=%s)", uid)
+        return AuthContext(user_id=SecretStr(uid), company_id=SecretStr(cid))
+    return None
+
+
+def _chat_from_meta(meta: Mapping[str, Any]) -> ChatContext | None:
+    """Build a :class:`ChatContext` from request ``_meta``.
+
+    Returns ``None`` when no ``chat-id`` is present; otherwise fills the
+    mandatory ``assistant_id`` and other chat-message-scope fields from
+    ``_meta``, falling back to the MCP sentinel when the host did not
+    forward them.
+    """
+    chat_id = _pick_meta(meta, MetaKeys.CHAT_ID)
+    if not chat_id:
+        return None
+
+    assistant_id = _pick_meta(meta, MetaKeys.ASSISTANT_ID) or _MCP_CHAT_CONTEXT_SENTINEL
+    last_user_message_id = _pick_meta(meta, MetaKeys.USER_MESSAGE_ID)
+    last_assistant_message_id = _pick_meta(meta, MetaKeys.LAST_ASSISTANT_MESSAGE_ID)
+    last_user_message_text = _pick_meta(meta, MetaKeys.LAST_USER_MESSAGE_TEXT)
+    parent_chat_id = _pick_meta(meta, MetaKeys.PARENT_CHAT_ID)
+
+    return ChatContext(
+        chat_id=chat_id,
+        assistant_id=assistant_id,
+        last_assistant_message_id=last_assistant_message_id,
+        last_user_message_id=last_user_message_id,
+        last_user_message_text=last_user_message_text,
+        parent_chat_id=parent_chat_id,
+    )
 
 
 def _fastmcp_access_token_to_auth_context() -> AuthContext | None:
@@ -119,18 +177,39 @@ def _base_settings() -> UniqueSettings:
     return UniqueSettings.from_env_auto_with_sdk_init()
 
 
+def get_request_meta() -> dict[str, Any] | None:
+    """Return the raw ``_meta`` dict of the active FastMCP request, if any.
+
+    Public injector, typically used via ``Depends(get_request_meta)`` by
+    tools that need access to request-scope keys that are not covered by
+    :class:`~unique_toolkit.app.unique_settings.AuthContext` or
+    :class:`~unique_toolkit.app.unique_settings.ChatContext` (for example
+    search scoping fields like ``unique.app/search/content-ids``).
+    """
+    return _read_meta_dict()
+
+
 def get_unique_settings() -> UniqueSettings:
     settings = _base_settings()
 
-    # 1. _meta of the request has highest priority
-    if auth_context := _fastmcp_context_to_auth_context():
-        return settings.with_auth(auth_context)
+    meta = _read_meta_dict()
 
-    # 2. JWT claims of IDP have second highest priority
+    if meta is not None:
+        auth_context = _auth_from_meta(meta)
+        chat_context = _chat_from_meta(meta)
+        if auth_context is not None:
+            settings = settings.with_auth(auth_context)
+        if chat_context is not None:
+            settings = settings.with_chat(chat_context)
+        if auth_context is not None:
+            return settings
+
+    # When `_meta` carries chat keys but no auth keys, we may have applied
+    # `with_chat` above and still need JWT/env auth here. `with_auth` keeps
+    # the already-bound chat context (see `UniqueSettings.with_auth`).
     if auth_context := _fastmcp_access_token_to_auth_context():
         return settings.with_auth(auth_context)
 
-    # 3. Use auth from env variables
     return settings
 
 

--- a/unique_mcp/src/unique_mcp/unique_injectors.py
+++ b/unique_mcp/src/unique_mcp/unique_injectors.py
@@ -28,7 +28,7 @@ from unique_toolkit.app.unique_settings import (
 from unique_toolkit.services.factory import UniqueServiceFactory
 
 from unique_mcp.auth.zitadel.oauth_proxy import ZitadelOAuthProxySettings
-from unique_mcp.meta_keys import _LEGACY_NAMESPACE_ALIASES, META_FLAT_ALIASES, MetaKeys
+from unique_mcp.meta_keys import META_FLAT_ALIASES, MetaKeys
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -71,12 +71,6 @@ def _pick_meta(meta: Mapping[str, Any], canonical_key: str) -> str | None:
         flat_alias = META_FLAT_ALIASES.get(canonical_key)
         if flat_alias is not None:
             fallback = meta.get(flat_alias)
-            if isinstance(fallback, str) and fallback:
-                return fallback
-
-        old_ns_key = _LEGACY_NAMESPACE_ALIASES.get(canonical_key)
-        if old_ns_key is not None:
-            fallback = meta.get(old_ns_key)
             if isinstance(fallback, str) and fallback:
                 return fallback
 

--- a/unique_mcp/src/unique_mcp/unique_injectors.py
+++ b/unique_mcp/src/unique_mcp/unique_injectors.py
@@ -178,13 +178,9 @@ def _base_settings() -> UniqueSettings:
 
 
 def get_request_meta() -> dict[str, Any] | None:
-    """Return the raw ``_meta`` dict of the active FastMCP request, if any.
+    """Standard injector for raw ``_meta`` access.
 
-    Public injector, typically used via ``Depends(get_request_meta)`` by
-    tools that need access to request-scope keys that are not covered by
-    :class:`~unique_toolkit.app.unique_settings.AuthContext` or
-    :class:`~unique_toolkit.app.unique_settings.ChatContext` (for example
-    search scoping fields like ``unique.app/search/content-ids``).
+    Use via ``Depends(get_request_meta)`` instead of reaching into FastMCP internals.
     """
     return _fastmcp_read_meta_dict()
 

--- a/unique_mcp/src/unique_mcp/unique_injectors.py
+++ b/unique_mcp/src/unique_mcp/unique_injectors.py
@@ -193,14 +193,10 @@ def get_unique_settings() -> UniqueSettings:
     meta = get_request_meta()
 
     if meta is not None:
-        auth_context = _auth_from_meta(meta)
-        chat_context = _chat_from_meta(meta)
-        if auth_context is not None:
-            settings = settings.with_auth(auth_context)
-        if chat_context is not None:
+        if chat_context := _chat_from_meta(meta):
             settings = settings.with_chat(chat_context)
-        if auth_context is not None:
-            return settings
+        if auth_context := _auth_from_meta(meta):
+            return settings.with_auth(auth_context)
 
     # When `_meta` carries chat keys but no auth keys, we may have applied
     # `with_chat` above and still need JWT/env auth here. `with_auth` keeps

--- a/unique_mcp/src/unique_mcp/unique_injectors.py
+++ b/unique_mcp/src/unique_mcp/unique_injectors.py
@@ -28,7 +28,7 @@ from unique_toolkit.app.unique_settings import (
 from unique_toolkit.services.factory import UniqueServiceFactory
 
 from unique_mcp.auth.zitadel.oauth_proxy import ZitadelOAuthProxySettings
-from unique_mcp.meta_keys import META_FLAT_ALIASES, MetaKeys
+from unique_mcp.meta_keys import _LEGACY_NAMESPACE_ALIASES, META_FLAT_ALIASES, MetaKeys
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -71,6 +71,12 @@ def _pick_meta(meta: Mapping[str, Any], canonical_key: str) -> str | None:
         flat_alias = META_FLAT_ALIASES.get(canonical_key)
         if flat_alias is not None:
             fallback = meta.get(flat_alias)
+            if isinstance(fallback, str) and fallback:
+                return fallback
+
+        old_ns_key = _LEGACY_NAMESPACE_ALIASES.get(canonical_key)
+        if old_ns_key is not None:
+            fallback = meta.get(old_ns_key)
             if isinstance(fallback, str) and fallback:
                 return fallback
 
@@ -196,13 +202,10 @@ def get_unique_settings() -> UniqueSettings:
 
     if meta is not None:
         auth_context = _auth_from_meta(meta)
-        chat_context = _chat_from_meta(meta)
-        if auth_context is not None:
-            settings = settings.with_auth(auth_context)
-        if chat_context is not None:
+        if chat_context := _chat_from_meta(meta):
             settings = settings.with_chat(chat_context)
         if auth_context is not None:
-            return settings
+            return settings.with_auth(auth_context)
 
     # When `_meta` carries chat keys but no auth keys, we may have applied
     # `with_chat` above and still need JWT/env auth here. `with_auth` keeps

--- a/unique_mcp/src/unique_mcp/unique_injectors.py
+++ b/unique_mcp/src/unique_mcp/unique_injectors.py
@@ -99,19 +99,14 @@ def _chat_from_meta(meta: Mapping[str, Any]) -> ChatContext | None:
     if not chat_id:
         return None
 
-    assistant_id = _pick_meta(meta, MetaKeys.ASSISTANT_ID) or _MCP_CHAT_CONTEXT_SENTINEL
-    last_user_message_id = _pick_meta(meta, MetaKeys.USER_MESSAGE_ID)
-    last_assistant_message_id = _pick_meta(meta, MetaKeys.LAST_ASSISTANT_MESSAGE_ID)
-    last_user_message_text = _pick_meta(meta, MetaKeys.LAST_USER_MESSAGE_TEXT)
-    parent_chat_id = _pick_meta(meta, MetaKeys.PARENT_CHAT_ID)
-
     return ChatContext(
         chat_id=chat_id,
-        assistant_id=assistant_id,
-        last_assistant_message_id=last_assistant_message_id,
-        last_user_message_id=last_user_message_id,
-        last_user_message_text=last_user_message_text,
-        parent_chat_id=parent_chat_id,
+        assistant_id=_pick_meta(meta, MetaKeys.ASSISTANT_ID)
+        or _MCP_CHAT_CONTEXT_SENTINEL,
+        last_user_message_id=_pick_meta(meta, MetaKeys.USER_MESSAGE_ID),
+        last_assistant_message_id=_pick_meta(meta, MetaKeys.LAST_ASSISTANT_MESSAGE_ID),
+        last_user_message_text=_pick_meta(meta, MetaKeys.LAST_USER_MESSAGE_TEXT),
+        parent_chat_id=_pick_meta(meta, MetaKeys.PARENT_CHAT_ID),
     )
 
 

--- a/unique_mcp/src/unique_mcp/unique_injectors.py
+++ b/unique_mcp/src/unique_mcp/unique_injectors.py
@@ -194,10 +194,13 @@ def get_unique_settings() -> UniqueSettings:
 
     if meta is not None:
         auth_context = _auth_from_meta(meta)
-        if chat_context := _chat_from_meta(meta):
+        chat_context = _chat_from_meta(meta)
+        if auth_context is not None:
+            settings = settings.with_auth(auth_context)
+        if chat_context is not None:
             settings = settings.with_chat(chat_context)
         if auth_context is not None:
-            return settings.with_auth(auth_context)
+            return settings
 
     # When `_meta` carries chat keys but no auth keys, we may have applied
     # `with_chat` above and still need JWT/env auth here. `with_auth` keeps

--- a/unique_mcp/src/unique_mcp/unique_injectors.py
+++ b/unique_mcp/src/unique_mcp/unique_injectors.py
@@ -38,7 +38,7 @@ _MCP_CHAT_CONTEXT_SENTINEL = "mcp-unknown"
 _HTTP_CLIENT = httpx.AsyncClient(timeout=10.0)
 
 
-def _read_meta_dict() -> dict[str, Any] | None:
+def _fastmcp_read_meta_dict() -> dict[str, Any] | None:
     """Return the raw ``_meta`` dict of the active FastMCP request, if any."""
     try:
         ctx = get_context()
@@ -186,13 +186,13 @@ def get_request_meta() -> dict[str, Any] | None:
     :class:`~unique_toolkit.app.unique_settings.ChatContext` (for example
     search scoping fields like ``unique.app/search/content-ids``).
     """
-    return _read_meta_dict()
+    return _fastmcp_read_meta_dict()
 
 
 def get_unique_settings() -> UniqueSettings:
     settings = _base_settings()
 
-    meta = _read_meta_dict()
+    meta = _fastmcp_read_meta_dict()
 
     if meta is not None:
         auth_context = _auth_from_meta(meta)

--- a/unique_mcp/tests/test_context_requirements.py
+++ b/unique_mcp/tests/test_context_requirements.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import pytest
+
+from unique_mcp.context_requirements import (
+    CONTEXT_REQUIREMENTS_META_KEY,
+    ContextRequirements,
+    merge_tool_meta,
+)
+from unique_mcp.meta_keys import MetaKeys
+
+
+@pytest.mark.ai
+def test_to_tool_meta_emits_canonical_key() -> None:
+    reqs = ContextRequirements(
+        required=[MetaKeys.USER_ID, MetaKeys.COMPANY_ID],
+        optional=[MetaKeys.CONTENT_IDS],
+    )
+    meta = reqs.to_tool_meta()
+    assert CONTEXT_REQUIREMENTS_META_KEY in meta
+    payload = meta[CONTEXT_REQUIREMENTS_META_KEY]
+    assert isinstance(payload, dict)
+    assert payload["required"] == [MetaKeys.USER_ID, MetaKeys.COMPANY_ID]
+    assert payload["optional"] == [MetaKeys.CONTENT_IDS]
+    assert payload["accepts_custom"] is False
+
+
+@pytest.mark.ai
+def test_merge_tool_meta_preserves_existing_keys() -> None:
+    base: dict[str, object] = {
+        "unique.app/icon": "data:image/svg",
+        "other": 1,
+    }
+    reqs = ContextRequirements(required=[MetaKeys.USER_ID])
+    merged = merge_tool_meta(base, reqs)
+
+    assert merged["unique.app/icon"] == "data:image/svg"
+    assert merged["other"] == 1
+    assert CONTEXT_REQUIREMENTS_META_KEY in merged
+    assert base == {"unique.app/icon": "data:image/svg", "other": 1}, (
+        "merge_tool_meta must not mutate the input base dict"
+    )
+
+
+@pytest.mark.ai
+def test_accepts_custom_flag_serialises() -> None:
+    reqs = ContextRequirements(required=[MetaKeys.USER_ID], accepts_custom=True)
+    payload = reqs.to_tool_meta()[CONTEXT_REQUIREMENTS_META_KEY]
+    assert isinstance(payload, dict)
+    assert payload["accepts_custom"] is True
+
+
+@pytest.mark.ai
+def test_merge_tool_meta_with_none_base() -> None:
+    reqs = ContextRequirements(required=[MetaKeys.USER_ID])
+    merged = merge_tool_meta(None, reqs)
+    assert list(merged.keys()) == [CONTEXT_REQUIREMENTS_META_KEY]

--- a/unique_mcp/tests/test_context_requirements.py
+++ b/unique_mcp/tests/test_context_requirements.py
@@ -14,14 +14,14 @@ from unique_mcp.meta_keys import MetaKeys
 def test_to_tool_meta_emits_canonical_key() -> None:
     reqs = ContextRequirements(
         required=[MetaKeys.USER_ID, MetaKeys.COMPANY_ID],
-        optional=[MetaKeys.CONTENT_IDS],
+        optional=["unique.app/search/content-ids"],
     )
     meta = reqs.to_tool_meta()
     assert CONTEXT_REQUIREMENTS_META_KEY in meta
     payload = meta[CONTEXT_REQUIREMENTS_META_KEY]
     assert isinstance(payload, dict)
     assert payload["required"] == [MetaKeys.USER_ID, MetaKeys.COMPANY_ID]
-    assert payload["optional"] == [MetaKeys.CONTENT_IDS]
+    assert payload["optional"] == ["unique.app/search/content-ids"]
     assert payload["accepts_custom"] is False
 
 

--- a/unique_mcp/tests/test_meta_keys.py
+++ b/unique_mcp/tests/test_meta_keys.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import pytest
+
+from unique_mcp.meta_keys import META_FLAT_ALIASES, MetaKeys
+
+
+@pytest.mark.ai
+def test_metakeys_is_str_enum() -> None:
+    """Every member must behave as a plain string (StrEnum contract)."""
+    assert isinstance(MetaKeys.USER_ID, str)
+    assert MetaKeys.USER_ID == "unique.app/auth/user-id"
+
+
+@pytest.mark.ai
+def test_all_flat_aliases_map_to_known_canonical_keys() -> None:
+    canonical_values = {member.value for member in MetaKeys}
+    for canonical in META_FLAT_ALIASES:
+        assert canonical in canonical_values
+
+
+@pytest.mark.ai
+def test_all_canonical_keys_are_namespaced() -> None:
+    for member in MetaKeys:
+        assert member.value.startswith("unique.app/"), (
+            f"{member.name}={member.value!r} must be under the unique.app/ namespace"
+        )
+
+
+@pytest.mark.ai
+def test_flat_aliases_are_camel_case_strings() -> None:
+    for alias in META_FLAT_ALIASES.values():
+        assert isinstance(alias, str) and alias
+        assert "/" not in alias, (
+            f"Flat aliases should be camelCase (no slashes); got {alias!r}"
+        )
+
+
+@pytest.mark.ai
+def test_metakeys_reverse_lookup() -> None:
+    """Round-tripping a wire value produces the matching enum member."""
+    assert MetaKeys("unique.app/chat/chat-id") is MetaKeys.CHAT_ID

--- a/unique_mcp/tests/test_unique_injectors.py
+++ b/unique_mcp/tests/test_unique_injectors.py
@@ -119,12 +119,12 @@ def test_get_unique_settings__uses_meta_auth__when_present(
     """
     Purpose: _meta-derived auth overrides env when FastMCP request carries both IDs.
     Why this matters: Internal callers can override identity via MCP _meta.
-    Setup summary: Patch _base_settings and _fastmcp_read_meta_dict with auth keys.
+    Setup summary: Patch _base_settings and get_request_meta with auth keys.
     """
     with (
         patch(f"{_MOD}._base_settings", return_value=base_settings),
         patch(
-            f"{_MOD}._fastmcp_read_meta_dict",
+            f"{_MOD}.get_request_meta",
             return_value={
                 MetaKeys.USER_ID: "mu",
                 MetaKeys.COMPANY_ID: "mc",
@@ -147,7 +147,7 @@ def test_get_unique_settings__uses_jwt_claims__when_meta_absent(
     """
     with (
         patch(f"{_MOD}._base_settings", return_value=base_settings),
-        patch(f"{_MOD}._fastmcp_read_meta_dict", return_value=None),
+        patch(f"{_MOD}.get_request_meta", return_value=None),
         patch(
             f"{_MOD}._fastmcp_access_token_to_auth_context",
             return_value=AuthContext(
@@ -173,7 +173,7 @@ def test_get_unique_settings__meta_wins_over_jwt(
     with (
         patch(f"{_MOD}._base_settings", return_value=base_settings),
         patch(
-            f"{_MOD}._fastmcp_read_meta_dict",
+            f"{_MOD}.get_request_meta",
             return_value={
                 MetaKeys.USER_ID: "meta-u",
                 MetaKeys.COMPANY_ID: "meta-c",
@@ -203,7 +203,7 @@ def test_get_unique_settings__falls_back_to_env__when_no_meta_no_jwt(
     """
     with (
         patch(f"{_MOD}._base_settings", return_value=base_settings),
-        patch(f"{_MOD}._fastmcp_read_meta_dict", return_value=None),
+        patch(f"{_MOD}.get_request_meta", return_value=None),
         patch(f"{_MOD}._fastmcp_access_token_to_auth_context", return_value=None),
     ):
         s = get_unique_settings()
@@ -222,7 +222,7 @@ def test_get_unique_settings__reuses_app_and_api_from_base(
     """
     with (
         patch(f"{_MOD}._base_settings", return_value=base_settings),
-        patch(f"{_MOD}._fastmcp_read_meta_dict", return_value=None),
+        patch(f"{_MOD}.get_request_meta", return_value=None),
         patch(
             f"{_MOD}._fastmcp_access_token_to_auth_context",
             return_value=AuthContext(
@@ -244,7 +244,7 @@ def test_get_unique_settings__binds_chat_context_when_chat_id_present(
     with (
         patch(f"{_MOD}._base_settings", return_value=base_settings),
         patch(
-            f"{_MOD}._fastmcp_read_meta_dict",
+            f"{_MOD}.get_request_meta",
             return_value={
                 MetaKeys.USER_ID: "u",
                 MetaKeys.COMPANY_ID: "c",
@@ -267,7 +267,7 @@ def test_get_unique_settings__meta_chat_only_then_jwt_auth_preserves_chat(
     with (
         patch(f"{_MOD}._base_settings", return_value=base_settings),
         patch(
-            f"{_MOD}._fastmcp_read_meta_dict",
+            f"{_MOD}.get_request_meta",
             return_value={MetaKeys.CHAT_ID: "chat-1"},
         ),
         patch(

--- a/unique_mcp/tests/test_unique_injectors.py
+++ b/unique_mcp/tests/test_unique_injectors.py
@@ -13,7 +13,7 @@ from unique_toolkit.app.unique_settings import (
 )
 
 from unique_mcp.auth.zitadel.oauth_proxy import ZitadelOAuthProxySettings
-from unique_mcp.meta_keys import _LEGACY_NAMESPACE_ALIASES, MetaKeys
+from unique_mcp.meta_keys import MetaKeys
 from unique_mcp.unique_injectors import (
     _CLAIM_COMPANY_ID,
     _CLAIM_USER_ID,
@@ -320,36 +320,6 @@ def test_pick_meta__ignores_flat_when_ff_disabled() -> None:
         return_value=False,
     ):
         assert _pick_meta(meta, MetaKeys.USER_ID) is None
-
-
-@pytest.mark.ai
-def test_pick_meta__uses_legacy_namespace_alias_when_ff_enabled() -> None:
-    """Old ``unique.app/user-id`` (pre-scope-segment) resolves via FF-gated fallback."""
-    old_key = _LEGACY_NAMESPACE_ALIASES[MetaKeys.USER_ID]
-    with patch(
-        f"{_MOD}.feature_flags.enable_mcp_metadata_fallback_un_19145.is_enabled",
-        return_value=True,
-    ):
-        assert _pick_meta({old_key: "u1"}, MetaKeys.USER_ID) == "u1"
-
-
-@pytest.mark.ai
-def test_pick_meta__ignores_legacy_namespace_alias_when_ff_disabled() -> None:
-    """Old ``unique.app/user-id`` must not resolve when the fallback FF is off."""
-    old_key = _LEGACY_NAMESPACE_ALIASES[MetaKeys.USER_ID]
-    with patch(
-        f"{_MOD}.feature_flags.enable_mcp_metadata_fallback_un_19145.is_enabled",
-        return_value=False,
-    ):
-        assert _pick_meta({old_key: "u1"}, MetaKeys.USER_ID) is None
-
-
-@pytest.mark.ai
-def test_pick_meta__canonical_wins_over_legacy_namespace() -> None:
-    """Canonical key takes priority over old-namespace alias even when both present."""
-    old_key = _LEGACY_NAMESPACE_ALIASES[MetaKeys.USER_ID]
-    result = _pick_meta({MetaKeys.USER_ID: "new", old_key: "old"}, MetaKeys.USER_ID)
-    assert result == "new"
 
 
 @pytest.mark.ai

--- a/unique_mcp/tests/test_unique_injectors.py
+++ b/unique_mcp/tests/test_unique_injectors.py
@@ -13,12 +13,17 @@ from unique_toolkit.app.unique_settings import (
 )
 
 from unique_mcp.auth.zitadel.oauth_proxy import ZitadelOAuthProxySettings
+from unique_mcp.meta_keys import MetaKeys
 from unique_mcp.unique_injectors import (
     _CLAIM_COMPANY_ID,
     _CLAIM_USER_ID,
     UniqueUserInfo,
+    _auth_from_meta,
     _base_settings,
+    _chat_from_meta,
+    _pick_meta,
     _userinfo_to_auth_context,
+    get_request_meta,
     get_unique_service_factory,
     get_unique_settings,
     get_unique_userinfo,
@@ -114,19 +119,16 @@ def test_get_unique_settings__uses_meta_auth__when_present(
     """
     Purpose: _meta-derived auth overrides env when FastMCP request carries both IDs.
     Why this matters: Internal callers can override identity via MCP _meta.
-    Setup summary: Patch from_env and _fastmcp_context_to_auth_context.
+    Setup summary: Patch _base_settings and _read_meta_dict with auth keys.
     """
     with (
+        patch(f"{_MOD}._base_settings", return_value=base_settings),
         patch(
-            f"{_MOD}._base_settings",
-            return_value=base_settings,
-        ),
-        patch(
-            f"{_MOD}._fastmcp_context_to_auth_context",
-            return_value=AuthContext(
-                user_id=SecretStr("mu"),
-                company_id=SecretStr("mc"),
-            ),
+            f"{_MOD}._read_meta_dict",
+            return_value={
+                MetaKeys.USER_ID: "mu",
+                MetaKeys.COMPANY_ID: "mc",
+            },
         ),
     ):
         s = get_unique_settings()
@@ -144,11 +146,8 @@ def test_get_unique_settings__uses_jwt_claims__when_meta_absent(
     Setup summary: Meta None, access-token helper returns AuthContext from JWT.
     """
     with (
-        patch(
-            f"{_MOD}._base_settings",
-            return_value=base_settings,
-        ),
-        patch(f"{_MOD}._fastmcp_context_to_auth_context", return_value=None),
+        patch(f"{_MOD}._base_settings", return_value=base_settings),
+        patch(f"{_MOD}._read_meta_dict", return_value=None),
         patch(
             f"{_MOD}._fastmcp_access_token_to_auth_context",
             return_value=AuthContext(
@@ -172,16 +171,13 @@ def test_get_unique_settings__meta_wins_over_jwt(
     Setup summary: Both meta and JWT helpers return auth; expect meta values.
     """
     with (
+        patch(f"{_MOD}._base_settings", return_value=base_settings),
         patch(
-            f"{_MOD}._base_settings",
-            return_value=base_settings,
-        ),
-        patch(
-            f"{_MOD}._fastmcp_context_to_auth_context",
-            return_value=AuthContext(
-                user_id=SecretStr("meta-u"),
-                company_id=SecretStr("meta-c"),
-            ),
+            f"{_MOD}._read_meta_dict",
+            return_value={
+                MetaKeys.USER_ID: "meta-u",
+                MetaKeys.COMPANY_ID: "meta-c",
+            },
         ),
         patch(
             f"{_MOD}._fastmcp_access_token_to_auth_context",
@@ -197,34 +193,6 @@ def test_get_unique_settings__meta_wins_over_jwt(
 
 
 @pytest.mark.ai
-def test_get_unique_settings__uses_jwt_when_meta_partial_or_absent(
-    base_settings: UniqueSettings,
-) -> None:
-    """
-    Purpose: When _meta does not yield both IDs, JWT claims are used if complete.
-    Why this matters: Partial _meta must not block a valid OAuth JWT.
-    Setup summary: Meta None; JWT helper returns full claims.
-    """
-    with (
-        patch(
-            f"{_MOD}._base_settings",
-            return_value=base_settings,
-        ),
-        patch(f"{_MOD}._fastmcp_context_to_auth_context", return_value=None),
-        patch(
-            f"{_MOD}._fastmcp_access_token_to_auth_context",
-            return_value=AuthContext(
-                user_id=SecretStr("jwt-u"),
-                company_id=SecretStr("jwt-c"),
-            ),
-        ),
-    ):
-        s = get_unique_settings()
-    assert s.authcontext.get_confidential_user_id() == "jwt-u"
-    assert s.authcontext.get_confidential_company_id() == "jwt-c"
-
-
-@pytest.mark.ai
 def test_get_unique_settings__falls_back_to_env__when_no_meta_no_jwt(
     base_settings: UniqueSettings,
 ) -> None:
@@ -234,37 +202,13 @@ def test_get_unique_settings__falls_back_to_env__when_no_meta_no_jwt(
     Setup summary: Both resolution helpers return None; expect base_settings auth.
     """
     with (
-        patch(
-            f"{_MOD}._base_settings",
-            return_value=base_settings,
-        ),
-        patch(f"{_MOD}._fastmcp_context_to_auth_context", return_value=None),
+        patch(f"{_MOD}._base_settings", return_value=base_settings),
+        patch(f"{_MOD}._read_meta_dict", return_value=None),
         patch(f"{_MOD}._fastmcp_access_token_to_auth_context", return_value=None),
     ):
         s = get_unique_settings()
     assert s.authcontext.get_confidential_user_id() == "dummy_user"
     assert s.authcontext.get_confidential_company_id() == "dummy_company"
-
-
-@pytest.mark.ai
-def test_get_unique_settings__jwt_incomplete_falls_back_to_env(
-    base_settings: UniqueSettings,
-) -> None:
-    """
-    Purpose: Incomplete JWT (missing company claim) does not apply; env auth remains.
-    Why this matters: get_unique_settings does not call userinfo; partial JWT → env.
-    Setup summary: JWT helper returns None (simulating incomplete claims).
-    """
-    with (
-        patch(
-            f"{_MOD}._base_settings",
-            return_value=base_settings,
-        ),
-        patch(f"{_MOD}._fastmcp_context_to_auth_context", return_value=None),
-        patch(f"{_MOD}._fastmcp_access_token_to_auth_context", return_value=None),
-    ):
-        s = get_unique_settings()
-    assert s.authcontext.get_confidential_user_id() == "dummy_user"
 
 
 @pytest.mark.ai
@@ -277,11 +221,8 @@ def test_get_unique_settings__reuses_app_and_api_from_base(
     Setup summary: Patch JWT path; compare app/api identity to base_settings.
     """
     with (
-        patch(
-            f"{_MOD}._base_settings",
-            return_value=base_settings,
-        ),
-        patch(f"{_MOD}._fastmcp_context_to_auth_context", return_value=None),
+        patch(f"{_MOD}._base_settings", return_value=base_settings),
+        patch(f"{_MOD}._read_meta_dict", return_value=None),
         patch(
             f"{_MOD}._fastmcp_access_token_to_auth_context",
             return_value=AuthContext(
@@ -293,6 +234,111 @@ def test_get_unique_settings__reuses_app_and_api_from_base(
         s = get_unique_settings()
     assert s.app is base_settings.app
     assert s.api is base_settings.api
+
+
+@pytest.mark.ai
+def test_get_unique_settings__binds_chat_context_when_chat_id_present(
+    base_settings: UniqueSettings,
+) -> None:
+    """Purpose: `_meta` carrying chat-id produces settings bound with chat context."""
+    with (
+        patch(f"{_MOD}._base_settings", return_value=base_settings),
+        patch(
+            f"{_MOD}._read_meta_dict",
+            return_value={
+                MetaKeys.USER_ID: "u",
+                MetaKeys.COMPANY_ID: "c",
+                MetaKeys.CHAT_ID: "chat-1",
+                MetaKeys.USER_MESSAGE_ID: "um-1",
+            },
+        ),
+    ):
+        s = get_unique_settings()
+
+    assert s.context.chat is not None
+    assert s.context.chat.chat_id == "chat-1"
+
+
+@pytest.mark.ai
+def test_get_unique_settings__meta_chat_only_then_jwt_auth_preserves_chat(
+    base_settings: UniqueSettings,
+) -> None:
+    """Chat from `_meta` without auth must survive a subsequent JWT `with_auth`."""
+    with (
+        patch(f"{_MOD}._base_settings", return_value=base_settings),
+        patch(
+            f"{_MOD}._read_meta_dict",
+            return_value={MetaKeys.CHAT_ID: "chat-1"},
+        ),
+        patch(
+            f"{_MOD}._fastmcp_access_token_to_auth_context",
+            return_value=AuthContext(
+                user_id=SecretStr("jwt-u"),
+                company_id=SecretStr("jwt-c"),
+            ),
+        ),
+    ):
+        s = get_unique_settings()
+
+    assert s.authcontext.get_confidential_user_id() == "jwt-u"
+    assert s.context.chat is not None
+    assert s.context.chat.chat_id == "chat-1"
+
+
+@pytest.mark.ai
+def test_get_request_meta__returns_raw_meta_dict() -> None:
+    """`get_request_meta` is a thin public wrapper over `_read_meta_dict`."""
+    raw = {MetaKeys.CONTENT_IDS: ["c1"]}
+    with patch(f"{_MOD}._read_meta_dict", return_value=raw):
+        assert get_request_meta() == raw
+
+
+@pytest.mark.ai
+def test_pick_meta__prefers_namespaced_over_flat() -> None:
+    """Canonical keys always win over flat aliases."""
+    meta = {MetaKeys.USER_ID: "new", "userId": "old"}
+    assert _pick_meta(meta, MetaKeys.USER_ID) == "new"
+
+
+@pytest.mark.ai
+def test_pick_meta__falls_back_to_flat_when_ff_enabled() -> None:
+    """Flat alias is honoured when the canonical key is absent."""
+    meta = {"userId": "old"}
+    with patch(
+        f"{_MOD}.feature_flags.enable_mcp_metadata_fallback_un_19145.is_enabled",
+        return_value=True,
+    ):
+        assert _pick_meta(meta, MetaKeys.USER_ID) == "old"
+
+
+@pytest.mark.ai
+def test_pick_meta__ignores_flat_when_ff_disabled() -> None:
+    """Flat alias is ignored when the fallback feature flag is off."""
+    meta = {"userId": "old"}
+    with patch(
+        f"{_MOD}.feature_flags.enable_mcp_metadata_fallback_un_19145.is_enabled",
+        return_value=False,
+    ):
+        assert _pick_meta(meta, MetaKeys.USER_ID) is None
+
+
+@pytest.mark.ai
+def test_auth_from_meta__returns_none_when_only_one_id_present() -> None:
+    """Partial auth (user but no company) must not yield an AuthContext."""
+    assert _auth_from_meta({MetaKeys.USER_ID: "u"}) is None
+
+
+@pytest.mark.ai
+def test_chat_from_meta__returns_none_without_chat_id() -> None:
+    assert _chat_from_meta({}) is None
+
+
+@pytest.mark.ai
+def test_chat_from_meta__fills_sentinel_for_missing_assistant_id() -> None:
+    chat = _chat_from_meta({MetaKeys.CHAT_ID: "chat-1"})
+    assert chat is not None
+    assert chat.chat_id == "chat-1"
+    assert chat.assistant_id == "mcp-unknown"
 
 
 @pytest.mark.ai

--- a/unique_mcp/tests/test_unique_injectors.py
+++ b/unique_mcp/tests/test_unique_injectors.py
@@ -119,12 +119,12 @@ def test_get_unique_settings__uses_meta_auth__when_present(
     """
     Purpose: _meta-derived auth overrides env when FastMCP request carries both IDs.
     Why this matters: Internal callers can override identity via MCP _meta.
-    Setup summary: Patch _base_settings and _read_meta_dict with auth keys.
+    Setup summary: Patch _base_settings and _fastmcp_read_meta_dict with auth keys.
     """
     with (
         patch(f"{_MOD}._base_settings", return_value=base_settings),
         patch(
-            f"{_MOD}._read_meta_dict",
+            f"{_MOD}._fastmcp_read_meta_dict",
             return_value={
                 MetaKeys.USER_ID: "mu",
                 MetaKeys.COMPANY_ID: "mc",
@@ -147,7 +147,7 @@ def test_get_unique_settings__uses_jwt_claims__when_meta_absent(
     """
     with (
         patch(f"{_MOD}._base_settings", return_value=base_settings),
-        patch(f"{_MOD}._read_meta_dict", return_value=None),
+        patch(f"{_MOD}._fastmcp_read_meta_dict", return_value=None),
         patch(
             f"{_MOD}._fastmcp_access_token_to_auth_context",
             return_value=AuthContext(
@@ -173,7 +173,7 @@ def test_get_unique_settings__meta_wins_over_jwt(
     with (
         patch(f"{_MOD}._base_settings", return_value=base_settings),
         patch(
-            f"{_MOD}._read_meta_dict",
+            f"{_MOD}._fastmcp_read_meta_dict",
             return_value={
                 MetaKeys.USER_ID: "meta-u",
                 MetaKeys.COMPANY_ID: "meta-c",
@@ -203,7 +203,7 @@ def test_get_unique_settings__falls_back_to_env__when_no_meta_no_jwt(
     """
     with (
         patch(f"{_MOD}._base_settings", return_value=base_settings),
-        patch(f"{_MOD}._read_meta_dict", return_value=None),
+        patch(f"{_MOD}._fastmcp_read_meta_dict", return_value=None),
         patch(f"{_MOD}._fastmcp_access_token_to_auth_context", return_value=None),
     ):
         s = get_unique_settings()
@@ -222,7 +222,7 @@ def test_get_unique_settings__reuses_app_and_api_from_base(
     """
     with (
         patch(f"{_MOD}._base_settings", return_value=base_settings),
-        patch(f"{_MOD}._read_meta_dict", return_value=None),
+        patch(f"{_MOD}._fastmcp_read_meta_dict", return_value=None),
         patch(
             f"{_MOD}._fastmcp_access_token_to_auth_context",
             return_value=AuthContext(
@@ -244,7 +244,7 @@ def test_get_unique_settings__binds_chat_context_when_chat_id_present(
     with (
         patch(f"{_MOD}._base_settings", return_value=base_settings),
         patch(
-            f"{_MOD}._read_meta_dict",
+            f"{_MOD}._fastmcp_read_meta_dict",
             return_value={
                 MetaKeys.USER_ID: "u",
                 MetaKeys.COMPANY_ID: "c",
@@ -267,7 +267,7 @@ def test_get_unique_settings__meta_chat_only_then_jwt_auth_preserves_chat(
     with (
         patch(f"{_MOD}._base_settings", return_value=base_settings),
         patch(
-            f"{_MOD}._read_meta_dict",
+            f"{_MOD}._fastmcp_read_meta_dict",
             return_value={MetaKeys.CHAT_ID: "chat-1"},
         ),
         patch(
@@ -287,9 +287,9 @@ def test_get_unique_settings__meta_chat_only_then_jwt_auth_preserves_chat(
 
 @pytest.mark.ai
 def test_get_request_meta__returns_raw_meta_dict() -> None:
-    """`get_request_meta` is a thin public wrapper over `_read_meta_dict`."""
+    """`get_request_meta` is a thin public wrapper over `_fastmcp_read_meta_dict`."""
     raw = {"unique.app/search/content-ids": ["c1"]}
-    with patch(f"{_MOD}._read_meta_dict", return_value=raw):
+    with patch(f"{_MOD}._fastmcp_read_meta_dict", return_value=raw):
         assert get_request_meta() == raw
 
 

--- a/unique_mcp/tests/test_unique_injectors.py
+++ b/unique_mcp/tests/test_unique_injectors.py
@@ -13,7 +13,7 @@ from unique_toolkit.app.unique_settings import (
 )
 
 from unique_mcp.auth.zitadel.oauth_proxy import ZitadelOAuthProxySettings
-from unique_mcp.meta_keys import MetaKeys
+from unique_mcp.meta_keys import _LEGACY_NAMESPACE_ALIASES, MetaKeys
 from unique_mcp.unique_injectors import (
     _CLAIM_COMPANY_ID,
     _CLAIM_USER_ID,
@@ -320,6 +320,36 @@ def test_pick_meta__ignores_flat_when_ff_disabled() -> None:
         return_value=False,
     ):
         assert _pick_meta(meta, MetaKeys.USER_ID) is None
+
+
+@pytest.mark.ai
+def test_pick_meta__uses_legacy_namespace_alias_when_ff_enabled() -> None:
+    """Old ``unique.app/user-id`` (pre-scope-segment) resolves via FF-gated fallback."""
+    old_key = _LEGACY_NAMESPACE_ALIASES[MetaKeys.USER_ID]
+    with patch(
+        f"{_MOD}.feature_flags.enable_mcp_metadata_fallback_un_19145.is_enabled",
+        return_value=True,
+    ):
+        assert _pick_meta({old_key: "u1"}, MetaKeys.USER_ID) == "u1"
+
+
+@pytest.mark.ai
+def test_pick_meta__ignores_legacy_namespace_alias_when_ff_disabled() -> None:
+    """Old ``unique.app/user-id`` must not resolve when the fallback FF is off."""
+    old_key = _LEGACY_NAMESPACE_ALIASES[MetaKeys.USER_ID]
+    with patch(
+        f"{_MOD}.feature_flags.enable_mcp_metadata_fallback_un_19145.is_enabled",
+        return_value=False,
+    ):
+        assert _pick_meta({old_key: "u1"}, MetaKeys.USER_ID) is None
+
+
+@pytest.mark.ai
+def test_pick_meta__canonical_wins_over_legacy_namespace() -> None:
+    """Canonical key takes priority over old-namespace alias even when both present."""
+    old_key = _LEGACY_NAMESPACE_ALIASES[MetaKeys.USER_ID]
+    result = _pick_meta({MetaKeys.USER_ID: "new", old_key: "old"}, MetaKeys.USER_ID)
+    assert result == "new"
 
 
 @pytest.mark.ai

--- a/unique_mcp/tests/test_unique_injectors.py
+++ b/unique_mcp/tests/test_unique_injectors.py
@@ -288,7 +288,7 @@ def test_get_unique_settings__meta_chat_only_then_jwt_auth_preserves_chat(
 @pytest.mark.ai
 def test_get_request_meta__returns_raw_meta_dict() -> None:
     """`get_request_meta` is a thin public wrapper over `_read_meta_dict`."""
-    raw = {MetaKeys.CONTENT_IDS: ["c1"]}
+    raw = {"unique.app/search/content-ids": ["c1"]}
     with patch(f"{_MOD}._read_meta_dict", return_value=raw):
         assert get_request_meta() == raw
 

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-08T12:08:49.478002Z"
+exclude-newer = "2026-04-08T14:38:35.201257Z"
 exclude-newer-span = "P2W"
 
 [options.exclude-newer-package]
@@ -5308,7 +5308,7 @@ dev = []
 
 [[package]]
 name = "unique-mcp"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "unique_mcp" }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

- Add `MetaKeys` StrEnum with namespaced `unique.app/auth/*`, `unique.app/chat/*`, `unique.app/search/*` keys — single source of truth for typed, typo-safe `_meta` access
- Add `META_FLAT_ALIASES` mapping from legacy camelCase flat keys, gated behind `enable_mcp_metadata_fallback_un_19145` FF for rollout safety
- Add `ContextRequirements` pydantic model + `merge_tool_meta` helper — tools self-declare which `_meta` keys they require/optionally consume via `unique.app/context-requirements`
- Add `get_request_meta` injector — exposes raw `_meta` dict to tool handlers that need search-scoping fields beyond auth/chat
- Refactor `get_unique_settings` to compose `AuthContext` + `ChatContext` from `_meta` using `MetaKeys`, with FF-gated flat alias fallback for pre-migration clients

## ⚠️ Merge order

**This PR must be merged after [#1460](https://github.com/Unique-AG/ai/pull/1460)** (`feat/UN-19818-toolkit-mcp-prereqs`). It depends on `UniqueSettings.with_chat` and the `enable_mcp_metadata_fallback_un_19145` FF which are introduced there. Once #1460 is merged and `unique-toolkit 1.77.2` is published, retarget this PR to `main` before merging.

## Test plan
- [ ] `uv run pytest unique_mcp/tests/test_meta_keys.py unique_mcp/tests/test_context_requirements.py unique_mcp/tests/test_unique_injectors.py -q`
- [ ] `uv run basedpyright unique_mcp/src/unique_mcp/meta_keys.py unique_mcp/src/unique_mcp/context_requirements.py unique_mcp/src/unique_mcp/unique_injectors.py`

Refs: UN-19818