### PR TITLE
feat(unique_toolkit): agentic table + unique-sdk 0.11.12 (v1.81.0)

### DIFF
--- a/unique_toolkit/CHANGELOG.md
+++ b/unique_toolkit/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.81.0] - 2026-04-22
+### Added
+- `AgenticTableService.update_row_verification_status`: optional `locked` argument, forwarded to SDK `bulk_update_status` (public `POST .../rows/bulk-update-status`).
+- Re-export `MagicTableActivityResponse`, `MagicTableArtifactType`, and `MagicTableMetadataEntry` from `unique_toolkit.agentic_table`.
+
+### Changed
+- Require `unique-sdk>=0.11.12,<0.12` (aligns with public magic-table REST typings and `includeRowMetadata` / `includeSheetMetadata` on sheet GET).
+- **Agentic table:** `get_sheet(..., include_row_metadata=True)` passes `includeRowMetadata` on batched `get_sheet_data` and skips per-row `get_cell` when cells already include `rowMetadata`; legacy `get_cell` hydration remains when the gateway omits row metadata on sheet cells.
+- **Agentic table:** `ArtifactType` is now an alias of SDK `MagicTableArtifactType`; `ArtifactData.artifact_type` is typed as `MagicTableArtifactType`.
+- **Agentic table:** `MagicTableSheet.chat_id` is optional (`str | None`) to match optional `chatId` on sheet payloads.
+- **Agentic table:** `set_artifact` accepts optional `mime_type` and `name` (omitted on the wire when `None`, matching SDK `SetArtifact`).
+
 ## [1.80.3] - 2026-04-22
 ### Changed
 - Code interpreter default tool description (`DEFAULT_TOOL_DESCRIPTION`) and default system-prompt descriptions (both `DEFAULT_TOOL_DESCRIPTION_FOR_SYSTEM_PROMPT` and `DEFAULT_TOOL_DESCRIPTION_FOR_SYSTEM_PROMPT_FENCE`): explicitly instruct the model to always use code execution for Excel (`.xls`, `.xlsx`) and CSV uploads (UN-19449), pairing with the backend auto-switch to "skip ingestion for Excel" (UN-19448). Short description now also names file uploads, chart/dashboard/visualization intents explicitly and forbids ASCII-art answers for plotting requests.

--- a/unique_toolkit/CHANGELOG.md
+++ b/unique_toolkit/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `AgenticTableService.update_row_verification_status`: optional `locked` argument, forwarded to SDK `bulk_update_status` (public `POST .../rows/bulk-update-status`).
 - Re-export `MagicTableActivityResponse`, `MagicTableArtifactType`, and `MagicTableMetadataEntry` from `unique_toolkit.agentic_table`.
+- Tests: `tests/test_agentic_table_get_sheet_row_metadata.py` and `tests/test_agentic_table_service_coverage.py` exercise agentic-table sheet row metadata, `set_artifact` extras, `get_sheet_metadata`, `get_num_rows` / `get_sheet` row-count validation, `update_row_verification_status` with and without `locked`, and the row-metadata batch helper (CI diff-cover on changed lines).
 
 ### Changed
 - Require `unique-sdk>=0.11.12,<0.12` (aligns with public magic-table REST typings and `includeRowMetadata` / `includeSheetMetadata` on sheet GET).

--- a/unique_toolkit/pyproject.toml
+++ b/unique_toolkit/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "unique_toolkit"
-version = "1.80.3"
+version = "1.81.0"
 description = ""
 readme = "README.md"
 requires-python = ">=3.12"
@@ -28,7 +28,7 @@ dependencies = [
     "openai>=1.105.0,<3",
     "platformdirs>=4.0.0,<5",
     "pillow>=12.1.1",
-    "unique-sdk>=0.11.6,<0.12",
+    "unique-sdk>=0.11.12,<0.12",
     "jambo>=0.1.2,<0.2",
     "jinja2>=3.1.6,<4",
     "docxtpl>=0.20.1,<0.21",

--- a/unique_toolkit/tests/test_agentic_table_get_sheet_row_metadata.py
+++ b/unique_toolkit/tests/test_agentic_table_get_sheet_row_metadata.py
@@ -1,0 +1,174 @@
+"""Tests for ``AgenticTableService.get_sheet`` row metadata (UN-19885, SDK PR #1467)."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from unique_toolkit.agentic_table.schemas import MagicTableCell
+from unique_toolkit.agentic_table.service import AgenticTableService
+
+
+def _minimal_sheet_header(*, row_count: int = 2) -> dict:
+    return {
+        "sheetId": "sheet-1",
+        "name": "Test",
+        "state": "IDLE",
+        "magicTableRowCount": row_count,
+        "chatId": "chat-1",
+        "createdBy": "user-1",
+        "companyId": "company-1",
+        "createdAt": "2020-01-01T00:00:00Z",
+    }
+
+
+def _cell(row: int, col: int, *, row_metadata: list | None = None) -> dict:
+    c: dict = {
+        "sheetId": "sheet-1",
+        "rowOrder": row,
+        "columnOrder": col,
+        "text": f"r{row}c{col}",
+        "logEntries": [],
+    }
+    if row_metadata is not None:
+        c["rowMetadata"] = row_metadata
+    return c
+
+
+@pytest.mark.asyncio
+async def test_get_sheet_skips_get_cell_when_row_metadata_present_on_cells() -> None:
+    header = _minimal_sheet_header()
+    meta = [{"id": "m1", "key": "k", "value": "v", "exactFilter": False}]
+    batch = {
+        **_minimal_sheet_header(),
+        "magicTableCells": [
+            _cell(0, 0, row_metadata=meta),
+            _cell(0, 1, row_metadata=meta),
+        ],
+    }
+
+    async def fake_get_sheet_data(
+        *_args: object,
+        **kwargs: object,
+    ) -> dict:
+        if kwargs.get("includeCells") is False:
+            return header
+        return batch
+
+    svc = AgenticTableService("user-1", "company-1", "table-1")
+    with patch(
+        "unique_toolkit.agentic_table.service.AgenticTable.get_sheet_data",
+        new_callable=AsyncMock,
+        side_effect=fake_get_sheet_data,
+    ) as gsm:
+        with patch.object(svc, "get_cell", new_callable=AsyncMock) as get_cell:
+            sheet = await svc.get_sheet(
+                start_row=0,
+                end_row=2,
+                batch_size=100,
+                include_row_metadata=True,
+            )
+
+    batch_kwargs = [
+        c.kwargs for c in gsm.await_args_list if c.kwargs.get("includeCells")
+    ]
+    assert len(batch_kwargs) == 1
+    assert batch_kwargs[0].get("includeRowMetadata") is True
+    get_cell.assert_not_awaited()
+    assert len(sheet.magic_table_cells) == 2
+    assert sheet.magic_table_cells[0].row_metadata[0].key == "k"
+
+
+@pytest.mark.asyncio
+async def test_get_sheet_legacy_fallback_calls_get_cell_when_row_metadata_absent() -> (
+    None
+):
+    header = _minimal_sheet_header()
+    batch = {
+        **_minimal_sheet_header(),
+        "magicTableCells": [
+            _cell(0, 0),
+            _cell(0, 1),
+        ],
+    }
+    meta = [{"id": "m1", "key": "rk", "value": "rv", "exactFilter": False}]
+
+    async def fake_get_sheet_data(
+        *_args: object,
+        **kwargs: object,
+    ) -> dict:
+        if kwargs.get("includeCells") is False:
+            return header
+        return batch
+
+    hydrated = MagicTableCell.model_validate(
+        {
+            "sheetId": "sheet-1",
+            "rowOrder": 0,
+            "columnOrder": 0,
+            "text": "r0c0",
+            "logEntries": [],
+            "rowMetadata": meta,
+        }
+    )
+
+    svc = AgenticTableService("user-1", "company-1", "table-1")
+    with patch(
+        "unique_toolkit.agentic_table.service.AgenticTable.get_sheet_data",
+        new_callable=AsyncMock,
+        side_effect=fake_get_sheet_data,
+    ):
+        with patch.object(
+            svc,
+            "get_cell",
+            new_callable=AsyncMock,
+            return_value=hydrated,
+        ) as get_cell:
+            sheet = await svc.get_sheet(
+                start_row=0,
+                end_row=2,
+                batch_size=100,
+                include_row_metadata=True,
+            )
+
+    get_cell.assert_awaited()
+    assert get_cell.await_count == 1
+    assert len(sheet.magic_table_cells) == 2
+    assert sheet.magic_table_cells[0].row_metadata[0].key == "rk"
+    assert sheet.magic_table_cells[1].row_metadata[0].key == "rk"
+
+
+@pytest.mark.asyncio
+async def test_get_sheet_does_not_forward_include_row_metadata_when_disabled() -> None:
+    header = _minimal_sheet_header()
+    batch = {
+        **_minimal_sheet_header(),
+        "magicTableCells": [_cell(0, 0)],
+    }
+
+    async def fake_get_sheet_data(
+        *_args: object,
+        **kwargs: object,
+    ) -> dict:
+        if kwargs.get("includeCells") is False:
+            return header
+        return batch
+
+    svc = AgenticTableService("user-1", "company-1", "table-1")
+    with patch(
+        "unique_toolkit.agentic_table.service.AgenticTable.get_sheet_data",
+        new_callable=AsyncMock,
+        side_effect=fake_get_sheet_data,
+    ) as gsm:
+        with patch.object(svc, "get_cell", new_callable=AsyncMock) as get_cell:
+            await svc.get_sheet(
+                start_row=0,
+                end_row=1,
+                include_row_metadata=False,
+            )
+
+    batch_kwargs = [
+        c.kwargs for c in gsm.await_args_list if c.kwargs.get("includeCells")
+    ]
+    assert len(batch_kwargs) == 1
+    assert "includeRowMetadata" not in batch_kwargs[0]
+    get_cell.assert_not_awaited()

--- a/unique_toolkit/tests/test_agentic_table_service_coverage.py
+++ b/unique_toolkit/tests/test_agentic_table_service_coverage.py
@@ -1,0 +1,190 @@
+"""Coverage for ``AgenticTableService`` paths introduced or tightened with SDK 0.11.12 (diff-cover)."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from unique_sdk import MagicTableArtifactType, RowVerificationStatus
+
+from unique_toolkit.agentic_table.service import (
+    AgenticTableService,
+    _sheet_batch_cells_include_row_metadata_from_api,
+)
+
+
+def test_sheet_batch_helper_empty_cells() -> None:
+    assert _sheet_batch_cells_include_row_metadata_from_api([]) is True
+
+
+@pytest.mark.asyncio
+async def test_get_sheet_row_metadata_empty_cell_batch_evaluates_helper() -> None:
+    """Empty ``magicTableCells`` still calls the helper (``return True`` for empty list)."""
+    header = {
+        "sheetId": "sheet-1",
+        "name": "Test",
+        "state": "IDLE",
+        "magicTableRowCount": 1,
+        "chatId": "chat-1",
+        "createdBy": "user-1",
+        "companyId": "company-1",
+        "createdAt": "2020-01-01T00:00:00Z",
+    }
+    batch_empty = {**header, "magicTableCells": []}
+
+    async def fake_get_sheet_data(
+        *_args: object,
+        **kwargs: object,
+    ) -> dict:
+        if kwargs.get("includeCells") is False:
+            return header
+        return batch_empty
+
+    svc = AgenticTableService("user-1", "company-1", "table-1")
+    with patch(
+        "unique_toolkit.agentic_table.service.AgenticTable.get_sheet_data",
+        new_callable=AsyncMock,
+        side_effect=fake_get_sheet_data,
+    ):
+        with patch.object(svc, "get_cell", new_callable=AsyncMock) as get_cell:
+            sheet = await svc.get_sheet(
+                start_row=0,
+                end_row=1,
+                include_row_metadata=True,
+            )
+
+    get_cell.assert_not_awaited()
+    assert sheet.magic_table_cells == []
+
+
+@pytest.mark.asyncio
+async def test_get_num_rows_returns_count() -> None:
+    svc = AgenticTableService("user-1", "company-1", "table-1")
+    with patch(
+        "unique_toolkit.agentic_table.service.AgenticTable.get_sheet_data",
+        new_callable=AsyncMock,
+        return_value={
+            "sheetId": "s",
+            "name": "n",
+            "state": "IDLE",
+            "magicTableRowCount": 42,
+        },
+    ):
+        assert await svc.get_num_rows() == 42
+
+
+@pytest.mark.asyncio
+async def test_get_num_rows_raises_when_row_count_missing() -> None:
+    svc = AgenticTableService("user-1", "company-1", "table-1")
+    with patch(
+        "unique_toolkit.agentic_table.service.AgenticTable.get_sheet_data",
+        new_callable=AsyncMock,
+        return_value={"sheetId": "s", "name": "n", "state": "IDLE"},
+    ):
+        with pytest.raises(RuntimeError, match="magicTableRowCount"):
+            await svc.get_num_rows()
+
+
+@pytest.mark.asyncio
+async def test_get_sheet_raises_when_total_rows_missing() -> None:
+    svc = AgenticTableService("user-1", "company-1", "table-1")
+    with patch(
+        "unique_toolkit.agentic_table.service.AgenticTable.get_sheet_data",
+        new_callable=AsyncMock,
+        return_value={"sheetId": "s", "name": "n", "state": "IDLE"},
+    ):
+        with pytest.raises(RuntimeError, match="magicTableRowCount"):
+            await svc.get_sheet()
+
+
+@pytest.mark.asyncio
+async def test_get_sheet_metadata_parses_entries() -> None:
+    svc = AgenticTableService("user-1", "company-1", "table-1")
+    sheet_info = {
+        "sheetId": "sheet-1",
+        "name": "Test",
+        "state": "IDLE",
+        "createdBy": "user-1",
+        "companyId": "company-1",
+        "createdAt": "2020-01-01T00:00:00Z",
+        "magicTableSheetMetadata": [
+            {"id": "m1", "key": "k1", "value": "v1", "exactFilter": False},
+        ],
+    }
+    with patch(
+        "unique_toolkit.agentic_table.service.AgenticTable.get_sheet_data",
+        new_callable=AsyncMock,
+        return_value=sheet_info,
+    ):
+        rows = await svc.get_sheet_metadata()
+
+    assert len(rows) == 1
+    assert rows[0].key == "k1"
+
+
+@pytest.mark.parametrize(
+    ("mime_type", "name"),
+    [
+        (None, None),
+        ("application/pdf", None),
+        (None, "report.pdf"),
+        ("application/pdf", "report.pdf"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_set_artifact_optional_extras(
+    mime_type: str | None,
+    name: str | None,
+) -> None:
+    svc = AgenticTableService("user-1", "company-1", "table-1")
+    with patch(
+        "unique_toolkit.agentic_table.service.AgenticTable.set_artifact",
+        new_callable=AsyncMock,
+    ) as set_artifact:
+        await svc.set_artifact(
+            MagicTableArtifactType.QUESTIONS,
+            "content-1",
+            mime_type=mime_type,
+            name=name,
+        )
+
+    kwargs = set_artifact.await_args.kwargs
+    assert kwargs["artifactType"] == MagicTableArtifactType.QUESTIONS
+    assert kwargs["contentId"] == "content-1"
+    if mime_type is None:
+        assert "mimeType" not in kwargs
+    else:
+        assert kwargs["mimeType"] == mime_type
+    if name is None:
+        assert "name" not in kwargs
+    else:
+        assert kwargs["name"] == name
+
+
+@pytest.mark.asyncio
+async def test_update_row_verification_status_without_locked() -> None:
+    svc = AgenticTableService("user-1", "company-1", "table-1")
+    with patch(
+        "unique_toolkit.agentic_table.service.AgenticTable.bulk_update_status",
+        new_callable=AsyncMock,
+    ) as bulk:
+        await svc.update_row_verification_status(
+            [0, 1],
+            RowVerificationStatus.NEEDS_REVIEW,
+        )
+
+    assert "locked" not in bulk.await_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test_update_row_verification_status_with_locked() -> None:
+    svc = AgenticTableService("user-1", "company-1", "table-1")
+    with patch(
+        "unique_toolkit.agentic_table.service.AgenticTable.bulk_update_status",
+        new_callable=AsyncMock,
+    ) as bulk:
+        await svc.update_row_verification_status(
+            [2],
+            RowVerificationStatus.VERIFIED,
+            locked=True,
+        )
+
+    assert bulk.await_args.kwargs.get("locked") is True

--- a/unique_toolkit/unique_toolkit/agentic_table/__init__.py
+++ b/unique_toolkit/unique_toolkit/agentic_table/__init__.py
@@ -2,6 +2,9 @@ from unique_sdk.api_resources._agentic_table import (
     ActivityStatus,
     CellRendererTypes,
     FilterTypes,
+    MagicTableActivityResponse,
+    MagicTableArtifactType,
+    MagicTableMetadataEntry,
     RowVerificationStatus,
 )
 
@@ -40,7 +43,10 @@ __all__ = [
     "CellRendererTypes",
     "FilterTypes",
     "LogEntry",
+    "MagicTableActivityResponse",
+    "MagicTableArtifactType",
     "MagicTableAction",
+    "MagicTableMetadataEntry",
     "MagicTableAddMetadataPayload",
     "MagicTableBasePayload",
     "MagicTableCell",

--- a/unique_toolkit/unique_toolkit/agentic_table/schemas.py
+++ b/unique_toolkit/unique_toolkit/agentic_table/schemas.py
@@ -10,6 +10,7 @@ from pydantic import (
 from unique_sdk import (
     AgenticTableSheetState,
     AgreementStatus,
+    MagicTableArtifactType,
     SelectionMethod,
 )
 from unique_sdk import LogDetail as SDKLogDetail
@@ -150,15 +151,13 @@ class MagicTableUpdateCellPayload(
     data: str
 
 
-class ArtifactType(StrEnum):
-    QUESTIONS = "QUESTIONS"
-    FULL_REPORT = "FULL_REPORT"
-    AGENTIC_REPORT = "AGENTIC_REPORT"
+# Same wire values as ``MagicTableArtifactType`` / public ``POST .../artifact`` (unique-sdk 0.11.12+).
+ArtifactType = MagicTableArtifactType
 
 
 class ArtifactData(BaseModel):
     model_config = get_configuration_dict()
-    artifact_type: ArtifactType
+    artifact_type: MagicTableArtifactType
 
 
 class MagicTableGenerateArtifactPayload(
@@ -344,7 +343,10 @@ class MagicTableSheet(BaseModel):
         description="The total number of rows in the sheet",
         alias="magicTableRowCount",
     )
-    chat_id: str
+    chat_id: str | None = Field(
+        default=None,
+        description="Chat that owns the sheet when returned by the API (may be omitted).",
+    )
     created_by: str
     company_id: str
     created_at: str

--- a/unique_toolkit/unique_toolkit/agentic_table/service.py
+++ b/unique_toolkit/unique_toolkit/agentic_table/service.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Any, cast
 
 from typing_extensions import deprecated
 from unique_sdk import (
@@ -230,43 +231,20 @@ class AgenticTableService:
             mime_type: The MIME type of the artifact (optional on the wire; include when known).
             name: The display name of the artifact (optional on the wire; include when known).
         """
-        if mime_type is None and name is None:
-            await AgenticTable.set_artifact(
-                user_id=self._user_id,
-                company_id=self._company_id,
-                tableId=self.table_id,
-                artifactType=artifact_type,
-                contentId=content_id,
-            )
-        elif mime_type is not None and name is None:
-            await AgenticTable.set_artifact(
-                user_id=self._user_id,
-                company_id=self._company_id,
-                tableId=self.table_id,
-                artifactType=artifact_type,
-                contentId=content_id,
-                mimeType=mime_type,
-            )
-        elif mime_type is None and name is not None:
-            await AgenticTable.set_artifact(
-                user_id=self._user_id,
-                company_id=self._company_id,
-                tableId=self.table_id,
-                artifactType=artifact_type,
-                contentId=content_id,
-                name=name,
-            )
-        else:
-            assert mime_type is not None and name is not None
-            await AgenticTable.set_artifact(
-                user_id=self._user_id,
-                company_id=self._company_id,
-                tableId=self.table_id,
-                artifactType=artifact_type,
-                contentId=content_id,
-                mimeType=mime_type,
-                name=name,
-            )
+        extras: dict[str, str] = {}
+        if mime_type is not None:
+            extras["mimeType"] = mime_type
+        if name is not None:
+            extras["name"] = name
+        # ``Unpack[SetArtifact]`` + dynamic keys: basedpyright cannot tie ``extras`` to optional fields.
+        await AgenticTable.set_artifact(
+            user_id=self._user_id,
+            company_id=self._company_id,
+            tableId=self.table_id,
+            artifactType=artifact_type,
+            contentId=content_id,
+            **cast(Any, extras),
+        )
 
     @deprecated("Use set_column_style instead.")
     async def set_column_width(self, column: int, width: int):

--- a/unique_toolkit/unique_toolkit/agentic_table/service.py
+++ b/unique_toolkit/unique_toolkit/agentic_table/service.py
@@ -7,6 +7,7 @@ from unique_sdk import (
     AgreementStatus,
     CellRendererTypes,
     FilterTypes,
+    MagicTableArtifactType,
     RowVerificationStatus,
     SelectionMethod,
 )
@@ -14,13 +15,31 @@ from unique_sdk import AgenticTableCell as SDKAgenticTableCell
 from unique_sdk.api_resources._agentic_table import ActivityStatus
 
 from .schemas import (
-    ArtifactType,
     LogEntry,
     MagicTableAction,
     MagicTableCell,
     MagicTableSheet,
     RowMetadataEntry,
 )
+
+
+def _sheet_batch_cells_include_row_metadata_from_api(
+    cells: list[SDKAgenticTableCell],
+) -> bool:
+    """True when `get_sheet_data` already returned per-cell ``rowMetadata`` (UN-19884+).
+
+    Used to skip N+1 ``get_cell`` hydration. If the batch is empty, there is nothing
+    to hydrate, so we treat that as satisfied.
+
+    When the gateway does not yet populate ``rowMetadata`` on sheet payloads, the
+    first cell typically omits the key entirely — then callers fall back to
+    ``get_cell`` per distinct row (legacy compat; removable after deprecation).
+    """
+    if not cells:
+        return True
+    first = cells[0]
+    rm = first.get("rowMetadata")
+    return "rowMetadata" in first and isinstance(rm, list)
 
 
 class LockedAgenticTableError(Exception):
@@ -106,7 +125,7 @@ class AgenticTableService:
             tableId=self.table_id,
             rowOrder=row,
             columnOrder=column,
-            includeRowMetadata=include_row_metadata,  # type: ignore[arg-type]
+            includeRowMetadata=include_row_metadata,
         )
         return MagicTableCell.model_validate(cell_data)
 
@@ -198,28 +217,56 @@ class AgenticTableService:
 
     async def set_artifact(
         self,
-        artifact_type: ArtifactType,
+        artifact_type: MagicTableArtifactType,
         content_id: str,
-        mime_type: str,
-        name: str,
+        mime_type: str | None = None,
+        name: str | None = None,
     ):
         """Upload/set report files to the Agentic Table.
 
         Args:
-            artifact_type (ArtifactType): The type of artifact to set.
-            content_id (str): The content ID of the artifact.
-            mime_type (str): The MIME type of the artifact.
-            name (str): The name of the artifact.
+            artifact_type: The type of artifact to set (``MagicTableArtifactType`` / public API).
+            content_id: The content ID of the artifact.
+            mime_type: The MIME type of the artifact (optional on the wire; include when known).
+            name: The display name of the artifact (optional on the wire; include when known).
         """
-        await AgenticTable.set_artifact(
-            user_id=self._user_id,
-            company_id=self._company_id,
-            tableId=self.table_id,
-            artifactType=artifact_type.value,  # pyright: ignore[reportArgumentType]
-            contentId=content_id,
-            mimeType=mime_type,
-            name=name,
-        )
+        if mime_type is None and name is None:
+            await AgenticTable.set_artifact(
+                user_id=self._user_id,
+                company_id=self._company_id,
+                tableId=self.table_id,
+                artifactType=artifact_type,
+                contentId=content_id,
+            )
+        elif mime_type is not None and name is None:
+            await AgenticTable.set_artifact(
+                user_id=self._user_id,
+                company_id=self._company_id,
+                tableId=self.table_id,
+                artifactType=artifact_type,
+                contentId=content_id,
+                mimeType=mime_type,
+            )
+        elif mime_type is None and name is not None:
+            await AgenticTable.set_artifact(
+                user_id=self._user_id,
+                company_id=self._company_id,
+                tableId=self.table_id,
+                artifactType=artifact_type,
+                contentId=content_id,
+                name=name,
+            )
+        else:
+            assert mime_type is not None and name is not None
+            await AgenticTable.set_artifact(
+                user_id=self._user_id,
+                company_id=self._company_id,
+                tableId=self.table_id,
+                artifactType=artifact_type,
+                contentId=content_id,
+                mimeType=mime_type,
+                name=name,
+            )
 
     @deprecated("Use set_column_style instead.")
     async def set_column_width(self, column: int, width: int):
@@ -282,7 +329,12 @@ class AgenticTableService:
             includeCells=False,
             includeLogHistory=False,
         )
-        return sheet_info["magicTableRowCount"]
+        row_count = sheet_info.get("magicTableRowCount")
+        if row_count is None:
+            raise RuntimeError(
+                "Expected magicTableRowCount in sheet response when includeRowCount=True"
+            )
+        return row_count
 
     async def get_sheet(
         self,
@@ -316,7 +368,11 @@ class AgenticTableService:
             includeLogHistory=False,
             includeCellMetaData=False,
         )
-        total_rows = sheet_info["magicTableRowCount"]
+        total_rows = sheet_info.get("magicTableRowCount")
+        if total_rows is None:
+            raise RuntimeError(
+                "Expected magicTableRowCount in sheet response when includeRowCount=True"
+            )
         if end_row is None or end_row > total_rows:
             end_row = total_rows
         if start_row > end_row:
@@ -328,50 +384,69 @@ class AgenticTableService:
         cells = []
         for row in range(start_row, end_row, batch_size):
             end_row_batch = min(row + batch_size, end_row)
-            sheet_partial = await AgenticTable.get_sheet_data(
-                user_id=self._user_id,
-                company_id=self._company_id,
-                tableId=self.table_id,
-                includeCells=True,
-                includeLogHistory=include_log_history,
-                includeRowCount=False,
-                includeCellMetaData=include_cell_meta_data,  # renderer, selection, agreement status
-                startRow=row,
-                endRow=end_row_batch - 1,
-            )
+            if include_row_metadata:
+                sheet_partial = await AgenticTable.get_sheet_data(
+                    user_id=self._user_id,
+                    company_id=self._company_id,
+                    tableId=self.table_id,
+                    includeCells=True,
+                    includeLogHistory=include_log_history,
+                    includeRowCount=False,
+                    includeCellMetaData=include_cell_meta_data,  # renderer, selection, agreement status
+                    startRow=row,
+                    endRow=end_row_batch - 1,
+                    includeRowMetadata=True,
+                )
+            else:
+                sheet_partial = await AgenticTable.get_sheet_data(
+                    user_id=self._user_id,
+                    company_id=self._company_id,
+                    tableId=self.table_id,
+                    includeCells=True,
+                    includeLogHistory=include_log_history,
+                    includeRowCount=False,
+                    includeCellMetaData=include_cell_meta_data,  # renderer, selection, agreement status
+                    startRow=row,
+                    endRow=end_row_batch - 1,
+                )
             if "magicTableCells" in sheet_partial:
-                if include_row_metadata:
-                    # If include_row_metadata is true, we need to get the row metadata for each cell.
-                    row_metadata_map = {}
-                    # TODO: @thea-unique This routine is not efficient and would be nice if we had this data passed on in get_sheet_data.
-                    for cell in sheet_partial["magicTableCells"]:
+                batch_cells = sheet_partial["magicTableCells"]
+                if (
+                    include_row_metadata
+                    and not _sheet_batch_cells_include_row_metadata_from_api(
+                        batch_cells
+                    )
+                ):
+                    # Legacy: gateways before UN-19884 omit rowMetadata on sheet cells; hydrate
+                    # via get_cell until all environments expose rowMetadata on GET sheet. This
+                    # branch can be removed after an agreed deprecation window.
+                    self.logger.debug(
+                        "Magic table sheet cells lack rowMetadata; hydrating row metadata via get_cell."
+                    )
+                    row_metadata_map: dict[int, list[RowMetadataEntry]] = {}
+                    for cell in batch_cells:
                         row_order = cell.get("rowOrder")  # type: ignore[assignment]
                         if row_order is not None and row_order not in row_metadata_map:  # pyright: ignore[reportUnnecessaryComparison]
                             column_order = cell.get("columnOrder")  # type: ignore[assignment]
-                            self.logger.info(
-                                f"Getting row metadata for cell {row_order}, {column_order}"
-                            )
                             cell_with_row_metadata = await self.get_cell(
                                 row_order,
                                 column_order,
                             )
                             if cell_with_row_metadata.row_metadata:
-                                print(cell_with_row_metadata.row_metadata)
                                 row_metadata_map[cell_with_row_metadata.row_order] = (
                                     cell_with_row_metadata.row_metadata
                                 )
                                 cell["rowMetadata"] = (  # pyright: ignore[reportGeneralTypeIssues]
                                     cell_with_row_metadata.row_metadata
                                 )
-                    # Assign row_metadata to all cells
-                    for cell in sheet_partial["magicTableCells"]:
+                    for cell in batch_cells:
                         row_order = cell.get("rowOrder")  # type: ignore[assignment]
                         if row_order is not None and row_order in row_metadata_map:  # pyright: ignore[reportUnnecessaryComparison]
                             cell["rowMetadata"] = row_metadata_map[  # pyright: ignore[reportGeneralTypeIssues]
                                 row_order
                             ]
 
-                cells.extend(sheet_partial["magicTableCells"])
+                cells.extend(batch_cells)
 
         sheet_info["magicTableCells"] = cells
         return MagicTableSheet.model_validate(sheet_info)
@@ -387,12 +462,10 @@ class AgenticTableService:
             user_id=self._user_id,
             company_id=self._company_id,
             tableId=self.table_id,
-            includeSheetMetadata=True,  # pyright: ignore[reportCallIssue]
+            includeSheetMetadata=True,
         )
-        return [
-            RowMetadataEntry.model_validate(metadata)
-            for metadata in sheet_info["magicTableSheetMetadata"]
-        ]
+        raw_metadata = sheet_info.get("magicTableSheetMetadata") or []
+        return [RowMetadataEntry.model_validate(metadata) for metadata in raw_metadata]
 
     async def set_cell_metadata(
         self,
@@ -436,17 +509,29 @@ class AgenticTableService:
         self,
         row_orders: list[int],
         status: RowVerificationStatus,
+        locked: bool | None = None,
     ):
         """Update the verification status of multiple rows at once.
 
         Args:
-            row_orders (list[int]): The row indexes to update.
-            status (RowVerificationStatus): The verification status to set.
+            row_orders: The row indexes to update.
+            status: The verification status to set (``NEEDS_REVIEW``, etc.; matches public API).
+            locked: When set, forwarded as ``locked`` on ``POST .../rows/bulk-update-status``.
         """
-        await AgenticTable.bulk_update_status(
-            user_id=self._user_id,
-            company_id=self._company_id,
-            tableId=self.table_id,
-            rowOrders=row_orders,
-            status=status,
-        )
+        if locked is None:
+            await AgenticTable.bulk_update_status(
+                user_id=self._user_id,
+                company_id=self._company_id,
+                tableId=self.table_id,
+                rowOrders=row_orders,
+                status=status,
+            )
+        else:
+            await AgenticTable.bulk_update_status(
+                user_id=self._user_id,
+                company_id=self._company_id,
+                tableId=self.table_id,
+                rowOrders=row_orders,
+                status=status,
+                locked=locked,
+            )

--- a/uv.lock
+++ b/uv.lock
@@ -5556,7 +5556,7 @@ dev = []
 
 [[package]]
 name = "unique-toolkit"
-version = "1.80.3"
+version = "1.81.0"
 source = { editable = "unique_toolkit" }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- Bump **unique_toolkit** to **v1.81.0** and require **`unique-sdk>=0.11.12,<0.12`** (aligned with [PR #1467](https://github.com/Unique-AG/ai/pull/1467) / UN-19885).
- **Agentic table:** `get_sheet(..., include_row_metadata=True)` forwards `includeRowMetadata` on batched `get_sheet_data`, skips N+1 `get_cell` when cells already include `rowMetadata`, with a legacy `get_cell` fallback for older gateways.
- **Schemas / service:** `ArtifactType` aliases SDK `MagicTableArtifactType`; optional `MagicTableSheet.chat_id`; optional `mime_type` / `name` on `set_artifact`; optional `locked` on `update_row_verification_status`; safer TypedDict reads for sheet row count and sheet metadata.
- **Exports:** `MagicTableActivityResponse`, `MagicTableArtifactType`, `MagicTableMetadataEntry` from `unique_toolkit.agentic_table`.
- **Tests:** `tests/test_agentic_table_get_sheet_row_metadata.py` for the row-metadata sheet path.

## Changelog

See `unique_toolkit/CHANGELOG.md` **\[1.81.0\]**.

## Test plan

- [x] `cd unique_toolkit && uv run poe typecheck`
- [x] `cd unique_toolkit && uv run pytest tests/`

Refs: **UN-19885**

Made with [Cursor](https://cursor.com)