### PR TITLE
fix(ci): arm release via PR instead of direct push to main

### DIFF
--- a/.github/scripts/prepare-next-cycle.sh
+++ b/.github/scripts/prepare-next-cycle.sh
@@ -119,5 +119,3 @@ gh pr create \
   --body "Arms the next CalVer cycle. Once merged, release-please will retarget the standing Release PR to \`${VERSION}\`."
 
 echo "Opened arm PR for ${VERSION}. Release-please will update the ${BRANCH} Release PR once it is merged."
-
-

--- a/.github/scripts/prepare-next-cycle.sh
+++ b/.github/scripts/prepare-next-cycle.sh
@@ -119,3 +119,5 @@ gh pr create \
   --body "Arms the next CalVer cycle. Once merged, release-please will retarget the standing Release PR to \`${VERSION}\`."
 
 echo "Opened arm PR for ${VERSION}. Release-please will update the ${BRANCH} Release PR once it is merged."
+
+

--- a/.github/scripts/prepare-next-cycle.sh
+++ b/.github/scripts/prepare-next-cycle.sh
@@ -102,8 +102,14 @@ git commit --allow-empty \
   -m "chore: arm release ${VERSION}" \
   -m "Release-As: ${VERSION}"
 
-# Force-push so a retry after a partial failure (branch pushed but gh pr create
-# failed, or a previously closed arm PR) doesn't hit a non-fast-forward error.
+# Populate the local tracking ref so --force-with-lease has something to
+# compare against. Without this fetch, --force-with-lease treats a missing
+# tracking ref as "expect the remote branch not to exist" and rejects the push
+# when the branch already exists (e.g. branch pushed but gh pr create failed,
+# or a previously closed arm PR). The || true handles the case where the branch
+# does not yet exist on the remote.
+git fetch --no-tags "$REMOTE" \
+  "refs/heads/${CYCLE_BRANCH}:refs/remotes/${REMOTE}/${CYCLE_BRANCH}" 2>/dev/null || true
 git push --force-with-lease "$REMOTE" "HEAD:refs/heads/${CYCLE_BRANCH}"
 
 gh pr create \

--- a/.github/scripts/prepare-next-cycle.sh
+++ b/.github/scripts/prepare-next-cycle.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Arms the next stable release by pushing an empty `Release-As: YYYY.WW.0`
-# commit to `main`. Release-please then rewrites its standing Release PR on
-# `main` to target that version, so the PR always reflects the authoritative
-# next CalVer (never a SemVer placeholder).
+# Arms the next stable release by opening a PR that carries an empty
+# `Release-As: YYYY.WW.0` commit. Once merged, release-please rewrites its
+# standing Release PR on `main` to target that version.
+#
+# The commit lands on a side branch (`chore/arm-YYYY.WW.0`) and is merged via
+# the normal merge queue. This avoids needing a branch-protection bypass for
+# direct pushes to `main`.
 #
 # Inputs (via flags):
 #   --year-week YYYY.WW  Explicit target cycle (e.g. 2026.20). Optional.
@@ -12,10 +15,11 @@ set -euo pipefail
 #                        .release-please-manifest.json (manifest + 2 weeks,
 #                        fallback: next even ISO week).
 #   --remote NAME        Remote to push to. Default: origin.
-#   --branch NAME        Branch to push to. Default: main.
+#   --branch NAME        Base branch (PR target). Default: main.
 #
-# Idempotent: if a `Release-As: <version>` trailer is already present in
-# unreleased main history, exits 0 without pushing.
+# Idempotent: exits 0 without opening a PR if the Release-As trailer is
+# already on the base branch, or if an arm PR for the same version is already
+# open.
 
 REMOTE="origin"
 BRANCH="main"
@@ -81,9 +85,28 @@ if git log "${REMOTE}/${BRANCH}" "${SINCE_FLAG[@]}" \
   exit 0
 fi
 
+CYCLE_BRANCH="chore/arm-${VERSION}"
+
+OPEN_PRS=$(gh pr list \
+  --base "$BRANCH" \
+  --head "$CYCLE_BRANCH" \
+  --state open \
+  --json number \
+  --jq 'length' 2>/dev/null || echo "0")
+if [[ "$OPEN_PRS" != "0" ]]; then
+  echo "Arm PR for ${VERSION} already open on ${CYCLE_BRANCH}; nothing to do."
+  exit 0
+fi
+
 git commit --allow-empty \
   -m "chore: arm release ${VERSION}" \
   -m "Release-As: ${VERSION}"
-git push "$REMOTE" "HEAD:${BRANCH}"
+git push "$REMOTE" "HEAD:refs/heads/${CYCLE_BRANCH}"
 
-echo "Pushed Release-As: ${VERSION}. Release-please will update the ${BRANCH} Release PR on its next run."
+gh pr create \
+  --base "$BRANCH" \
+  --head "$CYCLE_BRANCH" \
+  --title "chore: arm release ${VERSION}" \
+  --body "Arms the next CalVer cycle. Once merged, release-please will retarget the standing Release PR to \`${VERSION}\`."
+
+echo "Opened arm PR for ${VERSION}. Release-please will update the ${BRANCH} Release PR once it is merged."

--- a/.github/scripts/prepare-next-cycle.sh
+++ b/.github/scripts/prepare-next-cycle.sh
@@ -101,7 +101,10 @@ fi
 git commit --allow-empty \
   -m "chore: arm release ${VERSION}" \
   -m "Release-As: ${VERSION}"
-git push "$REMOTE" "HEAD:refs/heads/${CYCLE_BRANCH}"
+
+# Force-push so a retry after a partial failure (branch pushed but gh pr create
+# failed, or a previously closed arm PR) doesn't hit a non-fast-forward error.
+git push --force-with-lease "$REMOTE" "HEAD:refs/heads/${CYCLE_BRANCH}"
 
 gh pr create \
   --base "$BRANCH" \

--- a/.github/workflows/cd-arm-version.yaml
+++ b/.github/workflows/cd-arm-version.yaml
@@ -19,7 +19,7 @@ name: "[CD] Release · Arm Version"
 
 permissions:
   contents: write
-  actions: write  # needed for `gh workflow run cd-release.yaml`
+  pull-requests: write
 
 on:
   workflow_dispatch:
@@ -51,17 +51,10 @@ jobs:
       - name: Arm cycle
         env:
           YEAR_WEEK: ${{ inputs.year_week }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [[ -n "$YEAR_WEEK" ]]; then
             ./.github/scripts/prepare-next-cycle.sh --year-week "$YEAR_WEEK"
           else
             ./.github/scripts/prepare-next-cycle.sh
           fi
-
-      - name: Kick release-please
-        # The push above used GITHUB_TOKEN and therefore did not fire
-        # cd-release.yaml via its push trigger. Invoke it manually so
-        # the standing Release PR is refreshed immediately.
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh workflow run cd-release.yaml --ref main

--- a/.github/workflows/cd-release.yaml
+++ b/.github/workflows/cd-release.yaml
@@ -80,16 +80,9 @@ jobs:
         run: ./.github/scripts/cut-release-branch.sh
 
       - name: Arm next cycle on main
-        run: ./.github/scripts/prepare-next-cycle.sh
-
-      - name: Kick release-please
-        # The arm step above pushed with GITHUB_TOKEN, which can't
-        # re-trigger this workflow via push. Dispatch ourselves so the
-        # standing Release PR is refreshed immediately with the newly
-        # armed CalVer.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh workflow run cd-release.yaml --ref main
+        run: ./.github/scripts/prepare-next-cycle.sh
 
       - name: Summary
         run: |
@@ -97,6 +90,5 @@ jobs:
             echo "### Post-release actions"
             echo "- Cut \`release/\` branch from the tagged release commit"
             echo "- Kicked \`cd-publish.yaml\` (package=all) via \`publish-stable\` job"
-            echo "- Pushed \`Release-As:\` trailer on \`main\` to arm the next cycle"
-            echo "- Kicked release-please to refresh the standing Release PR"
+            echo "- Opened arm PR on \`main\` to arm the next CalVer cycle"
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- \`prepare-next-cycle.sh\` previously tried to push the \`Release-As:\` commit directly to \`main\`, which is blocked by branch protection (merge queue required). This changes it to push to a side branch (\`chore/arm-YYYY.WW.0\`) and open a PR instead.
- The PR goes through the merge queue normally — no bypass rule or GitHub App needed.
- Idempotency extended: also checks for an already-open arm PR before creating a new one.

## Changes
- \`.github/scripts/prepare-next-cycle.sh\` — push to \`chore/arm-VERSION\`, open PR via \`gh pr create\`
- \`.github/workflows/cd-arm-version.yaml\` — add \`GH_TOKEN\` env + \`pull-requests: write\` permission; remove now-unnecessary \`Kick release-please\` step (release-please will run when the arm PR merges via its push trigger on \`main\`)
- \`.github/workflows/cd-release.yaml\` — add \`GH_TOKEN\` env to arm step; update summary text

## Test plan
- [ ] Dispatch \`cd-arm-version.yaml\` manually: verify it creates \`chore/arm-YYYY.WW.0\` branch and opens a PR
- [ ] Merge the arm PR through the queue → release-please picks up \`Release-As: YYYY.WW.0\` and retargets the standing Release PR

Refs: UN-18411

Made with [Cursor](https://cursor.com)