### PR TITLE
refactor(unique_search_mcp): Use FileSystemProvider and mcp.mount

### DIFF
--- a/tutorials/mcp/mcp_search/README.md
+++ b/tutorials/mcp/mcp_search/README.md
@@ -110,13 +110,26 @@ curl -X POST http://localhost:8003/mcp \
 
 ## 5. Developing with the MCP Inspector
 
-Start the official mcp inspector using 
+Start the MCP Inspector against the local streamable HTTP endpoint defined in [`inspector_mcp_server.json`](./inspector_mcp_server.json):
 
-```
-npx @modelcontextprotocol/inspector
+```bash
+npx @modelcontextprotocol/inspector --config ./inspector_mcp_server.json --server default-server
 ```
 
-The MCP Inspector act as an MCP Client, there if you want to authenticate we must register its redirect URI (usually http://localhost:6247/oauth/callback) on our IDP (in this case Zitadel).
+That config points the client at `http://localhost:8003/mcp` (run `uv run mcp-search` first). The Inspector acts as an MCP client; for OAuth you must register its redirect URI with your IdP (often `http://localhost:6274/oauth/callback` or similar—check the Inspector’s console output).
+
+### `user_id` and `company_id` in tool calls
+
+The Unique stack resolves **user** and **company** for tools from the MCP request. You can supply them in the **`_meta`** object sent with tool invocations, using these keys:
+
+| Key | Purpose |
+|-----|---------|
+| `unique.app/auth/user-id` | User id |
+| `unique.app/auth/company-id` | Company id |
+
+**Both** keys must be set to non-empty strings in `_meta` for that path to apply; otherwise identity falls back to the OAuth token (JWT claims / userinfo) and, when configured, environment variables such as `UNIQUE_AUTH_USER_ID` and `UNIQUE_AUTH_COMPANY_ID`.
+
+See also `MetaKeys` in `unique_mcp` and the example in [`src/mcp_search/mcp_client.py`](./src/mcp_search/mcp_client.py) (`call_tool(..., meta={...})`).
 
 
 

--- a/tutorials/mcp/mcp_search/inspector_mcp_server.json
+++ b/tutorials/mcp/mcp_search/inspector_mcp_server.json
@@ -1,0 +1,11 @@
+{
+    "mcpServers": {
+        "default-server": {
+            "type": "streamable-http",
+            "url": "http://localhost:8003/mcp",
+            "note": "For Streamable HTTP connections, add this URL directly in your MCP Client"
+        }
+    }
+}
+
+

--- a/tutorials/mcp/mcp_search/pyproject.toml
+++ b/tutorials/mcp/mcp_search/pyproject.toml
@@ -7,7 +7,7 @@ authors = [{ name = "Cedric Klinkert", email = "cedric@unique.ch" }]
 requires-python = ">=3.12"
 dependencies = [
     "fastapi>=0.120.2",
-    "fastmcp>=3.1.1,<4",
+    "fastmcp>=3.2.0,<4",
     "pydantic>=2.12.3",
     "unique-mcp>=0.2.0",
     "unique-toolkit>=1.61.0",

--- a/tutorials/mcp/mcp_search/src/mcp_search/mcp_client.py
+++ b/tutorials/mcp/mcp_search/src/mcp_search/mcp_client.py
@@ -3,6 +3,8 @@ import os
 
 from fastmcp import Client
 
+from unique_mcp.meta_keys import MetaKeys
+
 MCP_URL = os.environ.get("MCP_SEARCH_URL", "http://localhost:8003/mcp")
 
 SEARCH_ARGS = {
@@ -36,8 +38,8 @@ async def main() -> None:
         meta_user = os.environ.get("UNIQUE_AUTH_USER_ID", "meta-test-user")
         meta_company = os.environ.get("UNIQUE_AUTH_COMPANY_ID", "meta-test-company")
         meta_override = {
-            "unique.app/user-id": meta_user,
-            "unique.app/company-id": meta_company,
+            MetaKeys.USER_ID.value: meta_user,
+            MetaKeys.COMPANY_ID.value: meta_company,
         }
         print(f"\n--- Call 2: auth from _meta {meta_override} ---")
         result = await client.call_tool("search", SEARCH_ARGS, meta=meta_override)

--- a/tutorials/mcp/mcp_search/src/mcp_search/mcp_client.py
+++ b/tutorials/mcp/mcp_search/src/mcp_search/mcp_client.py
@@ -35,11 +35,13 @@ async def main() -> None:
         _print_result(result)
 
         # --- Call 2: override auth via _meta ---
-        meta_user = os.environ.get("UNIQUE_AUTH_USER_ID", "meta-test-user")
-        meta_company = os.environ.get("UNIQUE_AUTH_COMPANY_ID", "meta-test-company")
         meta_override = {
-            MetaKeys.USER_ID.value: meta_user,
-            MetaKeys.COMPANY_ID.value: meta_company,
+            MetaKeys.USER_ID.value: os.environ.get(
+                "UNIQUE_AUTH_USER_ID", "meta-test-user"
+            ),
+            MetaKeys.COMPANY_ID.value: os.environ.get(
+                "UNIQUE_AUTH_COMPANY_ID", "meta-test-company"
+            ),
         }
         print(f"\n--- Call 2: auth from _meta {meta_override} ---")
         result = await client.call_tool("search", SEARCH_ARGS, meta=meta_override)

--- a/tutorials/mcp/mcp_search/src/mcp_search/mcp_search_server.py
+++ b/tutorials/mcp/mcp_search/src/mcp_search/mcp_search_server.py
@@ -6,9 +6,9 @@ from starlette.middleware import Middleware
 from starlette.middleware.cors import CORSMiddleware
 
 from mcp_search.routes import get_custom_routes_provider
-from unique_mcp.auth.zitadel.oauth_proxy import (
-    ZitadelOAuthProxySettings,
-    create_zitadel_oauth_proxy,
+from unique_mcp.auth.zitadel.oidc_proxy import (
+    ZitadelOIDCProxySettings,
+    create_zitadel_oidc_proxy,
 )
 from unique_mcp.settings import ServerSettings
 
@@ -18,23 +18,19 @@ def main() -> None:
 
     server_settings = ServerSettings()
 
-    # TODO: Replace by OIDC Proxy
-    zitadel_settings = ZitadelOAuthProxySettings()
-    oauth_proxy = create_zitadel_oauth_proxy(
+    oidc_proxy = create_zitadel_oidc_proxy(
         mcp_server_base_url=server_settings.base_url.encoded_string(),
-        zitadel_oauth_proxy_settings=zitadel_settings,
+        zitadel_oidc_proxy_settings=ZitadelOIDCProxySettings(),  # type: ignore[call-arg]
     )
 
     tools_provider = FileSystemProvider(Path(__file__).parent / "tools")
 
     mcp = FastMCP(
-        "Knowledge Base Search 🚀", auth=oauth_proxy, providers=[tools_provider]
+        "Knowledge Base Search 🚀", auth=oidc_proxy, providers=[tools_provider]
     )
 
     mcp.mount(get_custom_routes_provider())
 
-    # TODO: Talk to Andreas why we need this
-    # FastMcp recommends against it https://gofastmcp.com/integrations/fastapi#cors-middleware
     middleware = [
         Middleware(
             CORSMiddleware,

--- a/tutorials/mcp/mcp_search/src/mcp_search/mcp_search_server.py
+++ b/tutorials/mcp/mcp_search/src/mcp_search/mcp_search_server.py
@@ -1,9 +1,11 @@
+from pathlib import Path
+
 from fastmcp import FastMCP
+from fastmcp.server.providers import FileSystemProvider
 from starlette.middleware import Middleware
 from starlette.middleware.cors import CORSMiddleware
 
-from mcp_search.routes import MCPBaseRoutes
-from mcp_search.tools import UniqueKnowledgeBaseTools
+from mcp_search.routes import get_custom_routes_provider
 from unique_mcp.auth.zitadel.oauth_proxy import (
     ZitadelOAuthProxySettings,
     create_zitadel_oauth_proxy,
@@ -15,16 +17,24 @@ def main() -> None:
     """Main entry point for the MCP Search server."""
 
     server_settings = ServerSettings()
-    zitadel_settings = ZitadelOAuthProxySettings()
 
+    # TODO: Replace by OIDC Proxy
+    zitadel_settings = ZitadelOAuthProxySettings()
     oauth_proxy = create_zitadel_oauth_proxy(
         mcp_server_base_url=server_settings.base_url.encoded_string(),
         zitadel_oauth_proxy_settings=zitadel_settings,
     )
 
-    mcp = FastMCP("Knowledge Base Search 🚀", auth=oauth_proxy)
+    file_system_provider = FileSystemProvider(Path(__file__).parent)
 
-    custom_middleware = [
+    mcp = FastMCP(
+        "Knowledge Base Search 🚀", auth=oauth_proxy, providers=[file_system_provider]
+    )
+    mcp.mount(get_custom_routes_provider())
+
+    # TODO: Talk to Andreas why we need this
+    # FastMcp recommends against it https://gofastmcp.com/integrations/fastapi#cors-middleware
+    middleware = [
         Middleware(
             CORSMiddleware,
             allow_credentials=True,
@@ -34,15 +44,12 @@ def main() -> None:
         )
     ]
 
-    UniqueKnowledgeBaseTools().register(mcp=mcp)
-    MCPBaseRoutes().register(mcp=mcp)
-
     mcp.run(
         transport=server_settings.transport_scheme,
         host=server_settings.local_base_url.host,
         port=server_settings.local_base_url.port,
         log_level="debug",
-        middleware=custom_middleware,
+        middleware=middleware,
     )
 
 

--- a/tutorials/mcp/mcp_search/src/mcp_search/mcp_search_server.py
+++ b/tutorials/mcp/mcp_search/src/mcp_search/mcp_search_server.py
@@ -25,11 +25,12 @@ def main() -> None:
         zitadel_oauth_proxy_settings=zitadel_settings,
     )
 
-    file_system_provider = FileSystemProvider(Path(__file__).parent)
+    tools_provider = FileSystemProvider(Path(__file__).parent / "tools")
 
     mcp = FastMCP(
-        "Knowledge Base Search 🚀", auth=oauth_proxy, providers=[file_system_provider]
+        "Knowledge Base Search 🚀", auth=oauth_proxy, providers=[tools_provider]
     )
+
     mcp.mount(get_custom_routes_provider())
 
     # TODO: Talk to Andreas why we need this

--- a/tutorials/mcp/mcp_search/src/mcp_search/routes.py
+++ b/tutorials/mcp/mcp_search/src/mcp_search/routes.py
@@ -4,19 +4,23 @@ from fastapi.responses import FileResponse, JSONResponse
 from fastmcp import FastMCP
 from starlette.requests import Request
 
-from unique_mcp.provider import BaseProvider
+_CUSTOM_ROUTES_PROVIDER = FastMCP()
 
 
-class MCPBaseRoutes(BaseProvider):
-    def register(self, *, mcp: FastMCP) -> None:
-        @mcp.custom_route("/", methods=["GET"])
-        async def get_status(request: Request) -> JSONResponse:
-            return JSONResponse({"server": "running"})
+@_CUSTOM_ROUTES_PROVIDER.custom_route("/", methods=["GET"])
+async def get_status(request: Request) -> JSONResponse:
+    return JSONResponse({"server": "running"})
 
-        @mcp.custom_route("/favicon.ico", methods=["GET"])
-        async def favicon(request: Request) -> FileResponse:
-            return FileResponse(path=Path(__file__).parent / "favicon.ico")
 
-        @mcp.custom_route("/health", methods=["GET"])
-        async def health(request: Request) -> JSONResponse:
-            return JSONResponse({"status": "healthy"})
+@_CUSTOM_ROUTES_PROVIDER.custom_route("/favicon.ico", methods=["GET"])
+async def favicon(request: Request) -> FileResponse:
+    return FileResponse(path=Path(__file__).parent / "favicon.ico")
+
+
+@_CUSTOM_ROUTES_PROVIDER.custom_route("/health", methods=["GET"])
+async def health(request: Request) -> JSONResponse:
+    return JSONResponse({"status": "healthy"})
+
+
+def get_custom_routes_provider() -> FastMCP:
+    return _CUSTOM_ROUTES_PROVIDER

--- a/tutorials/mcp/mcp_search/src/mcp_search/tools.py
+++ b/tutorials/mcp/mcp_search/src/mcp_search/tools.py
@@ -1,63 +1,58 @@
 from typing import Annotated
 
-from fastmcp import FastMCP
 from fastmcp.dependencies import Depends
+from fastmcp.tools import tool
 from mcp.types import CallToolResult, TextContent
 from pydantic import Field
 
 from unique_mcp import get_unique_service_factory
-from unique_mcp.provider import BaseProvider
 from unique_toolkit.content.schemas import ContentSearchType
 from unique_toolkit.services.factory import UniqueServiceFactory
 
 
-class UniqueKnowledgeBaseTools(BaseProvider):
-    def register(self, *, mcp: FastMCP) -> None:
-        @mcp.tool(
-            name="search",
-            description="This tool does search in the knowledge base for the given search string and search type and returns the search results",
-            meta={
-                "unique.app/icon": "search",
-                "unique.app/system-prompt": "Choose this tool if you need to search in the knowledge base",
-            },
-        )
-        async def _search(
-            search_string: Annotated[
-                str,
-                Field(
-                    description="The search string that will be used to do the search in the knowledge base"
-                ),
-            ],
-            search_type: Annotated[
-                ContentSearchType,
-                Field(
-                    default=ContentSearchType.VECTOR,
-                    description="The search type that will be used to do the search in the knowledge base",
-                ),
-            ] = ContentSearchType.VECTOR,
-            limit: Annotated[
-                int,
-                Field(
-                    description="The limit for the number of search results",
-                    default=10,
-                ),
-            ] = 10,
-            service_factory: UniqueServiceFactory = Depends(get_unique_service_factory),
-        ) -> CallToolResult:
-            """Search in the knowledge base"""
+@tool(
+    name="search",
+    description="This tool does search in the knowledge base for the given search string and search type and returns the search results",
+    meta={
+        "unique.app/icon": "search",
+        "unique.app/system-prompt": "Choose this tool if you need to search in the knowledge base",
+    },
+)
+async def _search(
+    search_string: Annotated[
+        str,
+        Field(
+            description="The search string that will be used to do the search in the knowledge base"
+        ),
+    ],
+    search_type: Annotated[
+        ContentSearchType,
+        Field(
+            default=ContentSearchType.VECTOR,
+            description="The search type that will be used to do the search in the knowledge base",
+        ),
+    ] = ContentSearchType.VECTOR,
+    limit: Annotated[
+        int,
+        Field(
+            description="The limit for the number of search results",
+            default=10,
+        ),
+    ] = 10,
+    service_factory: UniqueServiceFactory = Depends(get_unique_service_factory),
+) -> CallToolResult:
+    """Search in the knowledge base"""
 
-            content_chunks = (
-                service_factory.knowledge_base_service().search_content_chunks(
-                    search_string=search_string,
-                    search_type=search_type,
-                    limit=limit,
-                    scope_ids=None,  # type: ignore
-                )
-            )
+    content_chunks = service_factory.knowledge_base_service().search_content_chunks(
+        search_string=search_string,
+        search_type=search_type,
+        limit=limit,
+        scope_ids=None,  # type: ignore
+    )
 
-            return CallToolResult(
-                content=[
-                    TextContent(type="text", text=chunk.text, _meta=chunk.model_dump())
-                    for chunk in content_chunks
-                ],
-            )
+    return CallToolResult(
+        content=[
+            TextContent(type="text", text=chunk.text, _meta=chunk.model_dump())
+            for chunk in content_chunks
+        ],
+    )

--- a/tutorials/mcp/mcp_search/src/mcp_search/tools/search.py
+++ b/tutorials/mcp/mcp_search/src/mcp_search/tools/search.py
@@ -56,13 +56,3 @@ async def search(
             for chunk in content_chunks
         ],
     )
-
-
-@tool
-def show_env() -> dict:
-    import os
-
-    return {
-        "UNIQUE_AUTH_USER_ID": os.getenv("UNIQUE_AUTH_USER_ID"),
-        "UNIQUE_AUTH_COMPANY_ID": os.getenv("UNIQUE_AUTH_COMPANY_ID"),
-    }

--- a/tutorials/mcp/mcp_search/src/mcp_search/tools/search.py
+++ b/tutorials/mcp/mcp_search/src/mcp_search/tools/search.py
@@ -18,7 +18,7 @@ from unique_toolkit.services.factory import UniqueServiceFactory
         "unique.app/system-prompt": "Choose this tool if you need to search in the knowledge base",
     },
 )
-async def _search(
+async def search(
     search_string: Annotated[
         str,
         Field(
@@ -56,3 +56,13 @@ async def _search(
             for chunk in content_chunks
         ],
     )
+
+
+@tool
+def show_env() -> dict:
+    import os
+
+    return {
+        "UNIQUE_AUTH_USER_ID": os.getenv("UNIQUE_AUTH_USER_ID"),
+        "UNIQUE_AUTH_COMPANY_ID": os.getenv("UNIQUE_AUTH_COMPANY_ID"),
+    }

--- a/unique_mcp/src/unique_mcp/auth/zitadel/oauth_proxy.py
+++ b/unique_mcp/src/unique_mcp/auth/zitadel/oauth_proxy.py
@@ -4,6 +4,7 @@ from fastmcp.server.auth.oauth_proxy import OAuthProxy
 from fastmcp.server.auth.providers.jwt import JWTVerifier
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from unique_mcp.auth.zitadel.scopes import ZITADEL_DEFAULT_MCP_SCOPES
 from unique_mcp.util.find_env_file import find_env_file
 
 if TYPE_CHECKING:
@@ -71,6 +72,9 @@ def create_zitadel_oauth_proxy(
         # required_scopes=[],
     )
 
+    if valid_scopes := kwargs.get("valid_scopes", []):
+        valid_scopes = ZITADEL_DEFAULT_MCP_SCOPES
+
     return OAuthProxy(
         upstream_authorization_endpoint=settings.authorize_endpoint,
         upstream_token_endpoint=settings.token_endpoint,
@@ -83,16 +87,7 @@ def create_zitadel_oauth_proxy(
         issuer_url=None,
         service_documentation_url=None,
         allowed_client_redirect_uris=None,
-        valid_scopes=[
-            "mcp:tools",
-            "mcp:prompts",
-            "mcp:resources",
-            "mcp:resource-templates",
-            "email",
-            "openid",
-            "profile",
-            "urn:zitadel:iam:user:resourceowner",
-        ],
+        valid_scopes=valid_scopes,
         forward_pkce=True,
         token_endpoint_auth_method="client_secret_post",
         extra_authorize_params=None,

--- a/unique_mcp/src/unique_mcp/auth/zitadel/oauth_proxy.py
+++ b/unique_mcp/src/unique_mcp/auth/zitadel/oauth_proxy.py
@@ -72,8 +72,7 @@ def create_zitadel_oauth_proxy(
         # required_scopes=[],
     )
 
-    if valid_scopes := kwargs.pop("valid_scopes", []):
-        valid_scopes = ZITADEL_DEFAULT_MCP_SCOPES
+    valid_scopes = kwargs.pop("valid_scopes", ZITADEL_DEFAULT_MCP_SCOPES)
 
     return OAuthProxy(
         upstream_authorization_endpoint=settings.authorize_endpoint,

--- a/unique_mcp/src/unique_mcp/auth/zitadel/oauth_proxy.py
+++ b/unique_mcp/src/unique_mcp/auth/zitadel/oauth_proxy.py
@@ -72,7 +72,7 @@ def create_zitadel_oauth_proxy(
         # required_scopes=[],
     )
 
-    if valid_scopes := kwargs.get("valid_scopes", []):
+    if valid_scopes := kwargs.pop("valid_scopes", []):
         valid_scopes = ZITADEL_DEFAULT_MCP_SCOPES
 
     return OAuthProxy(

--- a/unique_mcp/src/unique_mcp/auth/zitadel/oidc_proxy.py
+++ b/unique_mcp/src/unique_mcp/auth/zitadel/oidc_proxy.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any
 from fastmcp.server.auth.oidc_proxy import OIDCProxy
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from unique_mcp.auth.zitadel.scopes import ZITADEL_DEFAULT_MCP_SCOPES
 from unique_mcp.util.find_env_file import find_env_file
 
 if TYPE_CHECKING:
@@ -40,12 +41,25 @@ def create_zitadel_oidc_proxy(
     Args:
         mcp_server_base_url: Base URL of the MCP server (e.g., http://localhost:8003).
         zitadel_oidc_proxy_settings: Optional settings instance. If not provided,
-            a new instance will be created.
+            a new instance will be created from environment variables.
+        client_storage: Storage backend for OAuth state.
+        **kwargs: Forwarded directly to ``OIDCProxy``. Unless ``extra_authorize_params``
+            already sets ``scope``, the default Zitadel/MCP scope list is injected so
+            Zitadel never receives an empty scope on the authorize request.
+            Do NOT use ``required_scopes`` for this: Zitadel access tokens often omit
+            several requested scopes from the JWT, which would cause the JWT verifier
+            to reject every token (invalid_token loop).
 
     Returns:
         Configured OIDCProxy instance
     """
     settings = zitadel_oidc_proxy_settings or ZitadelOIDCProxySettings()  # type: ignore[call-arg]
+
+    extra_authorize_params: dict[str, str] = dict(
+        kwargs.pop("extra_authorize_params", None) or {}
+    )
+    if "scope" not in extra_authorize_params:
+        extra_authorize_params["scope"] = " ".join(ZITADEL_DEFAULT_MCP_SCOPES)
 
     return OIDCProxy(
         config_url=settings.config_url,
@@ -54,5 +68,6 @@ def create_zitadel_oidc_proxy(
         base_url=mcp_server_base_url,
         token_endpoint_auth_method="client_secret_post",
         client_storage=client_storage,
+        extra_authorize_params=extra_authorize_params,
         **kwargs,
     )

--- a/unique_mcp/src/unique_mcp/auth/zitadel/scopes.py
+++ b/unique_mcp/src/unique_mcp/auth/zitadel/scopes.py
@@ -1,0 +1,12 @@
+"""Default OAuth scopes for Zitadel-backed MCP proxy."""
+
+ZITADEL_DEFAULT_MCP_SCOPES: list[str] = [
+    "mcp:tools",
+    "mcp:prompts",
+    "mcp:resources",
+    "mcp:resource-templates",
+    "email",
+    "openid",
+    "profile",
+    "urn:zitadel:iam:user:resourceowner",
+]


### PR DESCRIPTION
## Summary

Updates the **mcp_search** tutorial to match current **FastMCP** / **unique_mcp** patterns, and documents how to run the **MCP Inspector** against the local server and how **user** / **company** identity is passed on tool calls.

## Changes

- **Server layout**: Tools are loaded via the filesystem provider (`FileSystemProvider` / `mcp.mount`-style setup) with the search tool in `src/mcp_search/tools/search.py` instead of a single monolithic `tools.py`.
- **Inspector**: Added `inspector_mcp_server.json` so the official inspector can connect with **streamable HTTP** to `http://localhost:8003/mcp`.
- **README**:
  - Documented the inspector command: `npx @modelcontextprotocol/inspector --config ./inspector_mcp_server.json --server default-server`
  - Documented that **user id** and **company id** are taken from request **`_meta`** when both are set, using the canonical keys `unique.app/auth/user-id` and `unique.app/auth/company-id` (see `MetaKeys` in `unique_mcp`), with fallback to OAuth / JWT and env (`UNIQUE_AUTH_*`) when `_meta` does not supply both.
- **Example client**: `mcp_client.py` uses the same `unique.app/auth/*` keys for the `call_tool(..., meta=...)` example so it matches the server’s `unique_mcp` injectors.

## How to test

1. `uv sync` in `tutorials/mcp/mcp_search`, load env, run `uv run mcp-search`.
2. `curl http://localhost:8003/health` → healthy.
3. Start the inspector with the command above and connect to the configured URL.
4. Optional: run the example MCP client to exercise OAuth and `_meta` override.
