### PR TITLE
fix(ci): skip no-manual-release check on release-please PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,7 +86,7 @@ jobs:
 
   no-manual-release:
     name: No Manual Release Changes
-    if: github.event_name == 'pull_request' && github.actor != 'release-please[bot]'
+    if: github.event_name == 'pull_request' && github.actor != 'release-please[bot]' && !startsWith(github.head_ref, 'release-please--')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/unique_toolkit/unique_toolkit/content/schemas.py
+++ b/unique_toolkit/unique_toolkit/content/schemas.py
@@ -46,7 +46,7 @@ class ContentChunk(BaseModel):
     )
     key: str | None = Field(
         default=None,
-        description="The key of the chunk. For document chunks this is the the filename",
+        description="The key of the chunk. For document chunks this is the filename",
     )
     chunk_id: str | None = Field(
         default=None,
@@ -136,7 +136,7 @@ class Content(BaseModel):
     )
     key: str = Field(
         default="",
-        description="The key of the content. For documents this is the the filename",
+        description="The key of the content. For documents this is the filename",
     )
     title: str | None = Field(
         default=None,


### PR DESCRIPTION
## Summary

- The \`no-manual-release\` check already filtered \`github.actor == 'release-please[bot]'\` but any subsequent push to the release PR branch (e.g. our new \`update-release-lockfile\` job committing \`uv.lock\`) fires as \`github-actions[bot]\`, bypassing the filter — causing the check to see CHANGELOG and \`pyproject.toml\` version bumps and fail.
- Adds \`!startsWith(github.head_ref, 'release-please--')\` to skip the check on all release-please PRs regardless of which actor triggered the \`synchronize\` event.
- Also fixes two duplicate-word typos in \`content/schemas.py\` (\`"the the filename"\` → \`"the filename"\`) as a \`fix(unique-toolkit)\` commit that will exercise the lockfile regeneration job once this lands on main.

## Test plan

- [ ] Merge this PR
- [ ] Observe the release-please PR: \`no-manual-release\` should now show as **skipped** rather than failing

Refs: UN-18411

Made with [Cursor](https://cursor.com)