### PR TITLE
fix(ci): random delimiter for publish-dev GITHUB_OUTPUT multiline

### DIFF
--- a/.github/workflows/publish-dev.yaml
+++ b/.github/workflows/publish-dev.yaml
@@ -170,13 +170,14 @@ jobs:
               --selected-ids "$SELECTED_IDS" \
               --output-dir "$RUNNER_TEMP/resolve" \
             | tee -a "$GITHUB_STEP_SUMMARY"
+          DELIM="$(openssl rand -hex 16)"
           {
-            echo "new_versions<<EOF"
+            echo "new_versions<<${DELIM}"
             cat "$RUNNER_TEMP/resolve/new_versions.json"
-            echo "EOF"
-            echo "dep_pins<<EOF"
+            echo "${DELIM}"
+            echo "dep_pins<<${DELIM}"
             cat "$RUNNER_TEMP/resolve/dep_pins.json"
-            echo "EOF"
+            echo "${DELIM}"
           } >> "$GITHUB_OUTPUT"
 
   publish:


### PR DESCRIPTION
## Problem
`publish-dev` failed in **Resolve dev versions and dep pins** after the select-packages fix:

```
Invalid value. Matching delimiter not found 'EOF'
```

The step wrote `new_versions` / `dep_pins` to `GITHUB_OUTPUT` with a fixed `<<EOF` heredoc. Pretty-printed JSON from `resolve-dev-versions.py` can include a line that matches the closing delimiter (or otherwise confuse the parser), so GitHub Actions rejects the output.

## Change
Generate a random 32-char hex delimiter with `openssl rand -hex 16` and use it for both multiline outputs (same pattern as GitHub’s docs recommend when content might collide with a fixed delimiter).

## Refs
Follow-up to publish-dev / #1477.

Made with [Cursor](https://cursor.com)