### PR TITLE
ci(release): add rc pre-release publish workflow

### DIFF
--- a/.github/scripts/resolve-dev-versions.py
+++ b/.github/scripts/resolve-dev-versions.py
@@ -23,7 +23,7 @@ From that we produce:
       - otherwise                           -> ``>=<pyproject version>``
 
 Both maps key cross-package names by their PEP 503 normalized form so
-``rewrite-pyproject-for-dev.py`` can match regardless of whether the
+``rewrite-pyproject-pre-release.py`` can match regardless of whether the
 requirement spells the name with ``-``, ``_`` or ``.``.
 """
 

--- a/.github/scripts/resolve-rc-versions.py
+++ b/.github/scripts/resolve-rc-versions.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Resolve rc versions and exact dep pins for an rc publish run.
+
+Unlike dev publishes (per-package contiguous ``devN`` counters), an rc
+cut republishes **every** publishable AI package at a single shared
+``{cycle}.0rcN`` version. The shared counter is what lets sibling deps
+be pinned with ``==``: every package in the cut resolves to the same
+concrete release, so ``pip install`` always picks a mutually consistent
+set. Mixing different ``rcN`` counters across packages would defeat the
+``==`` pins.
+
+Counter selection
+=================
+For the chosen cycle, query PyPI for the highest ``rcN`` already
+published against any publishable package, and emit ``rc(N+1)`` (or
+``rc1`` if nothing exists yet). PyPI is the source of truth, so two rc
+workflows running in parallel can never land on the same N — whichever
+publishes first wins, and the second observes it and steps to the next
+counter. Within the workflow the publish step itself is also serialized
+under the ``publish-prerelease`` concurrency group, but that is belt-and-
+suspenders: the PyPI lookup alone already protects against duplicate
+counters.
+
+Outputs
+=======
+* ``new_versions``: pkg_id -> ``{cycle}.0rcN`` for every publishable
+  package. Always covers the full publishable set — rc cuts do not
+  honor a "selected" subset because every sibling needs to resolve.
+
+* ``dep_pins``: normalized PyPI name -> ``=={cycle}.0rcN`` for every
+  publishable package. Consumed by ``rewrite-pyproject-pre-release.py``,
+  which stamps these into wheel ``Requires-Dist`` so the resulting
+  release is a closed set with no drift between siblings.
+
+Names in both maps are PEP 503 normalized so the rewrite step matches
+``unique-sdk``, ``unique_sdk`` and ``Unique.SDK`` to the same entry.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+
+# Reuse the helpers from the dev resolver — same PyPI lookup, same
+# normalization, same package-config loader. Keeps the two resolvers in
+# lockstep so a fix to either path benefits both.
+from importlib import util as _import_util
+from pathlib import Path
+
+_DEV_RESOLVER_PATH = Path(__file__).resolve().with_name("resolve-dev-versions.py")
+_spec = _import_util.spec_from_file_location("_resolve_dev", _DEV_RESOLVER_PATH)
+assert _spec is not None and _spec.loader is not None
+_resolve_dev = _import_util.module_from_spec(_spec)
+_spec.loader.exec_module(_resolve_dev)
+normalize = _resolve_dev.normalize
+_fetch_versions = _resolve_dev._fetch_versions
+_load_publishable = _resolve_dev._load_publishable
+DEFAULT_PACKAGE_CONFIG = _resolve_dev.DEFAULT_PACKAGE_CONFIG
+DEFAULT_PYPI_BASE_URL = _resolve_dev.DEFAULT_PYPI_BASE_URL
+
+_CYCLE_RE = re.compile(r"^\d{4}\.\d{2}$")
+
+
+def highest_rc_in_cycle(
+    pypi_name: str,
+    cycle: str,
+    base_url: str,
+    *,
+    fetcher=_fetch_versions,
+) -> int | None:
+    """Return the highest ``N`` for which ``{cycle}.0rcN`` exists on PyPI."""
+    pattern = re.compile(rf"^{re.escape(cycle)}\.0rc(\d+)$")
+    ns = [
+        int(m.group(1)) for v in fetcher(pypi_name, base_url) if (m := pattern.match(v))
+    ]
+    return max(ns) if ns else None
+
+
+def resolve(
+    *,
+    cycle: str,
+    publishable: list[dict],
+    pypi_base_url: str,
+    fetcher=_fetch_versions,
+) -> tuple[dict[str, str], dict[str, str], int]:
+    """Return ``(new_versions, dep_pins, rc_n)``.
+
+    The shared ``rc_n`` is the global highest existing rc counter for
+    the cycle plus one (or ``1`` when none exist). All publishable
+    packages get the same version and the same exact pin.
+    """
+    if not _CYCLE_RE.match(cycle):
+        raise SystemExit(f"invalid cycle: {cycle!r}")
+
+    # Global max across every publishable package; one rc counter for the
+    # whole cut so sibling ``==`` pins always resolve consistently.
+    seen: list[int] = []
+    for pkg in publishable:
+        n = highest_rc_in_cycle(pkg["pypi_name"], cycle, pypi_base_url, fetcher=fetcher)
+        if n is not None:
+            seen.append(n)
+    rc_n = (max(seen) + 1) if seen else 1
+    version = f"{cycle}.0rc{rc_n}"
+
+    new_versions: dict[str, str] = {}
+    dep_pins: dict[str, str] = {}
+    for pkg in publishable:
+        new_versions[pkg["id"]] = version
+        dep_pins[normalize(pkg["pypi_name"])] = f"=={version}"
+
+    return new_versions, dep_pins, rc_n
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cycle", required=True)
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument(
+        "--package-config", default=str(DEFAULT_PACKAGE_CONFIG), type=Path
+    )
+    parser.add_argument("--pypi-base-url", default=DEFAULT_PYPI_BASE_URL)
+    args = parser.parse_args(argv)
+
+    publishable = _load_publishable(args.package_config)
+    new_versions, dep_pins, rc_n = resolve(
+        cycle=args.cycle,
+        publishable=publishable,
+        pypi_base_url=args.pypi_base_url,
+    )
+    version = f"{args.cycle}.0rc{rc_n}"
+
+    out = Path(args.output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    # Trailing newlines: the publish-rc workflow streams these into
+    # GITHUB_OUTPUT as multiline values terminated by a delimiter on its
+    # own line. Without the final ``\n``, ``cat file; echo DELIM`` emits
+    # ``...}DELIM`` on one line and GitHub reports "Matching delimiter
+    # not found".
+    (out / "new_versions.json").write_text(json.dumps(new_versions, indent=2) + "\n")
+    (out / "dep_pins.json").write_text(json.dumps(dep_pins, indent=2) + "\n")
+    (out / "rc_version.txt").write_text(version + "\n")
+    (out / "rc_n.txt").write_text(f"{rc_n}\n")
+
+    print("### RC publish — version resolution\n")
+    print(f"- Cycle: `{args.cycle}`")
+    print(f"- RC version: `{version}` (counter: `rc{rc_n}`)")
+    print(f"- Packages in cut: {len(publishable)}\n")
+    print("| package | new version |\n| --- | --- |")
+    for pid in sorted(new_versions):
+        print(f"| `{pid}` | `{new_versions[pid]}` |")
+    print("\n| dep | pinned to |\n| --- | --- |")
+    for name in sorted(dep_pins):
+        print(f"| `{name}` | `{dep_pins[name]}` |")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/rewrite-pyproject-pre-release.py
+++ b/.github/scripts/rewrite-pyproject-pre-release.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
-"""Rewrite a package's pyproject.toml for a .devN build.
+"""Rewrite a package's pyproject.toml for a pre-release build.
 
-Two things happen in place:
+Used by both the dev (``.devN``) and release-candidate (``rcN``)
+publish workflows. Two things happen in place:
 
 1. ``project.version`` is replaced with the caller's ``--own-version``.
 2. In every PEP 621 dependency array (``project.dependencies`` and each
@@ -19,26 +20,25 @@ Two things happen in place:
            ->  "unique-toolkit[monitoring]>=2026.18.0.dev7"
 
 Because the constraint explicitly contains a PEP 440 pre-release segment
-(``devN``), pip/uv will resolve to dev versions without ``--pre``.
+(``devN`` or ``rcN``), pip/uv resolves to pre-release versions without
+``--pre``.
 
-The pin map is computed upstream in ``resolve-dev-versions.py`` and
-encodes three cases per cross-package dep:
+The pin map is computed upstream by either ``resolve-dev-versions.py``
+or ``resolve-rc-versions.py``:
 
-  * The dep is being published in the same push     -> ``>=<new-version>``
-  * The cycle already has a dev wheel for the dep   -> ``>=<latest-dev>``
-  * Otherwise (nothing in the cycle yet)            -> ``>=<last-stable>``
-
-The second and third cases produce a floor that an older locally-
-installed dev wheel can never satisfy (because ``>=`` includes the
-specified version), so ``pip install -U`` correctly upgrades siblings
-even when they weren't republished in this push.
+  * Dev publish (``resolve-dev-versions.py``) emits ``>=<version>`` pins;
+    siblings drift forward independently and ``pip install -U`` upgrades
+    siblings that were not republished.
+  * RC publish (``resolve-rc-versions.py``) emits ``==<version>`` pins,
+    because every publishable package is republished at the same
+    ``{cycle}.0rcN`` for a fully reproducible cut.
 
 Non-AI dependencies are left untouched. ``project.name`` and ``[tool.*]``
 tables are never touched. Formatting and comments in the TOML file are
 preserved via tomlkit.
 
 Usage:
-    rewrite-pyproject-for-dev.py <pyproject.toml>
+    rewrite-pyproject-pre-release.py <pyproject.toml>
         --own-version <v> --dep-pins <json>
 """
 
@@ -52,17 +52,16 @@ from pathlib import Path
 import tomlkit
 
 _REQ_RE = re.compile(r"^\s*([A-Za-z0-9_.\-]+)(\[[^\]]*\])?\s*(.*)$")
-# Own version is always CalVer .devN — the dev publish never stamps a
-# stable version into a package.
-_VERSION_RE = re.compile(r"^\d{4}\.\d{2}\.\d+\.dev\d+$")
-# Dep pins come in three flavors out of resolve-dev-versions.py:
-#   >=<CalVer dev>   (sibling in this push, or cycle-dev already on PyPI)
-#   >=<stable>       (last stable fallback; may be legacy pre-CalVer)
-# All three cases use >= so future dev releases of the same package
-# remain installable without republishing every transitive dependent.
-# Dotted numerics of arbitrary length are accepted so legacy
-# "0.3.3"-style versions pass through.
-_PIN_RE = re.compile(r"^>=\d+(\.\d+)*(\.dev\d+)?$")
+# Own version is always a CalVer pre-release — either ``.devN`` (dev
+# publish) or ``rcN`` (release-candidate publish). Stable CalVers are
+# stamped by release-please, never by this script.
+_VERSION_RE = re.compile(r"^\d{4}\.\d{2}\.\d+(\.dev\d+|rc\d+)$")
+# Dep pins come from one of the two resolvers:
+#   >=<version>   from resolve-dev-versions.py (siblings drift forward)
+#   ==<version>   from resolve-rc-versions.py  (reproducible rc cut)
+# Versions may be CalVer with a ``.devN``/``rcN`` suffix, or legacy
+# pre-CalVer dotted numerics (e.g. "0.3.3") for last-stable fallbacks.
+_PIN_RE = re.compile(r"^(>=|==)\d+(\.\d+)*(\.dev\d+|rc\d+)?$")
 
 
 def normalize(name: str) -> str:

--- a/.github/scripts/tests/test_resolve_rc_versions.py
+++ b/.github/scripts/tests/test_resolve_rc_versions.py
@@ -1,0 +1,234 @@
+"""Unit tests for `.github/scripts/resolve-rc-versions.py`.
+
+Covers the shared rc counter logic, exact dep pinning across the full
+publishable set, PEP 503 normalization, and the trailing-newline guard
+on output files (the workflow streams them into GITHUB_OUTPUT under a
+multiline delimiter and a missing newline silently breaks parsing).
+
+PyPI is never contacted; a fake ``fetcher`` is injected into the
+resolver via the documented keyword argument.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+SCRIPT = (
+    Path(__file__).resolve().parents[3]
+    / ".github"
+    / "scripts"
+    / "resolve-rc-versions.py"
+)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("resolve_rc_versions", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["resolve_rc_versions"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+rrv = _load_module()
+
+
+def _fake_fetcher(versions_by_name: dict[str, list[str]]):
+    def fetcher(name: str, _base: str) -> list[str]:
+        return list(versions_by_name.get(name, []))
+
+    return fetcher
+
+
+class HighestRcInCycleTests(unittest.TestCase):
+    def test_returns_none_when_empty(self) -> None:
+        self.assertIsNone(
+            rrv.highest_rc_in_cycle(
+                "foo", "2026.20", "", fetcher=_fake_fetcher({"foo": []})
+            )
+        )
+
+    def test_ignores_other_cycles_devs_and_stables(self) -> None:
+        # Only ``{cycle}.0rcN`` counts; everything else (other cycles,
+        # devN, stable, hotfix patch) must be filtered out so the rc
+        # counter never picks up a stale match.
+        self.assertIsNone(
+            rrv.highest_rc_in_cycle(
+                "foo",
+                "2026.20",
+                "",
+                fetcher=_fake_fetcher(
+                    {
+                        "foo": [
+                            "2026.18.0rc1",
+                            "2026.20.0",
+                            "2026.20.1",
+                            "2026.20.0.dev3",
+                            "0.3.0",
+                        ]
+                    }
+                ),
+            )
+        )
+
+    def test_picks_highest_matching_rcN(self) -> None:
+        self.assertEqual(
+            7,
+            rrv.highest_rc_in_cycle(
+                "foo",
+                "2026.20",
+                "",
+                fetcher=_fake_fetcher(
+                    {
+                        "foo": [
+                            "2026.20.0rc1",
+                            "2026.20.0rc7",
+                            "2026.20.0rc3",
+                            "2026.20.0",  # eventual stable, not an rc
+                        ]
+                    }
+                ),
+            ),
+        )
+
+
+class ResolveTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.cycle = "2026.20"
+        self.publishable = [
+            {"id": "toolkit", "pypi_name": "unique_toolkit", "dir": "unique_toolkit"},
+            {"id": "sdk", "pypi_name": "unique_sdk", "dir": "unique_sdk"},
+            {"id": "mcp", "pypi_name": "unique-mcp", "dir": "unique_mcp"},
+        ]
+
+    def _resolve(self, pypi):
+        return rrv.resolve(
+            cycle=self.cycle,
+            publishable=self.publishable,
+            pypi_base_url="",
+            fetcher=_fake_fetcher(pypi),
+        )
+
+    def test_fresh_cycle_starts_at_rc1(self) -> None:
+        new_versions, dep_pins, rc_n = self._resolve(
+            pypi={"unique_toolkit": [], "unique_sdk": [], "unique-mcp": []},
+        )
+        self.assertEqual(rc_n, 1)
+        # Every publishable package gets the same shared rc version.
+        self.assertEqual(new_versions["toolkit"], "2026.20.0rc1")
+        self.assertEqual(new_versions["sdk"], "2026.20.0rc1")
+        self.assertEqual(new_versions["mcp"], "2026.20.0rc1")
+        # And every sibling dep is pinned with ``==`` to that same version.
+        self.assertEqual(dep_pins["unique-toolkit"], "==2026.20.0rc1")
+        self.assertEqual(dep_pins["unique-sdk"], "==2026.20.0rc1")
+        self.assertEqual(dep_pins["unique-mcp"], "==2026.20.0rc1")
+
+    def test_global_max_drives_shared_counter(self) -> None:
+        # Different packages are at different rc counters on PyPI; the
+        # next cut must use ``max + 1`` shared across the full set so
+        # ``==`` pins still resolve to one concrete release.
+        new_versions, dep_pins, rc_n = self._resolve(
+            pypi={
+                "unique_toolkit": ["2026.20.0rc1", "2026.20.0rc2"],
+                "unique_sdk": ["2026.20.0rc4"],
+                "unique-mcp": ["2026.20.0rc1"],
+            },
+        )
+        self.assertEqual(rc_n, 5)
+        for pid in ("toolkit", "sdk", "mcp"):
+            self.assertEqual(new_versions[pid], "2026.20.0rc5")
+        for name in ("unique-toolkit", "unique-sdk", "unique-mcp"):
+            self.assertEqual(dep_pins[name], "==2026.20.0rc5")
+
+    def test_publishable_without_rc_history_still_gets_shared_counter(self) -> None:
+        # A brand-new package never published to PyPI must still land at
+        # the shared rc counter; the resolver does not fall back to
+        # per-package counters.
+        new_versions, dep_pins, rc_n = self._resolve(
+            pypi={
+                "unique_toolkit": ["2026.20.0rc3"],
+                "unique_sdk": [],  # never published
+                "unique-mcp": [],
+            },
+        )
+        self.assertEqual(rc_n, 4)
+        self.assertEqual(new_versions["sdk"], "2026.20.0rc4")
+        self.assertEqual(dep_pins["unique-sdk"], "==2026.20.0rc4")
+
+    def test_pep503_normalization(self) -> None:
+        # ``unique_toolkit`` and ``unique-mcp`` must both land under
+        # PEP 503 normalized keys so the rewrite step matches them
+        # regardless of how the requirement is spelled.
+        _, dep_pins, _ = self._resolve(
+            pypi={"unique_toolkit": [], "unique_sdk": [], "unique-mcp": []},
+        )
+        self.assertIn("unique-toolkit", dep_pins)
+        self.assertIn("unique-sdk", dep_pins)
+        self.assertIn("unique-mcp", dep_pins)
+        self.assertNotIn("unique_toolkit", dep_pins)
+
+    def test_invalid_cycle(self) -> None:
+        with self.assertRaises(SystemExit):
+            rrv.resolve(
+                cycle="not-a-cycle",
+                publishable=self.publishable,
+                pypi_base_url="",
+                fetcher=_fake_fetcher({}),
+            )
+
+
+class MainOutputFilesTests(unittest.TestCase):
+    """Guards that the JSON / text files consumed by publish-rc.yaml end
+    with a trailing newline. The workflow streams them into GITHUB_OUTPUT
+    with a delimiter on its own line; without the final `\\n`, GitHub
+    reports "Matching delimiter not found"."""
+
+    def test_files_end_with_newline(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            cfg = Path(td) / "pkgs.json"
+            cfg.write_text(
+                json.dumps(
+                    [{"id": "toolkit", "pypi_name": "unique_toolkit", "dir": "u"}]
+                )
+            )
+            out = Path(td) / "out"
+
+            def fake_resolve(**_):
+                return (
+                    {"toolkit": "2026.20.0rc1"},
+                    {"unique-toolkit": "==2026.20.0rc1"},
+                    1,
+                )
+
+            with patch.object(rrv, "resolve", side_effect=fake_resolve):
+                rc = rrv.main(
+                    [
+                        "--cycle",
+                        "2026.20",
+                        "--output-dir",
+                        str(out),
+                        "--package-config",
+                        str(cfg),
+                        "--pypi-base-url",
+                        "",
+                    ]
+                )
+            self.assertEqual(rc, 0)
+            self.assertTrue((out / "new_versions.json").read_text().endswith("\n"))
+            self.assertTrue((out / "dep_pins.json").read_text().endswith("\n"))
+            self.assertTrue((out / "rc_version.txt").read_text().endswith("\n"))
+            self.assertTrue((out / "rc_n.txt").read_text().endswith("\n"))
+            self.assertEqual(
+                (out / "rc_version.txt").read_text().strip(), "2026.20.0rc1"
+            )
+            self.assertEqual((out / "rc_n.txt").read_text().strip(), "1")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/tests/test_rewrite_pyproject_pre_release.py
+++ b/.github/scripts/tests/test_rewrite_pyproject_pre_release.py
@@ -1,8 +1,9 @@
-"""Unit tests for `.github/scripts/rewrite-pyproject-for-dev.py`.
+"""Unit tests for `.github/scripts/rewrite-pyproject-pre-release.py`.
 
 Verifies the in-place rewrite of ``project.version`` plus PEP 621
 dependency arrays (including optional-dependencies groups) against the
-dep-pin map produced by ``resolve-dev-versions.py``.
+dep-pin map produced by ``resolve-dev-versions.py`` or
+``resolve-rc-versions.py``.
 """
 
 from __future__ import annotations
@@ -15,19 +16,21 @@ import unittest
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
-SCRIPT = REPO_ROOT / ".github" / "scripts" / "rewrite-pyproject-for-dev.py"
+SCRIPT = REPO_ROOT / ".github" / "scripts" / "rewrite-pyproject-pre-release.py"
 
 
 def _load_module():
-    spec = importlib.util.spec_from_file_location("rewrite_pyproject_for_dev", SCRIPT)
+    spec = importlib.util.spec_from_file_location(
+        "rewrite_pyproject_pre_release", SCRIPT
+    )
     assert spec is not None and spec.loader is not None
     mod = importlib.util.module_from_spec(spec)
-    sys.modules["rewrite_pyproject_for_dev"] = mod
+    sys.modules["rewrite_pyproject_pre_release"] = mod
     spec.loader.exec_module(mod)
     return mod
 
 
-rpd = _load_module()
+rppr = _load_module()
 
 
 SAMPLE_PYPROJECT = """\
@@ -57,7 +60,7 @@ class RewriteTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             path = Path(td) / "pyproject.toml"
             path.write_text(SAMPLE_PYPROJECT)
-            rc = rpd.main(
+            rc = rppr.main(
                 [
                     str(path),
                     "--own-version",
@@ -122,7 +125,7 @@ class RewriteTests(unittest.TestCase):
             path = Path(td) / "pyproject.toml"
             path.write_text(SAMPLE_PYPROJECT)
             with self.assertRaises(SystemExit):
-                rpd.main(
+                rppr.main(
                     [
                         str(path),
                         "--own-version",
@@ -137,7 +140,7 @@ class RewriteTests(unittest.TestCase):
             path = Path(td) / "pyproject.toml"
             path.write_text(SAMPLE_PYPROJECT)
             with self.assertRaises(SystemExit):
-                rpd.main(
+                rppr.main(
                     [
                         str(path),
                         "--own-version",
@@ -147,22 +150,48 @@ class RewriteTests(unittest.TestCase):
                     ]
                 )
 
-    def test_rejects_non_dev_own_version(self) -> None:
-        # The rewriter is only ever invoked for dev publishes — stable
-        # CalVers are stamped by release-please, not by this script.
+    def test_rejects_non_pre_release_own_version(self) -> None:
+        # The rewriter is only ever invoked for pre-release publishes
+        # (.devN or rcN). Stable CalVers are stamped by release-please,
+        # not by this script.
         with tempfile.TemporaryDirectory() as td:
             path = Path(td) / "pyproject.toml"
             path.write_text(SAMPLE_PYPROJECT)
             with self.assertRaises(SystemExit):
-                rpd.main(
+                rppr.main(
                     [
                         str(path),
                         "--own-version",
-                        "2026.18.0",  # stable, no .devN — must be rejected
+                        "2026.18.0",  # stable — must be rejected
                         "--dep-pins",
                         json.dumps({}),
                     ]
                 )
+
+    def test_accepts_rc_own_version_and_equality_pins(self) -> None:
+        # The rc publish path stamps {cycle}.0rcN versions and ``==`` pins
+        # so every package in the cut resolves to the same rc.
+        out = self._run(
+            {
+                "unique-sdk": "==2026.20.0rc1",
+                "unique-orchestrator": "==2026.20.0rc1",
+                "unique-mcp": "==2026.20.0rc1",
+            },
+            own_version="2026.20.0rc1",
+        )
+        self.assertIn('version = "2026.20.0rc1"', out)
+        self.assertIn('"unique-sdk==2026.20.0rc1"', out)
+        self.assertIn('"unique_orchestrator==2026.20.0rc1"', out)
+        self.assertIn('"unique-mcp[extra]==2026.20.0rc1"', out)
+
+    def test_accepts_higher_rc_number(self) -> None:
+        # rcN counter can grow without bound within a cycle.
+        out = self._run(
+            {"unique-sdk": "==2026.20.0rc7"},
+            own_version="2026.20.0rc7",
+        )
+        self.assertIn('version = "2026.20.0rc7"', out)
+        self.assertIn('"unique-sdk==2026.20.0rc7"', out)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/cd-publish-dev.yaml
+++ b/.github/workflows/cd-publish-dev.yaml
@@ -25,7 +25,7 @@ name: "[CD] Publish dev builds to PyPI"
 # Dep pins (cross-package AI deps, per publish)
 # =============================================
 #   Computed once in `resolve` and stamped into every wheel's
-#   Requires-Dist by `rewrite-pyproject-for-dev.py`:
+#   Requires-Dist by `rewrite-pyproject-pre-release.py`:
 #     - dep IS publishing in this push          -> `==<its new_version>`
 #         (siblings are locked together so `pip install` always pulls a
 #          mutually-consistent set)
@@ -38,10 +38,20 @@ name: "[CD] Publish dev builds to PyPI"
 #
 # Serialization
 # =============
-#   The workflow runs under a global `publish-dev` concurrency group
-#   with `cancel-in-progress: false`, so two pushes never race on the
-#   same PyPI write. Each run observes the previous run's published
-#   versions before computing its own devN counters.
+#   The workflow runs under a global `publish-prerelease` concurrency
+#   group with `cancel-in-progress: false`, so two pushes never race on
+#   the same PyPI write. The same group is shared with `cd-publish-rc.yaml`
+#   so dev and rc publishes also serialize against each other. Each run
+#   observes the previous run's published versions before computing its
+#   own devN counters.
+#
+# Cut tagging
+# ===========
+#   After a successful publish, the workflow tags the head SHA as
+#   `dev-cut-<SHORT_SHA>` and creates a matching GitHub pre-release that
+#   lists every package version produced by the run. This gives `cd-publish-rc`
+#   a stable, reproducible promotion target — pick a `dev-cut-*` tag and
+#   republish that exact set of packages as `{cycle}.0rcN`.
 
 on:
   push:
@@ -52,7 +62,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: publish-dev
+  group: publish-prerelease
   cancel-in-progress: false
 
 jobs:
@@ -87,7 +97,7 @@ jobs:
           # auto-detect mode (selected='').
           INVALIDATORS=(
             ".github/workflows/cd-publish-dev.yaml"
-            ".github/scripts/rewrite-pyproject-for-dev.py"
+            ".github/scripts/rewrite-pyproject-pre-release.py"
             ".github/scripts/resolve-dev-versions.py"
             ".github/scripts/compute-calver.sh"
             ".github/actions/get-packages-matrix/package_configuration.json"
@@ -222,7 +232,7 @@ jobs:
           PYPROJECT: ${{ matrix.dir }}/pyproject.toml
         run: |
           uv run --quiet --no-project --with 'tomlkit==0.14.0' -- \
-            python3 .github/scripts/rewrite-pyproject-for-dev.py \
+            python3 .github/scripts/rewrite-pyproject-pre-release.py \
               "$PYPROJECT" \
               --own-version "$OWN_VERSION" \
               --dep-pins "$DEP_PINS"
@@ -264,6 +274,76 @@ jobs:
       - name: Publish to PyPI
         working-directory: ${{ matrix.dir }}
         run: uv publish --username __token__ --password "${{ secrets.PYPI_TOKEN }}"
+
+  tag-cut:
+    # Tag every successful dev publish so it can later be promoted to an
+    # rc release by `cd-publish-rc.yaml`. The Git tag (`dev-cut-<SHORT_SHA>`)
+    # plus the matching GitHub pre-release lock down what the cut actually
+    # contained — which packages were rebuilt, at what versions, and with
+    # which sibling pins — without anyone having to scrape PyPI by date.
+    needs: [resolve, publish]
+    if: needs.publish.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          # Tag and notes target the commit the dev wheels were built from,
+          # not whatever main looks like by the time this job runs.
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+
+      - name: Tag dev cut
+        env:
+          SHA: ${{ github.sha }}
+        run: |
+          SHORT="$(git rev-parse --short=12 "$SHA")"
+          TAG="dev-cut-${SHORT}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "$TAG" "$SHA"
+          git push origin "$TAG"
+          echo "tag=$TAG"     >> "$GITHUB_OUTPUT"
+          echo "short=$SHORT" >> "$GITHUB_OUTPUT"
+        id: tag
+
+      - name: Create GitHub pre-release for cut
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEW_VERSIONS: ${{ needs.resolve.outputs.new_versions }}
+          DEP_PINS: ${{ needs.resolve.outputs.dep_pins }}
+          CYCLE: ${{ needs.resolve.outputs.cycle }}
+          SHA: ${{ github.sha }}
+          TAG: ${{ steps.tag.outputs.tag }}
+          SHORT: ${{ steps.tag.outputs.short }}
+        run: |
+          BODY_FILE="$(mktemp)"
+          {
+            echo "Dev cut from \`${SHA}\` (cycle \`${CYCLE}\`)."
+            echo
+            echo "## Packages published in this cut"
+            echo
+            echo "| package | version |"
+            echo "| --- | --- |"
+            jq -r 'to_entries | sort_by(.key) | .[] | "| `\(.key)` | `\(.value)` |"' <<<"$NEW_VERSIONS"
+            echo
+            echo "## Sibling dependency pins stamped into wheel METADATA"
+            echo
+            echo "These are the pins \`rewrite-pyproject-pre-release.py\` injected into every"
+            echo "rebuilt package. \`==\` means the sibling was published in the same run;"
+            echo "\`>=\` means it was reused from PyPI (current cycle dev or last stable)."
+            echo
+            echo '```json'
+            jq -S . <<<"$DEP_PINS"
+            echo '```'
+          } > "$BODY_FILE"
+
+          gh release create "$TAG" \
+            --prerelease \
+            --target "$SHA" \
+            --title "dev cut ${SHORT}" \
+            --notes-file "$BODY_FILE"
 
   open-dev-bump-pr:
     # Opens (or replaces) a PR that writes the latest dev versions into every
@@ -330,7 +410,7 @@ jobs:
                 fi
                 echo "Rewriting $dir/pyproject.toml → version=$version"
                 uv run --quiet --no-project --with 'tomlkit==0.14.0' -- \
-                  python3 .github/scripts/rewrite-pyproject-for-dev.py \
+                  python3 .github/scripts/rewrite-pyproject-pre-release.py \
                     "$dir/pyproject.toml" \
                     --own-version "$version" \
                     --dep-pins "$DEP_PINS"

--- a/.github/workflows/cd-publish-rc.yaml
+++ b/.github/workflows/cd-publish-rc.yaml
@@ -1,0 +1,411 @@
+name: "[CD] Publish rc release to PyPI"
+
+# Promote a previously published *dev cut* to a release-candidate (rc)
+# release on PyPI. Manually triggered, takes a `dev-cut-<SHA>` tag as
+# input, and republishes *every* package in that cut at version
+# `{cycle}.0rcN` with sibling deps pinned to `==`.
+#
+# Why rc instead of dev for "ship something between weekly releases"
+# ==================================================================
+#   PEP 440 orders pre-releases as ``dev < a < b < rc < final < post``.
+#   A ``2026.20.0rc1`` therefore:
+#     - sorts BEFORE the eventual ``2026.20.0`` weekly release, so it
+#       does not shadow it
+#     - sorts AFTER any ``2026.18.x`` hotfix, so a customer that wants
+#       a fix between weekly releases can pin ``>= 2026.18.0`` and pick
+#       it up via normal upgrades
+#     - is opt-in by default for pip / uv (pre-releases require
+#       ``--pre`` or an explicit pin), unlike a stable release which
+#       would be picked up by the next weekly automation
+#
+# Why "dev cut" as the promotion unit
+# ===================================
+#   ``cd-publish-dev`` only rebuilds the packages whose sources changed
+#   in the push range. Two consecutive dev publishes therefore produce
+#   *different sets* of sibling versions on PyPI. A "dev cut" is the
+#   reproducible unit that pins this down: one SHA on ``main`` plus
+#   the exact ``(package, version)`` map produced from it. Each
+#   successful dev publish tags ``dev-cut-<SHORT_SHA>`` and creates a
+#   matching GitHub pre-release that records the map.
+#
+#   This workflow always promotes the WHOLE cut (every publishable
+#   package), not just packages that changed since the last release.
+#   That keeps `==` sibling pins in the rc wheels honest: every rc
+#   in a cycle resolves to one consistent set of versions.
+#
+# RC monotonicity
+# ===============
+#   ``rcN+1`` must be a superset of ``rcN`` so a customer who pinned
+#   ``==2026.20.0rcN`` can move forward to ``rcN+1`` without losing
+#   fixes. We enforce this by requiring the chosen cut SHA to be a
+#   descendant of the previous rc cut SHA in the same cycle. Override
+#   with ``force_non_linear: true`` only when intentionally branching
+#   (e.g. dropping an unwanted commit).
+#
+# Tag and release artifacts
+# =========================
+#   - Git tag: ``rc-{cycle}.0rcN`` on the dev cut SHA (so the same SHA
+#     can carry both ``dev-cut-<SHORT>`` and the matching rc tag).
+#   - GitHub pre-release: title = rc version, target = cut SHA,
+#     ``--notes-start-tag`` = highest earlier ``rc-{cycle}.0rc*`` tag
+#     when present (so notes only cover what landed between rcs);
+#     omitted on the first rc of a cycle, where ``--generate-notes``
+#     falls back to GitHub's default last-release heuristic.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Dev cut tag to promote (e.g. dev-cut-abc123def456). Pick from a "dev cut" GitHub pre-release.'
+        required: true
+        type: string
+      force_non_linear:
+        description: 'Skip the monotonicity check (cut SHA must be descendant of the previous rc cut SHA in the same cycle). Only set when intentionally branching off the current rc lineage.'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+# Shared with cd-publish-dev so dev and rc publishes serialize against
+# each other. Two PyPI writes for the same cycle would otherwise race
+# on the rc counter resolution.
+concurrency:
+  group: publish-prerelease
+  cancel-in-progress: false
+
+jobs:
+  resolve:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.publishable.outputs.matrix }}
+      new_versions: ${{ steps.resolve_versions.outputs.new_versions }}
+      dep_pins: ${{ steps.resolve_versions.outputs.dep_pins }}
+      cycle: ${{ steps.calver.outputs.cycle }}
+      rc_version: ${{ steps.resolve_versions.outputs.rc_version }}
+      rc_n: ${{ steps.resolve_versions.outputs.rc_n }}
+      cut_sha: ${{ steps.cut.outputs.sha }}
+      cut_short: ${{ steps.cut.outputs.short }}
+      previous_rc_tag: ${{ steps.previous.outputs.tag }}
+    steps:
+      - name: Validate input ref
+        env:
+          INPUT_REF: ${{ inputs.ref }}
+        run: |
+          # Restrict promotion to the cut tag namespace so we can't
+          # accidentally rc-publish from an arbitrary branch / SHA where
+          # the package set was never recorded.
+          if [[ ! "$INPUT_REF" =~ ^dev-cut-[0-9a-f]{12}$ ]]; then
+            echo "Error: ref must be a dev-cut tag like 'dev-cut-abc123def456'." >&2
+            echo "Got: '$INPUT_REF'" >&2
+            exit 1
+          fi
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          # Need full history + all tags for ancestor checks and the
+          # "highest previous rc tag in cycle" lookup.
+          fetch-depth: 0
+          fetch-tags: true
+          # Check out the dev cut tag itself; every subsequent build /
+          # rewrite step must see the source tree as it was when the
+          # dev wheels were produced, not whatever main looks like now.
+          ref: ${{ inputs.ref }}
+
+      - name: Resolve cut SHA
+        id: cut
+        env:
+          INPUT_REF: ${{ inputs.ref }}
+        run: |
+          SHA="$(git rev-parse "$INPUT_REF^{commit}")"
+          SHORT="$(git rev-parse --short=12 "$SHA")"
+          echo "sha=$SHA"     >> "$GITHUB_OUTPUT"
+          echo "short=$SHORT" >> "$GITHUB_OUTPUT"
+          echo "Resolved $INPUT_REF -> $SHA"
+
+      - name: Verify cut SHA is on main
+        env:
+          CUT_SHA: ${{ steps.cut.outputs.sha }}
+        run: |
+          # rc publishes promote main-line history. If the cut SHA is
+          # not an ancestor of origin/main, something has gone wrong
+          # (force-push, deleted commit, tag pointing somewhere odd).
+          git fetch --no-tags --depth=1 origin main
+          if ! git merge-base --is-ancestor "$CUT_SHA" origin/main; then
+            echo "Error: cut SHA $CUT_SHA is not an ancestor of origin/main." >&2
+            echo "rc publishes must come from a dev cut on main." >&2
+            exit 1
+          fi
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+        with:
+          version: '0.11.5'
+
+      - name: Compute CalVer cycle
+        id: calver
+        run: |
+          # Run from the cut SHA's tree so the cycle is the one that was
+          # active when the dev was published, not "now". This matters
+          # if the rc is promoted weeks after the dev cut landed.
+          CYCLE="$(./.github/scripts/compute-calver.sh)"
+          echo "cycle=$CYCLE" >> "$GITHUB_OUTPUT"
+          echo "- CalVer cycle: \`$CYCLE\`" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Build publishable matrix
+        id: publishable
+        env:
+          PKG_CONFIG: .github/actions/get-packages-matrix/package_configuration.json
+        run: |
+          # rc cuts always include every publishable package, no
+          # change-detection: the dev cut already locked the version
+          # graph, and partial rc publishes would break `==` sibling
+          # pins for anything left behind on PyPI.
+          MATRIX=$(jq -c '{include: [.[] | select((.publish_skip != true) and (.pypi_name != null))]}' "$PKG_CONFIG")
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+          {
+            echo "### RC publish — selection"
+            echo ""
+            echo "- Source ref: \`${{ inputs.ref }}\` (\`${{ steps.cut.outputs.sha }}\`)"
+            echo "- Packages queued: $(jq '.include | length' <<<"$MATRIX")"
+            echo ""
+            echo '```json'
+            jq . <<<"$MATRIX"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Resolve rc versions and dep pins
+        id: resolve_versions
+        env:
+          CYCLE: ${{ steps.calver.outputs.cycle }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/resolve"
+          uv run --quiet --no-project -- \
+            python3 .github/scripts/resolve-rc-versions.py \
+              --cycle "$CYCLE" \
+              --output-dir "$RUNNER_TEMP/resolve" \
+            | tee -a "$GITHUB_STEP_SUMMARY"
+          DELIM="$(openssl rand -hex 16)"
+          {
+            echo "new_versions<<${DELIM}"
+            printf '%s\n' "$(cat "$RUNNER_TEMP/resolve/new_versions.json")"
+            echo "${DELIM}"
+            echo "dep_pins<<${DELIM}"
+            printf '%s\n' "$(cat "$RUNNER_TEMP/resolve/dep_pins.json")"
+            echo "${DELIM}"
+            echo "rc_version=$(tr -d '\n' < "$RUNNER_TEMP/resolve/rc_version.txt")"
+            echo "rc_n=$(tr -d '\n' < "$RUNNER_TEMP/resolve/rc_n.txt")"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Find previous rc tag in cycle and check monotonicity
+        id: previous
+        env:
+          CYCLE: ${{ steps.calver.outputs.cycle }}
+          CUT_SHA: ${{ steps.cut.outputs.sha }}
+          FORCE_NON_LINEAR: ${{ inputs.force_non_linear }}
+        run: |
+          # Highest existing rc tag (if any) for this cycle, used both
+          # for `--notes-start-tag` later and for the monotonicity
+          # check. Tag pattern: rc-{cycle}.0rc{N}.
+          PREV_TAG=$(git tag --list "rc-${CYCLE}.0rc*" \
+            | awk -F'rc' '{ printf "%d %s\n", $NF, $0 }' \
+            | sort -n -k1,1 \
+            | tail -n1 \
+            | awk '{ print $2 }' || true)
+
+          if [[ -z "$PREV_TAG" ]]; then
+            echo "No previous rc tag in cycle $CYCLE — first rc."
+            echo "tag=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          PREV_SHA="$(git rev-parse "$PREV_TAG^{commit}")"
+          echo "Previous rc tag: $PREV_TAG (sha $PREV_SHA)"
+          echo "tag=$PREV_TAG" >> "$GITHUB_OUTPUT"
+
+          # Monotonicity: the new cut must be a descendant of (or equal
+          # to) the previous rc cut, so customers who pinned to it can
+          # always move forward without losing fixes. Override only when
+          # intentionally branching off the previous rc lineage.
+          if git merge-base --is-ancestor "$PREV_SHA" "$CUT_SHA"; then
+            echo "✓ Cut SHA descends from previous rc cut — monotonicity preserved."
+          else
+            if [[ "$FORCE_NON_LINEAR" == "true" ]]; then
+              echo "::warning::Cut SHA $CUT_SHA is NOT a descendant of $PREV_TAG ($PREV_SHA), but force_non_linear=true was set. Proceeding."
+            else
+              echo "Error: cut SHA $CUT_SHA is not a descendant of previous rc tag $PREV_TAG ($PREV_SHA)." >&2
+              echo "rc lineage must be linear within a cycle. Re-run with force_non_linear=true if you intend to branch off." >&2
+              exit 1
+            fi
+          fi
+
+  publish:
+    needs: resolve
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.resolve.outputs.matrix) }}
+    name: publish-rc-${{ matrix.id }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          # Build from the dev cut SHA, never from main HEAD — same
+          # source as the original dev wheels, just with rc version
+          # numbers and `==` sibling pins.
+          ref: ${{ needs.resolve.outputs.cut_sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+        with:
+          version: '0.11.5'
+
+      - name: Rewrite pyproject.toml for rc version
+        env:
+          OWN_VERSION: ${{ fromJson(needs.resolve.outputs.new_versions)[matrix.id] }}
+          DEP_PINS: ${{ needs.resolve.outputs.dep_pins }}
+          PYPROJECT: ${{ matrix.dir }}/pyproject.toml
+        run: |
+          # Same rewrite script as dev — it accepts both `.devN` /`>=`
+          # (dev path) and `rcN` / `==` (rc path) version+pin shapes.
+          uv run --quiet --no-project --with 'tomlkit==0.14.0' -- \
+            python3 .github/scripts/rewrite-pyproject-pre-release.py \
+              "$PYPROJECT" \
+              --own-version "$OWN_VERSION" \
+              --dep-pins "$DEP_PINS"
+
+      - name: Show rewrite diff
+        run: |
+          echo "### ${{ matrix.id }} — pyproject.toml rewrite" >> "$GITHUB_STEP_SUMMARY"
+          echo '```diff' >> "$GITHUB_STEP_SUMMARY"
+          git --no-pager diff --no-color -- "${{ matrix.dir }}/pyproject.toml" | tee -a "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Build package
+        working-directory: ${{ matrix.dir }}
+        env:
+          UV_NO_SOURCES: 1
+        run: uv build -o dist
+
+      - name: Show wheel metadata
+        working-directory: ${{ matrix.dir }}
+        run: |
+          WHEEL=$(ls dist/*.whl | head -n1)
+          echo "### ${{ matrix.id }} — wheel METADATA ($(basename "$WHEEL"))" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          python3 -c "
+          import sys, zipfile, re
+          wheel = sys.argv[1]
+          with zipfile.ZipFile(wheel) as zf:
+              meta_name = next(n for n in zf.namelist() if n.endswith('.dist-info/METADATA'))
+              text = zf.read(meta_name).decode()
+          for line in text.splitlines():
+              if re.match(r'^(Name|Version|Requires-Dist):', line):
+                  print(line)
+          " "$WHEEL" | tee -a "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Publish to PyPI
+        working-directory: ${{ matrix.dir }}
+        run: uv publish --username __token__ --password "${{ secrets.PYPI_TOKEN }}"
+
+  tag-release:
+    # After every package in the cut publishes successfully, tag the
+    # cut SHA with the rc version and create the matching GitHub
+    # pre-release. We do not block on tag-release for PyPI: even if
+    # tagging fails, the wheels are already shipped.
+    needs: [resolve, publish]
+    if: needs.publish.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          # Same SHA the dev wheels were built from. Tag goes on this
+          # commit; release notes use the source tree at this commit.
+          ref: ${{ needs.resolve.outputs.cut_sha }}
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Tag rc release
+        env:
+          CUT_SHA: ${{ needs.resolve.outputs.cut_sha }}
+          RC_VERSION: ${{ needs.resolve.outputs.rc_version }}
+        run: |
+          TAG="rc-${RC_VERSION}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "$TAG" "$CUT_SHA"
+          git push origin "$TAG"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+        id: tag
+
+      - name: Create GitHub pre-release for rc cut
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEW_VERSIONS: ${{ needs.resolve.outputs.new_versions }}
+          DEP_PINS: ${{ needs.resolve.outputs.dep_pins }}
+          CYCLE: ${{ needs.resolve.outputs.cycle }}
+          RC_VERSION: ${{ needs.resolve.outputs.rc_version }}
+          CUT_SHA: ${{ needs.resolve.outputs.cut_sha }}
+          CUT_SHORT: ${{ needs.resolve.outputs.cut_short }}
+          INPUT_REF: ${{ inputs.ref }}
+          PREV_TAG: ${{ needs.resolve.outputs.previous_rc_tag }}
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          BODY_FILE="$(mktemp)"
+          {
+            echo "Release candidate \`${RC_VERSION}\` for cycle \`${CYCLE}\`."
+            echo
+            echo "- Source dev cut: [\`${INPUT_REF}\`](../../releases/tag/${INPUT_REF})"
+            echo "- Cut SHA: \`${CUT_SHA}\`"
+            if [[ -n "$PREV_TAG" ]]; then
+              echo "- Previous rc in cycle: [\`${PREV_TAG}\`](../../releases/tag/${PREV_TAG})"
+            else
+              echo "- Previous rc in cycle: _none — first rc of \`${CYCLE}\`_"
+            fi
+            echo
+            echo "## Packages published in this rc cut"
+            echo
+            echo "| package | version |"
+            echo "| --- | --- |"
+            jq -r 'to_entries | sort_by(.key) | .[] | "| `\(.key)` | `\(.value)` |"' <<<"$NEW_VERSIONS"
+            echo
+            echo "## Sibling dependency pins stamped into wheel METADATA"
+            echo
+            echo "All cross-package AI deps are pinned with \`==\` to the same rc version,"
+            echo "so installing any package in this cut resolves to a single consistent set."
+            echo
+            echo '```json'
+            jq -S . <<<"$DEP_PINS"
+            echo '```'
+            echo
+            echo "## Auto-generated changes since previous rc"
+          } > "$BODY_FILE"
+
+          # `--notes-start-tag` produces a commit-list / PR list between
+          # the previous rc and this cut. On the first rc of a cycle we
+          # have no anchor, so we let `--generate-notes` use GitHub's
+          # default "since last release" heuristic instead.
+          if [[ -n "$PREV_TAG" ]]; then
+            gh release create "$TAG" \
+              --prerelease \
+              --target "$CUT_SHA" \
+              --title "$RC_VERSION" \
+              --notes-file "$BODY_FILE" \
+              --generate-notes \
+              --notes-start-tag "$PREV_TAG"
+          else
+            gh release create "$TAG" \
+              --prerelease \
+              --target "$CUT_SHA" \
+              --title "$RC_VERSION" \
+              --notes-file "$BODY_FILE" \
+              --generate-notes
+          fi


### PR DESCRIPTION
## Summary

- Adds `cd-publish-rc.yaml`, a new manual workflow that promotes a specific dev cut (identified by a `dev-cut-<SHA>` tag) to an rc pre-release (e.g. `2026.20.0rc1`). rc releases are PEP 440 pre-releases that pip treats as non-dev — useful for shipping to a customer between two weekly stable cuts without causing version-range conflicts.
- Extends `cd-publish-dev.yaml` to tag every successful dev publish as `dev-cut-<SHORT_SHA>` and create a matching GitHub pre-release, making dev cuts auditable and promotable.
- Adds `resolve-rc-versions.py` to compute a global monotonic `rcN` counter across the cycle and produce exact `==` sibling pins, ensuring rc wheels are fully reproducible.

## Changes

### `.github/workflows/`
- `cd-publish-rc.yaml` *(new)* — `workflow_dispatch` workflow; takes a required `ref` (`dev-cut-<SHA>` tag), validates input, checks monotonicity (later rc must be a descendant of the previous rc in the cycle; `force_non_linear` escape hatch available), resolves `{cycle}.0rcN` for every publishable package, rebuilds all wheels with `==` sibling pins, publishes to PyPI, creates `rc-{version}` Git tag, and opens a GitHub pre-release with auto-generated notes. Shares the `publish-prerelease` concurrency group with `cd-publish-dev.yaml` so dev and rc publishes never race on PyPI.
- `cd-publish-dev.yaml` — adds a `tag-cut` job after a successful publish: creates a `dev-cut-<SHORT_SHA>` Git tag at the published SHA and a GitHub pre-release that lists every package and version in the cut.
- Concurrency group renamed `publish-pypi` → `publish-prerelease`.

### `.github/scripts/`
- `resolve-rc-versions.py` *(new)* — queries PyPI for `{cycle}.0rcN` versions, picks global `max(N) + 1`, emits `new_versions` (all `rcN`) and `dep_pins` (all `==`) in the same JSON shape as `resolve-dev-versions.py`.
- `rewrite-pyproject-for-dev.py` → `rewrite-pyproject-pre-release.py` — renamed and generalised to accept both `.devN`/`>=` (dev path) and `rcN`/`==` (rc path).
- `test_rewrite_pyproject_for_dev.py` → `test_rewrite_pyproject_pre_release.py` — renamed; new tests for rc version and `==` pins added.
- `test_resolve_rc_versions.py` *(new)* — covers rc counter logic, exact pinning, PEP 503 normalisation, and output file newline requirements.

## Test plan

- [x] All 31 unit tests pass: `uv run --quiet --no-project --with 'tomlkit==0.14.0' -- python3 -m unittest discover -s .github/scripts/tests -p 'test_*.py'`
- [ ] After merge: trigger `cd-publish-dev.yaml` on main and verify a `dev-cut-*` tag + pre-release are created in GitHub Releases
- [ ] After a dev cut exists: trigger `cd-publish-rc.yaml` with that tag and verify `{cycle}.0rc1` packages appear on PyPI and a `rc-*` GitHub pre-release is created

## Risk / rollout

- rc publishes share the `publish-prerelease` concurrency group with dev publishes, so they cannot interleave.
- The monotonicity guard prevents publishing an rc from a commit older than the previous rc in the same cycle; use `force_non_linear: true` to override if needed.
- No changes to the stable release path (`cd-release.yaml`) or `release-please` configuration.

Refs: UN-20105

Made with [Cursor](https://cursor.com)