### PR TITLE
fix(ci): use frozen mode for base commit in config compatibility check

### DIFF
--- a/.github/actions/setup-uv/action.yml
+++ b/.github/actions/setup-uv/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: 'Whether to install package dependencies after setting up uv'
     required: false
     default: 'true'
+  lock_mode:
+    description: 'uv lock mode: locked (default, asserts lock file is up-to-date) or frozen (uses lock file as-is, no staleness check)'
+    required: false
+    default: 'locked'
 
 outputs:
   uv-version:
@@ -45,5 +49,5 @@ runs:
       run: |
         PKG_NAME=$(grep '^name' "${{ inputs.package_dir }}/pyproject.toml" | head -1 | sed 's/.*= *"\(.*\)"/\1/')
         echo "Syncing package: $PKG_NAME"
-        uv sync --locked --package "$PKG_NAME"
-        uv sync --locked --inexact --only-dev
+        uv sync --${{ inputs.lock_mode }} --package "$PKG_NAME"
+        uv sync --${{ inputs.lock_mode }} --inexact --only-dev

--- a/.github/workflows/ci-config-check.yaml
+++ b/.github/workflows/ci-config-check.yaml
@@ -106,6 +106,7 @@ jobs:
         with:
           package_dir: ${{ matrix.dir }}
           python_version: ${{ matrix.python }}
+          lock_mode: frozen
 
       - name: Export base defaults
         working-directory: ${{ matrix.dir }}


### PR DESCRIPTION
## Summary

- The config compatibility check was failing on PRs targeting release branches because \`uv sync --locked\` errored out during the base commit checkout step
- Root cause: uv 0.11.5 considers the base commit's lockfile stale (format drift across uv versions), even when dependencies haven't changed
- Fix: add a \`lock_mode\` input (default: \`locked\`) to \`setup-uv\` and use \`frozen\` for the base commit step, which skips the staleness check entirely

## Changes

- \`.github/actions/setup-uv/action.yml\` — new \`lock_mode\` input wired into both \`uv sync\` calls
- \`.github/workflows/ci-config-check.yaml\` — base commit's \`Setup uv\` step now passes \`lock_mode: frozen\`; tip step retains the default \`locked\`

## Test plan

- [ ] Triggered by the failing CI on #1534 — this fix should unblock it
- [ ] The tip step still uses \`--locked\`, so lock file drift introduced by a PR is still caught

## Risk / rollout

No functional change to what gets installed; only the staleness assertion is relaxed for the base commit step, which is intentional.

Made with [Cursor](https://cursor.com)