### PR TITLE
fix(ci): compact packages JSON in select-packages all-branch

### DIFF
--- a/.github/actions/select-packages/action.yml
+++ b/.github/actions/select-packages/action.yml
@@ -30,7 +30,11 @@ runs:
         CHANGES='${{ inputs.changes }}'
 
         if [ "$SELECTED" = "all" ]; then
-          MATRIX="$PACKAGES"
+          # Compact the JSON so GITHUB_OUTPUT below stays single-line.
+          # inputs.packages arrives pretty-printed from get-packages-matrix
+          # (heredoc of package_configuration.json), which breaks the
+          # `name=value` GITHUB_OUTPUT syntax when written unchanged.
+          MATRIX=$(echo "$PACKAGES" | jq -c '.')
         elif [ -n "$SELECTED" ]; then
           # Filter by selected package id
           MATRIX=$(echo "$PACKAGES" | jq -c --arg id "$SELECTED" '[.[] | select(.id == $id)]')


### PR DESCRIPTION
## Summary

- `select-packages` forwarded the multi-line pretty-printed JSON from `get-packages-matrix` straight into `GITHUB_OUTPUT` via the single-line `name=value` syntax when `selected=all`, so GHA rejected the write with `Invalid format`.
- First failure: [run 24824628830](https://github.com/Unique-AG/ai/actions/runs/24824628830) — the merge commit of #1470 touched invalidator paths, which forced `publish-dev`'s invalidator override to `selected=all` and tripped the dormant bug.
- Pipe through `jq -c` in the `all` branch so it matches the other two branches and emits a single compact line.

## Why this was latent

Every existing caller either picked a specific package id or used auto-detect, both of which already ran through `jq -c`. Nothing in CI had ever exercised `selected=all` with real (pretty-printed) input until `publish-dev.yaml` landed on main.

## Test plan

Local reproduction of the three branches against the real package configuration:

- `SELECTED=all` — `GITHUB_OUTPUT` is 1 line; downstream `jq` filter returns 12 publishable packages.
- `SELECTED=sdk` — single compact object, unchanged behaviour.
- `SELECTED=` + mocked `CHANGES={"toolkit":"true"}` — single compact object, unchanged behaviour.

Validation in CI will come from the next push-to-main run of `publish-dev.yaml`, which will take the `selected=all` path again because this PR touches an invalidator (`select-packages/action.yml`) and should resolve + publish `2026.12.0.dev0` for every package.

Made with [Cursor](https://cursor.com)