### PR TITLE
fix(cd): regenerate uv.lock and guard open-PR step in dev-bump job

### DIFF
--- a/.github/workflows/cd-publish-dev.yaml
+++ b/.github/workflows/cd-publish-dev.yaml
@@ -336,7 +336,11 @@ jobs:
                     --dep-pins "$DEP_PINS"
               done
 
+      - name: Regenerate lockfile
+        run: uv lock
+
       - name: Commit and push
+        id: commit
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -344,12 +348,15 @@ jobs:
           git add .
           if git diff --cached --quiet; then
             echo "No changes — nothing to push." >&2
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           git commit -m "chore: bump dev versions for cycle $CYCLE"
           git push -u origin HEAD
+          echo "pushed=true" >> "$GITHUB_OUTPUT"
 
       - name: Open PR
+        if: steps.commit.outputs.pushed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ALL_CURRENT_VERSIONS: ${{ needs.resolve.outputs.all_current_versions }}


### PR DESCRIPTION
## Summary

Two fixes to the `open-dev-bump-pr` job in `cd-publish-dev.yaml`:

**1. Regenerate `uv.lock` after pyproject.toml rewrites**
The job was updating `version` and cross-dep floors in every `pyproject.toml` but never relocking. Developers rebasing on the dev-bump branch would get an inconsistent lockfile. A `uv lock` step is added between the rewrite and the commit.

**2. Guard "Open PR" when nothing was pushed** (supersedes #1520)
When the rewrite produces no diff, the commit step exits early without pushing. The subsequent `gh pr create --head "$BRANCH"` would then fail because the remote branch doesn't exist. Fixed by emitting `pushed=true/false` from the commit step and adding `if: steps.commit.outputs.pushed == 'true'` to the "Open PR" step.

Closes #1520.

## AI assist

![light AI assist](https://img.shields.io/badge/AI_assist-light-lightgrey)

Made with [Cursor](https://cursor.com)