### PR TITLE
feat(unique-sdk): preview-PDF upload via file_io

### DIFF
--- a/unique_sdk/tests/test_file_io_preview_pdf.py
+++ b/unique_sdk/tests/test_file_io_preview_pdf.py
@@ -229,6 +229,26 @@ class TestUploadFilePreviewPdfPath:
                 preview_pdf_path="/definitely/not/a/real/file.pdf",
             )
 
+    def test_preview_filename_without_path_raises(self, sample_pptx: str) -> None:
+        """Passing ``preview_pdf_filename`` without ``preview_pdf_path``
+        would register a phantom preview on the Content row but never
+        upload any bytes (because the PUT is gated on the path). Treat
+        the inconsistent argument combo as a programmer mistake and
+        refuse before touching the network."""
+        with pytest.raises(ValueError, match="preview_pdf_filename"):
+            file_io.upload_file(
+                userId="user-1",
+                companyId="company-1",
+                path_to_file=sample_pptx,
+                displayed_filename="deck.pptx",
+                mime_type=(
+                    "application/vnd.openxmlformats-officedocument."
+                    "presentationml.presentation"
+                ),
+                chat_id="chat-1",
+                preview_pdf_filename="orphan.pdf",
+            )
+
 
 class TestDerivePreviewPdfFilename:
     @pytest.mark.parametrize(

--- a/unique_sdk/tests/test_file_io_preview_pdf.py
+++ b/unique_sdk/tests/test_file_io_preview_pdf.py
@@ -1,0 +1,244 @@
+"""Unit tests for the preview-PDF upload path in
+``unique_sdk.utils.file_io.upload_file``.
+
+These tests pin the contract that the user-facing one-call upload
+shape covers the Office → PDF preview flow:
+
+* ``previewPdfFileName`` is forwarded into both upsert calls (the
+  ``writeUrl`` round and the post-upload ``byteSize`` round) so the
+  Content row in node-ingestion stores the preview filename
+  consistently.
+* The PDF blob is PUT to the SAS URL the server returned on the
+  first upsert; nothing more, nothing less.
+* Skipping ``preview_pdf_path`` keeps the legacy single-blob
+  behaviour (no ``previewPdfFileName``, no preview PUT) — important
+  because we don't want to regress every existing call site that
+  uses ``upload_file`` purely for an original-only upload.
+* A missing ``pdfPreviewWriteUrl`` on the response is treated as a
+  hard error rather than silently dropping the preview, so
+  server-side regressions surface immediately.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from unique_sdk.utils import file_io
+
+
+@pytest.fixture
+def sample_pptx(tmp_path: Any) -> str:
+    pptx = tmp_path / "deck.pptx"
+    pptx.write_bytes(b"fake-pptx-bytes")
+    return str(pptx)
+
+
+@pytest.fixture
+def sample_pdf(tmp_path: Any) -> str:
+    pdf = tmp_path / "deck-rendered.pdf"
+    pdf.write_bytes(b"%PDF-1.4 fake")
+    return str(pdf)
+
+
+def _fake_created_content(**overrides: Any) -> MagicMock:
+    content = MagicMock()
+    content.writeUrl = "https://blob.example/write-original?sig=1"
+    content.readUrl = "https://blob.example/read-original?sig=1"
+    content.pdfPreviewWriteUrl = "https://blob.example/write-preview?sig=2"
+    for key, value in overrides.items():
+        setattr(content, key, value)
+    return content
+
+
+class TestUploadFilePreviewPdfPath:
+    def test_skipping_preview_keeps_legacy_behaviour(self, sample_pptx: str) -> None:
+        """Without ``preview_pdf_path``, no preview filename is registered
+        and only the original blob is PUT — same as the SDK shipped
+        for years."""
+        created = _fake_created_content()
+        upsert_calls: list[dict[str, Any]] = []
+
+        def upsert(**kwargs: Any) -> Any:
+            upsert_calls.append(kwargs)
+            return created
+
+        put_mock = MagicMock(return_value=MagicMock(status_code=200))
+
+        with (
+            patch.object(file_io.Content, "upsert", side_effect=upsert),
+            patch.object(file_io.unique_sdk.Content, "upsert", side_effect=upsert),
+            patch.object(file_io.requests, "put", put_mock),
+        ):
+            file_io.upload_file(
+                userId="user-1",
+                companyId="company-1",
+                path_to_file=sample_pptx,
+                displayed_filename="deck.pptx",
+                mime_type=(
+                    "application/vnd.openxmlformats-officedocument."
+                    "presentationml.presentation"
+                ),
+                chat_id="chat-1",
+            )
+
+        for call in upsert_calls:
+            assert call.get("previewPdfFileName") is None
+        # Only one PUT — for the original blob; no preview PUT.
+        assert put_mock.call_count == 1
+        original_put = put_mock.call_args_list[0]
+        assert original_put.args[0] == created.writeUrl
+
+    def test_preview_pdf_path_uploads_both_blobs_and_registers_preview(
+        self, sample_pptx: str, sample_pdf: str
+    ) -> None:
+        """With ``preview_pdf_path``, the SDK registers the preview
+        filename on the upserted content, PUTs the original to
+        ``writeUrl``, then PUTs the PDF to ``pdfPreviewWriteUrl``."""
+        created = _fake_created_content()
+        upsert_calls: list[dict[str, Any]] = []
+
+        def upsert(**kwargs: Any) -> Any:
+            upsert_calls.append(kwargs)
+            return created
+
+        put_mock = MagicMock(return_value=MagicMock(status_code=200))
+
+        with (
+            patch.object(file_io.Content, "upsert", side_effect=upsert),
+            patch.object(file_io.unique_sdk.Content, "upsert", side_effect=upsert),
+            patch.object(file_io.requests, "put", put_mock),
+        ):
+            file_io.upload_file(
+                userId="user-1",
+                companyId="company-1",
+                path_to_file=sample_pptx,
+                displayed_filename="deck.pptx",
+                mime_type=(
+                    "application/vnd.openxmlformats-officedocument."
+                    "presentationml.presentation"
+                ),
+                chat_id="chat-1",
+                preview_pdf_path=sample_pdf,
+            )
+
+        # Both upserts include the same derived preview filename so the
+        # Content row settles on a deterministic blob name.
+        assert len(upsert_calls) == 2
+        for call in upsert_calls:
+            assert call["previewPdfFileName"] == "deck_preview.pdf"
+
+        # Two PUTs: original first (writeUrl), preview second
+        # (pdfPreviewWriteUrl). Order matters — preview PUT must run
+        # after the upsert mints the SAS URL.
+        assert put_mock.call_count == 2
+        assert put_mock.call_args_list[0].args[0] == created.writeUrl
+        assert put_mock.call_args_list[1].args[0] == created.pdfPreviewWriteUrl
+        preview_headers = put_mock.call_args_list[1].kwargs.get("headers", {})
+        assert preview_headers.get("X-Ms-Blob-Content-Type") == "application/pdf"
+        assert preview_headers.get("X-Ms-Blob-Type") == "BlockBlob"
+
+    def test_explicit_preview_pdf_filename_overrides_default(
+        self, sample_pptx: str, sample_pdf: str
+    ) -> None:
+        """An explicit ``preview_pdf_filename`` wins over the
+        ``<stem>_preview.pdf`` default, which lets callers store
+        previews under a name that matches their archival scheme."""
+        created = _fake_created_content()
+        upsert_calls: list[dict[str, Any]] = []
+
+        def upsert(**kwargs: Any) -> Any:
+            upsert_calls.append(kwargs)
+            return created
+
+        with (
+            patch.object(file_io.Content, "upsert", side_effect=upsert),
+            patch.object(file_io.unique_sdk.Content, "upsert", side_effect=upsert),
+            patch.object(
+                file_io.requests,
+                "put",
+                MagicMock(return_value=MagicMock(status_code=200)),
+            ),
+        ):
+            file_io.upload_file(
+                userId="user-1",
+                companyId="company-1",
+                path_to_file=sample_pptx,
+                displayed_filename="deck.pptx",
+                mime_type=(
+                    "application/vnd.openxmlformats-officedocument."
+                    "presentationml.presentation"
+                ),
+                chat_id="chat-1",
+                preview_pdf_path=sample_pdf,
+                preview_pdf_filename="custom-archive-name.pdf",
+            )
+
+        for call in upsert_calls:
+            assert call["previewPdfFileName"] == "custom-archive-name.pdf"
+
+    def test_missing_preview_write_url_raises(
+        self, sample_pptx: str, sample_pdf: str
+    ) -> None:
+        """The server only mints ``pdfPreviewWriteUrl`` when
+        ``previewPdfFileName`` reaches the upsert resolver. If the
+        response is missing the URL, the server is misconfigured —
+        surface the error instead of silently dropping the preview."""
+        created = _fake_created_content(pdfPreviewWriteUrl=None)
+
+        with (
+            patch.object(file_io.Content, "upsert", return_value=created),
+            patch.object(file_io.unique_sdk.Content, "upsert", return_value=created),
+            patch.object(
+                file_io.requests,
+                "put",
+                MagicMock(return_value=MagicMock(status_code=200)),
+            ),
+            pytest.raises(RuntimeError, match="pdfPreviewWriteUrl"),
+        ):
+            file_io.upload_file(
+                userId="user-1",
+                companyId="company-1",
+                path_to_file=sample_pptx,
+                displayed_filename="deck.pptx",
+                mime_type=(
+                    "application/vnd.openxmlformats-officedocument."
+                    "presentationml.presentation"
+                ),
+                chat_id="chat-1",
+                preview_pdf_path=sample_pdf,
+            )
+
+    def test_missing_preview_path_raises(self, sample_pptx: str) -> None:
+        """A non-existent ``preview_pdf_path`` is a programmer mistake
+        — fail before touching the network so the caller knows
+        immediately."""
+        with pytest.raises(ValueError, match="preview_pdf_path"):
+            file_io.upload_file(
+                userId="user-1",
+                companyId="company-1",
+                path_to_file=sample_pptx,
+                displayed_filename="deck.pptx",
+                mime_type=(
+                    "application/vnd.openxmlformats-officedocument."
+                    "presentationml.presentation"
+                ),
+                chat_id="chat-1",
+                preview_pdf_path="/definitely/not/a/real/file.pdf",
+            )
+
+
+class TestDerivePreviewPdfFilename:
+    @pytest.mark.parametrize(
+        "displayed,expected",
+        [
+            ("deck.pptx", "deck_preview.pdf"),
+            ("Quarterly Report.docx", "Quarterly Report_preview.pdf"),
+            ("noext", "noext_preview.pdf"),
+            ("multi.dot.name.xlsx", "multi.dot.name_preview.pdf"),
+        ],
+    )
+    def test_derives_predictable_blob_name(self, displayed: str, expected: str) -> None:
+        assert file_io._derive_preview_pdf_filename(displayed) == expected

--- a/unique_sdk/tests/test_file_io_preview_pdf.py
+++ b/unique_sdk/tests/test_file_io_preview_pdf.py
@@ -84,8 +84,12 @@ class TestUploadFilePreviewPdfPath:
                 chat_id="chat-1",
             )
 
+        # Key must be *absent* (not present-as-None): an explicit
+        # ``"previewPdfFileName": null`` in the JSON body would tell
+        # the server to clear an existing preview, silently regressing
+        # callers who re-upload content that already has one.
         for call in upsert_calls:
-            assert call.get("previewPdfFileName") is None
+            assert "previewPdfFileName" not in call
         # Only one PUT — for the original blob; no preview PUT.
         assert put_mock.call_count == 1
         original_put = put_mock.call_args_list[0]
@@ -187,6 +191,48 @@ class TestUploadFilePreviewPdfPath:
         response is missing the URL, the server is misconfigured —
         surface the error instead of silently dropping the preview."""
         created = _fake_created_content(pdfPreviewWriteUrl=None)
+
+        with (
+            patch.object(file_io.Content, "upsert", return_value=created),
+            patch.object(file_io.unique_sdk.Content, "upsert", return_value=created),
+            patch.object(
+                file_io.requests,
+                "put",
+                MagicMock(return_value=MagicMock(status_code=200)),
+            ),
+            pytest.raises(RuntimeError, match="pdfPreviewWriteUrl"),
+        ):
+            file_io.upload_file(
+                userId="user-1",
+                companyId="company-1",
+                path_to_file=sample_pptx,
+                displayed_filename="deck.pptx",
+                mime_type=(
+                    "application/vnd.openxmlformats-officedocument."
+                    "presentationml.presentation"
+                ),
+                chat_id="chat-1",
+                preview_pdf_path=sample_pdf,
+            )
+
+    def test_absent_preview_write_url_attribute_raises_runtime_error(
+        self, sample_pptx: str, sample_pdf: str
+    ) -> None:
+        """An older gateway may omit ``pdfPreviewWriteUrl`` entirely
+        from the upsert response. ``UniqueObject.__getattr__`` would
+        normally surface that as ``AttributeError``, which would skip
+        the descriptive ``RuntimeError`` guard. We must still surface
+        the same actionable error so callers can diagnose a stale
+        gateway without reading a traceback into ``__getattr__``."""
+
+        class _ResponseWithoutPreviewUrl:
+            writeUrl = "https://blob.example/write-original?sig=1"
+            readUrl = "https://blob.example/read-original?sig=1"
+
+            def __getattr__(self, name: str) -> Any:  # mimic UniqueObject
+                raise AttributeError(name)
+
+        created = _ResponseWithoutPreviewUrl()
 
         with (
             patch.object(file_io.Content, "upsert", return_value=created),

--- a/unique_sdk/unique_sdk/api_resources/_content.py
+++ b/unique_sdk/unique_sdk/api_resources/_content.py
@@ -31,6 +31,16 @@ class Content(APIResource["Content"]):
     expiredAt: str | None
     appliedIngestionConfig: dict[str, Any] | None
     mimeType: str | None
+    # Optional preview PDF blob registered against this content. When the
+    # caller passes ``previewPdfFileName`` to :meth:`upsert` (or to
+    # :func:`unique_sdk.utils.file_io.upload_file` via ``preview_pdf_path``),
+    # the platform stores the filename here and returns
+    # ``pdfPreviewWriteUrl`` so the PDF bytes can be uploaded directly to
+    # blob storage. The chat side panel resolves this filename to the
+    # ``/v1/content/{id}/preview-file`` endpoint when rendering Office /
+    # other formats whose in-browser preview is unreliable.
+    previewPdfFileName: str | None
+    pdfPreviewWriteUrl: str | None
 
     class QueryMode(Enum):
         Default = "default"
@@ -155,6 +165,11 @@ class Content(APIResource["Content"]):
         sourceOwnerType: NotRequired[str | None]
         storeInternally: NotRequired[bool | None]
         fileUrl: NotRequired[str | None]
+        # Pass a blob filename to attach a PDF preview to the upserted
+        # content. The response then carries ``pdfPreviewWriteUrl`` —
+        # a SAS URL the caller PUTs the PDF bytes to. ``file_io.upload_file``
+        # exposes this as ``preview_pdf_path`` for a one-call flow.
+        previewPdfFileName: NotRequired[str | None]
 
     class UpdateParams(RequestOptions):
         contentId: NotRequired[str]

--- a/unique_sdk/unique_sdk/utils/file_io.py
+++ b/unique_sdk/unique_sdk/utils/file_io.py
@@ -2,12 +2,21 @@ import asyncio
 import os
 import tempfile
 from pathlib import Path
-from typing import Any
+from typing import Any, TypedDict
 
 import requests
 
 import unique_sdk
 from unique_sdk.api_resources._content import Content
+
+
+class _PreviewKwargs(TypedDict, total=False):
+    """Subset of ``Content.UpsertParams`` that we conditionally forward
+    to ``upsert``. Typing it as a ``total=False`` TypedDict lets us
+    expand ``**preview_kwargs`` without basedpyright assuming the dict
+    could collide with non-string params like ``headers``."""
+
+    previewPdfFileName: str
 
 
 # download readUrl a random directory in /tmp
@@ -136,6 +145,15 @@ def upload_file(
         if preview_pdf_path is not None
         else None
     )
+    # Only forward ``previewPdfFileName`` when we actually have one.
+    # Sending ``None`` would serialize as ``"previewPdfFileName": null``,
+    # which the server treats as a clearing operation and would erase
+    # an existing preview on a re-upload that doesn't ship one.
+    preview_kwargs: _PreviewKwargs = (
+        {"previewPdfFileName": resolved_preview_filename}
+        if resolved_preview_filename is not None
+        else {}
+    )
 
     createdContent = Content.upsert(
         user_id=userId,
@@ -150,7 +168,7 @@ def upload_file(
         },
         scopeId=scope_or_unique_path,
         chatId=chat_id,
-        previewPdfFileName=resolved_preview_filename,
+        **preview_kwargs,
     )
 
     uploadUrl = createdContent.writeUrl
@@ -174,7 +192,11 @@ def upload_file(
     # (the server only mints it when previewPdfFileName is set, so a
     # missing URL signals a server-side regression).
     if preview_pdf_path is not None:
-        preview_write_url = createdContent.pdfPreviewWriteUrl
+        # ``getattr`` so an older gateway that omits the field falls
+        # through to the RuntimeError below instead of raising the
+        # opaque ``AttributeError`` that ``UniqueObject.__getattr__``
+        # produces on a missing key.
+        preview_write_url = getattr(createdContent, "pdfPreviewWriteUrl", None)
         if not preview_write_url:
             raise RuntimeError(
                 "preview_pdf_path was provided but the upsert response carries "
@@ -199,7 +221,7 @@ def upload_file(
             },
             fileUrl=createdContent.readUrl,
             chatId=chat_id,
-            previewPdfFileName=resolved_preview_filename,
+            **preview_kwargs,
         )
     else:
         unique_sdk.Content.upsert(
@@ -216,7 +238,7 @@ def upload_file(
             },
             fileUrl=createdContent.readUrl,
             scopeId=scope_or_unique_path,
-            previewPdfFileName=resolved_preview_filename,
+            **preview_kwargs,
         )
 
     return createdContent

--- a/unique_sdk/unique_sdk/utils/file_io.py
+++ b/unique_sdk/unique_sdk/utils/file_io.py
@@ -120,9 +120,19 @@ def upload_file(
             f"preview_pdf_path does not point to a readable file: {preview_pdf_path}"
         )
 
+    # A filename without a path would register a phantom preview on the
+    # Content row (the upsert mints a pdfPreviewWriteUrl, but we never
+    # PUT any bytes), leaving the side panel pointing at a nonexistent
+    # blob. Treat it as a programmer mistake and fail fast.
+    if preview_pdf_filename is not None and preview_pdf_path is None:
+        raise ValueError(
+            "preview_pdf_filename was provided without preview_pdf_path; "
+            "pass the PDF path so the preview blob actually gets uploaded."
+        )
+
     size = os.path.getsize(path_to_file)
-    resolved_preview_filename = preview_pdf_filename or (
-        _derive_preview_pdf_filename(displayed_filename)
+    resolved_preview_filename = (
+        (preview_pdf_filename or _derive_preview_pdf_filename(displayed_filename))
         if preview_pdf_path is not None
         else None
     )

--- a/unique_sdk/unique_sdk/utils/file_io.py
+++ b/unique_sdk/unique_sdk/utils/file_io.py
@@ -32,6 +32,38 @@ def download_file(url: str, filename: str):
     return file_path
 
 
+_PREVIEW_PDF_MIME_TYPE = "application/pdf"
+
+
+def _derive_preview_pdf_filename(displayed_filename: str) -> str:
+    """Return ``<stem>_preview.pdf`` for *displayed_filename*.
+
+    Keeps the preview blob filename predictable and collision-free with
+    the original (which has the user-visible extension), while still
+    making it obvious in storage which content the preview belongs to.
+    """
+    stem = displayed_filename.rsplit(".", 1)[0] or displayed_filename
+    return f"{stem}_preview.pdf"
+
+
+def _put_preview_pdf(write_url: str, preview_pdf_path: str) -> None:
+    """PUT *preview_pdf_path* bytes to the SAS URL returned by upsert."""
+    with open(preview_pdf_path, "rb") as preview_file:
+        response = requests.put(
+            write_url,
+            data=preview_file,
+            headers={
+                "X-Ms-Blob-Content-Type": _PREVIEW_PDF_MIME_TYPE,
+                "X-Ms-Blob-Type": "BlockBlob",
+            },
+        )
+    if response.status_code >= 400:
+        raise RuntimeError(
+            f"Preview PDF upload failed with status {response.status_code}: "
+            f"{response.text[:500]}"
+        )
+
+
 def upload_file(
     userId,
     companyId,
@@ -43,12 +75,58 @@ def upload_file(
     chat_id=None,
     ingestion_config: Content.IngestionConfig | None = None,
     metadata: dict[str, Any] | None = None,
+    preview_pdf_path: str | None = None,
+    preview_pdf_filename: str | None = None,
 ):
+    """Upload *path_to_file* as a Unique :class:`Content`.
+
+    When ``preview_pdf_path`` is provided, the caller gets a single-call
+    Office → PDF preview flow: we attach a ``previewPdfFileName`` to the
+    upserted content (so the platform mints a ``pdfPreviewWriteUrl``),
+    PUT the original blob, then PUT the PDF preview blob. The chat side
+    panel will pick the preview up automatically when rendering
+    PowerPoint / Word / similar formats whose in-browser preview is
+    unreliable.
+
+    Args:
+        userId: Acting user id.
+        companyId: Tenant id.
+        path_to_file: Path to the original blob to upload.
+        displayed_filename: Human-readable filename. Used as the content
+            ``key`` and ``title``.
+        mime_type: MIME type of the original blob.
+        description: Optional description.
+        scope_or_unique_path: Either a scope id, a folder path, or
+            ``None`` (when uploading into a chat).
+        chat_id: Chat id when uploading a chat attachment.
+        ingestion_config: Ingestion options.
+        metadata: Free-form metadata.
+        preview_pdf_path: Optional path to a sibling PDF that should be
+            rendered as the side-panel preview for this content. When
+            set, the upsert registers ``previewPdfFileName`` on the row
+            and the PDF bytes are PUT to ``pdfPreviewWriteUrl`` after the
+            original upload.
+        preview_pdf_filename: Optional override for the blob filename
+            stored against ``previewPdfFileName``. Defaults to
+            ``<displayed_filename without extension>_preview.pdf`` so
+            the preview blob is uniquely identifiable in storage.
+    """
     # check that chatid or scope_or_unique_path is provided
     if not chat_id and not scope_or_unique_path:
         raise ValueError("chat_id or scope_or_unique_path must be provided")
 
+    if preview_pdf_path is not None and not os.path.isfile(preview_pdf_path):
+        raise ValueError(
+            f"preview_pdf_path does not point to a readable file: {preview_pdf_path}"
+        )
+
     size = os.path.getsize(path_to_file)
+    resolved_preview_filename = preview_pdf_filename or (
+        _derive_preview_pdf_filename(displayed_filename)
+        if preview_pdf_path is not None
+        else None
+    )
+
     createdContent = Content.upsert(
         user_id=userId,
         company_id=companyId,
@@ -62,6 +140,7 @@ def upload_file(
         },
         scopeId=scope_or_unique_path,
         chatId=chat_id,
+        previewPdfFileName=resolved_preview_filename,
     )
 
     uploadUrl = createdContent.writeUrl
@@ -79,6 +158,22 @@ def upload_file(
             },
         )
 
+    # Attach the optional preview-PDF blob in the same call. We do this
+    # *before* the second upsert so the byteSize patch and the preview
+    # don't race; if the SAS URL is missing we surface a clear error
+    # (the server only mints it when previewPdfFileName is set, so a
+    # missing URL signals a server-side regression).
+    if preview_pdf_path is not None:
+        preview_write_url = createdContent.pdfPreviewWriteUrl
+        if not preview_write_url:
+            raise RuntimeError(
+                "preview_pdf_path was provided but the upsert response carries "
+                "no pdfPreviewWriteUrl — refusing to silently drop the preview. "
+                "Verify the API gateway and node-ingestion expose "
+                "previewPdfFileName on the upsert mutation."
+            )
+        _put_preview_pdf(preview_write_url, preview_pdf_path)
+
     if chat_id:
         unique_sdk.Content.upsert(
             user_id=userId,
@@ -94,6 +189,7 @@ def upload_file(
             },
             fileUrl=createdContent.readUrl,
             chatId=chat_id,
+            previewPdfFileName=resolved_preview_filename,
         )
     else:
         unique_sdk.Content.upsert(
@@ -110,6 +206,7 @@ def upload_file(
             },
             fileUrl=createdContent.readUrl,
             scopeId=scope_or_unique_path,
+            previewPdfFileName=resolved_preview_filename,
         )
 
     return createdContent


### PR DESCRIPTION
## Summary

Adds first-class support in `unique_sdk` for the platform's
`previewPdfFileName` slot on `Content`. Programmers using the SDK can
now register and upload a PDF preview alongside the original blob in a
single call.

Companion PR (monorepo backend that exposes the field):
[Unique-AG/monorepo#23257](https://github.com/Unique-AG/monorepo/pull/23257).

## API surface

`Content` resource gains two fields:

- `previewPdfFileName: str | None`
- `pdfPreviewWriteUrl: str | None`

`Content.UpsertParams` gains an optional `previewPdfFileName` so
`Content.upsert(...)` accepts it directly.

`utils.file_io.upload_file` gains two optional parameters for the
"register + upload" flow:

```python
file_io.upload_file(
    userId=user_id,
    companyId=company_id,
    path_to_file="/tmp/deck.pptx",
    displayed_filename="deck.pptx",
    mime_type="application/vnd.openxmlformats-officedocument.presentationml.presentation",
    chat_id=chat_id,
    preview_pdf_path="/tmp/deck.pdf",          # ← new
    # preview_pdf_filename="custom.pdf",       # ← optional override
)
```

When `preview_pdf_path` is set the helper:
1. Derives `<stem>_preview.pdf` (or honours `preview_pdf_filename`).
2. Upserts the `Content` with `previewPdfFileName` set so the server
   mints a `pdfPreviewWriteUrl`.
3. PUTs the original blob to `writeUrl` (unchanged).
4. PUTs the PDF blob to `pdfPreviewWriteUrl`.
5. Forwards `previewPdfFileName` again on the post-upload finalisation
   upsert so a stale render doesn't accidentally null it out.

## Defensive shape

- Missing `preview_pdf_path` raises `ValueError` before any network call.
- Response without `pdfPreviewWriteUrl` (server-side regression / older
  gateway) raises `RuntimeError` instead of silently dropping the
  preview.
- Without `preview_pdf_path`, the function behaves exactly like before
  (no `previewPdfFileName`, single PUT) — verified by a regression test.

## Test plan

- [x] `pytest tests/test_file_io_preview_pdf.py -v` — 9 passing
- [x] `pytest tests/` (full suite) — 440 passing
- [x] `ruff check` + `ruff format --check` clean on changed files

## Notes for reviewers

- The shape mirrors the platform's worker-side `contentServiceUpdate(previewPdfFileName)` plus the existing `pdfPreviewWriteUrl` field resolver. The new behaviour is enabled by the companion monorepo PR, which exposes both on the user-facing upsert mutations.
- The helper is intentionally toolkit-free (`unique_sdk` only) so callers outside the monorepo do not need to wait for a new `unique_toolkit` release.


Made with [Cursor](https://cursor.com)