### PR TITLE
fix(cd): pass target-branch to release-please-action for hotfix releases

### DIFF
--- a/.github/workflows/cd-release.yaml
+++ b/.github/workflows/cd-release.yaml
@@ -35,6 +35,7 @@ jobs:
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          target-branch: ${{ github.ref_name }}
 
   # After release-please updates the PR with new version bumps it does not
   # update uv.lock. This job finds the open release PR via its label, checks


### PR DESCRIPTION
## Summary

Without \`target-branch\`, \`googleapis/release-please-action\` always targets the repository's default branch (\`main\`), regardless of which branch triggered the workflow.

This meant that hotfix commits merged into \`release/*\` branches were silently added to the \`chore: release main\` PR instead of creating a dedicated \`chore: release 2026.18.1\` PR on the release branch.

**Fix:** pass \`target-branch: \${{ github.ref_name }}\` so release-please targets the triggering branch — \`main\` when triggered from main, \`release/2026.18\` when triggered from a hotfix commit on that branch.

Discovered during the first hotfix attempt on \`release/2026.18\`.

Made with [Cursor](https://cursor.com)