### PR TITLE
fix(orchestrator): align uploaded-search ingestion tests with new is_ingested semantics

### DIFF
--- a/unique_orchestrator/CHANGELOG.md
+++ b/unique_orchestrator/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.22.2] - 2026-04-22
+- Align `SKIP_EXCEL_INGESTION` tests in `_configure_uploaded_search_tool` with the new `Content.is_ingested` semantics from `unique_toolkit` 1.80.1; also pin non-Excel behavior with a regression test.
+
 ## [1.22.1] - 2026-04-20
 - Pass `selected_content_ids` to `OpenFileToolRuntimeConfig` so only user-selected uploaded PDFs are included
 - Fix `filter_uploaded_documents_by_selection` call to handle missing `additional_parameters` gracefully

--- a/unique_orchestrator/pyproject.toml
+++ b/unique_orchestrator/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "unique_orchestrator"
-version = "1.22.1"
+version = "1.22.2"
 description = ""
 readme = "README.md"
 license = { text = "Proprietary" }

--- a/unique_orchestrator/unique_orchestrator/tests/test_unique_ai_builder_uploaded_search.py
+++ b/unique_orchestrator/unique_orchestrator/tests/test_unique_ai_builder_uploaded_search.py
@@ -309,9 +309,11 @@ class TestConfigureUploadedSearchToolIngestionFilter:
         event.payload.tool_choices = tool_choices or []
         return event
 
-    def _make_doc(self, applied_ingestion_config):
+    def _make_doc(self, applied_ingestion_config, mime_type=None):
         return Content(
-            expired_at=None, applied_ingestion_config=applied_ingestion_config
+            expired_at=None,
+            applied_ingestion_config=applied_ingestion_config,
+            mime_type=mime_type,
         )
 
     def _run(self, docs, tool_choices=None):
@@ -343,10 +345,29 @@ class TestConfigureUploadedSearchToolIngestionFilter:
         assert UploadedSearchTool.name not in tool_names
 
     def test_skip_excel_ingestion_mode_is_excluded(self):
-        doc = self._make_doc({"uniqueIngestionMode": "SKIP_EXCEL_INGESTION"})
+        # SKIP_EXCEL_INGESTION only excludes the doc when the mime type is
+        # actually Excel/CSV (see unique_toolkit.Content.is_ingested after
+        # #1454). A SKIP_EXCEL_INGESTION doc with a non-Excel or unknown
+        # mime type is still considered ingested.
+        doc = self._make_doc(
+            {"uniqueIngestionMode": "SKIP_EXCEL_INGESTION"},
+            mime_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        )
         common = self._run([doc])
         tool_names = [t.name for t in common.tool_manager_config.tools]
         assert UploadedSearchTool.name not in tool_names
+
+    def test_skip_excel_ingestion_with_non_excel_mime_is_included(self):
+        # Counterpart to test_skip_excel_ingestion_mode_is_excluded: a doc
+        # with SKIP_EXCEL_INGESTION but a non-Excel mime is considered
+        # ingested and must keep the uploaded search tool enabled.
+        doc = self._make_doc(
+            {"uniqueIngestionMode": "SKIP_EXCEL_INGESTION"},
+            mime_type="application/pdf",
+        )
+        common = self._run([doc])
+        tool_names = [t.name for t in common.tool_manager_config.tools]
+        assert UploadedSearchTool.name in tool_names
 
     def test_mixed_docs_tool_added_when_at_least_one_is_ingested(self):
         skip_doc = self._make_doc({"uniqueIngestionMode": "SKIP_INGESTION"})
@@ -358,7 +379,10 @@ class TestConfigureUploadedSearchToolIngestionFilter:
     def test_all_skip_docs_tool_not_added(self):
         docs = [
             self._make_doc({"uniqueIngestionMode": "SKIP_INGESTION"}),
-            self._make_doc({"uniqueIngestionMode": "SKIP_EXCEL_INGESTION"}),
+            self._make_doc(
+                {"uniqueIngestionMode": "SKIP_EXCEL_INGESTION"},
+                mime_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            ),
         ]
         common = self._run(docs)
         tool_names = [t.name for t in common.tool_manager_config.tools]

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-08T08:10:09.82818Z"
+exclude-newer = "2026-04-08T11:39:35.57966Z"
 exclude-newer-span = "P2W"
 
 [options.exclude-newer-package]
@@ -5334,7 +5334,7 @@ dev = []
 
 [[package]]
 name = "unique-orchestrator"
-version = "1.22.1"
+version = "1.22.2"
 source = { editable = "unique_orchestrator" }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## 🚀 Summary

#1454 (`fix(toolkit): Fix is_ingested logic in Content`) changed `Content.is_ingested` so that `SKIP_EXCEL_INGESTION` now returns `False` only when `mime_type` is actually Excel or CSV. Previously it always returned `False` regardless of mime type.

The orchestrator tests in `test_unique_ai_builder_uploaded_search.py` were written against the old always-excluded behavior, but the toolkit-only PR did not trigger orchestrator CI via `detect-changes`, so the breakage landed on `main` silently. Any PR that touches the orchestrator now has 2 failing tests it did not cause.

## ✅ Changes

- [x] `test_skip_excel_ingestion_mode_is_excluded` and `test_all_skip_docs_tool_not_added`: pass an explicit Excel mime type (`application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`) so the tests still exercise the "SKIP_EXCEL_INGESTION excludes the doc" path under the new semantics.
- [x] Add `test_skip_excel_ingestion_with_non_excel_mime_is_included` to pin the counterpart behavior from the orchestrator side: a `SKIP_EXCEL_INGESTION` doc with a non-Excel mime (`application/pdf`) keeps the uploaded search tool enabled.
- [x] Bump orchestrator to `1.22.2` + changelog entry.

## 🧪 Testing

```
uv run pytest unique_orchestrator/unique_orchestrator/tests/test_unique_ai_builder_uploaded_search.py::TestConfigureUploadedSearchToolIngestionFilter -v
```

All 7 tests pass locally.

Made with [Cursor](https://cursor.com)