### PR TITLE
fix(planning): Use tool calling for planning in responses api

### DIFF
--- a/unique_toolkit/tests/agentic/test_responses_planning_middleware.py
+++ b/unique_toolkit/tests/agentic/test_responses_planning_middleware.py
@@ -237,9 +237,7 @@ async def test_responses_planning__forwards_whitelisted_options() -> None:
     openai_client.responses.create = AsyncMock(return_value=_make_response())
 
     reasoning = {"effort": "high"}
-    await middleware(
-        **_base_kwargs(reasoning=reasoning, temperature=0.1, top_p=0.5)
-    )
+    await middleware(**_base_kwargs(reasoning=reasoning, temperature=0.1, top_p=0.5))
 
     call_kwargs = openai_client.responses.create.call_args[1]
     assert call_kwargs["reasoning"] == reasoning
@@ -252,30 +250,116 @@ async def test_responses_planning__forwards_whitelisted_options() -> None:
 async def test_responses_planning__does_not_forward_non_whitelisted_options() -> None:
     """
     Purpose: Loop-runner kwargs that conflict with the forced-tool-call setup
-    (``tools``, ``tool_choices``, ``text``) or are loop-runner control knobs
-    must not leak into ``responses.create``.
+    (``tool_choices``, ``text``) must not leak into ``responses.create``.
+    (``tools`` is handled separately — see the tool-passthrough tests.)
     """
     middleware, _, openai_client = _make_middleware()
     openai_client.responses.create = AsyncMock(return_value=_make_response())
 
     await middleware(
         **_base_kwargs(
-            tools=[MagicMock()],
             tool_choices=[{"type": "function", "name": "other"}],
             text={"format": {"type": "text"}},
         )
     )
 
     call_kwargs = openai_client.responses.create.call_args[1]
-    # Our forced plan tool is the only tool, and tool_choice targets it.
-    assert len(call_kwargs["tools"]) == 1
-    assert call_kwargs["tools"][0]["name"] == _PLAN_TOOL_NAME
     assert call_kwargs["tool_choice"] == {
         "type": "function",
         "name": _PLAN_TOOL_NAME,
     }
     assert "text" not in call_kwargs
     assert "tool_choices" not in call_kwargs
+
+
+@pytest.mark.asyncio
+@pytest.mark.ai
+async def test_responses_planning__forwards_loop_runner_tools() -> None:
+    """
+    Purpose: The loop runner's ``tools`` are passed alongside the forced
+    ``plan`` tool so the model can reason about what it will eventually call.
+    Why this matters: The planning prompt explicitly asks the model to name
+    the next tool to invoke; it needs the tool catalogue in context.
+    """
+    middleware, _, openai_client = _make_middleware()
+    openai_client.responses.create = AsyncMock(return_value=_make_response())
+
+    existing_tool: dict = {
+        "type": "function",
+        "name": "search_docs",
+        "description": "Search the docs.",
+        "parameters": {"type": "object", "properties": {}},
+        "strict": False,
+    }
+    await middleware(**_base_kwargs(tools=[existing_tool]))
+
+    call_kwargs = openai_client.responses.create.call_args[1]
+    names = [t["name"] for t in call_kwargs["tools"]]
+    assert names[0] == _PLAN_TOOL_NAME
+    assert "search_docs" in names
+    assert call_kwargs["tool_choice"] == {
+        "type": "function",
+        "name": _PLAN_TOOL_NAME,
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.ai
+async def test_responses_planning__converts_tool_description_objects() -> None:
+    """
+    Purpose: ``LanguageModelToolDescription`` instances in ``tools`` are
+    converted to the Responses-API ``FunctionToolParam`` shape before being
+    sent.
+    """
+    from pydantic import BaseModel
+
+    from unique_toolkit.language_model.schemas import LanguageModelToolDescription
+
+    class _Params(BaseModel):
+        query: str
+
+    tool_desc = LanguageModelToolDescription(
+        name="search_docs",
+        description="Search the docs.",
+        parameters=_Params,
+    )
+
+    middleware, _, openai_client = _make_middleware()
+    openai_client.responses.create = AsyncMock(return_value=_make_response())
+
+    await middleware(**_base_kwargs(tools=[tool_desc]))
+
+    call_kwargs = openai_client.responses.create.call_args[1]
+    names = [t["name"] for t in call_kwargs["tools"]]
+    assert names == [_PLAN_TOOL_NAME, "search_docs"]
+    search_tool = call_kwargs["tools"][1]
+    assert search_tool["type"] == "function"
+    assert isinstance(search_tool["parameters"], dict)
+
+
+@pytest.mark.asyncio
+@pytest.mark.ai
+async def test_responses_planning__drops_duplicate_plan_named_tool() -> None:
+    """
+    Purpose: If a loop-runner tool happens to be named ``plan``, it is dropped
+    in favor of the middleware's forced planning tool.
+    """
+    middleware, _, openai_client = _make_middleware()
+    openai_client.responses.create = AsyncMock(return_value=_make_response())
+
+    conflicting: dict = {
+        "type": "function",
+        "name": _PLAN_TOOL_NAME,
+        "description": "impostor",
+        "parameters": {"type": "object", "properties": {}},
+        "strict": False,
+    }
+    await middleware(**_base_kwargs(tools=[conflicting]))
+
+    tools = openai_client.responses.create.call_args[1]["tools"]
+    plan_tools = [t for t in tools if t["name"] == _PLAN_TOOL_NAME]
+    assert len(plan_tools) == 1
+    assert plan_tools[0]["description"] != "impostor"
 
 
 @pytest.mark.asyncio
@@ -312,9 +396,7 @@ async def test_responses_planning__forwards_and_filters_other_options() -> None:
     middleware, _, openai_client = _make_middleware(config=config)
     openai_client.responses.create = AsyncMock(return_value=_make_response())
 
-    await middleware(
-        **_base_kwargs(other_options={"user": "u-1", "store": True})
-    )
+    await middleware(**_base_kwargs(other_options={"user": "u-1", "store": True}))
 
     call_kwargs = openai_client.responses.create.call_args[1]
     assert call_kwargs["user"] == "u-1"
@@ -337,7 +419,7 @@ async def test_run_plan_step__returns_none_on_empty_arguments() -> None:
     openai_client.responses.create = AsyncMock(return_value=_make_response(""))
 
     result = await middleware._run_plan_step(
-        openai_messages="test", model_name="gpt-4o", forwarded_options={}
+        openai_messages="test", model_name="gpt-4o", tools=[], forwarded_options={}
     )
 
     assert result is None
@@ -355,7 +437,7 @@ async def test_run_plan_step__returns_arguments_on_success() -> None:
     )
 
     result = await middleware._run_plan_step(
-        openai_messages="test", model_name="gpt-4o", forwarded_options={}
+        openai_messages="test", model_name="gpt-4o", tools=[], forwarded_options={}
     )
 
     assert result == '{"plan": "search"}'
@@ -372,7 +454,7 @@ async def test_run_plan_step__returns_none_on_exception() -> None:
     openai_client.responses.create = AsyncMock(side_effect=RuntimeError("API down"))
 
     result = await middleware._run_plan_step(
-        openai_messages="test", model_name="gpt-4o", forwarded_options={}
+        openai_messages="test", model_name="gpt-4o", tools=[], forwarded_options={}
     )
 
     assert result is None
@@ -390,8 +472,13 @@ async def test_run_plan_step__sends_forced_tool_call() -> None:
     middleware, _, openai_client = _make_middleware()
     openai_client.responses.create = AsyncMock(return_value=_make_response())
 
+    prepared_tools = middleware._build_tools({})
+
     await middleware._run_plan_step(
-        openai_messages="test", model_name="gpt-4o", forwarded_options={}
+        openai_messages="test",
+        model_name="gpt-4o",
+        tools=prepared_tools,
+        forwarded_options={},
     )
 
     call_kwargs = openai_client.responses.create.call_args[1]
@@ -419,6 +506,7 @@ async def test_run_plan_step__splats_forwarded_options() -> None:
     await middleware._run_plan_step(
         openai_messages="test",
         model_name="gpt-4o",
+        tools=[],
         forwarded_options={"reasoning": {"effort": "low"}, "temperature": 0.3},
     )
 

--- a/unique_toolkit/tests/agentic/test_responses_planning_middleware.py
+++ b/unique_toolkit/tests/agentic/test_responses_planning_middleware.py
@@ -3,12 +3,13 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from openai.types.responses import Response, ResponseOutputMessage, ResponseOutputText
+from openai.types.responses import Response, ResponseFunctionToolCall
 
 from unique_toolkit.agentic.loop_runner.middleware.planning.planning import (
+    _PLAN_TOOL_NAME,
     PlanningConfig,
     ResponsesPlanningMiddleware,
-    _get_first_output_text,
+    _get_first_tool_call_arguments,
 )
 from unique_toolkit.language_model.schemas import (
     LanguageModelAssistantMessage,
@@ -21,13 +22,14 @@ def _make_middleware(
     *,
     loop_runner: AsyncMock | None = None,
     history_manager: MagicMock | None = None,
+    config: PlanningConfig | None = None,
 ) -> tuple[ResponsesPlanningMiddleware, AsyncMock, AsyncMock]:
     """Create a ResponsesPlanningMiddleware with mocked dependencies."""
     openai_client = AsyncMock()
     runner = loop_runner or AsyncMock()
     middleware = ResponsesPlanningMiddleware(
         loop_runner=runner,
-        config=PlanningConfig(),
+        config=config or PlanningConfig(),
         openai_client=openai_client,
         history_manager=history_manager,
     )
@@ -40,17 +42,17 @@ def _make_model_mock(name: str = "gpt-4o") -> MagicMock:
     return model
 
 
-def _make_response(output_text: str = '{"plan": "do stuff"}') -> MagicMock:
-    """Create a mock Response with a single ResponseOutputMessage containing text."""
-    text_content = MagicMock(spec=ResponseOutputText)
-    text_content.type = "output_text"
-    text_content.text = output_text
+def _make_tool_call(arguments: str = '{"plan": "do stuff"}') -> MagicMock:
+    call = MagicMock(spec=ResponseFunctionToolCall)
+    call.arguments = arguments
+    call.name = _PLAN_TOOL_NAME
+    return call
 
-    message = MagicMock(spec=ResponseOutputMessage)
-    message.content = [text_content]
 
+def _make_response(arguments: str = '{"plan": "do stuff"}') -> MagicMock:
+    """Create a mock Response whose output contains a single forced tool call."""
     response = MagicMock(spec=Response)
-    response.output = [message]
+    response.output = [_make_tool_call(arguments)]
     return response
 
 
@@ -222,6 +224,103 @@ async def test_responses_planning__passes_model_name_to_openai() -> None:
     assert create_call.call_args[1]["model"] == "o3-mini"
 
 
+@pytest.mark.asyncio
+@pytest.mark.ai
+async def test_responses_planning__forwards_whitelisted_options() -> None:
+    """
+    Purpose: Whitelisted Responses options (e.g. ``reasoning``, ``temperature``)
+    present on the loop-runner kwargs should flow into the plan call.
+    Why this matters: Reasoning models and temperature tuning must apply to the
+    planning step just like the main loop.
+    """
+    middleware, _, openai_client = _make_middleware()
+    openai_client.responses.create = AsyncMock(return_value=_make_response())
+
+    reasoning = {"effort": "high"}
+    await middleware(
+        **_base_kwargs(reasoning=reasoning, temperature=0.1, top_p=0.5)
+    )
+
+    call_kwargs = openai_client.responses.create.call_args[1]
+    assert call_kwargs["reasoning"] == reasoning
+    assert call_kwargs["temperature"] == 0.1
+    assert call_kwargs["top_p"] == 0.5
+
+
+@pytest.mark.asyncio
+@pytest.mark.ai
+async def test_responses_planning__does_not_forward_non_whitelisted_options() -> None:
+    """
+    Purpose: Loop-runner kwargs that conflict with the forced-tool-call setup
+    (``tools``, ``tool_choices``, ``text``) or are loop-runner control knobs
+    must not leak into ``responses.create``.
+    """
+    middleware, _, openai_client = _make_middleware()
+    openai_client.responses.create = AsyncMock(return_value=_make_response())
+
+    await middleware(
+        **_base_kwargs(
+            tools=[MagicMock()],
+            tool_choices=[{"type": "function", "name": "other"}],
+            text={"format": {"type": "text"}},
+        )
+    )
+
+    call_kwargs = openai_client.responses.create.call_args[1]
+    # Our forced plan tool is the only tool, and tool_choice targets it.
+    assert len(call_kwargs["tools"]) == 1
+    assert call_kwargs["tools"][0]["name"] == _PLAN_TOOL_NAME
+    assert call_kwargs["tool_choice"] == {
+        "type": "function",
+        "name": _PLAN_TOOL_NAME,
+    }
+    assert "text" not in call_kwargs
+    assert "tool_choices" not in call_kwargs
+
+
+@pytest.mark.asyncio
+@pytest.mark.ai
+async def test_responses_planning__respects_ignored_options_for_whitelisted() -> None:
+    """
+    Purpose: Options named in ``config.ignored_options`` are dropped even if
+    they are on the whitelist.
+    """
+    config = PlanningConfig(ignored_options=["reasoning", "temperature"])
+    middleware, _, openai_client = _make_middleware(config=config)
+    openai_client.responses.create = AsyncMock(return_value=_make_response())
+
+    await middleware(
+        **_base_kwargs(reasoning={"effort": "high"}, temperature=0.2, top_p=0.9)
+    )
+
+    call_kwargs = openai_client.responses.create.call_args[1]
+    assert "reasoning" not in call_kwargs
+    assert "temperature" not in call_kwargs
+    assert call_kwargs["top_p"] == 0.9
+
+
+@pytest.mark.asyncio
+@pytest.mark.ai
+async def test_responses_planning__forwards_and_filters_other_options() -> None:
+    """
+    Purpose: Keys from the ``other_options`` dict are forwarded, minus any that
+    appear in ``ignored_options``.
+    Why this matters: ``other_options`` is the escape hatch for options not in
+    the whitelist; ``ignored_options`` must still gate it.
+    """
+    config = PlanningConfig(ignored_options=["parallel_tool_calls", "store"])
+    middleware, _, openai_client = _make_middleware(config=config)
+    openai_client.responses.create = AsyncMock(return_value=_make_response())
+
+    await middleware(
+        **_base_kwargs(other_options={"user": "u-1", "store": True})
+    )
+
+    call_kwargs = openai_client.responses.create.call_args[1]
+    assert call_kwargs["user"] == "u-1"
+    assert "store" not in call_kwargs
+
+
 # ============================================================================
 # Tests for _run_plan_step
 # ============================================================================
@@ -229,18 +328,16 @@ async def test_responses_planning__passes_model_name_to_openai() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.ai
-async def test_run_plan_step__returns_none_on_empty_output_text() -> None:
+async def test_run_plan_step__returns_none_on_empty_arguments() -> None:
     """
-    Purpose: Verify _run_plan_step returns None when the response has empty output_text.
+    Purpose: Verify _run_plan_step returns None when the tool call has empty arguments.
     Why this matters: Empty plans should be treated as failures and trigger the fallback path.
-    Setup summary: Mock response.output_text as empty string.
     """
     middleware, _, openai_client = _make_middleware()
-    empty_response = _make_response(output_text="")
-    openai_client.responses.create = AsyncMock(return_value=empty_response)
+    openai_client.responses.create = AsyncMock(return_value=_make_response(""))
 
     result = await middleware._run_plan_step(
-        openai_messages="test", model_name="gpt-4o"
+        openai_messages="test", model_name="gpt-4o", forwarded_options={}
     )
 
     assert result is None
@@ -248,18 +345,17 @@ async def test_run_plan_step__returns_none_on_empty_output_text() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.ai
-async def test_run_plan_step__returns_text_on_success() -> None:
+async def test_run_plan_step__returns_arguments_on_success() -> None:
     """
-    Purpose: Verify _run_plan_step returns the output text string on success.
-    Why this matters: The caller uses the returned text to build the assistant message.
-    Setup summary: Mock a valid response, verify the text is returned.
+    Purpose: Verify _run_plan_step returns the tool call arguments on success.
     """
     middleware, _, openai_client = _make_middleware()
-    plan_response = _make_response('{"plan": "search"}')
-    openai_client.responses.create = AsyncMock(return_value=plan_response)
+    openai_client.responses.create = AsyncMock(
+        return_value=_make_response('{"plan": "search"}')
+    )
 
     result = await middleware._run_plan_step(
-        openai_messages="test", model_name="gpt-4o"
+        openai_messages="test", model_name="gpt-4o", forwarded_options={}
     )
 
     assert result == '{"plan": "search"}'
@@ -271,13 +367,12 @@ async def test_run_plan_step__returns_none_on_exception() -> None:
     """
     Purpose: Verify _run_plan_step returns None when the OpenAI call raises.
     Why this matters: The @failsafe_async decorator should catch exceptions and return None.
-    Setup summary: Mock openai_client to raise, verify None returned.
     """
     middleware, _, openai_client = _make_middleware()
     openai_client.responses.create = AsyncMock(side_effect=RuntimeError("API down"))
 
     result = await middleware._run_plan_step(
-        openai_messages="test", model_name="gpt-4o"
+        openai_messages="test", model_name="gpt-4o", forwarded_options={}
     )
 
     assert result is None
@@ -285,84 +380,102 @@ async def test_run_plan_step__returns_none_on_exception() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.ai
-async def test_run_plan_step__sends_json_schema_format() -> None:
+async def test_run_plan_step__sends_forced_tool_call() -> None:
     """
-    Purpose: Verify the planning schema is sent as a JSON schema format parameter.
-    Why this matters: Structured output requires the correct format specification.
-    Setup summary: Inspect the `text` kwarg passed to openai_client.responses.create.
+    Purpose: The plan step must issue a forced function tool call carrying the
+    planning JSON schema.
+    Why this matters: This is the core fix for the duplicate-output issue the
+    Responses API exhibits with ``text.format=json_schema``.
     """
     middleware, _, openai_client = _make_middleware()
     openai_client.responses.create = AsyncMock(return_value=_make_response())
 
-    await middleware._run_plan_step(openai_messages="test", model_name="gpt-4o")
+    await middleware._run_plan_step(
+        openai_messages="test", model_name="gpt-4o", forwarded_options={}
+    )
 
     call_kwargs = openai_client.responses.create.call_args[1]
-    text_param = call_kwargs["text"]
-    assert "format" in text_param
-    assert text_param["format"]["type"] == "json_schema"
-    assert "schema" in text_param["format"]
+    assert "text" not in call_kwargs
+    assert call_kwargs["tool_choice"] == {
+        "type": "function",
+        "name": _PLAN_TOOL_NAME,
+    }
+    tools = call_kwargs["tools"]
+    assert len(tools) == 1
+    assert tools[0]["type"] == "function"
+    assert tools[0]["name"] == _PLAN_TOOL_NAME
+    assert isinstance(tools[0]["parameters"], dict)
+
+
+@pytest.mark.asyncio
+@pytest.mark.ai
+async def test_run_plan_step__splats_forwarded_options() -> None:
+    """
+    Purpose: ``forwarded_options`` are spread as kwargs onto ``responses.create``.
+    """
+    middleware, _, openai_client = _make_middleware()
+    openai_client.responses.create = AsyncMock(return_value=_make_response())
+
+    await middleware._run_plan_step(
+        openai_messages="test",
+        model_name="gpt-4o",
+        forwarded_options={"reasoning": {"effort": "low"}, "temperature": 0.3},
+    )
+
+    call_kwargs = openai_client.responses.create.call_args[1]
+    assert call_kwargs["reasoning"] == {"effort": "low"}
+    assert call_kwargs["temperature"] == 0.3
 
 
 # ============================================================================
-# Tests for _get_first_output_text
+# Tests for _get_first_tool_call_arguments
 # ============================================================================
 
 
 @pytest.mark.ai
-def test_get_first_output_text__picks_first_message_from_multiple_outputs() -> None:
+def test_get_first_tool_call_arguments__picks_first_call_from_multiple() -> None:
     """
-    Purpose: Verify that only the first viable message text is returned when
-    the response contains multiple output items.
-    Why this matters: The Responses API can return multiple outputs; we must
-    use only the first text to avoid concatenating unrelated content.
+    Purpose: When multiple tool-call items are returned, only the first one's
+    arguments are used.
+    Why this matters: Avoids concatenating / confusing duplicate plans.
     """
-    text1 = MagicMock(spec=ResponseOutputText)
-    text1.type = "output_text"
-    text1.text = "first plan"
-
-    text2 = MagicMock(spec=ResponseOutputText)
-    text2.type = "output_text"
-    text2.text = "second plan"
-
-    msg1 = MagicMock(spec=ResponseOutputMessage)
-    msg1.content = [text1]
-
-    msg2 = MagicMock(spec=ResponseOutputMessage)
-    msg2.content = [text2]
-
     response = MagicMock(spec=Response)
-    response.output = [msg1, msg2]
+    response.output = [_make_tool_call("first plan"), _make_tool_call("second plan")]
 
-    assert _get_first_output_text(response) == "first plan"
+    assert _get_first_tool_call_arguments(response) == "first plan"
 
 
 @pytest.mark.ai
-def test_get_first_output_text__skips_non_message_outputs() -> None:
+def test_get_first_tool_call_arguments__skips_non_tool_call_outputs() -> None:
     """
-    Purpose: Verify that non-message output items (e.g. tool calls) are skipped.
-    Why this matters: The output list can contain tool calls and other item types.
+    Purpose: Non-tool-call output items (e.g. plain messages) must be skipped.
     """
-    tool_call = MagicMock()  # Not a ResponseOutputMessage
-
-    text = MagicMock(spec=ResponseOutputText)
-    text.type = "output_text"
-    text.text = "the plan"
-
-    msg = MagicMock(spec=ResponseOutputMessage)
-    msg.content = [text]
+    other = MagicMock()  # not a ResponseFunctionToolCall
 
     response = MagicMock(spec=Response)
-    response.output = [tool_call, msg]
+    response.output = [other, _make_tool_call("the plan")]
 
-    assert _get_first_output_text(response) == "the plan"
+    assert _get_first_tool_call_arguments(response) == "the plan"
 
 
 @pytest.mark.ai
-def test_get_first_output_text__returns_none_for_empty_output() -> None:
+def test_get_first_tool_call_arguments__returns_none_for_empty_output() -> None:
     """
     Purpose: Verify None is returned when the output list is empty.
     """
     response = MagicMock(spec=Response)
     response.output = []
 
-    assert _get_first_output_text(response) is None
+    assert _get_first_tool_call_arguments(response) is None
+
+
+@pytest.mark.ai
+def test_get_first_tool_call_arguments__returns_none_for_empty_arguments() -> None:
+    """
+    Purpose: A tool call with empty ``arguments`` yields None.
+    """
+    call = _make_tool_call("")
+    response = MagicMock(spec=Response)
+    response.output = [call]
+
+    assert _get_first_tool_call_arguments(response) is None

--- a/unique_toolkit/unique_toolkit/agentic/loop_runner/middleware/planning/planning.py
+++ b/unique_toolkit/unique_toolkit/agentic/loop_runner/middleware/planning/planning.py
@@ -7,11 +7,12 @@ from openai.types.responses import (
     Response,
     ResponseFunctionToolCall,
     ResponseInputItemParam,
+    ToolParam,
 )
 from openai.types.responses.function_tool_param import FunctionToolParam
 from pydantic import BaseModel, Field
 
-from unique_toolkit import LanguageModelService
+from unique_toolkit import LanguageModelService, LanguageModelToolDescription
 from unique_toolkit._common.execution import failsafe_async
 from unique_toolkit._common.pydantic_helpers import get_configuration_dict
 from unique_toolkit.agentic.history_manager.history_manager import HistoryManager
@@ -180,15 +181,18 @@ class ResponsesPlanningMiddleware(ResponsesLoopIterationRunner):
         forwarded.update({k: v for k, v in other_options.items() if k not in ignored})
         return forwarded
 
-    @failsafe_async(failure_return_value=None, logger=_LOGGER)
-    async def _run_plan_step(
-        self,
-        openai_messages: str | list[ResponseInputItemParam],
-        model_name: str,
-        forwarded_options: dict[str, Any],
-    ) -> str | None:
-        planning_schema = get_planning_schema(self._config.planning_schema_config)
+    def _build_tools(
+        self, kwargs: _ResponsesLoopIterationRunnerKwargs
+    ) -> list[FunctionToolParam | ToolParam]:
+        """
+        Build the tool list sent to the planning call: the forced ``plan`` tool
+        plus the loop runner's regular tools (converted to Responses API shape).
 
+        Passing the regular tools gives the model the information it needs to
+        reason about *which* tool to call next, even though ``tool_choice``
+        pins the actual call to ``plan``.
+        """
+        planning_schema = get_planning_schema(self._config.planning_schema_config)
         plan_tool = FunctionToolParam(
             type="function",
             name=_PLAN_TOOL_NAME,
@@ -197,10 +201,30 @@ class ResponsesPlanningMiddleware(ResponsesLoopIterationRunner):
             strict=False,
         )
 
+        extra_tools: list[FunctionToolParam | ToolParam] = []
+        for tool in kwargs.get("tools") or []:
+            if isinstance(tool, LanguageModelToolDescription):
+                converted = tool.to_openai(mode="responses")
+            else:
+                converted = tool
+            if converted.get("name") == _PLAN_TOOL_NAME:
+                continue
+            extra_tools.append(converted)
+
+        return [plan_tool, *extra_tools]
+
+    @failsafe_async(failure_return_value=None, logger=_LOGGER)
+    async def _run_plan_step(
+        self,
+        openai_messages: str | list[ResponseInputItemParam],
+        model_name: str,
+        tools: list[FunctionToolParam | ToolParam],
+        forwarded_options: dict[str, Any],
+    ) -> str | None:
         response = await self._openai_client.responses.create(
             model=model_name,
             input=openai_messages,
-            tools=[plan_tool],
+            tools=tools,
             tool_choice={"type": "function", "name": _PLAN_TOOL_NAME},
             parallel_tool_calls=False,
             **forwarded_options,
@@ -221,6 +245,7 @@ class ResponsesPlanningMiddleware(ResponsesLoopIterationRunner):
         output_text = await self._run_plan_step(
             openai_messages=openai_messages,
             model_name=kwargs["model"].name,
+            tools=self._build_tools(kwargs),
             forwarded_options=self._build_forwarded_options(kwargs),
         )
 

--- a/unique_toolkit/unique_toolkit/agentic/loop_runner/middleware/planning/planning.py
+++ b/unique_toolkit/unique_toolkit/agentic/loop_runner/middleware/planning/planning.py
@@ -1,15 +1,14 @@
 import json
 import logging
-from typing import Unpack
+from typing import Any, Unpack
 
 from openai import AsyncOpenAI
 from openai.types.responses import (
     Response,
-    ResponseFormatTextJSONSchemaConfigParam,
+    ResponseFunctionToolCall,
     ResponseInputItemParam,
-    ResponseOutputMessage,
-    ResponseTextConfigParam,
 )
+from openai.types.responses.function_tool_param import FunctionToolParam
 from pydantic import BaseModel, Field
 
 from unique_toolkit import LanguageModelService
@@ -40,11 +39,36 @@ from unique_toolkit.language_model.schemas import (
 _LOGGER = logging.getLogger(__name__)
 
 
-def _get_first_output_text(response: Response) -> str | None:
+_PLAN_TOOL_NAME = "plan"
+_PLAN_TOOL_DESCRIPTION = (
+    "Record the plan for the next step. Call this tool exactly once."
+)
+
+# Kwargs from _ResponsesLoopIterationRunnerKwargs that make sense to forward to
+# the planning `responses.create` call. We deliberately exclude anything that
+# conflicts with the forced-tool-call setup (`tools`, `tool_choices`, `text`,
+# `parallel_tool_calls`) and anything that is a loop-runner control knob rather
+# than a model option.
+_FORWARDABLE_RESPONSES_OPTIONS: frozenset[str] = frozenset(
+    {
+        "temperature",
+        "top_p",
+        "reasoning",
+        "max_output_tokens",
+        "metadata",
+        "include",
+        "instructions",
+    }
+)
+
+
+def _get_first_tool_call_arguments(response: Response) -> str | None:
     """
-    The Responses API can return multiple output items when doing structured output
-    (https://community.openai.com/t/multiple-outputs-from-responses-api/1291026),
-    We should tell the model not to do this in the schema, as well as extract only the first one
+    Extract the arguments of the first ``function_call`` output item.
+
+    Using a forced tool call (``tool_choice={"type": "function", ...}``) avoids
+    the duplicate-output issue the Responses API exhibits with
+    ``text.format=json_schema`` structured output.
     """
     if len(response.output) > 1:
         _LOGGER.warning(
@@ -53,10 +77,8 @@ def _get_first_output_text(response: Response) -> str | None:
         )
 
     for item in response.output:
-        if isinstance(item, ResponseOutputMessage):
-            for content in item.content:
-                if content.type == "output_text" and content.text:
-                    return content.text
+        if isinstance(item, ResponseFunctionToolCall) and item.arguments:
+            return item.arguments
     return None
 
 
@@ -144,32 +166,47 @@ class ResponsesPlanningMiddleware(ResponsesLoopIterationRunner):
         self._history_manager = history_manager
         self._openai_client = openai_client
 
+    def _build_forwarded_options(
+        self, kwargs: _ResponsesLoopIterationRunnerKwargs
+    ) -> dict[str, Any]:
+        ignored = set(self._config.ignored_options)
+        forwarded: dict[str, Any] = {
+            k: v
+            for k, v in kwargs.items()
+            if k in _FORWARDABLE_RESPONSES_OPTIONS and k not in ignored
+        }
+
+        other_options = kwargs.get("other_options") or {}
+        forwarded.update({k: v for k, v in other_options.items() if k not in ignored})
+        return forwarded
+
     @failsafe_async(failure_return_value=None, logger=_LOGGER)
     async def _run_plan_step(
         self,
         openai_messages: str | list[ResponseInputItemParam],
         model_name: str,
+        forwarded_options: dict[str, Any],
     ) -> str | None:
         planning_schema = get_planning_schema(self._config.planning_schema_config)
+
+        plan_tool = FunctionToolParam(
+            type="function",
+            name=_PLAN_TOOL_NAME,
+            description=_PLAN_TOOL_DESCRIPTION,
+            parameters=planning_schema,
+            strict=False,
+        )
 
         response = await self._openai_client.responses.create(
             model=model_name,
             input=openai_messages,
-            text=ResponseTextConfigParam(
-                {
-                    "format": ResponseFormatTextJSONSchemaConfigParam(
-                        {
-                            "type": "json_schema",
-                            "name": planning_schema.get("title", "Plan"),
-                            "schema": planning_schema,
-                            "strict": False,
-                        }
-                    )
-                }
-            ),
+            tools=[plan_tool],
+            tool_choice={"type": "function", "name": _PLAN_TOOL_NAME},
+            parallel_tool_calls=False,
+            **forwarded_options,
         )
 
-        output_text = _get_first_output_text(response)
+        output_text = _get_first_tool_call_arguments(response)
         if not output_text:
             _LOGGER.info("Empty planning response")
             return None
@@ -184,6 +221,7 @@ class ResponsesPlanningMiddleware(ResponsesLoopIterationRunner):
         output_text = await self._run_plan_step(
             openai_messages=openai_messages,
             model_name=kwargs["model"].name,
+            forwarded_options=self._build_forwarded_options(kwargs),
         )
 
         if output_text is None:


### PR DESCRIPTION
## 🚀 Summary

Responses API planning middleware generates multiple outputs (structured output) which slows down the whole process
- Use tool calling instead
- Forward options such as reasoning, etc to the model

## ✅ Changes

- [X] Added feature / fixed bug / updated docs
- [ ] Refactored code / cleaned up
- [ ] Other (describe below)

## 🧪 Testing

Explain what has been tested and how.
