### PR TITLE
fix(ci): trigger CI on release-please PRs via workflow_dispatch

### DIFF
--- a/.github/workflows/cd-release.yaml
+++ b/.github/workflows/cd-release.yaml
@@ -109,6 +109,15 @@ jobs:
           git commit -m "chore: update dependency floors and regenerate uv.lock for release"
           git push
 
+      - name: Kick CI on release PR branch
+        if: steps.pr-info.outputs.branch != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run ci.yaml \
+            --repo "${{ github.repository }}" \
+            --ref "${{ steps.pr-info.outputs.branch }}"
+
   # Dispatch cd-publish.yaml for stable wheels. Works for both main
   # (YYYY.WW.0) and release/* (YYYY.WW.PATCH) since both flows land tags
   # the same way. Runs on a separate runner so it doesn't block

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,7 @@ name: CI
 on:
   pull_request:
   merge_group:
+  workflow_dispatch:
 
 jobs:
   detect-changes:


### PR DESCRIPTION
## Summary

- Adds `workflow_dispatch` trigger to `ci.yaml`
- In `cd-release.yaml`, after the lockfile update commit, dispatches `ci.yaml` on the release-please PR branch

**Root cause:** release-please creates PRs using `GITHUB_TOKEN`. GitHub's anti-recursion rule prevents `pull_request` events from firing on such PRs, so `CI / Gatekeeper` never runs and the check never turns green.

**Fix:** `gh workflow run ci.yaml --ref <rp-branch>` dispatches CI explicitly after our lockfile update. `workflow_dispatch` events are exempt from the anti-recursion rule and will fire correctly.

**Why no changes to `ci.yaml` jobs needed:** `pr-title` and `no-manual-release` are already gated on `github.event_name == 'pull_request'` so they skip cleanly. The `status` step already falls back to `github.sha` when there is no PR head SHA.

> Also needs cherry-picking to `release/2026.18`.

## AI assist

![light AI assist](https://img.shields.io/badge/AI_assist-light-lightgrey)

Made with [Cursor](https://cursor.com)