### PR TITLE
docs(sdk): clarify module weight description

### DIFF
--- a/unique_sdk/docs/api_resources/module.md
+++ b/unique_sdk/docs/api_resources/module.md
@@ -7,7 +7,7 @@ Create, list, retrieve, update, and delete assistant modules. Modules define the
 Each module belongs to an **assistant** and configures:
 
 - A **name** and optional **description**
-- A **weight** controlling evaluation priority (higher = higher priority)
+- A **weight** controlling evaluation priority (higher weight takes precedence)
 - Whether the module is **external** (`isExternal`)
 - Whether **custom instructions** are enabled (`isCustomInstructionEnabled`)
 - An optional **configuration** object (arbitrary key/value settings)

--- a/unique_sdk/unique_sdk/api_resources/_module.py
+++ b/unique_sdk/unique_sdk/api_resources/_module.py
@@ -13,7 +13,7 @@ class Module(APIResource["Module"]):
     """An assistant module that configures behaviour, tools, and instructions.
 
     Modules are attached to assistants (spaces) and define their capabilities,
-    configuration, and tool definitions.  They control weight/priority, whether
+    configuration, and tool definitions.  They control priority weight, whether
     the module is external, and whether custom instructions are enabled.
     """
 


### PR DESCRIPTION
Improves the wording in the `Module` API resource docstring and its documentation page for clarity.

Made with [Cursor](https://cursor.com)