### PR TITLE
feat(toolkit): harden default code interpreter prompt for Excel + concise calc answers (UN-19449, UN-19450, UN-19364)

### DIFF
--- a/unique_toolkit/CHANGELOG.md
+++ b/unique_toolkit/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.80.3] - 2026-04-22
+### Changed
+- Code interpreter default tool description (`DEFAULT_TOOL_DESCRIPTION`) and default system-prompt descriptions (both `DEFAULT_TOOL_DESCRIPTION_FOR_SYSTEM_PROMPT` and `DEFAULT_TOOL_DESCRIPTION_FOR_SYSTEM_PROMPT_FENCE`): explicitly instruct the model to always use code execution for Excel (`.xls`, `.xlsx`) and CSV uploads (UN-19449), pairing with the backend auto-switch to "skip ingestion for Excel" (UN-19448). Short description now also names file uploads, chart/dashboard/visualization intents explicitly and forbids ASCII-art answers for plotting requests.
+- Code interpreter default system-prompt descriptions: return calculation, retrieval, and exploratory-analysis answers concisely as inline markdown in chat rather than emitting a separate artifact file, unless the user explicitly asked for a downloadable output (UN-19364).
+
 ## [1.80.2] - 2026-04-22
 ### Fixed
 - Code interpreter fence system prompt (`DEFAULT_TOOL_DESCRIPTION_FOR_SYSTEM_PROMPT_FENCE`): tighten HTML/CSS guidance for chat iframe rendering (UN-19711) — forbid viewport/percentage heights on `html`/`body`, require bounded measurable heights for chart/dashboard containers, discourage top-level `position: fixed`/`absolute` that break auto-height measurement, and require Plotly `write_html`/`to_html` to use `include_plotlyjs="cdn"` plus `default_height` so outputs stay uploadable and measurable in chat.

--- a/unique_toolkit/pyproject.toml
+++ b/unique_toolkit/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "unique_toolkit"
-version = "1.80.2"
+version = "1.80.3"
 description = ""
 readme = "README.md"
 requires-python = ">=3.12"

--- a/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/config.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/config.py
@@ -49,6 +49,8 @@ Handling User Queries:
 - Whenever the user query requires using the python tool, you must always think first about the steps required.
 - CRITICAL: If any step generates a plot or visualization, that code block MUST include `plt.savefig('/mnt/data/<filename>.png', bbox_inches='tight')` and `plt.close()` as the final lines. Code that only calls `plt.show()` without saving will NOT display the image to the user.
 - CRITICAL: NEVER reference a `sandbox:/mnt/data/<filename>` link unless you have already executed code in this response that saved that exact file. Referencing a file that was not created by executed code will result in a broken link.
+- CRITICAL: For Excel files (`.xls`, `.xlsx`) and CSV files uploaded to the chat, ALWAYS use this tool to read and process them (e.g. `pandas.read_excel`, `pandas.read_csv`, `openpyxl`). Do NOT rely on the chat's text content or prior ingestion for spreadsheet data — the raw file contents are only accessible via code execution from `/mnt/data/<filename>`.
+- For calculation, retrieval, or exploratory-analysis answers, return the result concisely in the chat as markdown (key numbers inline, short tables where useful). Do NOT produce a separate artifact file (HTML, PDF, etc.) unless the user explicitly asked for a downloadable output or the request clearly calls for a dashboard/report.
 - Use the tool multiple times:
     - You MUST NOT guess anything about the structure of the data / files uploaded. Rather, you MUST perform some data exploration first.
         - Example: User uploads an excel files and asks a question about it. First Read the data, explore the columns, columns types, etc. Then use the tool to answer the user's query.
@@ -118,6 +120,8 @@ Handling User Queries:
 - CRITICAL: If any step generates a plot or visualization, that code block MUST include `plt.savefig('/mnt/data/<filename>.png', bbox_inches='tight')` and `plt.close()` as the final lines. Code that only calls `plt.show()` without saving will NOT display the image to the user.
 - CRITICAL: NEVER reference a `sandbox:/mnt/data/<filename>` link unless you have already executed code in this response that saved that exact file. Referencing a file that was not created by executed code will result in a broken link.
 - CRITICAL: The sandbox has NO internet access. NEVER use `requests`, `httpx`, `urllib`, or any other HTTP library to fetch data from the web — these calls will always fail. If the user's query requires live web data (e.g. market prices, news, APIs), you MUST retrieve it using the web search tool first and then pass the result into the code interpreter.
+- CRITICAL: For Excel files (`.xls`, `.xlsx`) and CSV files uploaded to the chat, ALWAYS use this tool to read and process them (e.g. `pandas.read_excel`, `pandas.read_csv`, `openpyxl`). Do NOT rely on the chat's text content or prior ingestion for spreadsheet data — the raw file contents are only accessible via code execution from `/mnt/data/<filename>`.
+- For calculation, retrieval, or exploratory-analysis answers, return the result concisely in the chat as markdown (key numbers inline, short tables where useful). Do NOT produce a separate artifact file (HTML, PDF, etc.) unless the user explicitly asked for a downloadable output or the request clearly calls for a dashboard/report.
 - Use the tool multiple times:
     - You MUST NOT guess anything about the structure of the data / files uploaded. Rather, you MUST perform some data exploration first.
         - Example: User uploads an excel files and asks a question about it. First Read the data, explore the columns, columns types, etc. Then use the tool to answer the user's query.
@@ -129,7 +133,7 @@ Handling User Queries:
 
 
 DEFAULT_TOOL_DESCRIPTION_FOR_USER_PROMPT = ""
-DEFAULT_TOOL_DESCRIPTION = "Use this tool to run python code, e.g to generate plots, process excel files, perform calculations, etc."
+DEFAULT_TOOL_DESCRIPTION = "Use this tool to run Python code: generate plots, process Excel/CSV files, perform calculations, create dashboards and data visualizations. ALWAYS use this tool when the user uploads a file (especially Excel/CSV) or asks for any chart, plot, graph, dashboard, analysis, visualization, or equation. Do not answer plotting or graphing requests with text or ASCII art — always produce a real image via the tool."
 
 
 @register_config()

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-08T11:39:35.57966Z"
+exclude-newer = "2026-04-08T12:08:49.478002Z"
 exclude-newer-span = "P2W"
 
 [options.exclude-newer-package]
@@ -5556,7 +5556,7 @@ dev = []
 
 [[package]]
 name = "unique-toolkit"
-version = "1.80.2"
+version = "1.80.3"
 source = { editable = "unique_toolkit" }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Refs: UN-19449, UN-19450, UN-19364 (all under parent UN-19372). Pairs with backend auto-switch UN-19448 (out of this repo).

## Summary

Targeted prompt hardening on the default code interpreter tool description. Paired with the backend UN-19448 ingestion toggle (monorepo side), this ships the sprint 2026.18 default-config update requested in UN-19372.

- **UN-19449 Excel routing** — add a CRITICAL bullet to both default system prompts instructing the model to ALWAYS use the tool for `.xls` / `.xlsx` / `.csv` uploads (`pandas.read_excel`, `read_csv`, `openpyxl`) and not rely on ingested chat text for spreadsheet data.
- **UN-19450 default config** — the tool description values in `OpenAICodeInterpreterConfig` pick up the 19449 strings automatically (`tool_description_for_system_prompt` already defaults to `DEFAULT_TOOL_DESCRIPTION_FOR_SYSTEM_PROMPT_FENCE`); new and existing spaces on default config pick up the updated values on the next 1.80.3 consumption.
- **UN-19364 calc simplification** — add a bullet telling the model to return calculation / retrieval / EDA answers concisely as inline markdown, and to only emit an artifact file when the user explicitly asks for a downloadable output or clearly asks for a dashboard/report. Removes the residual overfit behavior from the legacy jupyter-notebook-style prompt (no `.txt` save guidance was present to strip — already cleaned up in a prior iteration).
- **Short `DEFAULT_TOOL_DESCRIPTION`** — names Excel/CSV and file uploads explicitly, forbids ASCII-art responses for plotting requests.

Does **not** touch the UN-19711 HTML iframe / Plotly CDN rules shipped in 1.80.2.

## Why targeted deltas, not wholesale swap to medium/long

Per local DS evaluation (`.local-dev/code-execution-research/judge/analysis/summary.md`, 92 filled human-reviewer turns across 4 models × 3 prompts):

| prompt | n | mean | min(model) | std across models |
|---|---:|---:|---:|---:|
| default | 33 | 4.22 | 3.69 | **0.34** |
| medium | 32 | 3.83 | 2.92 | 0.57 |
| long | 27 | 3.61 | 2.97 | 0.62 |

Default wins on overall quality, D1 correctness (4.36 > 4.11 > 3.80), p50 latency (22.3s vs 31.9s vs 25.2s row mean), and — most importantly — robustness across models. Medium and long swing wildly per model (long goes 4.63 on gpt5_4 but collapses to 2.97 on gpt5_1), which is the signature of format rules overfit to one model's habits. We harvest the two small ideas that do pay off (Excel routing, calc conciseness) and leave the rest as reference docs clients can adapt.

## Changes

- `unique_toolkit/.../code_interpreter/config.py`: UN-19449 Excel bullet, UN-19364 calc-concise bullet, short description refresh.
- `unique_toolkit/CHANGELOG.md`: [1.80.3] entry.
- `unique_toolkit/pyproject.toml`: 1.80.3.
- `uv.lock`: workspace refresh for the toolkit bump.

## Out of scope / hand-offs

- **UN-19448** — the "auto-switch ingestion mode to skip ingestion for Excel" toggle lives in space-config / ingestion pipeline code in the monorepo. No toolkit field owns this behavior; will be handled on the backend side.

## Test plan

### Manual validation against updated default (gpt5 + gpt5_4)

| # | Scenario | gpt5 | gpt5_4 | Notes |
|---|---|:---:|:---:|---|
| T1 | Excel retrieval (AAPL call strike/qty, M03-style) | PASS | PASS | tool call fires, inline-only answer |
| T2 | Excel EDA ("what does this excel contain?", UN-19364 example) | PASS | PASS | no auto-dashboard |
| T3 | 50th prime > 2^100-1 (UN-19364) | PASS | PASS | concise inline answer, no artifact |
| T4 | HTML dashboard on explicit request (M02 turn 3 style) | PASS | PASS | UN-19711 iframe rules + Plotly CDN intact |
| T5 | Single PNG plot (S01) | PASS | PASS | no ASCII-art fallback |
| T6 | Multi-turn M03 condensed + explicit xlsx export | PASS | PASS | state preserved across turns |

Full prompt set and pass criteria documented alongside the other eval scenarios in `.local-dev/code-execution-research/automation/scenarios/starter_suite.json`.

### Automated

- `ruff check` / `ruff format` — pass (pre-commit).
- `basedpyright` — no new diagnostics in the edited file; remaining warnings are pre-existing missing-stub warnings.

## Risk / rollout

- Prompt-only change. Rollback = revert this commit.
- Blast radius: all spaces using the default `OpenAICodeInterpreterConfig` tool description on toolkit 1.80.3+.
- Known gap: UN-19711 / KB-upload httpx timeout follow-up (see `.local-dev/responses_api/ideas/kb-upload-httpx-timeout-large-html.md`) is still needed so multi-MB HTML dashboards reach the chat reliably — separate ticket.

Made with [Cursor](https://cursor.com)