### PR TITLE
fix(swot): correct spelling of 'occurred' in error messages

### DIFF
--- a/tool_packages/unique_swot/unique_swot/services/generation/agentic/operations.py
+++ b/tool_packages/unique_swot/unique_swot/services/generation/agentic/operations.py
@@ -119,7 +119,7 @@ async def handle_generate_operation(
         )
         await step_notifier.notify(
             title=notification_title,
-            description=f"An error occured while extracting facts for component {component}. This batch will be skipped.",
+            description=f"An error occurred while extracting facts for component {component}. This batch will be skipped.",
         )
     except FailedToGeneratePlanException as e:
         _LOGGER.exception(
@@ -127,7 +127,7 @@ async def handle_generate_operation(
         )
         await step_notifier.notify(
             title=notification_title,
-            description=f"An error occured while generating plan to update the SWOT report for component {component}. Extracted information will be discarded.",
+            description=f"An error occurred while generating plan to update the SWOT report for component {component}. Extracted information will be discarded.",
         )
     except Exception as e:
         _LOGGER.exception(
@@ -135,7 +135,7 @@ async def handle_generate_operation(
         )
         await step_notifier.notify(
             title=notification_title,
-            description=f"An unexpected error occured while updating the SWOT report for component {component}. Skipping this batch.",
+            description=f"An unexpected error occurred while updating the SWOT report for component {component}. Skipping this batch.",
         )
 
 

--- a/tool_packages/unique_swot/unique_swot/services/source_management/selection/agent.py
+++ b/tool_packages/unique_swot/unique_swot/services/source_management/selection/agent.py
@@ -56,8 +56,8 @@ class SourceSelectionAgent:
             _LOGGER.error(f"Failed to select the source for {company_name}")
             response = SourceSelectionResult(
                 should_select=True,
-                reason="An error occured while selecting the source.",
-                notification_message="An error occured while selecting the source. The source will be still considered for the SWOT as a safety measure.",
+                reason="An error occurred while selecting the source.",
+                notification_message="An error occurred while selecting the source. The source will be still considered for the SWOT as a safety measure.",
             )
         await step_notifier.notify(
             title=notification_title,


### PR DESCRIPTION
Fixes a consistent misspelling of 'occurred' (as 'occured') in SWOT error message strings. The test assertion already handles both spellings so no test change is needed.

Made with [Cursor](https://cursor.com)