### PR TITLE
fix(toolkit): correct "Unkown" typo to "Unknown" in two strings

### DIFF
--- a/unique_toolkit/unique_toolkit/_common/chunk_relevancy_sorter/schemas.py
+++ b/unique_toolkit/unique_toolkit/_common/chunk_relevancy_sorter/schemas.py
@@ -11,7 +11,7 @@ class ChunkRelevancy(BaseModel):
     relevancy: EvaluationMetricResult | None = None
 
     def get_document_name(self):
-        title = self.chunk.key or self.chunk.title or "Unkown"
+        title = self.chunk.key or self.chunk.title or "Unknown"
         return title.split(":")[0]
 
     def get_page_number(self):

--- a/unique_toolkit/unique_toolkit/agentic/tools/a2a/evaluation/_utils.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/a2a/evaluation/_utils.py
@@ -48,7 +48,7 @@ def get_valid_assessments(
             or assessment["label"] not in ChatMessageAssessmentLabel
         ):
             logger.warning(
-                "Unkown assistant label %s for assistant %s (sequence number: %s) will be ignored",
+                "Unknown assistant label %s for assistant %s (sequence number: %s) will be ignored",
                 assessment["label"],
                 display_name,
                 sequence_number,


### PR DESCRIPTION
## Summary

Fixes a typo in two user-visible strings in \`unique_toolkit\`:

- \`_common/chunk_relevancy_sorter/schemas.py\`: fallback document title \`\"Unkown\"\` → \`\"Unknown\"\`
- \`agentic/tools/a2a/evaluation/_utils.py\`: log warning message \`\"Unkown assistant label…\"\` → \`\"Unknown assistant label…\"\`

Both strings surface to users/operators (one as a displayed document name, one as a logged warning), so the fix is meaningful for a patch release.

Made with [Cursor](https://cursor.com)