### PR TITLE
fix(ci): use >= floor instead of == exact pin for sibling dev deps

### DIFF
--- a/.github/scripts/resolve-dev-versions.py
+++ b/.github/scripts/resolve-dev-versions.py
@@ -18,7 +18,7 @@ From that we produce:
 
   * ``dep_pins``: for every publishable AI package, the PEP 440 spec
     suffix downstream wheels should use for it:
-      - package is a sibling in this push   -> ``==<new version>``
+      - package is a sibling in this push   -> ``>=<new version>``
       - cycle already has a dev on PyPI     -> ``>={cycle}.0.dev<N>``
       - otherwise                           -> ``>=<pyproject version>``
 
@@ -114,7 +114,7 @@ def resolve(
         if pkg["id"] in selected:
             next_n = 0 if dev_n is None else dev_n + 1
             new_versions[pkg["id"]] = f"{cycle}.0.dev{next_n}"
-            dep_pins[key] = f"=={new_versions[pkg['id']]}"
+            dep_pins[key] = f">={new_versions[pkg['id']]}"
         elif dev_n is not None:
             dep_pins[key] = f">={cycle}.0.dev{dev_n}"
         else:

--- a/.github/scripts/rewrite-pyproject-for-dev.py
+++ b/.github/scripts/rewrite-pyproject-for-dev.py
@@ -9,12 +9,12 @@ Two things happen in place:
    names another AI monorepo package is rewritten to use the pin
    supplied via ``--dep-pins``. For example, with::
 
-       --dep-pins '{"unique-sdk": "==2026.18.0.dev3",
+       --dep-pins '{"unique-sdk": ">=2026.18.0.dev3",
                     "unique-toolkit": ">=2026.18.0.dev7"}'
 
    the rewriter produces::
 
-       "unique-sdk>=0.10.85,<0.12"  ->  "unique-sdk==2026.18.0.dev3"
+       "unique-sdk>=0.10.85,<0.12"  ->  "unique-sdk>=2026.18.0.dev3"
        "unique-toolkit[monitoring]>=1.69.6,<2"
            ->  "unique-toolkit[monitoring]>=2026.18.0.dev7"
 
@@ -24,7 +24,7 @@ Because the constraint explicitly contains a PEP 440 pre-release segment
 The pin map is computed upstream in ``resolve-dev-versions.py`` and
 encodes three cases per cross-package dep:
 
-  * The dep is being published in the same push     -> ``==<new-version>``
+  * The dep is being published in the same push     -> ``>=<new-version>``
   * The cycle already has a dev wheel for the dep   -> ``>=<latest-dev>``
   * Otherwise (nothing in the cycle yet)            -> ``>=<last-stable>``
 
@@ -56,12 +56,13 @@ _REQ_RE = re.compile(r"^\s*([A-Za-z0-9_.\-]+)(\[[^\]]*\])?\s*(.*)$")
 # stable version into a package.
 _VERSION_RE = re.compile(r"^\d{4}\.\d{2}\.\d+\.dev\d+$")
 # Dep pins come in three flavors out of resolve-dev-versions.py:
-#   ==<CalVer dev>   (sibling in this push)
-#   >=<CalVer dev>   (cycle-dev already on PyPI)
+#   >=<CalVer dev>   (sibling in this push, or cycle-dev already on PyPI)
 #   >=<stable>       (last stable fallback; may be legacy pre-CalVer)
-# The final branch has to accept dotted numerics of arbitrary length so
-# legacy "0.3.3"-style versions pass through.
-_PIN_RE = re.compile(r"^(==\d{4}\.\d{2}\.\d+\.dev\d+|>=\d+(\.\d+)*(\.dev\d+)?)$")
+# All three cases use >= so future dev releases of the same package
+# remain installable without republishing every transitive dependent.
+# Dotted numerics of arbitrary length are accepted so legacy
+# "0.3.3"-style versions pass through.
+_PIN_RE = re.compile(r"^>=\d+(\.\d+)*(\.dev\d+)?$")
 
 
 def normalize(name: str) -> str:

--- a/.github/scripts/tests/test_resolve_dev_versions.py
+++ b/.github/scripts/tests/test_resolve_dev_versions.py
@@ -1,7 +1,7 @@
 """Unit tests for `.github/scripts/resolve-dev-versions.py`.
 
 Covers the three dep-pin branches the workflow relies on — sibling
-``==``, in-cycle ``>=`` latest dev, pyproject-stable fallback ``>=`` —
+``>=``, in-cycle ``>=`` latest dev, pyproject-stable fallback ``>=`` —
 plus the per-package dev counter behaviour.
 
 PyPI is never contacted; a fake ``fetcher`` is injected into
@@ -119,7 +119,7 @@ class ResolveTests(unittest.TestCase):
             on_disk={"unique_sdk": "0.11.6", "unique_mcp": "0.3.3"},
         )
         self.assertEqual(new_versions, {"toolkit": "2026.18.0.dev0"})
-        self.assertEqual(dep_pins["unique-toolkit"], "==2026.18.0.dev0")
+        self.assertEqual(dep_pins["unique-toolkit"], ">=2026.18.0.dev0")
         self.assertEqual(dep_pins["unique-sdk"], ">=0.11.6")
         self.assertEqual(dep_pins["unique-mcp"], ">=0.3.3")
 
@@ -134,7 +134,7 @@ class ResolveTests(unittest.TestCase):
             on_disk={"unique_mcp": "0.3.3"},
         )
         self.assertEqual(new_versions, {"toolkit": "2026.18.0.dev4"})
-        self.assertEqual(dep_pins["unique-toolkit"], "==2026.18.0.dev4")
+        self.assertEqual(dep_pins["unique-toolkit"], ">=2026.18.0.dev4")
         self.assertEqual(dep_pins["unique-sdk"], ">=2026.18.0.dev2")
         self.assertEqual(dep_pins["unique-mcp"], ">=0.3.3")
 
@@ -151,8 +151,8 @@ class ResolveTests(unittest.TestCase):
         self.assertEqual(
             new_versions, {"toolkit": "2026.18.0.dev6", "sdk": "2026.18.0.dev10"}
         )
-        self.assertEqual(dep_pins["unique-toolkit"], "==2026.18.0.dev6")
-        self.assertEqual(dep_pins["unique-sdk"], "==2026.18.0.dev10")
+        self.assertEqual(dep_pins["unique-toolkit"], ">=2026.18.0.dev6")
+        self.assertEqual(dep_pins["unique-sdk"], ">=2026.18.0.dev10")
         self.assertEqual(dep_pins["unique-mcp"], ">=0.3.3")
 
     def test_pep503_normalization(self) -> None:
@@ -206,7 +206,7 @@ class MainOutputFilesTests(unittest.TestCase):
             def fake_resolve(**_):
                 return (
                     {"toolkit": "2026.18.0.dev0"},
-                    {"unique-toolkit": "==2026.18.0.dev0"},
+                    {"unique-toolkit": ">=2026.18.0.dev0"},
                 )
 
             with patch.object(rdv, "resolve", side_effect=fake_resolve):

--- a/.github/scripts/tests/test_rewrite_pyproject_for_dev.py
+++ b/.github/scripts/tests/test_rewrite_pyproject_for_dev.py
@@ -72,18 +72,18 @@ class RewriteTests(unittest.TestCase):
     def test_rewrites_own_version_and_ai_deps(self) -> None:
         out = self._run(
             {
-                "unique-sdk": "==2026.18.0.dev3",
+                "unique-sdk": ">=2026.18.0.dev3",
                 "unique-orchestrator": ">=2026.18.0.dev1",
                 "unique-mcp": ">=2026.14.0",
             },
         )
         self.assertIn('version = "2026.18.0.dev7"', out)
-        self.assertIn('"unique-sdk==2026.18.0.dev3"', out)
+        self.assertIn('"unique-sdk>=2026.18.0.dev3"', out)
         self.assertIn('"unique_orchestrator>=2026.18.0.dev1"', out)
         self.assertIn('"unique-mcp[extra]>=2026.14.0"', out)
 
     def test_leaves_non_ai_deps_alone(self) -> None:
-        out = self._run({"unique-sdk": "==2026.18.0.dev3"})
+        out = self._run({"unique-sdk": ">=2026.18.0.dev3"})
         self.assertIn('"pydantic>=2.0"', out)
         self.assertIn('"prometheus-client>=0.17"', out)
 
@@ -92,7 +92,7 @@ class RewriteTests(unittest.TestCase):
         # (e.g. unique-mcp 0.3.3). The rewriter must pass it through.
         out = self._run(
             {
-                "unique-sdk": "==2026.18.0.dev3",
+                "unique-sdk": ">=2026.18.0.dev3",
                 "unique-mcp": ">=0.3.3",
                 "unique-orchestrator": ">=1.22.2",
             }
@@ -101,7 +101,7 @@ class RewriteTests(unittest.TestCase):
         self.assertIn('"unique_orchestrator>=1.22.2"', out)
 
     def test_preserves_other_tool_tables(self) -> None:
-        out = self._run({"unique-sdk": "==2026.18.0.dev3"})
+        out = self._run({"unique-sdk": ">=2026.18.0.dev3"})
         self.assertIn("[tool.some-tool]", out)
         self.assertIn("keep_me = true", out)
 
@@ -110,12 +110,12 @@ class RewriteTests(unittest.TestCase):
         # the dep-pin map keys on the normalized "unique-orchestrator".
         out = self._run(
             {
-                "unique-orchestrator": "==2026.18.0.dev2",
-                "unique-sdk": "==2026.18.0.dev3",
+                "unique-orchestrator": ">=2026.18.0.dev2",
+                "unique-sdk": ">=2026.18.0.dev3",
                 "unique-mcp": ">=2026.14.0",
             }
         )
-        self.assertIn('"unique_orchestrator==2026.18.0.dev2"', out)
+        self.assertIn('"unique_orchestrator>=2026.18.0.dev2"', out)
 
     def test_rejects_unknown_dep_pin_format(self) -> None:
         with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
## Summary

- When two or more packages are published in the same dev push, `resolve-dev-versions.py` was emitting `==<new-version>` as the dep-pin for each sibling package.
- This caused version-solving failures as soon as any sibling advanced to a later dev iteration: e.g. `unique-web-search==2026.18.0.dev0` pinned `unique-toolkit==2026.18.0.dev0`, which then conflicted with anything requiring `unique-toolkit>=2026.18.0.dev2`.
- Fix: the sibling case now emits `>=<new-version>` (a floor, not an exact pin), consistent with the other two cases. Future dev releases of the same package remain installable without republishing every transitive dependent.

## Changes

- `resolve-dev-versions.py`: `==` → `>=` for sibling-in-same-push dep pins
- `rewrite-pyproject-for-dev.py`: remove `==` branch from `_PIN_RE` (no longer produced by the resolver); update docstrings and example
- `test_resolve_dev_versions.py` / `test_rewrite_pyproject_for_dev.py`: update all assertions and inputs accordingly (19/19 tests pass)

## Test plan

- [x] All 19 unit tests pass locally (`pytest .github/scripts/tests/test_resolve_dev_versions.py .github/scripts/tests/test_rewrite_pyproject_for_dev.py`)
- [ ] CI `scripts-test` job passes

Made with [Cursor](https://cursor.com)