### PR TITLE
feat(code_interpreter): Add option to specify files that will be always available for code execution

### DIFF
--- a/unique_toolkit/tests/agentic/tools/test_code_interpreter_service.py
+++ b/unique_toolkit/tests/agentic/tools/test_code_interpreter_service.py
@@ -751,9 +751,7 @@ async def test_check_container_exists__returns_false__when_not_found() -> None:
 
 @pytest.mark.ai
 @pytest.mark.asyncio
-async def test_check_container_exists__returns_false__when_status_is_not_live() -> (
-    None
-):
+async def test_check_container_exists__returns_false__when_status_is_not_live() -> None:
     """
     Purpose: Verify that a container in a non-live status (e.g. ``expired``) is treated
     as missing so the caller recreates it.
@@ -823,9 +821,7 @@ async def test_upload_files_to_container__isolates_failures__one_file_fails_othe
     Setup summary: Two files; downloader raises for ``bad``, returns bytes for ``good``.
     Assert only the good one lands in memory.file_ids and ``updated`` is True.
     """
-    memory = CodeExecutionShortTermMemorySchema(
-        container_id="ctr_isolate", file_ids={}
-    )
+    memory = CodeExecutionShortTermMemorySchema(container_id="ctr_isolate", file_ids={})
     good = Content(id="cont_good", key="good.csv")
     bad = Content(id="cont_bad", key="bad.csv")
 

--- a/unique_toolkit/tests/agentic/tools/test_code_interpreter_service.py
+++ b/unique_toolkit/tests/agentic/tools/test_code_interpreter_service.py
@@ -13,6 +13,8 @@ from unique_toolkit.agentic.tools.openai_builtin.code_interpreter.config import 
 from unique_toolkit.agentic.tools.openai_builtin.code_interpreter.service import (
     CodeExecutionShortTermMemorySchema,
     OpenAICodeInterpreterTool,
+    _resolve_kb_contents,
+    _upload_file_to_container,
     _upload_files_to_container,
 )
 from unique_toolkit.content.schemas import Content
@@ -284,13 +286,11 @@ async def test_upload_files_to_container__downloads_and_creates__when_file_not_i
         uploaded_files=[uploaded],
         memory=memory,
         content_service=content_service,
-        chat_id="chat_1",
     )
 
     assert result.file_ids["cont_upload_1"] == "file_openai_1"
     content_service.download_content_to_bytes_async.assert_awaited_once_with(
         content_id="cont_upload_1",
-        chat_id="chat_1",
     )
     files_create.assert_awaited_once()
     assert files_create.await_args.kwargs["container_id"] == "ctr_test"
@@ -326,9 +326,336 @@ async def test_upload_files_to_container__retries_download__after_transient_erro
         uploaded_files=[uploaded],
         memory=memory,
         content_service=content_service,
-        chat_id="chat_retry",
     )
 
     assert result.file_ids["cont_retry_1"] == "file_after_retry"
     assert content_service.download_content_to_bytes_async.await_count == 2
     files_create.assert_awaited_once()
+
+
+# ============================================================================
+# Tests for deduplication, skip-if-already-uploaded, and KB content resolution
+# ============================================================================
+
+
+@pytest.mark.ai
+@pytest.mark.asyncio
+async def test_upload_files_to_container__deduplicates_by_content_id__when_duplicates_present() -> (
+    None
+):
+    """
+    Purpose: Verify that _upload_files_to_container only downloads/uploads each unique
+    content id once, even when the input list contains duplicates.
+    Why this matters: Duplicates can arise from merging chat-uploaded files with
+    additional_uploaded_documents. Re-uploading wastes bandwidth and quota.
+    Setup summary: Pass a list with two entries sharing the same id; assert download
+    and containers.files.create are each awaited exactly once.
+    """
+    memory = CodeExecutionShortTermMemorySchema(container_id="ctr_dedup", file_ids={})
+    duplicate = Content(id="cont_dup", key="dup.csv")
+    content_service = MagicMock()
+    content_service.download_content_to_bytes_async = AsyncMock(return_value=b"x")
+    openai_file = MagicMock()
+    openai_file.id = "file_dup"
+    files_create = AsyncMock(return_value=openai_file)
+    client = MagicMock()
+    client.containers.files.create = files_create
+
+    result = await _upload_files_to_container(
+        client=client,
+        uploaded_files=[duplicate, duplicate],
+        memory=memory,
+        content_service=content_service,
+    )
+
+    assert result.file_ids == {"cont_dup": "file_dup"}
+    assert content_service.download_content_to_bytes_async.await_count == 1
+    files_create.assert_awaited_once()
+
+
+@pytest.mark.ai
+@pytest.mark.asyncio
+async def test_upload_file_to_container__skips_upload__when_already_present_in_container() -> (
+    None
+):
+    """
+    Purpose: Verify that _upload_file_to_container short-circuits when memory already
+    maps the content id to a container file and containers.files.retrieve succeeds.
+    Why this matters: Avoids redundant uploads on repeated tool builds within a chat.
+    Setup summary: Pre-populate memory.file_ids; stub retrieve to return a file; assert
+    no download or create is attempted.
+    """
+    memory = CodeExecutionShortTermMemorySchema(
+        container_id="ctr_skip",
+        file_ids={"cont_skip": "file_existing"},
+    )
+    content_service = MagicMock()
+    content_service.download_content_to_bytes_async = AsyncMock()
+    client = MagicMock()
+    client.containers.files.retrieve = AsyncMock(return_value=MagicMock())
+    client.containers.files.create = AsyncMock()
+
+    await _upload_file_to_container(
+        client=client,
+        content_id="cont_skip",
+        filename="skip.csv",
+        memory=memory,
+        content_service=content_service,
+    )
+
+    client.containers.files.retrieve.assert_awaited_once_with(
+        container_id="ctr_skip", file_id="file_existing"
+    )
+    content_service.download_content_to_bytes_async.assert_not_awaited()
+    client.containers.files.create.assert_not_awaited()
+    assert memory.file_ids == {"cont_skip": "file_existing"}
+
+
+@pytest.mark.ai
+@pytest.mark.asyncio
+async def test_upload_file_to_container__reuploads__when_retrieve_raises_not_found() -> (
+    None
+):
+    """
+    Purpose: Verify that when the cached container file id no longer exists (NotFoundError
+    from retrieve), the file is re-downloaded and re-uploaded and memory is refreshed.
+    Why this matters: Container files expire; stale memory entries must not permanently
+    block re-uploads.
+    Setup summary: Seed memory with a stale mapping; retrieve raises NotFoundError;
+    create returns a new file; assert memory is updated with the new openai file id.
+    """
+    from httpx import Request, Response
+    from openai import NotFoundError
+
+    memory = CodeExecutionShortTermMemorySchema(
+        container_id="ctr_stale",
+        file_ids={"cont_stale": "file_gone"},
+    )
+    content_service = MagicMock()
+    content_service.download_content_to_bytes_async = AsyncMock(return_value=b"bytes")
+    new_file = MagicMock()
+    new_file.id = "file_new"
+    not_found = NotFoundError(
+        message="gone",
+        response=Response(404, request=Request("GET", "https://x")),
+        body=None,
+    )
+    client = MagicMock()
+    client.containers.files.retrieve = AsyncMock(side_effect=not_found)
+    client.containers.files.create = AsyncMock(return_value=new_file)
+
+    await _upload_file_to_container(
+        client=client,
+        content_id="cont_stale",
+        filename="stale.csv",
+        memory=memory,
+        content_service=content_service,
+    )
+
+    content_service.download_content_to_bytes_async.assert_awaited_once_with(
+        content_id="cont_stale",
+    )
+    client.containers.files.create.assert_awaited_once()
+    assert memory.file_ids["cont_stale"] == "file_new"
+
+
+@pytest.mark.ai
+@pytest.mark.asyncio
+async def test_resolve_kb_contents__returns_search_results__and_queries_by_id_in() -> (
+    None
+):
+    """
+    Purpose: Verify _resolve_kb_contents delegates to ContentService.search_contents_async
+    with a ``{"id": {"in": [...]}}`` filter and returns the resulting contents.
+    Why this matters: This is the KB lookup for additional_uploaded_documents; a wrong
+    filter shape would silently return nothing and break operator-configured templates.
+    Setup summary: Stub search_contents_async to return two Contents; assert the call
+    shape and the returned list.
+    """
+    found = [Content(id="cont_a", key="a.csv"), Content(id="cont_b", key="b.csv")]
+    content_service = MagicMock()
+    content_service.search_contents_async = AsyncMock(return_value=found)
+
+    result = await _resolve_kb_contents(
+        content_service=content_service,
+        content_ids=["cont_a", "cont_b"],
+    )
+
+    assert result == found
+    content_service.search_contents_async.assert_awaited_once_with(
+        where={"id": {"in": ["cont_a", "cont_b"]}},
+    )
+
+
+@pytest.mark.ai
+@pytest.mark.asyncio
+async def test_resolve_kb_contents__logs_warning_and_returns_partial__when_some_ids_missing(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    Purpose: Verify that when search_contents_async returns fewer contents than requested,
+    _resolve_kb_contents logs a warning naming the missing ids and returns whatever was found.
+    Why this matters: Operators need visibility when a configured template/content id is not
+    accessible; silently ignoring would make misconfigurations invisible in production.
+    Setup summary: Search returns only one of two requested ids; assert warning contains
+    the missing id and the returned list matches the search result.
+    """
+    found = [Content(id="cont_present", key="p.csv")]
+    content_service = MagicMock()
+    content_service.search_contents_async = AsyncMock(return_value=found)
+
+    with caplog.at_level(
+        "WARNING",
+        logger="unique_toolkit.agentic.tools.openai_builtin.code_interpreter.service",
+    ):
+        result = await _resolve_kb_contents(
+            content_service=content_service,
+            content_ids=["cont_present", "cont_missing"],
+        )
+
+    assert result == found
+    assert any(
+        "cont_missing" in record.message
+        and "additional_uploaded_documents" in record.message
+        for record in caplog.records
+    )
+
+
+# ============================================================================
+# Tests for build_tool integration with additional_uploaded_documents
+# ============================================================================
+
+
+@pytest.mark.ai
+@pytest.mark.asyncio
+async def test_build_tool__uploads_kb_documents__when_additional_uploaded_documents_set() -> (
+    None
+):
+    """
+    Purpose: End-to-end check that build_tool resolves KB content ids listed in
+    ``additional_uploaded_documents`` and forwards them to the upload path, while
+    also including chat-uploaded files when ``upload_files_in_chat_to_container`` is on.
+    Why this matters: This is the feature's integration seam; a regression here would
+    silently drop template/always-available files from operator configs.
+    Setup summary: Configure both sources; patch the container-creation and upload
+    helpers; assert the upload helper is called with the union of files.
+    """
+    config = OpenAICodeInterpreterConfig(
+        use_auto_container=False,
+        upload_files_in_chat_to_container=True,
+        additional_uploaded_documents=["cont_kb1"],
+    )
+    chat_file = Content(id="cont_chat1", key="chat.csv")
+    kb_file = Content(id="cont_kb1", key="template.csv")
+
+    content_service = MagicMock()
+    content_service.search_contents_async = AsyncMock(return_value=[kb_file])
+
+    memory_after_create = CodeExecutionShortTermMemorySchema(
+        container_id="ctr_built", file_ids={}
+    )
+    memory_manager = MagicMock()
+    memory_manager.load_async = AsyncMock(return_value=None)
+    memory_manager.save_async = AsyncMock()
+
+    service_mod = "unique_toolkit.agentic.tools.openai_builtin.code_interpreter.service"
+    with (
+        patch(
+            f"{service_mod}._get_container_code_execution_short_term_memory_manager",
+            return_value=memory_manager,
+        ),
+        patch(
+            f"{service_mod}._create_container_if_not_exists",
+            AsyncMock(return_value=memory_after_create),
+        ),
+        patch(
+            f"{service_mod}._upload_files_to_container",
+            AsyncMock(return_value=memory_after_create),
+        ) as mock_upload,
+    ):
+        tool = await OpenAICodeInterpreterTool.build_tool(
+            config=config,
+            uploaded_files=[chat_file],
+            client=MagicMock(),
+            content_service=content_service,
+            company_id="co",
+            user_id="u",
+            chat_id="c",
+        )
+
+    assert tool._container_id == "ctr_built"
+    mock_upload.assert_awaited_once()
+    passed_files = mock_upload.await_args.kwargs["uploaded_files"]
+    assert [f.id for f in passed_files] == ["cont_chat1", "cont_kb1"]
+    content_service.search_contents_async.assert_awaited_once_with(
+        where={"id": {"in": ["cont_kb1"]}},
+    )
+
+
+@pytest.mark.ai
+@pytest.mark.asyncio
+async def test_build_tool__skips_upload__when_no_sources_enabled() -> None:
+    """
+    Purpose: Verify build_tool does not invoke the upload helper when neither
+    ``upload_files_in_chat_to_container`` nor ``additional_uploaded_documents`` supplies files.
+    Why this matters: Avoids redundant work and KB lookups for the common empty-config case.
+    Setup summary: Pass no chat files and no KB document ids; assert _upload_files_to_container
+    and search_contents_async are never called.
+    """
+    config = OpenAICodeInterpreterConfig(
+        use_auto_container=False,
+        upload_files_in_chat_to_container=False,
+        additional_uploaded_documents=[],
+    )
+
+    content_service = MagicMock()
+    content_service.search_contents_async = AsyncMock()
+
+    memory_after_create = CodeExecutionShortTermMemorySchema(
+        container_id="ctr_empty", file_ids={}
+    )
+    memory_manager = MagicMock()
+    memory_manager.load_async = AsyncMock(return_value=None)
+    memory_manager.save_async = AsyncMock()
+
+    service_mod = "unique_toolkit.agentic.tools.openai_builtin.code_interpreter.service"
+    with (
+        patch(
+            f"{service_mod}._get_container_code_execution_short_term_memory_manager",
+            return_value=memory_manager,
+        ),
+        patch(
+            f"{service_mod}._create_container_if_not_exists",
+            AsyncMock(return_value=memory_after_create),
+        ),
+        patch(
+            f"{service_mod}._upload_files_to_container",
+            AsyncMock(return_value=memory_after_create),
+        ) as mock_upload,
+    ):
+        tool = await OpenAICodeInterpreterTool.build_tool(
+            config=config,
+            uploaded_files=[],
+            client=MagicMock(),
+            content_service=content_service,
+            company_id="co",
+            user_id="u",
+            chat_id="c",
+        )
+
+    assert tool._container_id == "ctr_empty"
+    mock_upload.assert_not_awaited()
+    content_service.search_contents_async.assert_not_awaited()
+
+
+@pytest.mark.ai
+def test_config__additional_uploaded_documents__defaults_to_empty_list() -> None:
+    """
+    Purpose: Verify that OpenAICodeInterpreterConfig.additional_uploaded_documents defaults
+    to an empty list so existing configs keep their prior behaviour.
+    Why this matters: This field was added as an additive change; an unexpected default
+    would retroactively enable KB lookups for every deployment.
+    Setup summary: Construct a config with no explicit value; assert the field is [].
+    """
+    config = OpenAICodeInterpreterConfig()
+    assert config.additional_uploaded_documents == []

--- a/unique_toolkit/tests/agentic/tools/test_code_interpreter_service.py
+++ b/unique_toolkit/tests/agentic/tools/test_code_interpreter_service.py
@@ -13,6 +13,9 @@ from unique_toolkit.agentic.tools.openai_builtin.code_interpreter.config import 
 from unique_toolkit.agentic.tools.openai_builtin.code_interpreter.service import (
     CodeExecutionShortTermMemorySchema,
     OpenAICodeInterpreterTool,
+    _check_container_exists,
+    _check_file_already_uploaded,
+    _create_container,
     _resolve_kb_contents,
     _upload_file_to_container,
     _upload_files_to_container,
@@ -281,13 +284,14 @@ async def test_upload_files_to_container__downloads_and_creates__when_file_not_i
     client = MagicMock()
     client.containers.files.create = files_create
 
-    result = await _upload_files_to_container(
+    result, updated = await _upload_files_to_container(
         client=client,
         uploaded_files=[uploaded],
         memory=memory,
         content_service=content_service,
     )
 
+    assert updated is True
     assert result.file_ids["cont_upload_1"] == "file_openai_1"
     content_service.download_content_to_bytes_async.assert_awaited_once_with(
         content_id="cont_upload_1",
@@ -321,13 +325,14 @@ async def test_upload_files_to_container__retries_download__after_transient_erro
     client = MagicMock()
     client.containers.files.create = files_create
 
-    result = await _upload_files_to_container(
+    result, updated = await _upload_files_to_container(
         client=client,
         uploaded_files=[uploaded],
         memory=memory,
         content_service=content_service,
     )
 
+    assert updated is True
     assert result.file_ids["cont_retry_1"] == "file_after_retry"
     assert content_service.download_content_to_bytes_async.await_count == 2
     files_create.assert_awaited_once()
@@ -361,13 +366,14 @@ async def test_upload_files_to_container__deduplicates_by_content_id__when_dupli
     client = MagicMock()
     client.containers.files.create = files_create
 
-    result = await _upload_files_to_container(
+    result, updated = await _upload_files_to_container(
         client=client,
         uploaded_files=[duplicate, duplicate],
         memory=memory,
         content_service=content_service,
     )
 
+    assert updated is True
     assert result.file_ids == {"cont_dup": "file_dup"}
     assert content_service.download_content_to_bytes_async.await_count == 1
     files_create.assert_awaited_once()
@@ -375,88 +381,108 @@ async def test_upload_files_to_container__deduplicates_by_content_id__when_dupli
 
 @pytest.mark.ai
 @pytest.mark.asyncio
-async def test_upload_file_to_container__skips_upload__when_already_present_in_container() -> (
+async def test_check_file_already_uploaded__returns_true__when_retrieve_succeeds() -> (
     None
 ):
     """
-    Purpose: Verify that _upload_file_to_container short-circuits when memory already
-    maps the content id to a container file and containers.files.retrieve succeeds.
-    Why this matters: Avoids redundant uploads on repeated tool builds within a chat.
-    Setup summary: Pre-populate memory.file_ids; stub retrieve to return a file; assert
-    no download or create is attempted.
+    Purpose: Verify that _check_file_already_uploaded returns True when memory has a
+    mapping for the content id and containers.files.retrieve succeeds.
+    Why this matters: This is the short-circuit that avoids redundant uploads on
+    repeated tool builds within a chat.
     """
     memory = CodeExecutionShortTermMemorySchema(
         container_id="ctr_skip",
         file_ids={"cont_skip": "file_existing"},
     )
-    content_service = MagicMock()
-    content_service.download_content_to_bytes_async = AsyncMock()
     client = MagicMock()
     client.containers.files.retrieve = AsyncMock(return_value=MagicMock())
-    client.containers.files.create = AsyncMock()
 
-    await _upload_file_to_container(
-        client=client,
-        content_id="cont_skip",
-        filename="skip.csv",
-        memory=memory,
-        content_service=content_service,
+    result = await _check_file_already_uploaded(
+        client=client, content_id="cont_skip", memory=memory
     )
 
+    assert result is True
     client.containers.files.retrieve.assert_awaited_once_with(
         container_id="ctr_skip", file_id="file_existing"
     )
-    content_service.download_content_to_bytes_async.assert_not_awaited()
-    client.containers.files.create.assert_not_awaited()
-    assert memory.file_ids == {"cont_skip": "file_existing"}
 
 
 @pytest.mark.ai
 @pytest.mark.asyncio
-async def test_upload_file_to_container__reuploads__when_retrieve_raises_not_found() -> (
+async def test_upload_files_to_container__reuploads__when_retrieve_raises_error() -> (
     None
 ):
     """
-    Purpose: Verify that when the cached container file id no longer exists (NotFoundError
-    from retrieve), the file is re-downloaded and re-uploaded and memory is refreshed.
+    Purpose: Verify that when the cached container file id no longer exists (the retrieve
+    call raises), _upload_files_to_container re-downloads and re-uploads the file and
+    records the new openai file id in memory.
     Why this matters: Container files expire; stale memory entries must not permanently
     block re-uploads.
-    Setup summary: Seed memory with a stale mapping; retrieve raises NotFoundError;
-    create returns a new file; assert memory is updated with the new openai file id.
+    Setup summary: Seed memory with a stale mapping; retrieve raises OpenAIError; create
+    returns a new file; assert memory is updated with the new openai file id.
     """
-    from httpx import Request, Response
-    from openai import NotFoundError
+    from openai import OpenAIError
 
     memory = CodeExecutionShortTermMemorySchema(
         container_id="ctr_stale",
         file_ids={"cont_stale": "file_gone"},
     )
+    stale = Content(id="cont_stale", key="stale.csv")
     content_service = MagicMock()
     content_service.download_content_to_bytes_async = AsyncMock(return_value=b"bytes")
     new_file = MagicMock()
     new_file.id = "file_new"
-    not_found = NotFoundError(
-        message="gone",
-        response=Response(404, request=Request("GET", "https://x")),
-        body=None,
-    )
     client = MagicMock()
-    client.containers.files.retrieve = AsyncMock(side_effect=not_found)
+    client.containers.files.retrieve = AsyncMock(side_effect=OpenAIError("gone"))
     client.containers.files.create = AsyncMock(return_value=new_file)
 
-    await _upload_file_to_container(
+    result, updated = await _upload_files_to_container(
         client=client,
-        content_id="cont_stale",
-        filename="stale.csv",
+        uploaded_files=[stale],
         memory=memory,
         content_service=content_service,
     )
 
+    assert updated is True
+    assert result.file_ids["cont_stale"] == "file_new"
     content_service.download_content_to_bytes_async.assert_awaited_once_with(
         content_id="cont_stale",
     )
     client.containers.files.create.assert_awaited_once()
-    assert memory.file_ids["cont_stale"] == "file_new"
+
+
+@pytest.mark.ai
+@pytest.mark.asyncio
+async def test_upload_file_to_container__returns_new_file_id__on_successful_upload() -> (
+    None
+):
+    """
+    Purpose: Verify _upload_file_to_container downloads content and creates a container
+    file, returning the new openai file id.
+    """
+    content_service = MagicMock()
+    content_service.download_content_to_bytes_async = AsyncMock(return_value=b"data")
+    openai_file = MagicMock()
+    openai_file.id = "file_created"
+    client = MagicMock()
+    client.containers.files.create = AsyncMock(return_value=openai_file)
+
+    file_id = await _upload_file_to_container(
+        client=client,
+        content_id="cont_new",
+        filename="new.csv",
+        content_service=content_service,
+        container_id="ctr_upload",
+    )
+
+    assert file_id == "file_created"
+    content_service.download_content_to_bytes_async.assert_awaited_once_with(
+        content_id="cont_new",
+    )
+    client.containers.files.create.assert_awaited_once()
+    assert client.containers.files.create.await_args.kwargs["container_id"] == (
+        "ctr_upload"
+    )
 
 
 @pytest.mark.ai
@@ -565,12 +591,16 @@ async def test_build_tool__uploads_kb_documents__when_additional_uploaded_docume
             return_value=memory_manager,
         ),
         patch(
-            f"{service_mod}._create_container_if_not_exists",
-            AsyncMock(return_value=memory_after_create),
+            f"{service_mod}._check_container_exists",
+            AsyncMock(return_value=False),
+        ),
+        patch(
+            f"{service_mod}._create_container",
+            AsyncMock(return_value="ctr_built"),
         ),
         patch(
             f"{service_mod}._upload_files_to_container",
-            AsyncMock(return_value=memory_after_create),
+            AsyncMock(return_value=(memory_after_create, True)),
         ) as mock_upload,
     ):
         tool = await OpenAICodeInterpreterTool.build_tool(
@@ -625,12 +655,16 @@ async def test_build_tool__skips_upload__when_no_sources_enabled() -> None:
             return_value=memory_manager,
         ),
         patch(
-            f"{service_mod}._create_container_if_not_exists",
-            AsyncMock(return_value=memory_after_create),
+            f"{service_mod}._check_container_exists",
+            AsyncMock(return_value=False),
+        ),
+        patch(
+            f"{service_mod}._create_container",
+            AsyncMock(return_value="ctr_empty"),
         ),
         patch(
             f"{service_mod}._upload_files_to_container",
-            AsyncMock(return_value=memory_after_create),
+            AsyncMock(return_value=(memory_after_create, True)),
         ) as mock_upload,
     ):
         tool = await OpenAICodeInterpreterTool.build_tool(
@@ -659,3 +693,385 @@ def test_config__additional_uploaded_documents__defaults_to_empty_list() -> None
     """
     config = OpenAICodeInterpreterConfig()
     assert config.additional_uploaded_documents == []
+
+
+# ============================================================================
+# Tests for _check_container_exists (status + NotFoundError handling)
+# ============================================================================
+
+
+@pytest.mark.ai
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", ["active", "running"])
+async def test_check_container_exists__returns_true__when_status_is_live(
+    status: str,
+) -> None:
+    """
+    Purpose: Verify _check_container_exists returns True for the two live container
+    statuses (``active`` and ``running``).
+    Why this matters: These are the only statuses where the cached container id can
+    be reused; anything else must trigger a recreate.
+    """
+    memory = CodeExecutionShortTermMemorySchema(container_id="ctr_live")
+    container = MagicMock()
+    container.status = status
+    client = MagicMock()
+    client.containers.retrieve = AsyncMock(return_value=container)
+
+    result = await _check_container_exists(client=client, memory=memory)
+
+    assert result is True
+    client.containers.retrieve.assert_awaited_once_with("ctr_live")
+
+
+@pytest.mark.ai
+@pytest.mark.asyncio
+async def test_check_container_exists__returns_false__when_not_found() -> None:
+    """
+    Purpose: Verify _check_container_exists returns False when the container id in
+    memory no longer exists (NotFoundError from the OpenAI client).
+    Why this matters: Containers expire; stale memory must not block rebuilding.
+    """
+    from httpx import Request, Response
+    from openai import NotFoundError
+
+    memory = CodeExecutionShortTermMemorySchema(container_id="ctr_gone")
+    not_found = NotFoundError(
+        message="gone",
+        response=Response(404, request=Request("GET", "https://x")),
+        body=None,
+    )
+    client = MagicMock()
+    client.containers.retrieve = AsyncMock(side_effect=not_found)
+
+    result = await _check_container_exists(client=client, memory=memory)
+
+    assert result is False
+
+
+@pytest.mark.ai
+@pytest.mark.asyncio
+async def test_check_container_exists__returns_false__when_status_is_not_live() -> (
+    None
+):
+    """
+    Purpose: Verify that a container in a non-live status (e.g. ``expired``) is treated
+    as missing so the caller recreates it.
+    """
+    memory = CodeExecutionShortTermMemorySchema(container_id="ctr_expired")
+    container = MagicMock()
+    container.status = "expired"
+    client = MagicMock()
+    client.containers.retrieve = AsyncMock(return_value=container)
+
+    result = await _check_container_exists(client=client, memory=memory)
+
+    assert result is False
+
+
+# ============================================================================
+# Tests for _create_container (name format + expires_after payload)
+# ============================================================================
+
+
+@pytest.mark.ai
+@pytest.mark.asyncio
+async def test_create_container__uses_scoped_name_and_expires_after() -> None:
+    """
+    Purpose: Verify _create_container calls ``containers.create`` with the scoped name
+    ``code_execution_{company}_{user}_{chat}`` and an ``expires_after`` payload anchored
+    at ``last_active_at`` with the configured minutes, and returns the new container id.
+    Why this matters: The scoped name is what isolates containers per chat; wrong
+    wiring would leak data across chats or users.
+    """
+    container = MagicMock()
+    container.id = "ctr_created"
+    client = MagicMock()
+    client.containers.create = AsyncMock(return_value=container)
+
+    result = await _create_container(
+        client=client,
+        chat_id="chat-1",
+        user_id="user-1",
+        company_id="company-1",
+        expires_after_minutes=15,
+    )
+
+    assert result == "ctr_created"
+    client.containers.create.assert_awaited_once_with(
+        name="code_execution_company-1_user-1_chat-1",
+        expires_after={"anchor": "last_active_at", "minutes": 15},
+    )
+
+
+# ============================================================================
+# Tests for failure isolation in _upload_files_to_container
+# ============================================================================
+
+
+@pytest.mark.ai
+@pytest.mark.asyncio
+async def test_upload_files_to_container__isolates_failures__one_file_fails_others_succeed() -> (
+    None
+):
+    """
+    Purpose: Verify that when one file's upload raises, sibling uploads still complete
+    and the successful ids are recorded in memory.
+    Why this matters: This is the reason ``SafeTaskExecutor`` replaced a bare
+    ``asyncio.gather``; without isolation one bad file would cancel every other upload
+    in the batch.
+    Setup summary: Two files; downloader raises for ``bad``, returns bytes for ``good``.
+    Assert only the good one lands in memory.file_ids and ``updated`` is True.
+    """
+    memory = CodeExecutionShortTermMemorySchema(
+        container_id="ctr_isolate", file_ids={}
+    )
+    good = Content(id="cont_good", key="good.csv")
+    bad = Content(id="cont_bad", key="bad.csv")
+
+    async def download(*, content_id: str) -> bytes:
+        if content_id == "cont_bad":
+            raise RuntimeError("download boom")
+        return b"good bytes"
+
+    content_service = MagicMock()
+    content_service.download_content_to_bytes_async = AsyncMock(side_effect=download)
+    openai_file = MagicMock()
+    openai_file.id = "file_good"
+    client = MagicMock()
+    client.containers.files.create = AsyncMock(return_value=openai_file)
+
+    result, updated = await _upload_files_to_container(
+        client=client,
+        uploaded_files=[bad, good],
+        memory=memory,
+        content_service=content_service,
+    )
+
+    assert updated is True
+    assert result.file_ids == {"cont_good": "file_good"}
+    assert "cont_bad" not in result.file_ids
+
+
+@pytest.mark.ai
+@pytest.mark.asyncio
+async def test_upload_files_to_container__returns_updated_false__when_all_files_already_present() -> (
+    None
+):
+    """
+    Purpose: Verify that when every file is already uploaded (retrieve succeeds for
+    every content id), ``_upload_files_to_container`` returns ``updated=False`` and
+    does not re-download or re-create anything.
+    Why this matters: This is the signal that short-term memory does not need to be
+    persisted — the caller relies on it to skip ``save_async``.
+    """
+    memory = CodeExecutionShortTermMemorySchema(
+        container_id="ctr_allcached",
+        file_ids={"cont_a": "file_a", "cont_b": "file_b"},
+    )
+    a = Content(id="cont_a", key="a.csv")
+    b = Content(id="cont_b", key="b.csv")
+    content_service = MagicMock()
+    content_service.download_content_to_bytes_async = AsyncMock()
+    client = MagicMock()
+    client.containers.files.retrieve = AsyncMock(return_value=MagicMock())
+    client.containers.files.create = AsyncMock()
+
+    result, updated = await _upload_files_to_container(
+        client=client,
+        uploaded_files=[a, b],
+        memory=memory,
+        content_service=content_service,
+    )
+
+    assert updated is False
+    assert result.file_ids == {"cont_a": "file_a", "cont_b": "file_b"}
+    content_service.download_content_to_bytes_async.assert_not_awaited()
+    client.containers.files.create.assert_not_awaited()
+
+
+# ============================================================================
+# Tests for build_tool conditional save_async gating
+# ============================================================================
+
+
+@pytest.mark.ai
+@pytest.mark.asyncio
+async def test_build_tool__skips_save_async__when_container_and_files_unchanged() -> (
+    None
+):
+    """
+    Purpose: Verify that when the existing container is still live and the upload
+    helper reports no changes, ``build_tool`` does not persist short-term memory.
+    Why this matters: This is the optimisation motivating the ``(memory, updated)``
+    tuple — unnecessary STM writes on every tool build would be wasteful.
+    """
+    config = OpenAICodeInterpreterConfig(
+        use_auto_container=False,
+        upload_files_in_chat_to_container=True,
+        additional_uploaded_documents=[],
+    )
+    chat_file = Content(id="cont_cached", key="c.csv")
+
+    memory_loaded = CodeExecutionShortTermMemorySchema(
+        container_id="ctr_existing", file_ids={"cont_cached": "file_cached"}
+    )
+    memory_manager = MagicMock()
+    memory_manager.load_async = AsyncMock(return_value=memory_loaded)
+    memory_manager.save_async = AsyncMock()
+
+    service_mod = "unique_toolkit.agentic.tools.openai_builtin.code_interpreter.service"
+    with (
+        patch(
+            f"{service_mod}._get_container_code_execution_short_term_memory_manager",
+            return_value=memory_manager,
+        ),
+        patch(
+            f"{service_mod}._check_container_exists",
+            AsyncMock(return_value=True),
+        ),
+        patch(
+            f"{service_mod}._create_container",
+            AsyncMock(),
+        ) as mock_create,
+        patch(
+            f"{service_mod}._upload_files_to_container",
+            AsyncMock(return_value=(memory_loaded, False)),
+        ),
+    ):
+        tool = await OpenAICodeInterpreterTool.build_tool(
+            config=config,
+            uploaded_files=[chat_file],
+            client=MagicMock(),
+            content_service=MagicMock(),
+            company_id="co",
+            user_id="u",
+            chat_id="c",
+        )
+
+    assert tool._container_id == "ctr_existing"
+    memory_manager.save_async.assert_not_awaited()
+    mock_create.assert_not_awaited()
+
+
+@pytest.mark.ai
+@pytest.mark.asyncio
+async def test_build_tool__saves_when_files_updated__even_if_container_unchanged() -> (
+    None
+):
+    """
+    Purpose: Verify that when the container is live but a new file was uploaded,
+    ``build_tool`` still persists short-term memory.
+    Why this matters: The files flag must drive persistence independently of the
+    container flag.
+    """
+    config = OpenAICodeInterpreterConfig(
+        use_auto_container=False,
+        upload_files_in_chat_to_container=True,
+        additional_uploaded_documents=[],
+    )
+    chat_file = Content(id="cont_new", key="n.csv")
+
+    memory_loaded = CodeExecutionShortTermMemorySchema(
+        container_id="ctr_live", file_ids={}
+    )
+    memory_after_upload = CodeExecutionShortTermMemorySchema(
+        container_id="ctr_live", file_ids={"cont_new": "file_new"}
+    )
+    memory_manager = MagicMock()
+    memory_manager.load_async = AsyncMock(return_value=memory_loaded)
+    memory_manager.save_async = AsyncMock()
+
+    service_mod = "unique_toolkit.agentic.tools.openai_builtin.code_interpreter.service"
+    with (
+        patch(
+            f"{service_mod}._get_container_code_execution_short_term_memory_manager",
+            return_value=memory_manager,
+        ),
+        patch(
+            f"{service_mod}._check_container_exists",
+            AsyncMock(return_value=True),
+        ),
+        patch(
+            f"{service_mod}._upload_files_to_container",
+            AsyncMock(return_value=(memory_after_upload, True)),
+        ),
+    ):
+        await OpenAICodeInterpreterTool.build_tool(
+            config=config,
+            uploaded_files=[chat_file],
+            client=MagicMock(),
+            content_service=MagicMock(),
+            company_id="co",
+            user_id="u",
+            chat_id="c",
+        )
+
+    memory_manager.save_async.assert_awaited_once_with(memory_after_upload)
+
+
+# ============================================================================
+# Test for end-to-end dedup across chat files and KB files
+# ============================================================================
+
+
+@pytest.mark.ai
+@pytest.mark.asyncio
+async def test_build_tool__deduplicates_chat_and_kb_overlap__uploads_each_content_once() -> (
+    None
+):
+    """
+    Purpose: Verify that when the same content id is passed both as a chat-uploaded
+    file and as part of ``additional_uploaded_documents``, it is downloaded and
+    uploaded only once.
+    Why this matters: Operators can configure a template that a user also happens to
+    attach in the chat; we must not pay for the same bytes twice.
+    Setup summary: Same id appears in both lists; real upload helper runs against
+    mocked client + content service; assert exactly one download/create.
+    """
+    config = OpenAICodeInterpreterConfig(
+        use_auto_container=False,
+        upload_files_in_chat_to_container=True,
+        additional_uploaded_documents=["cont_overlap"],
+    )
+    shared = Content(id="cont_overlap", key="shared.csv")
+
+    content_service = MagicMock()
+    content_service.search_contents_async = AsyncMock(return_value=[shared])
+    content_service.download_content_to_bytes_async = AsyncMock(return_value=b"x")
+
+    openai_file = MagicMock()
+    openai_file.id = "file_shared"
+    client = MagicMock()
+    client.containers.files.create = AsyncMock(return_value=openai_file)
+
+    memory_loaded = CodeExecutionShortTermMemorySchema(
+        container_id="ctr_dedup_e2e", file_ids={}
+    )
+    memory_manager = MagicMock()
+    memory_manager.load_async = AsyncMock(return_value=memory_loaded)
+    memory_manager.save_async = AsyncMock()
+
+    service_mod = "unique_toolkit.agentic.tools.openai_builtin.code_interpreter.service"
+    with (
+        patch(
+            f"{service_mod}._get_container_code_execution_short_term_memory_manager",
+            return_value=memory_manager,
+        ),
+        patch(
+            f"{service_mod}._check_container_exists",
+            AsyncMock(return_value=True),
+        ),
+    ):
+        await OpenAICodeInterpreterTool.build_tool(
+            config=config,
+            uploaded_files=[shared],
+            client=client,
+            content_service=content_service,
+            company_id="co",
+            user_id="u",
+            chat_id="c",
+        )
+
+    assert content_service.download_content_to_bytes_async.await_count == 1
+    assert client.containers.files.create.await_count == 1

--- a/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/config.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/config.py
@@ -181,6 +181,10 @@ class OpenAICodeInterpreterConfig(BaseToolConfig):
         default=False,
         description="If set, use the `auto` container setting from OpenAI. Note that this will recreate the container on each call.",
     )
+    additional_uploaded_documents: list[str] = Field(
+        default=[],
+        description="Documents (content_ids) to always upload to the container from the Knowledge Base. Useful for example for templates.",
+    )
 
 
 @register_config()

--- a/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/service.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/service.py
@@ -4,7 +4,12 @@ import asyncio
 import logging
 from typing import Any, override
 
-from openai import AsyncOpenAI, BaseModel, NotFoundError
+from openai import (
+    AsyncOpenAI,
+    BaseModel,
+    NotFoundError,
+    OpenAIError,
+)
 from openai.types.responses import ResponseCodeInterpreterToolCall, ResponseIncludable
 from openai.types.responses.tool_param import CodeInterpreter
 from tenacity import (
@@ -137,13 +142,15 @@ async def _upload_file_to_container(
     assert container_id is not None
 
     if content_id in memory.file_ids:
+        file_id = memory.file_ids[content_id]
         try:
             await client.containers.files.retrieve(
-                container_id=container_id, file_id=memory.file_ids[content_id]
+                container_id=container_id, file_id=file_id
             )
             logger.info("File with id %s already uploaded to container", content_id)
             return
-        except NotFoundError:
+        except OpenAIError:  # Azure API Errors are not stable
+            logger.exception("Error while retrieving file %s", file_id)
             pass
 
     logger.info(

--- a/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/service.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/service.py
@@ -20,6 +20,7 @@ from tenacity import (
 )
 
 from unique_toolkit import ContentService, ShortTermMemoryService
+from unique_toolkit._common.execution import SafeTaskExecutor
 from unique_toolkit.agentic.feature_flags.feature_flags import feature_flags
 from unique_toolkit.agentic.short_term_memory_manager.persistent_short_term_memory_manager import (
     PersistentShortMemoryManager,
@@ -62,7 +63,7 @@ _SHORT_TERM_MEMORY_NAME = "container_code_execution"
 
 
 class CodeExecutionShortTermMemorySchema(BaseModel):
-    container_id: str | None = None
+    container_id: str
     file_ids: dict[str, str] = {}  # Mapping of unique file id to openai file id
 
 
@@ -88,71 +89,76 @@ def _get_container_code_execution_short_term_memory_manager(
     return short_term_memory_manager
 
 
-async def _create_container_if_not_exists(
+async def _check_container_exists(
+    client: AsyncOpenAI,
+    memory: CodeExecutionShortTermMemorySchema,
+) -> bool:
+    try:
+        container = await client.containers.retrieve(memory.container_id)
+    except NotFoundError:
+        logger.info("Container %s not found", memory.container_id)
+        return False
+
+    if container.status not in ["active", "running"]:
+        logger.info(
+            "Container %s has status `%s`, recreating a new one",
+            memory.container_id,
+            container.status,
+        )
+        return False
+
+    logger.info("Container %s found in short term memory", memory.container_id)
+    return True
+
+
+async def _create_container(
     client: AsyncOpenAI,
     chat_id: str,
     user_id: str,
     company_id: str,
     expires_after_minutes: int,
-    memory: CodeExecutionShortTermMemorySchema | None = None,
-) -> CodeExecutionShortTermMemorySchema:
-    if memory is not None:
-        logger.info("Container found in short term memory")
-    else:
-        logger.info("No Container in short term memory, creating a new container")
-        memory = CodeExecutionShortTermMemorySchema()
+) -> str:
+    container = await client.containers.create(
+        name=f"code_execution_{company_id}_{user_id}_{chat_id}",
+        expires_after={
+            "anchor": "last_active_at",
+            "minutes": expires_after_minutes,
+        },
+    )
+    logger.info("Created new container %s", container.id)
+    return container.id
 
+
+async def _check_file_already_uploaded(
+    client: AsyncOpenAI,
+    content_id: str,
+    memory: CodeExecutionShortTermMemorySchema,
+) -> bool:
     container_id = memory.container_id
 
-    if container_id is not None:
-        try:
-            container = await client.containers.retrieve(container_id)
-            if container.status not in ["active", "running"]:
-                logger.info(
-                    "Container has status `%s`, recreating a new one", container.status
-                )
-                container_id = None
-        except NotFoundError:
-            container_id = None
+    if content_id not in memory.file_ids:
+        logger.info("File with id %s not in short term memory", content_id)
+        return False
 
-    if container_id is None:
-        memory = CodeExecutionShortTermMemorySchema()
-
-        container = await client.containers.create(
-            name=f"code_execution_{company_id}_{user_id}_{chat_id}",
-            expires_after={
-                "anchor": "last_active_at",
-                "minutes": expires_after_minutes,
-            },
+    file_id = memory.file_ids[content_id]
+    try:
+        await client.containers.files.retrieve(
+            container_id=container_id, file_id=file_id
         )
-
-        memory.container_id = container.id
-
-    return memory
+        logger.info("File with id %s already uploaded to container", content_id)
+        return True
+    except OpenAIError:  # Azure API Errors are not stable
+        logger.exception("Error while retrieving file %s", file_id)
+        return False
 
 
 async def _upload_file_to_container(
     client: AsyncOpenAI,
     content_id: str,
     filename: str,
-    memory: CodeExecutionShortTermMemorySchema,
     content_service: ContentService,
-) -> None:
-    container_id = memory.container_id
-    assert container_id is not None
-
-    if content_id in memory.file_ids:
-        file_id = memory.file_ids[content_id]
-        try:
-            await client.containers.files.retrieve(
-                container_id=container_id, file_id=file_id
-            )
-            logger.info("File with id %s already uploaded to container", content_id)
-            return
-        except OpenAIError:  # Azure API Errors are not stable
-            logger.exception("Error while retrieving file %s", file_id)
-            pass
-
+    container_id: str,
+) -> str:
     logger.info(
         "Uploading file %s (%s) to container %s",
         content_id,
@@ -176,15 +182,14 @@ async def _upload_file_to_container(
         container_id=container_id,
         file=(filename, file_content),
     )
-    memory.file_ids[content_id] = openai_file.id
-
     logger.info(
         "File %s successfully uploaded as OpenAI file %s in container %s",
         content_id,
         openai_file.id,
         container_id,
     )
-    return
+
+    return openai_file.id
 
 
 async def _upload_files_to_container(
@@ -192,23 +197,41 @@ async def _upload_files_to_container(
     uploaded_files: list[Content],
     memory: CodeExecutionShortTermMemorySchema,
     content_service: ContentService,
-) -> CodeExecutionShortTermMemorySchema:
+) -> tuple[CodeExecutionShortTermMemorySchema, bool]:
+
+    async def _check_and_upload(content: Content) -> str | None:
+        if await _check_file_already_uploaded(
+            client=client, content_id=content.id, memory=memory
+        ):
+            return None
+
+        return await _upload_file_to_container(
+            client=client,
+            content_id=content.id,
+            filename=content.key,
+            content_service=content_service,
+            container_id=memory.container_id,
+        )
+
     # Deduplicate
     unique_contents = {content.id: content for content in uploaded_files}.values()
 
-    await asyncio.gather(
+    executor = SafeTaskExecutor(logger=logger)
+
+    results = await asyncio.gather(
         *(
-            _upload_file_to_container(
-                client=client,
-                content_id=file.id,
-                filename=file.key,
-                memory=memory,
-                content_service=content_service,
-            )
-            for file in unique_contents
-        )
+            executor.execute_async(_check_and_upload, content)
+            for content in unique_contents
+        ),
     )
-    return memory
+
+    updated = False
+    for content, result in zip(unique_contents, results):
+        if result.success and (file_id := result.unpack()) is not None:
+            memory.file_ids[content.id] = file_id
+            updated = True
+
+    return memory, updated
 
 
 async def _resolve_kb_contents(
@@ -313,14 +336,19 @@ class OpenAICodeInterpreterTool(OpenAIBuiltInTool[CodeInterpreter]):
 
         memory = await memory_manager.load_async()
 
-        memory = await _create_container_if_not_exists(
-            client=client,
-            memory=memory,
-            chat_id=chat_id,
-            user_id=user_id,
-            company_id=company_id,
-            expires_after_minutes=config.expires_after_minutes,
-        )
+        container_updated = False
+        if memory is None or not await _check_container_exists(
+            client=client, memory=memory
+        ):
+            container_id = await _create_container(
+                client=client,
+                chat_id=chat_id,
+                user_id=user_id,
+                company_id=company_id,
+                expires_after_minutes=config.expires_after_minutes,
+            )
+            memory = CodeExecutionShortTermMemorySchema(container_id=container_id)
+            container_updated = True
 
         files_to_upload: list[Content] = []
         if config.upload_files_in_chat_to_container:
@@ -334,17 +362,17 @@ class OpenAICodeInterpreterTool(OpenAIBuiltInTool[CodeInterpreter]):
                 )
             )
 
+        files_updated = False
         if files_to_upload:
-            memory = await _upload_files_to_container(
+            memory, files_updated = await _upload_files_to_container(
                 client=client,
                 uploaded_files=files_to_upload,
                 content_service=content_service,
                 memory=memory,
             )
 
-        await memory_manager.save_async(memory)
-
-        assert memory.container_id is not None
+        if container_updated or files_updated:
+            await memory_manager.save_async(memory)
 
         return OpenAICodeInterpreterTool(
             config=config,

--- a/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/service.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any, override
 
@@ -125,63 +126,101 @@ async def _create_container_if_not_exists(
     return memory
 
 
+async def _upload_file_to_container(
+    client: AsyncOpenAI,
+    content_id: str,
+    filename: str,
+    memory: CodeExecutionShortTermMemorySchema,
+    content_service: ContentService,
+) -> None:
+    container_id = memory.container_id
+    assert container_id is not None
+
+    if content_id in memory.file_ids:
+        try:
+            await client.containers.files.retrieve(
+                container_id=container_id, file_id=memory.file_ids[content_id]
+            )
+            logger.info("File with id %s already uploaded to container", content_id)
+            return
+        except NotFoundError:
+            pass
+
+    logger.info(
+        "Uploading file %s (%s) to container %s",
+        content_id,
+        filename,
+        container_id,
+    )
+
+    file_content = await _build_upload_retry()(
+        content_service.download_content_to_bytes_async,
+        content_id=content_id,
+    )
+    logger.info(
+        "Downloaded %d bytes for file %s; uploading to container %s",
+        len(file_content),
+        content_id,
+        container_id,
+    )
+
+    openai_file = await _build_upload_retry()(
+        client.containers.files.create,
+        container_id=container_id,
+        file=(filename, file_content),
+    )
+    memory.file_ids[content_id] = openai_file.id
+
+    logger.info(
+        "File %s successfully uploaded as OpenAI file %s in container %s",
+        content_id,
+        openai_file.id,
+        container_id,
+    )
+    return
+
+
 async def _upload_files_to_container(
     client: AsyncOpenAI,
     uploaded_files: list[Content],
     memory: CodeExecutionShortTermMemorySchema,
     content_service: ContentService,
-    chat_id: str,
 ) -> CodeExecutionShortTermMemorySchema:
-    container_id = memory.container_id
-
-    assert container_id is not None
-
-    memory = memory.model_copy(deep=True)
-
-    for file in uploaded_files:
-        upload = True
-        if file.id in memory.file_ids:
-            try:
-                _ = await client.containers.files.retrieve(
-                    container_id=container_id, file_id=memory.file_ids[file.id]
-                )
-                logger.info("File with id %s already uploaded to container", file.id)
-                upload = False
-            except NotFoundError:
-                upload = True
-
-        if upload:
-            logger.info(
-                "Uploading file %s (%s) to container %s",
-                file.id,
-                file.key,
-                memory.container_id,
-            )
-            file_content = await _build_upload_retry()(
-                content_service.download_content_to_bytes_async,
+    await asyncio.gather(
+        *(
+            _upload_file_to_container(
+                client=client,
                 content_id=file.id,
-                chat_id=chat_id,
+                filename=file.key,
+                memory=memory,
+                content_service=content_service,
             )
-            logger.info(
-                "Downloaded %d bytes for file %s; uploading to container %s",
-                len(file_content),
-                file.id,
-                container_id,
-            )
-            openai_file = await _build_upload_retry()(
-                client.containers.files.create,
-                container_id=container_id,
-                file=(file.key, file_content),
-            )
-            memory.file_ids[file.id] = openai_file.id
-            logger.info(
-                "File %s successfully uploaded as OpenAI file %s in container %s",
-                file.id,
-                openai_file.id,
-                container_id,
-            )
-
+            for file in uploaded_files
+        )
+    )
     return memory
+
+
+async def _resolve_kb_contents(
+    content_service: ContentService,
+    content_ids: list[str],
+) -> list[Content]:
+    content_ids = list(set(content_ids))
+
+    contents = await content_service.search_contents_async(
+        where={"id": {"in": content_ids}},
+    )
+
+    found_ids = {c.id for c in contents}
+    missing = [content_id for content_id in content_ids if content_id not in found_ids]
+    if missing:
+        logger.warning(
+            "additional_uploaded_documents: %d content ids not found or not accessible in KB: %s",
+            len(missing),
+            missing,
+        )
+
+    return contents
 
 
 class OpenAICodeInterpreterTool(OpenAIBuiltInTool[CodeInterpreter]):
@@ -275,12 +314,23 @@ class OpenAICodeInterpreterTool(OpenAIBuiltInTool[CodeInterpreter]):
             expires_after_minutes=config.expires_after_minutes,
         )
 
+        files_to_upload: list[Content] = []
         if config.upload_files_in_chat_to_container:
+            files_to_upload.extend(uploaded_files)
+
+        if config.additional_uploaded_documents:
+            files_to_upload.extend(
+                await _resolve_kb_contents(
+                    content_service=content_service,
+                    content_ids=config.additional_uploaded_documents,
+                )
+            )
+
+        if files_to_upload:
             memory = await _upload_files_to_container(
                 client=client,
-                uploaded_files=uploaded_files,
+                uploaded_files=files_to_upload,
                 content_service=content_service,
-                chat_id=chat_id,
                 memory=memory,
             )
 

--- a/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/service.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/service.py
@@ -186,6 +186,9 @@ async def _upload_files_to_container(
     memory: CodeExecutionShortTermMemorySchema,
     content_service: ContentService,
 ) -> CodeExecutionShortTermMemorySchema:
+    # Deduplicate
+    unique_contents = {content.id: content for content in uploaded_files}.values()
+
     await asyncio.gather(
         *(
             _upload_file_to_container(
@@ -195,7 +198,7 @@ async def _upload_files_to_container(
                 memory=memory,
                 content_service=content_service,
             )
-            for file in uploaded_files
+            for file in unique_contents
         )
     )
     return memory
@@ -205,8 +208,6 @@ async def _resolve_kb_contents(
     content_service: ContentService,
     content_ids: list[str],
 ) -> list[Content]:
-    content_ids = list(set(content_ids))
-
     contents = await content_service.search_contents_async(
         where={"id": {"in": content_ids}},
     )


### PR DESCRIPTION
## 🚀 Summary
Refs: [UN-20033](https://unique-ch.atlassian.net/browse/UN-20033)

- Allow specifying a set of files in the kb that will always be available to code execution
- Parallelize upload of files to the container

## ✅ Changes

- [x] Added feature / fixed bug / updated docs
- [ ] Refactored code / cleaned up
- [ ] Other (describe below)

## 🧪 Testing

Local tests / unit tests.


[UN-20033]: https://unique-ch.atlassian.net/browse/UN-20033?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ