### PR TITLE
fix(ci): separate extras install from workspace reinstall; add use_workspace flag

### DIFF
--- a/.github/actions/run-coverage-check/action.yml
+++ b/.github/actions/run-coverage-check/action.yml
@@ -13,6 +13,13 @@ inputs:
     description: 'Extra names to install (e.g., "--extra fastapi --extra monitoring")'
     required: false
     default: ''
+  use_workspace:
+    description: >
+      When true (default), workspace sources are used for all intra-monorepo
+      deps. Set to false only on release branches to validate that the package
+      resolves correctly against its declared bounds on PyPI.
+    required: false
+    default: 'true'
   base_ref:
     description: 'Base branch/ref for comparison'
     required: false
@@ -32,7 +39,7 @@ runs:
         python_version: ${{ inputs.python_version }}
 
     - name: Install extra dependencies from PyPI
-      if: inputs.install_args != ''
+      if: inputs.install_args != '' && inputs.use_workspace != 'true'
       shell: bash
       working-directory: ${{ inputs.package_dir }}
       env:

--- a/.github/actions/run-coverage-check/action.yml
+++ b/.github/actions/run-coverage-check/action.yml
@@ -38,14 +38,21 @@ runs:
         package_dir: ${{ inputs.package_dir }}
         python_version: ${{ inputs.python_version }}
 
-    - name: Install extra dependencies from PyPI
-      if: inputs.install_args != '' && inputs.use_workspace != 'true'
+    - name: Install optional extras
+      if: inputs.install_args != ''
+      shell: bash
+      working-directory: ${{ inputs.package_dir }}
+      run: |
+        EXTRAS=$(echo "${{ inputs.install_args }}" | grep -oP '(?<=--extra )\w+' | paste -sd ',' -)
+        uv pip install ".[${EXTRAS}]"
+
+    - name: Reinstall intra-monorepo deps from PyPI
+      if: inputs.use_workspace != 'true'
       shell: bash
       working-directory: ${{ inputs.package_dir }}
       env:
         UV_NO_SOURCES: 1
       run: |
-        EXTRAS=$(echo "${{ inputs.install_args }}" | grep -oP '(?<=--extra )\w+' | paste -sd ',' -)
         WORKSPACE_PKGS=$(python3 -c "
         import tomllib
         with open('pyproject.toml', 'rb') as f:
@@ -54,11 +61,17 @@ runs:
         pkgs = [name for name, src in sources.items() if src.get('workspace') or 'path' in src]
         print(' '.join(pkgs))
         ")
+        if [ -z "$WORKSPACE_PKGS" ]; then exit 0; fi
         REINSTALL_ARGS=""
         for pkg in $WORKSPACE_PKGS; do
           REINSTALL_ARGS="$REINSTALL_ARGS --reinstall-package $pkg"
         done
-        uv pip install $REINSTALL_ARGS ".[${EXTRAS}]"
+        if [ -n "${{ inputs.install_args }}" ]; then
+          EXTRAS=$(echo "${{ inputs.install_args }}" | grep -oP '(?<=--extra )\w+' | paste -sd ',' -)
+          uv pip install $REINSTALL_ARGS ".[${EXTRAS}]"
+        else
+          uv pip install $REINSTALL_ARGS .
+        fi
 
     - name: Fetch base branch
       if: inputs.base_ref != ''

--- a/.github/actions/run-coverage-check/action.yml
+++ b/.github/actions/run-coverage-check/action.yml
@@ -43,8 +43,8 @@ runs:
       shell: bash
       working-directory: ${{ inputs.package_dir }}
       run: |
-        EXTRAS=$(echo "${{ inputs.install_args }}" | grep -oP '(?<=--extra )\w+' | paste -sd ',' -)
-        uv pip install ".[${EXTRAS}]"
+        EXTRA_FLAGS=$(echo "${{ inputs.install_args }}" | grep -oP '(?<=--extra )\w+' | sed 's/^/--extra /' | paste -sd ' ' -)
+        uv sync --locked $EXTRA_FLAGS
 
     - name: Reinstall intra-monorepo deps from PyPI
       if: inputs.use_workspace != 'true'

--- a/.github/actions/run-coverage-check/action.yml
+++ b/.github/actions/run-coverage-check/action.yml
@@ -44,7 +44,7 @@ runs:
       working-directory: ${{ inputs.package_dir }}
       run: |
         EXTRA_FLAGS=$(echo "${{ inputs.install_args }}" | grep -oP '(?<=--extra )\w+' | sed 's/^/--extra /' | paste -sd ' ' -)
-        uv sync --locked $EXTRA_FLAGS
+        uv sync --locked --inexact $EXTRA_FLAGS
 
     - name: Reinstall intra-monorepo deps from PyPI
       if: inputs.use_workspace != 'true'

--- a/.github/actions/run-coverage-check/action.yml
+++ b/.github/actions/run-coverage-check/action.yml
@@ -73,6 +73,11 @@ runs:
           uv pip install $REINSTALL_ARGS .
         fi
 
+    - name: Show installed unique-* packages
+      shell: bash
+      working-directory: ${{ inputs.package_dir }}
+      run: uv pip list | grep -i unique || true
+
     - name: Fetch base branch
       if: inputs.base_ref != ''
       shell: bash

--- a/.github/actions/run-coverage-check/action.yml
+++ b/.github/actions/run-coverage-check/action.yml
@@ -66,12 +66,7 @@ runs:
         for pkg in $WORKSPACE_PKGS; do
           REINSTALL_ARGS="$REINSTALL_ARGS --reinstall-package $pkg"
         done
-        if [ -n "${{ inputs.install_args }}" ]; then
-          EXTRAS=$(echo "${{ inputs.install_args }}" | grep -oP '(?<=--extra )\w+' | paste -sd ',' -)
-          uv pip install $REINSTALL_ARGS ".[${EXTRAS}]"
-        else
-          uv pip install $REINSTALL_ARGS .
-        fi
+        uv pip install $REINSTALL_ARGS .
 
     - name: Show installed unique-* packages
       shell: bash

--- a/.github/actions/run-min-tests-and-deptry/action.yml
+++ b/.github/actions/run-min-tests-and-deptry/action.yml
@@ -89,6 +89,13 @@ runs:
         # Package-level dev group: package-specific test deps (e.g. responses for unique_six)
         uv export --frozen --only-group dev --no-hashes 2>/dev/null | uv pip install -r - 2>/dev/null || true
 
+    - name: Show installed unique-* packages
+      shell: bash
+      working-directory: ${{ inputs.package_dir }}
+      env:
+        VIRTUAL_ENV: ${{ github.workspace }}/${{ inputs.package_dir }}/.venv
+      run: .venv/bin/pip list | grep -i unique || true
+
     - name: Run deptry
       shell: bash
       working-directory: ${{ inputs.package_dir }}

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -39,8 +39,8 @@ runs:
       shell: bash
       working-directory: ${{ inputs.package_dir }}
       run: |
-        EXTRAS=$(echo "${{ inputs.install_args }}" | grep -oP '(?<=--extra )\w+' | paste -sd ',' -)
-        uv pip install ".[${EXTRAS}]"
+        EXTRA_FLAGS=$(echo "${{ inputs.install_args }}" | grep -oP '(?<=--extra )\w+' | sed 's/^/--extra /' | paste -sd ' ' -)
+        uv sync --locked $EXTRA_FLAGS
 
     - name: Reinstall intra-monorepo deps from PyPI
       if: inputs.use_workspace != 'true'

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -71,6 +71,11 @@ runs:
           uv pip install $REINSTALL_ARGS .
         fi
 
+    - name: Show installed unique-* packages
+      shell: bash
+      working-directory: ${{ inputs.package_dir }}
+      run: uv pip list | grep -i unique || true
+
     - name: Run pytest
       shell: bash
       working-directory: ${{ inputs.package_dir }}

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -34,20 +34,23 @@ runs:
         package_dir: ${{ inputs.package_dir }}
         python_version: ${{ inputs.python_version }}
 
-    - name: Install extra dependencies from PyPI
-      if: inputs.install_args != '' && inputs.use_workspace != 'true'
+    - name: Install optional extras
+      if: inputs.install_args != ''
+      shell: bash
+      working-directory: ${{ inputs.package_dir }}
+      run: |
+        EXTRAS=$(echo "${{ inputs.install_args }}" | grep -oP '(?<=--extra )\w+' | paste -sd ',' -)
+        uv pip install ".[${EXTRAS}]"
+
+    - name: Reinstall intra-monorepo deps from PyPI
+      if: inputs.use_workspace != 'true'
       shell: bash
       working-directory: ${{ inputs.package_dir }}
       env:
         UV_NO_SOURCES: 1
       run: |
-        # Extract extra names from "--extra foo --extra bar" → "foo,bar"
-        EXTRAS=$(echo "${{ inputs.install_args }}" | grep -oP '(?<=--extra )\w+' | paste -sd ',' -)
-
-        # Find workspace-sourced deps in this package's pyproject.toml and
-        # reinstall them from PyPI to validate the declared version bounds
-        # against published releases. Only runs on release branches
-        # (use_workspace=false); all other branches use workspace sources.
+        # On release branches, replace workspace-sourced intra-monorepo deps with
+        # their published PyPI versions to validate the declared version bounds.
         WORKSPACE_PKGS=$(python3 -c "
         import tomllib
         with open('pyproject.toml', 'rb') as f:
@@ -56,13 +59,17 @@ runs:
         pkgs = [name for name, src in sources.items() if src.get('workspace') or 'path' in src]
         print(' '.join(pkgs))
         ")
-
+        if [ -z "$WORKSPACE_PKGS" ]; then exit 0; fi
         REINSTALL_ARGS=""
         for pkg in $WORKSPACE_PKGS; do
           REINSTALL_ARGS="$REINSTALL_ARGS --reinstall-package $pkg"
         done
-
-        uv pip install $REINSTALL_ARGS ".[${EXTRAS}]"
+        if [ -n "${{ inputs.install_args }}" ]; then
+          EXTRAS=$(echo "${{ inputs.install_args }}" | grep -oP '(?<=--extra )\w+' | paste -sd ',' -)
+          uv pip install $REINSTALL_ARGS ".[${EXTRAS}]"
+        else
+          uv pip install $REINSTALL_ARGS .
+        fi
 
     - name: Run pytest
       shell: bash

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -64,12 +64,7 @@ runs:
         for pkg in $WORKSPACE_PKGS; do
           REINSTALL_ARGS="$REINSTALL_ARGS --reinstall-package $pkg"
         done
-        if [ -n "${{ inputs.install_args }}" ]; then
-          EXTRAS=$(echo "${{ inputs.install_args }}" | grep -oP '(?<=--extra )\w+' | paste -sd ',' -)
-          uv pip install $REINSTALL_ARGS ".[${EXTRAS}]"
-        else
-          uv pip install $REINSTALL_ARGS .
-        fi
+        uv pip install $REINSTALL_ARGS .
 
     - name: Show installed unique-* packages
       shell: bash

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -17,6 +17,13 @@ inputs:
     description: 'Additional arguments to pass to pytest'
     required: false
     default: ''
+  use_workspace:
+    description: >
+      When true (default), workspace sources are used for all intra-monorepo
+      deps. Set to false only on release branches to validate that the package
+      resolves correctly against its declared bounds on PyPI.
+    required: false
+    default: 'true'
 
 runs:
   using: 'composite'
@@ -28,7 +35,7 @@ runs:
         python_version: ${{ inputs.python_version }}
 
     - name: Install extra dependencies from PyPI
-      if: inputs.install_args != ''
+      if: inputs.install_args != '' && inputs.use_workspace != 'true'
       shell: bash
       working-directory: ${{ inputs.package_dir }}
       env:
@@ -37,10 +44,10 @@ runs:
         # Extract extra names from "--extra foo --extra bar" → "foo,bar"
         EXTRAS=$(echo "${{ inputs.install_args }}" | grep -oP '(?<=--extra )\w+' | paste -sd ',' -)
 
-        # Find workspace-sourced deps in this package's pyproject.toml.
-        # These were installed from local paths by setup-uv; reinstall them
-        # from PyPI to test against released versions (SDK must be published
-        # before toolkit can be released, so the PyPI version always exists).
+        # Find workspace-sourced deps in this package's pyproject.toml and
+        # reinstall them from PyPI to validate the declared version bounds
+        # against published releases. Only runs on release branches
+        # (use_workspace=false); all other branches use workspace sources.
         WORKSPACE_PKGS=$(python3 -c "
         import tomllib
         with open('pyproject.toml', 'rb') as f:

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -40,7 +40,7 @@ runs:
       working-directory: ${{ inputs.package_dir }}
       run: |
         EXTRA_FLAGS=$(echo "${{ inputs.install_args }}" | grep -oP '(?<=--extra )\w+' | sed 's/^/--extra /' | paste -sd ' ' -)
-        uv sync --locked $EXTRA_FLAGS
+        uv sync --locked --inexact $EXTRA_FLAGS
 
     - name: Reinstall intra-monorepo deps from PyPI
       if: inputs.use_workspace != 'true'

--- a/.github/actions/type-check/action.yml
+++ b/.github/actions/type-check/action.yml
@@ -40,6 +40,11 @@ runs:
           rm -f .basedpyright/baseline.json
         fi
 
+    - name: Show installed unique-* packages
+      shell: bash
+      working-directory: ${{ inputs.package_dir }}
+      run: uv pip list | grep -i unique || true
+
     - name: Run basedpyright
       shell: bash
       working-directory: ${{ inputs.package_dir }}

--- a/.github/workflows/ci-coverage.yaml
+++ b/.github/workflows/ci-coverage.yaml
@@ -86,5 +86,6 @@ jobs:
           package_dir: ${{ matrix.dir }}
           python_version: ${{ matrix.python }}
           install_args: ${{ matrix.install_args }}
+          use_workspace: ${{ !startsWith(github.head_ref || github.ref_name, 'release-please--') }}
           base_ref: origin/${{ github.base_ref || 'main' }}
           min_coverage: ${{ matrix.min_coverage }}

--- a/.github/workflows/ci-pytest.yaml
+++ b/.github/workflows/ci-pytest.yaml
@@ -82,3 +82,4 @@ jobs:
           python_version: ${{ matrix.python }}
           install_args: ${{ matrix.install_args }}
           test_args: ${{ matrix.test_args }}
+          use_workspace: ${{ !startsWith(github.head_ref || github.ref_name, 'release-please--') }}

--- a/unique_toolkit/unique_toolkit/__init__.py
+++ b/unique_toolkit/unique_toolkit/__init__.py
@@ -83,3 +83,5 @@ if _CONFIG_CHECKER_AVAILABLE:
 # Add langchain-specific exports if available
 if _LANGCHAIN_AVAILABLE:
     __all__.append("get_langchain_client")
+
+# ci-trigger

--- a/unique_toolkit/unique_toolkit/__init__.py
+++ b/unique_toolkit/unique_toolkit/__init__.py
@@ -83,5 +83,3 @@ if _CONFIG_CHECKER_AVAILABLE:
 # Add langchain-specific exports if available
 if _LANGCHAIN_AVAILABLE:
     __all__.append("get_langchain_client")
-
-# ci-trigger


### PR DESCRIPTION
## Summary

- Separates two previously conflated concerns in \`run-tests\` and \`run-coverage-check\`:
  1. **Install optional extras** (e.g. \`fastapi\`, \`monitoring\`) — always runs when \`install_args\` is set, uses \`uv sync --locked --inexact\` so third-party transitive deps are pinned to the lockfile
  2. **Reinstall intra-monorepo deps from PyPI** — new step, only runs on release branches (\`use_workspace=false\`), swaps workspace-sourced deps (e.g. \`unique-sdk\`) for their published PyPI versions to validate declared version bounds
- Adds a \`use_workspace\` input (default \`true\`) to both actions
- \`ci-pytest.yaml\` and \`ci-coverage.yaml\` set the flag by branch name: \`false\` on \`release-please--*\` branches, \`true\` everywhere else
- Adds a diagnostic "Show installed unique-* packages" step to all four test/check actions so CI logs make the resolution source visible

## Motivation

The original single "Install extra dependencies from PyPI" step had two bugs:

1. **Wrong gate condition**: it was gated on \`install_args != ''\`, which was accidentally a proxy for "is unique-toolkit" — the only package with both extras *and* a workspace dep. Packages like orchestrator and web-search have workspace deps but no extras, so their workspace-to-PyPI reinstall was silently never happening on release branches.

2. **Dev branch regression**: switching to \`use_workspace=false\` on release branches gated the *entire* step, including extras installation. Feature branch builds for packages with extras would have skipped the extras install entirely and failed.

Splitting into two steps with independent conditions fixes both.

The extras step also switched from \`uv pip install\` (lockfile-free) to \`uv sync --locked --inexact\` so all third-party deps are pinned — the only thing that varies between runs is now the intra-monorepo packages, which is the intended variance.

## Test plan

- [ ] CI passes on this PR (feature branch → \`use_workspace=true\` → workspace, PyPI reinstall step skipped, extras installed via lockfile)
- [ ] "Show installed unique-* packages" step in CI logs confirms workspace versions
- [ ] Manually verify on a \`release-please--*\` branch that the PyPI reinstall step runs and logs show PyPI versions

Made with [Cursor](https://cursor.com)