### PR TITLE
fix(ci): skip no-manual-release check on dev-bump PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,7 +86,7 @@ jobs:
 
   no-manual-release:
     name: No Manual Release Changes
-    if: github.event_name == 'pull_request' && github.actor != 'release-please[bot]' && !startsWith(github.head_ref, 'release-please--')
+    if: github.event_name == 'pull_request' && github.actor != 'release-please[bot]' && !startsWith(github.head_ref, 'release-please--') && !startsWith(github.head_ref, 'chore/bump-dev-')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4


### PR DESCRIPTION
## Summary

The \`No Manual Release Changes\` check was failing on automated dev-bump PRs (\`chore/bump-dev-*\` branches) because those PRs legitimately update \`version\` and dep floors in \`pyproject.toml\` files.

Adds \`!startsWith(github.head_ref, 'chore/bump-dev-')\` to the \`no-manual-release\` job condition, alongside the existing \`release-please--\` exclusion.

## AI assist

![light AI assist](https://img.shields.io/badge/AI_assist-light-lightgrey)

Made with [Cursor](https://cursor.com)