### PR TITLE
ci(release): improve automatic PR titles

### DIFF
--- a/.github/workflows/cd-publish-dev.yaml
+++ b/.github/workflows/cd-publish-dev.yaml
@@ -286,6 +286,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      short: ${{ steps.tag.outputs.short }}
+      tag: ${{ steps.tag.outputs.tag }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -355,8 +358,8 @@ jobs:
     # (e.g. chore/bump-dev-2026.18-tk-5-sdk-4-orch-3) so each publish run
     # creates a unique, auditable branch.  Any older open dev-bump PR is
     # closed first to avoid stale branches accumulating.
-    needs: [resolve, publish]
-    if: needs.publish.result == 'success'
+    needs: [resolve, publish, tag-cut]
+    if: needs.publish.result == 'success' && needs.tag-cut.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -468,7 +471,7 @@ jobs:
             >> "$BODY_FILE"
 
           gh pr create \
-            --title "chore: bump dev versions ($CYCLE / ${{ needs.resolve.outputs.branch_suffix }})" \
+            --title "chore: pin dev-cut ${{ needs.tag-cut.outputs.short }}" \
             --body-file "$BODY_FILE" \
             --head "$BRANCH" \
             --base main \

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "python",
   "separate-pull-requests": false,
-  "group-pull-request-title-pattern": "chore: release ${branch}",
+  "group-pull-request-title-pattern": "chore: stable release ${version}",
   "include-component-in-tag": true,
   "include-v-in-tag": true,
   "tag-separator": "-",

--- a/release-please-config.release.json
+++ b/release-please-config.release.json
@@ -3,7 +3,7 @@
   "release-type": "python",
   "versioning": "always-bump-patch",
   "separate-pull-requests": false,
-  "group-pull-request-title-pattern": "chore: hotfix ${branch}",
+  "group-pull-request-title-pattern": "chore: hotfix ${branch} to ${version}",
   "include-component-in-tag": true,
   "include-v-in-tag": true,
   "tag-separator": "-",

--- a/release-please-config.release.json
+++ b/release-please-config.release.json
@@ -3,7 +3,7 @@
   "release-type": "python",
   "versioning": "always-bump-patch",
   "separate-pull-requests": false,
-  "group-pull-request-title-pattern": "chore: release ${branch}",
+  "group-pull-request-title-pattern": "chore: hotfix ${branch}",
   "include-component-in-tag": true,
   "include-v-in-tag": true,
   "tag-separator": "-",


### PR DESCRIPTION
## Summary

- Dev bump PR title changes from `chore: bump dev versions (CYCLE / devN)` to `chore: pin dev-cut <SHORT_SHA>` — the short SHA directly references the auditable `dev-cut-*` Git tag and GitHub pre-release created in the same run, so the PR title links to the exact snapshot.
- Stable release PR title changes from `chore: release main` to `chore: stable release ${version}` — explicit type and version number.
- Hotfix release PR title changes from `chore: release release/YYYY.WW` to `chore: hotfix release/YYYY.WW` — makes the intent clear at a glance.

## Changes

- `cd-publish-dev.yaml` — exposes `short` and `tag` as job outputs on `tag-cut`; adds `tag-cut` to `open-dev-bump-pr`'s `needs` (so the short SHA is available); updates PR title to `chore: pin dev-cut <SHORT_SHA>`.
- `release-please-config.json` — `group-pull-request-title-pattern`: `chore: release ${branch}` → `chore: stable release ${version}`
- `release-please-config.release.json` — `group-pull-request-title-pattern`: `chore: release ${branch}` → `chore: hotfix ${branch}`
- `unique_sdk/unique_sdk/api_resources/_module.py` + `unique_sdk/docs/api_resources/module.md` — minor docs wording fix (tautological "higher = higher priority" → "higher weight takes precedence").

## Test plan

- [ ] After merge: next dev publish will open a PR titled `chore: pin dev-cut <SHA>` — verify the SHA matches the `dev-cut-*` tag created in the same run
- [ ] After merge: next release-please run will open a PR titled `chore: stable release 2026.XX.0` (or `chore: stable release ${version}` if the token is unsupported — either way immediately visible)
- [ ] Next hotfix on a release branch will open a PR titled `chore: hotfix release/YYYY.WW`

## Risk / rollout

No runtime changes. All modifications are to CI workflow configuration and docs only.

Made with [Cursor](https://cursor.com)