### PR TITLE
feat(sdk): align AgenticTable with public magic-table API [UN-19885]

### DIFF
--- a/unique_sdk/CHANGELOG.md
+++ b/unique_sdk/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), 
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.12] - 2026-04-22
+- `AgenticTable.GetSheetData`: add `includeSheetMetadata` and `includeRowMetadata` (optional GET query params; `includeRowMetadata` for `GET /magic-table/{tableId}` aligns with in-flight public API work)
+- Align other `AgenticTable` request/response types with the public magic-table REST contract (`2023-12-06` / `node-chat`): `RowVerificationStatus` uses `NEEDS_REVIEW` to match `MagicTableRowStatus`; `MagicTableAction` adds `InsertRow` and `GenerateOverview`; `bulk_update_status` adds optional `locked`; `SetArtifact` optional `name`/`mimeType` and `MagicTableArtifactType` including `AGENTIC_REPORT`; `set_activity` returns `MagicTableActivityResponse`, `set_artifact` returns `ColumnMetadataUpdateStatus`; extend cell/sheet TypedDicts (`metaData`, `rowMetadata`, `magicTableSheetMetadata`, optional `chatId` / `magicTableRowCount`); export `AgenticTableCellMetaData`, `MagicTableActivityResponse`, `MagicTableArtifactType`, `MagicTableMetadataEntry`
+- Docs: update `agentic_table` reference for the above; add test coverage for `includeSheetMetadata` / `includeRowMetadata` on `get_sheet_data`
+
 ## [0.11.11] - 2026-04-22
 - Add `Space.get_spaces` / `Space.get_spaces_async` to list spaces with optional name filter and skip/take pagination
 

--- a/unique_sdk/docs/api_resources/agentic_table.md
+++ b/unique_sdk/docs/api_resources/agentic_table.md
@@ -67,6 +67,7 @@ Work with intelligent tables that support:
     - `tableId` (str, required) - Table/sheet ID
     - `rowOrder` (int, required) - Row index (0-based)
     - `columnOrder` (int, required) - Column index (0-based)
+    - `includeRowMetadata` (bool, optional) - When true, the response may include `rowMetadata` on the cell (public `GET /magic-table/{tableId}/cell`)
 
     **Returns:**
 
@@ -139,6 +140,8 @@ Work with intelligent tables that support:
     - `includeLogHistory` (bool, optional) - Include change logs
     - `includeRowCount` (bool, optional) - Include row count
     - `includeCellMetaData` (bool, optional) - Include cell metadata
+    - `includeSheetMetadata` (bool, optional) - Include sheet-level metadata (`magicTableSheetMetadata` on the sheet)
+    - `includeRowMetadata` (bool, optional) - When supported by the gateway, include per-row metadata on each cell in `magicTableCells` (same query shape as `includeCellMetaData`; wire-up on `GET /magic-table/{tableId}` may still be rolling out)
     - `startRow` (int, optional) - Start row index for range (0-based)
     - `endRow` (int, optional) - End row index for range (0-based)
 
@@ -157,6 +160,8 @@ Work with intelligent tables that support:
         includeLogHistory=True,
         includeRowCount=True,
         includeCellMetaData=True,
+        includeSheetMetadata=False,
+        includeRowMetadata=False,
         startRow=0,
         endRow=10
     )
@@ -221,13 +226,13 @@ Work with intelligent tables that support:
     **Parameters:**
 
     - `tableId` (str, required) - Table/sheet ID
-    - `activity` (Literal["DeleteRow", "DeleteColumn", "UpdateCell", "AddQuestionText", "AddMetaData", "GenerateArtifact", "SheetCompleted", "LibrarySheetRowVerified", "RerunRow"], required) - Activity type
-    - `status` (Literal["IN_PROGRESS", "COMPLETED", "FAILED"], required) - Activity status
+    - `activity` ([`MagicTableAction`](#magictableaction) / str, required) - Workflow action (e.g. `"UpdateCell"`, `"InsertRow"`, `"GenerateOverview"`, …)
+    - `status` ([`ActivityStatus`](#activitystatus) / str, required) - Activity status: `"IN_PROGRESS"`, `"COMPLETED"`, or `"FAILED"`
     - `text` (str, required) - Activity description text
 
     **Returns:**
 
-    Returns an [`AgenticTableCell`](#agentictablecell) object.
+    Returns a [`MagicTableActivityResponse`](#magictableactivityresponse) object (`{ "status": true | false }`).
 
     **Example:**
 
@@ -249,14 +254,14 @@ Work with intelligent tables that support:
     **Parameters:**
 
     - `tableId` (str, required) - Table/sheet ID
-    - `name` (str, required) - Artifact name
     - `contentId` (str, required) - Content ID of the artifact document
-    - `mimeType` (str, required) - MIME type (e.g., "application/pdf")
-    - `artifactType` (Literal["QUESTIONS", "FULL_REPORT"], required) - Artifact type
+    - `artifactType` ([`MagicTableArtifactType`](#magictableartifacttype) / str, required) - One of `"QUESTIONS"`, `"FULL_REPORT"`, or `"AGENTIC_REPORT"`
+    - `name` (str, optional) - Artifact name
+    - `mimeType` (str, optional) - MIME type (e.g. `"application/pdf"`)
 
     **Returns:**
 
-    Returns an [`AgenticTableCell`](#agentictablecell) object.
+    Returns a [`ColumnMetadataUpdateStatus`](#columnmetadataupdatestatus) object.
 
     **Example:**
 
@@ -348,7 +353,8 @@ Work with intelligent tables that support:
 
     - `tableId` (str, required) - Table/sheet ID
     - `rowOrders` (List[int], required) - List of row indices to update (0-based)
-    - `status` (RowVerificationStatus, required) - Verification status: `"NEED_REVIEW"`, `"READY_FOR_VERIFICATION"`, or `"VERIFIED"`
+    - `status` (RowVerificationStatus, required) - Verification status: `"NEEDS_REVIEW"`, `"READY_FOR_VERIFICATION"`, or `"VERIFIED"`
+    - `locked` (bool, optional) - Row lock flag (defaults are applied server-side when omitted)
 
     **Returns:**
 
@@ -486,7 +492,7 @@ Work with intelligent tables that support:
             company_id=company_id,
             tableId=table_id,
             rowOrders=list(range(10)),  # First 10 rows
-            status="NEED_REVIEW"
+            status="NEEDS_REVIEW"
         )
     ```
 
@@ -577,6 +583,46 @@ Work with intelligent tables that support:
     )
     ```
 
+## Enumerations (public API mirror)
+
+These mirror the public magic-table REST contract (`2023-12-06` / `node-chat`).
+
+#### MagicTableAction {#magictableaction}
+
+??? note "Workflow actions for `set_activity`"
+
+    String values include: `DeleteRow`, `DeleteColumn`, `InsertRow`, `UpdateCell`, `AddQuestionText`, `AddMetaData`, `GenerateArtifact`, `SheetCompleted`, `LibrarySheetRowVerified`, `SheetCreated`, `GenerateOverview`, `RerunRow`.
+
+#### ActivityStatus {#activitystatus}
+
+??? note "Activity lifecycle for `set_activity`"
+
+    Values: `IN_PROGRESS`, `COMPLETED`, `FAILED`.
+
+#### MagicTableActivityResponse {#magictableactivityresponse}
+
+??? note "JSON body from `POST .../activity`"
+
+    - `status` (bool) - Whether the activity was published (sheet found).
+
+#### MagicTableArtifactType {#magictableartifacttype}
+
+??? note "Artifact kinds for `set_artifact`"
+
+    Values: `QUESTIONS`, `FULL_REPORT`, `AGENTIC_REPORT`.
+
+#### MagicTableMetadataEntry {#magictablemetadataentry}
+
+??? note "Row or sheet metadata entry"
+
+    Fields: `id`, `key`, `value`, and optional `exactFilter` (bool).
+
+#### AgenticTableCellMetaData {#agentictablecellmetadata}
+
+??? note "Cell-level selection metadata"
+
+    Fields may include `selected`, `selectionMethod`, `agreementStatus`, `rowOrder`, `columnOrder`.
+
 ## Input Types
 
 #### LogEntry {#logentry}
@@ -611,8 +657,10 @@ Work with intelligent tables that support:
     - `rowLocked` (bool) - Whether row is locked
     - `text` (str) - Cell text content
     - `logEntries` (List[LogEntry]) - List of log entries. See [`LogEntry`](#logentry) for structure.
+    - `metaData` ([`AgenticTableCellMetaData`](#agentictablecellmetadata), optional) - Present when sheet data is fetched with `includeCellMetaData=true`
+    - `rowMetadata` (List[[`MagicTableMetadataEntry`](#magictablemetadataentry)], optional) - On `get_cell` when `includeRowMetadata=true`; on sheet payloads when `get_sheet_data` is called with `includeRowMetadata=true` once the public `GET /magic-table/{tableId}` supports it
 
-    **Returned by:** `AgenticTable.set_cell()`, `AgenticTable.get_cell()`, `AgenticTable.set_activity()`, `AgenticTable.set_artifact()`
+    **Returned by:** `AgenticTable.set_cell()`, `AgenticTable.get_cell()`, and (when `includeCells=true`) cells inside `AgenticTable.get_sheet_data()`
 
 #### AgenticTableSheet {#agentictablesheet}
 
@@ -623,12 +671,13 @@ Work with intelligent tables that support:
     - `sheetId` (str) - Unique sheet identifier
     - `name` (str) - Sheet name
     - `state` (AgenticTableSheetState) - Current state. See [`AgenticTableSheetState`](#agentictablesheetstate).
-    - `chatId` (str) - Associated chat ID
     - `createdBy` (str) - Creator user ID
     - `companyId` (str) - Company ID
     - `createdAt` (str) - Creation timestamp (ISO 8601)
-    - `magicTableRowCount` (int) - Total number of rows
-    - `magicTableCells` (List[AgenticTableCell] | None) - List of cells (if `includeCells=True`)
+    - `chatId` (str, optional) - Associated chat ID when present
+    - `magicTableRowCount` (int, optional) - Total row count when requested with `includeRowCount=true`
+    - `magicTableCells` (List[AgenticTableCell], optional) - Cells when `includeCells=true`
+    - `magicTableSheetMetadata` (List[[`MagicTableMetadataEntry`](#magictablemetadataentry)], optional) - When `includeSheetMetadata=true`
 
     **Returned by:** `AgenticTable.get_sheet_data()`
 
@@ -653,7 +702,7 @@ Work with intelligent tables that support:
     - `status` (bool) - Whether update was successful
     - `message` (str | None) - Status message
 
-    **Returned by:** `AgenticTable.set_column_metadata()`, `AgenticTable.set_cell_metadata()`, `AgenticTable.set_multiple_cells()`, `AgenticTable.bulk_update_status()`
+    **Returned by:** `AgenticTable.set_column_metadata()`, `AgenticTable.set_cell_metadata()`, `AgenticTable.set_multiple_cells()`, `AgenticTable.set_artifact()`, `AgenticTable.bulk_update_status()`
 
 #### UpdateSheetResponse {#updatesheetresponse}
 

--- a/unique_sdk/pyproject.toml
+++ b/unique_sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "unique_sdk"
-version = "0.11.11"
+version = "0.11.12"
 description = ""
 readme = "README.md"
 license = { text = "MIT" }

--- a/unique_sdk/tests/test_async_fixes.py
+++ b/unique_sdk/tests/test_async_fixes.py
@@ -26,6 +26,68 @@ async def test_set_column_metadata_uses_async_request():
 
 
 @pytest.mark.asyncio
+async def test_get_sheet_data_forwards_include_sheet_metadata_query_param():
+    with patch.object(
+        AgenticTable, "_static_request_async", new_callable=AsyncMock
+    ) as mock_req:
+        mock_req.return_value = {
+            "sheetId": "s1",
+            "name": "n",
+            "state": "IDLE",
+            "chatId": "ch1",
+            "createdBy": "u0",
+            "companyId": "c1",
+            "createdAt": "t0",
+            "magicTableRowCount": 0,
+        }
+
+        await AgenticTable.get_sheet_data(
+            user_id="u1",
+            company_id="c1",
+            tableId="t1",
+            includeCells=True,
+            includeSheetMetadata=True,
+        )
+
+        mock_req.assert_awaited_once()
+        _method, _url, _uid, _cid, params = mock_req.await_args[0]
+        assert params["tableId"] == "t1"
+        assert params["includeCells"] is True
+        assert params["includeSheetMetadata"] is True
+
+
+@pytest.mark.asyncio
+async def test_get_sheet_data_forwards_include_row_metadata_query_param():
+    with patch.object(
+        AgenticTable, "_static_request_async", new_callable=AsyncMock
+    ) as mock_req:
+        mock_req.return_value = {
+            "sheetId": "s1",
+            "name": "n",
+            "state": "IDLE",
+            "chatId": "ch1",
+            "createdBy": "u0",
+            "companyId": "c1",
+            "createdAt": "t0",
+            "magicTableRowCount": 0,
+        }
+
+        await AgenticTable.get_sheet_data(
+            user_id="u1",
+            company_id="c1",
+            tableId="t1",
+            includeCells=True,
+            includeRowMetadata=True,
+        )
+
+        mock_req.assert_awaited_once()
+        _method, _url, _uid, _cid, params = mock_req.await_args[0]
+        assert params["tableId"] == "t1"
+        assert params["includeCells"] is True
+        assert params["includeRowMetadata"] is True
+
+
+@pytest.mark.asyncio
 async def test_wait_for_ingestion_completion_uses_async_search():
     with patch(
         "unique_sdk.utils.file_io.Content.search_async", new_callable=AsyncMock

--- a/unique_sdk/unique_sdk/__init__.py
+++ b/unique_sdk/unique_sdk/__init__.py
@@ -110,6 +110,7 @@ from unique_sdk._unique_ql import UQLCombinator as UQLCombinator
 from .api_resources._agentic_table import (
     AgenticTable as AgenticTable,
     AgenticTableCell as AgenticTableCell,
+    AgenticTableCellMetaData as AgenticTableCellMetaData,
     AgenticTableSheet as AgenticTableSheet,
     AgenticTableSheetState as AgenticTableSheetState,
     LogEntry as LogEntry,
@@ -120,4 +121,7 @@ from .api_resources._agentic_table import (
     AgreementStatus as AgreementStatus,
     RowVerificationStatus as RowVerificationStatus,
     MagicTableAction as MagicTableAction,
+    MagicTableActivityResponse as MagicTableActivityResponse,
+    MagicTableArtifactType as MagicTableArtifactType,
+    MagicTableMetadataEntry as MagicTableMetadataEntry,
 )

--- a/unique_sdk/unique_sdk/api_resources/_agentic_table.py
+++ b/unique_sdk/unique_sdk/api_resources/_agentic_table.py
@@ -31,35 +31,6 @@ class LogEntry(TypedDict):
     details: NotRequired[LogDetail]
 
 
-class _AgenticTableCellRequired(TypedDict):
-    rowOrder: int
-    columnOrder: int
-    text: str
-
-
-class AgenticTableCell(_AgenticTableCellRequired, total=False):
-    sheetId: str
-    rowLocked: bool
-    logEntries: list[LogEntry] | None
-
-
-class ColumnMetadataUpdateStatus(TypedDict, total=False):
-    status: bool
-    message: str | None
-
-
-class AgenticTableSheet(TypedDict):
-    sheetId: str
-    name: str
-    state: AgenticTableSheetState
-    chatId: str
-    createdBy: str
-    companyId: str
-    createdAt: str
-    magicTableRowCount: int
-    magicTableCells: NotRequired[list[AgenticTableCell]]
-
-
 class FilterTypes(StrEnum):
     VALUE_MATCH_FILTER = "ValueMatchFilter"
     PARTIAL_MATCH_FILTER = "PartialMatchFilter"
@@ -78,8 +49,11 @@ class CellRendererTypes(StrEnum):
 
 
 class MagicTableAction(StrEnum):
+    """Workflow action strings for `POST /magic-table/{tableId}/activity` (matches `MagicTableAgenticWorkflowAction`)."""
+
     DELETE_ROW = "DeleteRow"
     DELETE_COLUMN = "DeleteColumn"
+    INSERT_ROW = "InsertRow"
     UPDATE_CELL = "UpdateCell"
     ADD_QUESTION_TEXT = "AddQuestionText"
     ADD_META_DATA = "AddMetaData"
@@ -87,6 +61,7 @@ class MagicTableAction(StrEnum):
     SHEET_COMPLETED = "SheetCompleted"
     LIBRARY_SHEET_ROW_VERIFIED = "LibrarySheetRowVerified"
     SHEET_CREATED = "SheetCreated"
+    GENERATE_OVERVIEW = "GenerateOverview"
     RERUN_ROW = "RerunRow"
 
 
@@ -112,9 +87,79 @@ class AgreementStatus(StrEnum):
 
 
 class RowVerificationStatus(StrEnum):
-    NEED_REVIEW = "NEED_REVIEW"
+    """Row verification status for `POST .../rows/bulk-update-status` (matches `MagicTableRowStatus`)."""
+
+    NEEDS_REVIEW = "NEEDS_REVIEW"
     READY_FOR_VERIFICATION = "READY_FOR_VERIFICATION"
     VERIFIED = "VERIFIED"
+
+
+class MagicTableArtifactType(StrEnum):
+    """Artifact type for `POST /magic-table/{tableId}/artifact` (matches `MagicTableArtifactType`)."""
+
+    QUESTIONS = "QUESTIONS"
+    FULL_REPORT = "FULL_REPORT"
+    AGENTIC_REPORT = "AGENTIC_REPORT"
+
+
+class MagicTableMetadataEntry(TypedDict, total=False):
+    """Row or sheet metadata entry as returned by the public magic-table API."""
+
+    id: str
+    key: str
+    value: str
+    exactFilter: bool
+
+
+class AgenticTableCellMetaData(TypedDict, total=False):
+    """Per-cell metadata object (`metaData` on `AgenticTableCell`) when `includeCellMetaData` is used."""
+
+    selected: bool
+    selectionMethod: SelectionMethod
+    agreementStatus: AgreementStatus
+    rowOrder: int
+    columnOrder: int
+
+
+class _AgenticTableCellRequired(TypedDict):
+    rowOrder: int
+    columnOrder: int
+    text: str
+
+
+class AgenticTableCell(_AgenticTableCellRequired, total=False):
+    sheetId: str
+    rowLocked: bool
+    logEntries: list[LogEntry] | None
+    metaData: AgenticTableCellMetaData
+    rowMetadata: list[MagicTableMetadataEntry]
+
+
+class ColumnMetadataUpdateStatus(TypedDict, total=False):
+    status: bool
+    message: str | None
+
+
+class MagicTableActivityResponse(TypedDict):
+    """Response body from `POST /magic-table/{tableId}/activity` (publish activity)."""
+
+    status: bool
+
+
+class _AgenticTableSheetRequired(TypedDict):
+    sheetId: str
+    name: str
+    state: AgenticTableSheetState
+    createdBy: str
+    companyId: str
+    createdAt: str
+
+
+class AgenticTableSheet(_AgenticTableSheetRequired, total=False):
+    chatId: str
+    magicTableRowCount: int
+    magicTableCells: list[AgenticTableCell]
+    magicTableSheetMetadata: list[MagicTableMetadataEntry]
 
 
 class AgenticTable(APIResource["AgenticTable"]):
@@ -143,10 +188,10 @@ class AgenticTable(APIResource["AgenticTable"]):
 
     class SetArtifact(RequestOptions):
         tableId: str
-        name: str
         contentId: str
-        mimeType: str
-        artifactType: Literal["QUESTIONS", "FULL_REPORT"]
+        artifactType: MagicTableArtifactType
+        name: NotRequired[str]
+        mimeType: NotRequired[str]
 
     class UpdateSheet(RequestOptions):
         tableId: str
@@ -166,11 +211,15 @@ class AgenticTable(APIResource["AgenticTable"]):
         editable: NotRequired[bool]
 
     class GetSheetData(RequestOptions):
+        """Query params for `GET /magic-table/{tableId}` (public `2023-12-06`)."""
+
         tableId: str
         includeCells: NotRequired[bool]
         includeLogHistory: NotRequired[bool]
         includeRowCount: NotRequired[bool]
         includeCellMetaData: NotRequired[bool]
+        includeSheetMetadata: NotRequired[bool]
+        includeRowMetadata: NotRequired[bool]
         startRow: NotRequired[int]
         endRow: NotRequired[int]
 
@@ -186,6 +235,7 @@ class AgenticTable(APIResource["AgenticTable"]):
         tableId: str
         rowOrders: list[int]
         status: RowVerificationStatus
+        locked: NotRequired[bool]
 
     @classmethod
     async def set_cell(
@@ -236,11 +286,10 @@ class AgenticTable(APIResource["AgenticTable"]):
         user_id: str,
         company_id: str,
         **params: Unpack["AgenticTable.SetActivityStatus"],
-    ) -> "AgenticTableCell":
-        """ """
+    ) -> MagicTableActivityResponse:
         url = f"/magic-table/{params['tableId']}/activity"
         return cast(
-            "AgenticTableCell",
+            MagicTableActivityResponse,
             await cls._static_request_async(
                 "post",
                 url,
@@ -256,11 +305,10 @@ class AgenticTable(APIResource["AgenticTable"]):
         user_id: str,
         company_id: str,
         **params: Unpack["AgenticTable.SetArtifact"],
-    ) -> "AgenticTableCell":
-        """ """
+    ) -> ColumnMetadataUpdateStatus:
         url = f"/magic-table/{params['tableId']}/artifact"
         return cast(
-            "AgenticTableCell",
+            ColumnMetadataUpdateStatus,
             await cls._static_request_async(
                 "post",
                 url,

--- a/uv.lock
+++ b/uv.lock
@@ -5396,7 +5396,7 @@ dev = []
 
 [[package]]
 name = "unique-sdk"
-version = "0.11.11"
+version = "0.11.12"
 source = { editable = "unique_sdk" }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Align `unique_sdk.AgenticTable` request/response TypedDicts and enums with the public magic-table REST API (`2023-12-06` / node-chat), including `includeSheetMetadata` and `includeRowMetadata` on `get_sheet_data` (GET sheet now supports row metadata on cells when both flags are used server-side).
- Fix `RowVerificationStatus` to use `NEEDS_REVIEW` (matches `MagicTableRowStatus`); extend `MagicTableAction` and `MagicTableArtifactType`; optional `locked` on bulk row status; correct return types for `set_activity` and `set_artifact`; richer cell/sheet response typing and new public exports.
- Docs (`agentic_table.md`), changelog, version **0.11.12** (single bump from `main`), and tests for `includeSheetMetadata` / `includeRowMetadata` query pass-through.

Refs: UN-19885

## Test plan
- [x] `cd unique_sdk && uv run poe lint && uv run poe test`

## Notes for reviewers
- **Breaking (typing / enum):** `RowVerificationStatus.NEED_REVIEW` removed in favor of `NEEDS_REVIEW` and wire value `"NEEDS_REVIEW"`. Call sites using the old member or wrong string should update.
- Return type of `set_activity` / `set_artifact` is now accurate vs HTTP JSON; callers that assumed a cell object would have been wrong at runtime anyway.

Made with [Cursor](https://cursor.com)