### PR TITLE
fix(web-search): correct "triggerd" typo to "triggered" in elicitation messages

### DIFF
--- a/tool_packages/unique_web_search/src/unique_web_search/services/query_elicitation.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/query_elicitation.py
@@ -149,13 +149,13 @@ class QueryElicitationService:
             elif elicitation.status == ElicitationStatus.DECLINED:
                 _LOGGER.info(f"Query elicitation {elicitation.id} declined")
                 raise ElicitationDeclinedException(
-                    f"Elicitation triggerd with queries {queries} was declined"
+                    f"Elicitation triggered with queries {queries} was declined"
                 )
 
             elif elicitation.status == ElicitationStatus.CANCELLED:
                 _LOGGER.info(f"Query elicitation {elicitation.id} cancelled")
                 raise ElicitationCancelledException(
-                    f"Elicitation triggerd with queries {queries} was cancelled"
+                    f"Elicitation triggered with queries {queries} was cancelled"
                 )
 
         raise ElicitationExpiredException(


### PR DESCRIPTION
## Summary

Corrects the misspelling \"triggerd\" → \"triggered\" in two log messages in \`query_elicitation.py\`.

## AI assist

![light AI assist](https://img.shields.io/badge/AI_assist-light-lightgrey)

Made with [Cursor](https://cursor.com)