### PR TITLE
fix(unique-swot): correct spelling of occurred in error messages

### DIFF
--- a/tool_packages/unique_swot/unique_swot/services/generation/agentic/operations.py
+++ b/tool_packages/unique_swot/unique_swot/services/generation/agentic/operations.py
@@ -119,7 +119,7 @@ async def handle_generate_operation(
         )
         await step_notifier.notify(
             title=notification_title,
-            description=f"An error occured while extracting facts for component {component}. This batch will be skipped.",
+            description=f"An error occurred while extracting facts for component {component}. This batch will be skipped.",
         )
     except FailedToGeneratePlanException as e:
         _LOGGER.exception(
@@ -127,7 +127,7 @@ async def handle_generate_operation(
         )
         await step_notifier.notify(
             title=notification_title,
-            description=f"An error occured while generating plan to update the SWOT report for component {component}. Extracted information will be discarded.",
+            description=f"An error occurred while generating plan to update the SWOT report for component {component}. Extracted information will be discarded.",
         )
     except Exception as e:
         _LOGGER.exception(
@@ -135,7 +135,7 @@ async def handle_generate_operation(
         )
         await step_notifier.notify(
             title=notification_title,
-            description=f"An unexpected error occured while updating the SWOT report for component {component}. Skipping this batch.",
+            description=f"An unexpected error occurred while updating the SWOT report for component {component}. Skipping this batch.",
         )
 
 

--- a/tool_packages/unique_swot/unique_swot/services/source_management/selection/agent.py
+++ b/tool_packages/unique_swot/unique_swot/services/source_management/selection/agent.py
@@ -56,8 +56,8 @@ class SourceSelectionAgent:
             _LOGGER.error(f"Failed to select the source for {company_name}")
             response = SourceSelectionResult(
                 should_select=True,
-                reason="An error occured while selecting the source.",
-                notification_message="An error occured while selecting the source. The source will be still considered for the SWOT as a safety measure.",
+                reason="An error occurred while selecting the source.",
+                notification_message="An error occurred while selecting the source. The source will be still considered for the SWOT as a safety measure.",
             )
         await step_notifier.notify(
             title=notification_title,

--- a/tool_packages/unique_swot/unique_swot/tests/services/source_management/test_selection.py
+++ b/tool_packages/unique_swot/unique_swot/tests/services/source_management/test_selection.py
@@ -144,7 +144,7 @@ async def test_selection_agent_handles_llm_failure(
 
         # Should default to selecting the source
         assert result.should_select is True
-        assert "error" in result.reason.lower() or "occured" in result.reason.lower()
+        assert "error" in result.reason.lower() or "occurred" in result.reason.lower()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Fixes typo `occured` → `occurred` in 3 error notification messages in `unique_swot`
- Updates the corresponding test assertion to match the corrected spelling

## AI assist

![light AI assist](https://img.shields.io/badge/AI_assist-light-lightgrey)

Made with [Cursor](https://cursor.com)