### PR TITLE
ci: simplify test pipelines — always use workspace, fix min-deps correctness

### DIFF
--- a/.github/actions/run-coverage-check/action.yml
+++ b/.github/actions/run-coverage-check/action.yml
@@ -13,13 +13,6 @@ inputs:
     description: 'Extra names to install (e.g., "--extra fastapi --extra monitoring")'
     required: false
     default: ''
-  use_workspace:
-    description: >
-      When true (default), workspace sources are used for all intra-monorepo
-      deps. Set to false only on release branches to validate that the package
-      resolves correctly against its declared bounds on PyPI.
-    required: false
-    default: 'true'
   base_ref:
     description: 'Base branch/ref for comparison'
     required: false
@@ -45,28 +38,6 @@ runs:
       run: |
         EXTRA_FLAGS=$(echo "${{ inputs.install_args }}" | grep -oP '(?<=--extra )\w+' | sed 's/^/--extra /' | paste -sd ' ' -)
         uv sync --locked --inexact $EXTRA_FLAGS
-
-    - name: Reinstall intra-monorepo deps from PyPI
-      if: inputs.use_workspace != 'true'
-      shell: bash
-      working-directory: ${{ inputs.package_dir }}
-      env:
-        UV_NO_SOURCES: 1
-      run: |
-        WORKSPACE_PKGS=$(python3 -c "
-        import tomllib
-        with open('pyproject.toml', 'rb') as f:
-            data = tomllib.load(f)
-        sources = data.get('tool', {}).get('uv', {}).get('sources', {})
-        pkgs = [name for name, src in sources.items() if src.get('workspace') or 'path' in src]
-        print(' '.join(pkgs))
-        ")
-        if [ -z "$WORKSPACE_PKGS" ]; then exit 0; fi
-        REINSTALL_ARGS=""
-        for pkg in $WORKSPACE_PKGS; do
-          REINSTALL_ARGS="$REINSTALL_ARGS --reinstall-package $pkg"
-        done
-        uv pip install $REINSTALL_ARGS .
 
     - name: Show installed unique-* packages
       shell: bash

--- a/.github/actions/run-min-tests-and-deptry/action.yml
+++ b/.github/actions/run-min-tests-and-deptry/action.yml
@@ -63,13 +63,18 @@ runs:
         # External deps stay at their lowest-direct versions; workspace packages
         # must always reflect current source code, not a stale PyPI snapshot.
         REPO_ROOT="${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel)}"
-        python3 - "$REPO_ROOT" <<'EOF'
-        import tomllib, pathlib, subprocess, sys
 
+        # Emit "<name>\t<path>" for every workspace member
+        while IFS=$'\t' read -r name path; do
+          [ -z "$name" ] && continue
+          if uv pip show "$name" >/dev/null 2>&1; then
+            uv pip install --no-deps -e "$path"
+          fi
+        done < <(python3 - "$REPO_ROOT" <<'EOF'
+        import tomllib, pathlib, sys
         repo_root = pathlib.Path(sys.argv[1])
         with open(repo_root / "pyproject.toml", "rb") as f:
             root = tomllib.load(f)
-
         members = root.get("tool", {}).get("uv", {}).get("workspace", {}).get("members", [])
         for pattern in members:
             for member_dir in sorted(repo_root.glob(pattern)):
@@ -79,18 +84,10 @@ runs:
                 with open(toml, "rb") as f:
                     data = tomllib.load(f)
                 name = data.get("project", {}).get("name", "")
-                # Only reinstall if the package is actually present in the venv
-                check = subprocess.run(
-                    [".venv/bin/pip", "show", name],
-                    cwd=repo_root,
-                    capture_output=True,
-                )
-                if check.returncode == 0:
-                    subprocess.run(
-                        ["uv", "pip", "install", "--no-deps", "-e", str(member_dir)],
-                        check=True,
-                    )
+                if name:
+                    print(f"{name}\t{member_dir}")
         EOF
+        )
 
     - name: Install dev tools
       shell: bash

--- a/.github/actions/run-min-tests-and-deptry/action.yml
+++ b/.github/actions/run-min-tests-and-deptry/action.yml
@@ -41,29 +41,6 @@ runs:
         # uv pip install is fully workspace-agnostic.
         uv venv --python "${{ inputs.python_version }}"
 
-        # Collect constraint-dependencies from all workspace members' pyproject.toml
-        # files (not just the current package). This ensures transitive constraints
-        # like lxml>=5.0.0 (defined in unique_toolkit) are applied even when
-        # installing unique_mcp which depends on toolkit indirectly.
-        REPO_ROOT="${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel)}"
-        python3 -c "
-        import tomllib, pathlib, sys
-        seen = set()
-        for p in pathlib.Path(sys.argv[1]).rglob('pyproject.toml'):
-            if '.venv' in p.parts or 'tutorials' in p.parts:
-                continue
-            data = tomllib.loads(p.read_text())
-            for dep in data.get('tool', {}).get('uv', {}).get('constraint-dependencies', []):
-                if dep not in seen:
-                    seen.add(dep)
-                    print(dep)
-        " "$REPO_ROOT" > /tmp/constraints.txt
-
-        CONSTRAINT_ARGS=""
-        if [ -s /tmp/constraints.txt ]; then
-          CONSTRAINT_ARGS="--constraint /tmp/constraints.txt"
-        fi
-
         EXTRAS=""
         for e in $(echo "${{ inputs.extras }}" | tr ',' ' '); do
           [ -n "$e" ] && EXTRAS="${EXTRAS:+$EXTRAS,}$e"
@@ -75,7 +52,7 @@ runs:
           PKG_SPEC="-e ."
         fi
 
-        uv pip install $PKG_SPEC --resolution lowest-direct $CONSTRAINT_ARGS
+        uv pip install $PKG_SPEC --resolution lowest-direct
 
     - name: Reinstall workspace packages from source
       shell: bash

--- a/.github/actions/run-min-tests-and-deptry/action.yml
+++ b/.github/actions/run-min-tests-and-deptry/action.yml
@@ -77,6 +77,44 @@ runs:
 
         uv pip install $PKG_SPEC --resolution lowest-direct $CONSTRAINT_ARGS
 
+    - name: Reinstall workspace packages from source
+      shell: bash
+      working-directory: ${{ inputs.package_dir }}
+      env:
+        VIRTUAL_ENV: ${{ github.workspace }}/${{ inputs.package_dir }}/.venv
+      run: |
+        # External deps stay at their lowest-direct versions; workspace packages
+        # must always reflect current source code, not a stale PyPI snapshot.
+        REPO_ROOT="${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel)}"
+        python3 - "$REPO_ROOT" <<'EOF'
+        import tomllib, pathlib, subprocess, sys
+
+        repo_root = pathlib.Path(sys.argv[1])
+        with open(repo_root / "pyproject.toml", "rb") as f:
+            root = tomllib.load(f)
+
+        members = root.get("tool", {}).get("uv", {}).get("workspace", {}).get("members", [])
+        for pattern in members:
+            for member_dir in sorted(repo_root.glob(pattern)):
+                toml = member_dir / "pyproject.toml"
+                if not toml.exists():
+                    continue
+                with open(toml, "rb") as f:
+                    data = tomllib.load(f)
+                name = data.get("project", {}).get("name", "")
+                # Only reinstall if the package is actually present in the venv
+                check = subprocess.run(
+                    [".venv/bin/pip", "show", name],
+                    cwd=repo_root,
+                    capture_output=True,
+                )
+                if check.returncode == 0:
+                    subprocess.run(
+                        ["uv", "pip", "install", "-e", str(member_dir)],
+                        check=True,
+                    )
+        EOF
+
     - name: Install dev tools
       shell: bash
       working-directory: ${{ inputs.package_dir }}

--- a/.github/actions/run-min-tests-and-deptry/action.yml
+++ b/.github/actions/run-min-tests-and-deptry/action.yml
@@ -106,7 +106,7 @@ runs:
       working-directory: ${{ inputs.package_dir }}
       env:
         VIRTUAL_ENV: ${{ github.workspace }}/${{ inputs.package_dir }}/.venv
-      run: .venv/bin/pip list
+      run: uv pip list
 
     - name: Run deptry
       shell: bash

--- a/.github/actions/run-min-tests-and-deptry/action.yml
+++ b/.github/actions/run-min-tests-and-deptry/action.yml
@@ -127,12 +127,12 @@ runs:
         # Package-level dev group: package-specific test deps (e.g. responses for unique_six)
         uv export --frozen --only-group dev --no-hashes 2>/dev/null | uv pip install -r - 2>/dev/null || true
 
-    - name: Show installed unique-* packages
+    - name: Show installed packages
       shell: bash
       working-directory: ${{ inputs.package_dir }}
       env:
         VIRTUAL_ENV: ${{ github.workspace }}/${{ inputs.package_dir }}/.venv
-      run: .venv/bin/pip list | grep -i unique || true
+      run: .venv/bin/pip list
 
     - name: Run deptry
       shell: bash

--- a/.github/actions/run-min-tests-and-deptry/action.yml
+++ b/.github/actions/run-min-tests-and-deptry/action.yml
@@ -110,7 +110,7 @@ runs:
                 )
                 if check.returncode == 0:
                     subprocess.run(
-                        ["uv", "pip", "install", "-e", str(member_dir)],
+                        ["uv", "pip", "install", "--no-deps", "-e", str(member_dir)],
                         check=True,
                     )
         EOF

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -17,14 +17,6 @@ inputs:
     description: 'Additional arguments to pass to pytest'
     required: false
     default: ''
-  use_workspace:
-    description: >
-      When true (default), workspace sources are used for all intra-monorepo
-      deps. Set to false only on release branches to validate that the package
-      resolves correctly against its declared bounds on PyPI.
-    required: false
-    default: 'true'
-
 runs:
   using: 'composite'
   steps:
@@ -42,30 +34,6 @@ runs:
         EXTRA_FLAGS=$(echo "${{ inputs.install_args }}" | grep -oP '(?<=--extra )\w+' | sed 's/^/--extra /' | paste -sd ' ' -)
         uv sync --locked --inexact $EXTRA_FLAGS
 
-    - name: Reinstall intra-monorepo deps from PyPI
-      if: inputs.use_workspace != 'true'
-      shell: bash
-      working-directory: ${{ inputs.package_dir }}
-      env:
-        UV_NO_SOURCES: 1
-      run: |
-        # On release branches, replace workspace-sourced intra-monorepo deps with
-        # their published PyPI versions to validate the declared version bounds.
-        WORKSPACE_PKGS=$(python3 -c "
-        import tomllib
-        with open('pyproject.toml', 'rb') as f:
-            data = tomllib.load(f)
-        sources = data.get('tool', {}).get('uv', {}).get('sources', {})
-        pkgs = [name for name, src in sources.items() if src.get('workspace') or 'path' in src]
-        print(' '.join(pkgs))
-        ")
-        if [ -z "$WORKSPACE_PKGS" ]; then exit 0; fi
-        REINSTALL_ARGS=""
-        for pkg in $WORKSPACE_PKGS; do
-          REINSTALL_ARGS="$REINSTALL_ARGS --reinstall-package $pkg"
-        done
-        uv pip install $REINSTALL_ARGS .
-
     - name: Show installed unique-* packages
       shell: bash
       working-directory: ${{ inputs.package_dir }}
@@ -74,6 +42,4 @@ runs:
     - name: Run pytest
       shell: bash
       working-directory: ${{ inputs.package_dir }}
-      env:
-        UV_NO_SOURCES: 1
       run: uv run pytest ${{ inputs.test_args }}

--- a/.github/workflows/ci-coverage.yaml
+++ b/.github/workflows/ci-coverage.yaml
@@ -86,6 +86,5 @@ jobs:
           package_dir: ${{ matrix.dir }}
           python_version: ${{ matrix.python }}
           install_args: ${{ matrix.install_args }}
-          use_workspace: ${{ !startsWith(github.head_ref || github.ref_name, 'release-please--') }}
           base_ref: origin/${{ github.base_ref || 'main' }}
           min_coverage: ${{ matrix.min_coverage }}

--- a/.github/workflows/ci-pytest.yaml
+++ b/.github/workflows/ci-pytest.yaml
@@ -82,4 +82,3 @@ jobs:
           python_version: ${{ matrix.python }}
           install_args: ${{ matrix.install_args }}
           test_args: ${{ matrix.test_args }}
-          use_workspace: ${{ !startsWith(github.head_ref || github.ref_name, 'release-please--') }}


### PR DESCRIPTION
## Summary
- Drop the \`use_workspace\` flag from \`run-tests\` and \`run-coverage-check\`: there is no scenario where CI should test against PyPI versions instead of workspace source.
- Fix \`run-min-tests-and-deptry\`: workspace packages were being pulled from PyPI at potentially stale minimum versions; they are now reinstalled from source with \`--no-deps\` so external deps stay at their lowest-direct versions while workspace deps always reflect current code.
- Remove the \`constraint-dependencies\` collection from min-deps tests so the floor is set strictly by the package under test, not by other workspace members.

## Changes

### \`.github/actions/run-tests/action.yml\`
- Removed \`use_workspace\` input and the "Reinstall intra-monorepo deps from PyPI" step
- Removed \`UV_NO_SOURCES: 1\` from the pytest step

### \`.github/actions/run-coverage-check/action.yml\`
- Same removals as \`run-tests\`

### \`.github/workflows/ci-pytest.yaml\` / \`ci-coverage.yaml\`
- Removed \`use_workspace\` pass-through

### \`.github/actions/run-min-tests-and-deptry/action.yml\`
- Added "Reinstall workspace packages from source" step after \`--resolution lowest-direct\` install: iterates workspace members via the root \`pyproject.toml\`, checks with \`uv pip show\` if installed, reinstalls with \`uv pip install --no-deps -e <path>\` (keeps external deps at minimum versions, workspace deps at current source)
- Removed constraint-dependencies collection so the install floor is set strictly by the package under test
- Changed "Show installed unique-* packages" to \`uv pip list\` (full list for easier debugging when min-deps fails)

## Test plan
- [ ] \`[CI] Dependencies\` (min-deps/deptry) passes for toolkit — dispatched manually since this PR only touches \`.github/\` files and change detection skips package jobs automatically
- [ ] \`[CI] Test\` (pytest) passes for toolkit — same, dispatched manually

## Risk / rollout
- The \`use_workspace\` removal is safe: workspace sources were already the default and the release-branch override path was the only consumer of \`use_workspace: false\`.
- Min-deps tests may now surface new failures if a workspace package currently relies on a feature not present in the minimum declared version of an external dep — these are real signal, not regressions.