### PR TITLE
fix(cd): skip open-PR step when no changes were pushed

### DIFF
--- a/.github/workflows/cd-publish-dev.yaml
+++ b/.github/workflows/cd-publish-dev.yaml
@@ -337,6 +337,7 @@ jobs:
               done
 
       - name: Commit and push
+        id: commit
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -344,12 +345,15 @@ jobs:
           git add .
           if git diff --cached --quiet; then
             echo "No changes — nothing to push." >&2
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           git commit -m "chore: bump dev versions for cycle $CYCLE"
           git push -u origin HEAD
+          echo "pushed=true" >> "$GITHUB_OUTPUT"
 
       - name: Open PR
+        if: steps.commit.outputs.pushed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ALL_CURRENT_VERSIONS: ${{ needs.resolve.outputs.all_current_versions }}


### PR DESCRIPTION
## Summary

Addresses Bugbot finding from #1505.

The "Open PR" step in `open-dev-bump-pr` ran unconditionally. When the rewrite produced no diff (e.g. versions already up to date), the "Commit and push" step exited early without pushing the branch — causing `gh pr create --head "$BRANCH"` to fail because the remote branch didn't exist.

**Fix:** add `id: commit` to the commit step, emit `pushed=true/false` via `$GITHUB_OUTPUT`, and gate the "Open PR" step on `steps.commit.outputs.pushed == 'true'`.

## AI assist

![light AI assist](https://img.shields.io/badge/AI_assist-light-lightgrey)

Made with [Cursor](https://cursor.com)