### PR TITLE
fix(ci): ensure trailing newline in dev-version JSON so GITHUB_OUTPUT delimiter is matched

### DIFF
--- a/.github/scripts/resolve-dev-versions.py
+++ b/.github/scripts/resolve-dev-versions.py
@@ -154,8 +154,12 @@ def main(argv: list[str] | None = None) -> int:
 
     out = Path(args.output_dir)
     out.mkdir(parents=True, exist_ok=True)
-    (out / "new_versions.json").write_text(json.dumps(new_versions, indent=2))
-    (out / "dep_pins.json").write_text(json.dumps(dep_pins, indent=2))
+    # Trailing newline is required: the publish-dev workflow streams these
+    # files into GITHUB_OUTPUT as multiline values terminated by a delimiter
+    # on its own line. Without the final `\n`, `cat file; echo DELIM` emits
+    # `...}DELIM` on one line and GitHub reports "Matching delimiter not found".
+    (out / "new_versions.json").write_text(json.dumps(new_versions, indent=2) + "\n")
+    (out / "dep_pins.json").write_text(json.dumps(dep_pins, indent=2) + "\n")
 
     print("### Dev publish — version resolution\n")
     print(f"- Cycle: `{args.cycle}`")

--- a/.github/scripts/tests/test_resolve_dev_versions.py
+++ b/.github/scripts/tests/test_resolve_dev_versions.py
@@ -187,6 +187,48 @@ class ResolveTests(unittest.TestCase):
             )
 
 
+class MainOutputFilesTests(unittest.TestCase):
+    """Guards that the JSON files consumed by publish-dev.yaml end with
+    a trailing newline. The workflow streams them into GITHUB_OUTPUT with
+    a delimiter on its own line; without the final `\\n`, GitHub reports
+    "Matching delimiter not found"."""
+
+    def test_files_end_with_newline(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            cfg = Path(td) / "pkgs.json"
+            cfg.write_text(
+                json.dumps(
+                    [{"id": "toolkit", "pypi_name": "unique_toolkit", "dir": "u"}]
+                )
+            )
+            out = Path(td) / "out"
+
+            def fake_resolve(**_):
+                return (
+                    {"toolkit": "2026.18.0.dev0"},
+                    {"unique-toolkit": "==2026.18.0.dev0"},
+                )
+
+            with patch.object(rdv, "resolve", side_effect=fake_resolve):
+                rc = rdv.main(
+                    [
+                        "--cycle",
+                        "2026.18",
+                        "--selected-ids",
+                        json.dumps(["toolkit"]),
+                        "--output-dir",
+                        str(out),
+                        "--package-config",
+                        str(cfg),
+                        "--pypi-base-url",
+                        "",
+                    ]
+                )
+            self.assertEqual(rc, 0)
+            self.assertTrue((out / "new_versions.json").read_text().endswith("\n"))
+            self.assertTrue((out / "dep_pins.json").read_text().endswith("\n"))
+
+
 class LoadPublishableTests(unittest.TestCase):
     def test_skips_publish_skip_and_missing_pypi_name(self) -> None:
         with tempfile.TemporaryDirectory() as td:

--- a/.github/workflows/publish-dev.yaml
+++ b/.github/workflows/publish-dev.yaml
@@ -170,13 +170,16 @@ jobs:
               --selected-ids "$SELECTED_IDS" \
               --output-dir "$RUNNER_TEMP/resolve" \
             | tee -a "$GITHUB_STEP_SUMMARY"
+          # Use a random delimiter (GitHub-recommended for multiline outputs).
+          # `printf '%s\n'` guarantees a newline before the delimiter even if
+          # the JSON file ever loses its trailing `\n` again.
           DELIM="$(openssl rand -hex 16)"
           {
             echo "new_versions<<${DELIM}"
-            cat "$RUNNER_TEMP/resolve/new_versions.json"
+            printf '%s\n' "$(cat "$RUNNER_TEMP/resolve/new_versions.json")"
             echo "${DELIM}"
             echo "dep_pins<<${DELIM}"
-            cat "$RUNNER_TEMP/resolve/dep_pins.json"
+            printf '%s\n' "$(cat "$RUNNER_TEMP/resolve/dep_pins.json")"
             echo "${DELIM}"
           } >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary

The \`publish-dev\` workflow kept failing at the \`Resolve dev versions and dep pins\` step with:

\`\`\`
Error: Invalid value. Matching delimiter not found 'b6ee0cdea525a870f47ece7208f3610c'
\`\`\`

even after we switched to a random delimiter.

**Root cause:** \`resolve-dev-versions.py\` writes \`new_versions.json\` / \`dep_pins.json\` via \`json.dumps(..., indent=2)\`, which does **not** append a trailing \`\n\`. The workflow then does:

\`\`\`bash
echo "new_versions<<$DELIM"
cat "$RUNNER_TEMP/resolve/new_versions.json"
echo "$DELIM"
\`\`\`

Without a final newline the file's last line is \`}\` and \`cat\` emits it with no newline, so the next \`echo\` produces a line \`}\` + the content, then \`$DELIM\` ends up glued to the previous content the shell buffered. GitHub's parser requires the closing delimiter to be on a line **by itself** → rejected.

## Fix

- \`resolve-dev-versions.py\`: explicitly append \`"\n"\` when writing both JSON files.
- \`publish-dev.yaml\`: belt-and-suspenders — replace \`cat file\` with \`printf '%s\n' "\$(cat file)"\` so a newline always precedes the closing delimiter, even if someone changes the script later.
- New unit test \`MainOutputFilesTests.test_files_end_with_newline\` locks the trailing-newline invariant so we don't regress.

## Test plan

- [x] \`python3 -m unittest test_resolve_dev_versions\` → 11 tests pass
- [x] \`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/publish-dev.yaml'))"\` → OK
- [ ] Merge and run \`publish-dev\` on \`main\` to confirm the step succeeds end-to-end.

Made with [Cursor](https://cursor.com)