### PR TITLE
fix(ci): include Release-As trailer in arm PR body so squash merge preserves it

### DIFF
--- a/.github/scripts/prepare-next-cycle.sh
+++ b/.github/scripts/prepare-next-cycle.sh
@@ -116,6 +116,8 @@ gh pr create \
   --base "$BRANCH" \
   --head "$CYCLE_BRANCH" \
   --title "chore: arm release ${VERSION}" \
-  --body "Arms the next CalVer cycle. Once merged, release-please will retarget the standing Release PR to \`${VERSION}\`."
+  --body "Arms the next CalVer cycle. Once merged, release-please will retarget the standing Release PR to \`${VERSION}\`.
+
+Release-As: ${VERSION}"
 
 echo "Opened arm PR for ${VERSION}. Release-please will update the ${BRANCH} Release PR once it is merged."


### PR DESCRIPTION
## Summary
GitHub squash-merges replace the entire commit message with the PR title + body, discarding any trailers that were only in the raw git commit. The arm commit carried `Release-As: VERSION` only in the commit itself, so after squash it was gone and release-please fell back to computing its own version (`2026.17.0` instead of `2026.18.0`).

Fix: add `Release-As: ${VERSION}` as a trailer in the PR body so the squash commit on `main` carries it.

Refs: UN-18411

Made with [Cursor](https://cursor.com)