### PR TITLE
docs(toolkit): fix typo in UniqueEnvironment docstring

### DIFF
--- a/unique_toolkit/unique_toolkit/app/unique_settings.py
+++ b/unique_toolkit/unique_toolkit/app/unique_settings.py
@@ -406,7 +406,7 @@ class UniqueChatEventFilterOptions(BaseSettings):
 class UniqueEnvironment:
     """
     Contains all settings that come exclusively from the environment.
-    This means if a setting can be intialized from either request or the environment, this class will not contain it.
+    This means if a setting can be initialized from either request or the environment, this class will not contain it.
     """
 
     def __init__(self, app: UniqueApp, api: UniqueApi) -> None:


### PR DESCRIPTION
## Summary
- Fix "intialized" → "initialized" in the `UniqueEnvironment` class docstring in `unique_toolkit/app/unique_settings.py`.
- Targets a publishable `.py` file so the `publish-dev` pipeline actually runs end-to-end (markdown-only changes are filtered out by `detect-changes`).

## Test plan
- [ ] `publish-dev` workflow triggers on the `toolkit` package
- [ ] New dev version is published to PyPI without `GITHUB_OUTPUT` errors

Made with [Cursor](https://cursor.com)