### PR TITLE
fix(cd): pass --repo to gh workflow run in publish-stable

### DIFF
--- a/.github/workflows/cd-release.yaml
+++ b/.github/workflows/cd-release.yaml
@@ -126,6 +126,7 @@ jobs:
           REF_SHA: ${{ github.sha }}
         run: |
           gh workflow run cd-publish.yaml \
+            --repo "${{ github.repository }}" \
             --ref "$REF_NAME" \
             -f package=all \
             -f ref="$REF_SHA"


### PR DESCRIPTION
## Summary

The \`publish-stable\` job in \`cd-release.yaml\` was failing with:

\`\`\`
failed to run git: fatal: not a git repository (or any of the parent directories): .git
\`\`\`

The \`gh\` CLI auto-detects the repository by walking up the directory tree looking for \`.git\`. Since the job has no \`actions/checkout\` step the runner directory contains no \`.git\`, causing the lookup to fail.

**Fix:** pass \`--repo "\${{ github.repository }}"\` explicitly to \`gh workflow run\`, which bypasses the git lookup entirely.

The stable wheels for the initial CalVer release were manually dispatched via:
\`\`\`
gh workflow run cd-publish.yaml --repo Unique-AG/ai --ref main -f package=all -f ref=2575286d65c0566cdca6c871e787304803ae65f4
\`\`\`

Made with [Cursor](https://cursor.com)