### PR TITLE
ci(release): always bump patch on release branches

### DIFF
--- a/.github/workflows/cd-release.yaml
+++ b/.github/workflows/cd-release.yaml
@@ -33,7 +33,7 @@ jobs:
       - id: rp
         uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
         with:
-          config-file: release-please-config.json
+          config-file: ${{ startsWith(github.ref_name, 'release/') && 'release-please-config.release.json' || 'release-please-config.json' }}
           manifest-file: .release-please-manifest.json
           target-branch: ${{ github.ref_name }}
 

--- a/release-please-config.release.json
+++ b/release-please-config.release.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "release-type": "python",
+  "versioning": "always-bump-patch",
+  "separate-pull-requests": false,
+  "group-pull-request-title-pattern": "chore: release ${branch}",
+  "include-component-in-tag": true,
+  "include-v-in-tag": true,
+  "tag-separator": "-",
+  "changelog-sections": [
+    {"type": "feat", "section": "Features"},
+    {"type": "fix", "section": "Bug Fixes"},
+    {"type": "perf", "section": "Performance"},
+    {"type": "revert", "section": "Reverts"},
+    {"type": "docs", "section": "Documentation", "hidden": true},
+    {"type": "chore", "section": "Miscellaneous", "hidden": true},
+    {"type": "refactor", "section": "Miscellaneous", "hidden": true},
+    {"type": "test", "section": "Tests", "hidden": true},
+    {"type": "ci", "section": "CI", "hidden": true},
+    {"type": "build", "section": "Build", "hidden": true}
+  ],
+  "packages": {
+    "unique_sdk": {
+      "component": "unique-sdk"
+    },
+    "unique_toolkit": {
+      "component": "unique-toolkit"
+    },
+    "unique_mcp": {
+      "component": "unique-mcp"
+    },
+    "unique_orchestrator": {
+      "component": "unique-orchestrator"
+    },
+    "tool_packages/unique_web_search": {
+      "component": "unique-web-search"
+    },
+    "tool_packages/unique_swot": {
+      "component": "unique-swot"
+    },
+    "tool_packages/unique_deep_research": {
+      "component": "unique-deep-research"
+    },
+    "tool_packages/unique_internal_search": {
+      "component": "unique-internal-search"
+    },
+    "postprocessors/unique_follow_up_questions": {
+      "component": "unique-follow-up-questions"
+    },
+    "postprocessors/unique_stock_ticker": {
+      "component": "unique-stock-ticker"
+    },
+    "connectors/unique_quartr": {
+      "component": "unique-quartr"
+    },
+    "connectors/unique_six": {
+      "component": "unique-six"
+    },
+    "tool_packages/unique_skill_tool": {
+      "component": "unique-skill-tool"
+    }
+  },
+  "plugins": [
+    {
+      "type": "linked-versions",
+      "groupName": "ai",
+      "components": [
+        "unique-sdk",
+        "unique-toolkit",
+        "unique-mcp",
+        "unique-orchestrator",
+        "unique-web-search",
+        "unique-swot",
+        "unique-deep-research",
+        "unique-internal-search",
+        "unique-follow-up-questions",
+        "unique-stock-ticker",
+        "unique-quartr",
+        "unique-six",
+        "unique-skill-tool"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Backport of #1541 to `release/2026.18`.

- Adds `release-please-config.release.json` with `versioning: always-bump-patch`
- Updates `cd-release.yaml` to use this config when running on `release/*` branches
- Ensures a `feat:` commit on a hotfix branch never incorrectly bumps the minor component (e.g. `2026.18.x → 2026.19.0`)

On `main` the default versioning strategy is unchanged.

Made with [Cursor](https://cursor.com)