### PR TITLE
docs(unique-toolkit): fix typo seperate -> separate

### DIFF
--- a/unique_toolkit/unique_toolkit/agentic/tools/a2a/postprocessing/_display_utils.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/a2a/postprocessing/_display_utils.py
@@ -126,7 +126,7 @@ def _get_display_template(
         case SubAgentResponseDisplayMode.DETAILS_CLOSED:
             template = _wrap_with_details_tag(template, "closed", title_template)
         case SubAgentResponseDisplayMode.PLAIN:
-            # Add a hidden block border to seperate sub agent answers from the rest of the text.
+            # Add a hidden block border to separate sub agent answers from the rest of the text.
             hidden_block_border = _wrap_hidden_div("sub_agent_answer_block")
             template = _join_text_blocks(title_template, template, hidden_block_border)
 


### PR DESCRIPTION
Fixes a comment typo in `_display_utils.py`. Used as a test commit to verify that the `cd-release` lockfile regeneration job fires correctly when release-please updates the standing release PR.

Made with [Cursor](https://cursor.com)