### PR TITLE
fix(cd-release): use gh pr list to find release PR for lockfile update

### DIFF
--- a/.github/workflows/cd-release.yaml
+++ b/.github/workflows/cd-release.yaml
@@ -55,10 +55,11 @@ jobs:
         id: pr-info
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_BRANCH: ${{ github.ref_name }}
         run: |
           branch=$(gh pr list \
             --repo "${{ github.repository }}" \
-            --base "${{ github.ref_name }}" \
+            --base "$BASE_BRANCH" \
             --label "autorelease: pending" \
             --state open \
             --json headRefName \
@@ -80,9 +81,11 @@ jobs:
 
       - name: Seed lockfile from base branch before regenerating
         if: steps.pr-info.outputs.branch != ''
+        env:
+          BASE_BRANCH: ${{ github.ref_name }}
         run: |
-          git fetch --depth=1 origin "${{ github.ref_name }}"
-          git show "origin/${{ github.ref_name }}:uv.lock" > uv.lock
+          git fetch --depth=1 origin "$BASE_BRANCH"
+          git show "origin/$BASE_BRANCH:uv.lock" > uv.lock
 
       - name: Regenerate lockfile
         if: steps.pr-info.outputs.branch != ''
@@ -119,11 +122,13 @@ jobs:
       - name: Kick ci-publish for stable wheels
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REF_NAME: ${{ github.ref_name }}
+          REF_SHA: ${{ github.sha }}
         run: |
           gh workflow run cd-publish.yaml \
-            --ref "${{ github.ref_name }}" \
+            --ref "$REF_NAME" \
             -f package=all \
-            -f ref="${{ github.sha }}"
+            -f ref="$REF_SHA"
 
   # Main-only post-release chores. Skipped on release/* because hotfix
   # cycles don't cut a new branch and don't advance the next CalVer.

--- a/.github/workflows/cd-release.yaml
+++ b/.github/workflows/cd-release.yaml
@@ -78,11 +78,11 @@ jobs:
         with:
           install_dependencies: "false"
 
-      - name: Seed lockfile from main before regenerating
+      - name: Seed lockfile from base branch before regenerating
         if: steps.pr-info.outputs.branch != ''
         run: |
-          git fetch --depth=1 origin main
-          git show origin/main:uv.lock > uv.lock
+          git fetch --depth=1 origin "${{ github.ref_name }}"
+          git show "origin/${{ github.ref_name }}:uv.lock" > uv.lock
 
       - name: Regenerate lockfile
         if: steps.pr-info.outputs.branch != ''

--- a/.github/workflows/cd-release.yaml
+++ b/.github/workflows/cd-release.yaml
@@ -58,6 +58,7 @@ jobs:
         run: |
           branch=$(gh pr list \
             --repo "${{ github.repository }}" \
+            --base "${{ github.ref_name }}" \
             --label "autorelease: pending" \
             --state open \
             --json headRefName \

--- a/.github/workflows/cd-release.yaml
+++ b/.github/workflows/cd-release.yaml
@@ -80,7 +80,9 @@ jobs:
 
       - name: Seed lockfile from main before regenerating
         if: steps.pr-info.outputs.branch != ''
-        run: git show origin/main:uv.lock > uv.lock
+        run: |
+          git fetch --depth=1 origin main
+          git show origin/main:uv.lock > uv.lock
 
       - name: Regenerate lockfile
         if: steps.pr-info.outputs.branch != ''

--- a/.github/workflows/cd-release.yaml
+++ b/.github/workflows/cd-release.yaml
@@ -29,7 +29,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       releases_created: ${{ steps.rp.outputs.releases_created }}
-      prs: ${{ steps.rp.outputs.prs }}
     steps:
       - id: rp
         uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
@@ -38,19 +37,31 @@ jobs:
           manifest-file: .release-please-manifest.json
 
   # After release-please updates the PR with new version bumps it does not
-  # update uv.lock. This job checks out the PR branch, reruns uv lock, and
-  # commits the result so the lockfile stays consistent with pyproject.toml.
+  # update uv.lock. This job finds the open release PR via its label, checks
+  # out that branch, reruns uv lock, and commits the result so the lockfile
+  # stays consistent with pyproject.toml.
+  #
+  # Why gh pr list instead of release-please outputs.prs?
+  # release-please only populates `prs` when it modifies the PR in the current
+  # run. Commits that don't trigger a version bump (docs, chore) leave `prs`
+  # empty even though an open release PR exists. Querying by label is reliable
+  # regardless of what release-please did in the current run.
   update-release-lockfile:
     needs: release-please
     if: needs.release-please.outputs.releases_created != 'true'
     runs-on: ubuntu-latest
     steps:
-      - name: Parse release PR branch
+      - name: Find open release PR branch
         id: pr-info
         env:
-          PRS_JSON: ${{ needs.release-please.outputs.prs }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          branch=$(echo "${PRS_JSON:-[]}" | jq -r '.[0].headBranchName // empty')
+          branch=$(gh pr list \
+            --repo "${{ github.repository }}" \
+            --label "autorelease: pending" \
+            --state open \
+            --json headRefName \
+            --jq '.[0].headRefName // empty')
           echo "branch=$branch" >> "$GITHUB_OUTPUT"
 
       - name: Checkout release PR branch

--- a/.github/workflows/cd-release.yaml
+++ b/.github/workflows/cd-release.yaml
@@ -77,6 +77,10 @@ jobs:
         with:
           install_dependencies: "false"
 
+      - name: Seed lockfile from main before regenerating
+        if: steps.pr-info.outputs.branch != ''
+        run: git show origin/main:uv.lock > uv.lock
+
       - name: Regenerate lockfile
         if: steps.pr-info.outputs.branch != ''
         run: uv lock


### PR DESCRIPTION
## Summary

The `update-release-lockfile` job was silently skipping when commits that don't trigger a version bump (e.g. `docs`, `chore`) were pushed to `main`. This happened because `release-please` only populates `outputs.prs` when it actively modifies the release PR in the current run — not when it finds nothing to do.

The fix switches from `outputs.prs` (unreliable) to `gh pr list --label "autorelease: pending"` (always correct), and removes the now-unused `prs` output from the `release-please` job.

## Test plan

- [ ] Merge this PR
- [ ] Push any commit to `main` (including a `docs` or `chore` type)
- [ ] Verify `update-release-lockfile` in the resulting run finds the open release PR branch and either updates `uv.lock` or exits cleanly with "already up to date"

Refs: UN-18411

Made with [Cursor](https://cursor.com)