### PR TITLE
fix(release): use >= dep pins for rc and dev co-publishing

### DIFF
--- a/.github/scripts/resolve-rc-versions.py
+++ b/.github/scripts/resolve-rc-versions.py
@@ -4,10 +4,9 @@
 Unlike dev publishes (per-package contiguous ``devN`` counters), an rc
 cut republishes **every** publishable AI package at a single shared
 ``{cycle}.0rcN`` version. The shared counter is what lets sibling deps
-be pinned with ``==``: every package in the cut resolves to the same
-concrete release, so ``pip install`` always picks a mutually consistent
-set. Mixing different ``rcN`` counters across packages would defeat the
-``==`` pins.
+be pinned with ``>=``: every package in the cut lands at the same
+``rcN`` floor, so ``pip install`` pulls a mutually consistent set while
+still allowing natural upgrades to later rcs or the final stable.
 
 Counter selection
 =================
@@ -27,10 +26,10 @@ Outputs
   package. Always covers the full publishable set — rc cuts do not
   honor a "selected" subset because every sibling needs to resolve.
 
-* ``dep_pins``: normalized PyPI name -> ``=={cycle}.0rcN`` for every
+* ``dep_pins``: normalized PyPI name -> ``>={cycle}.0rcN`` for every
   publishable package. Consumed by ``rewrite-pyproject-pre-release.py``,
-  which stamps these into wheel ``Requires-Dist`` so the resulting
-  release is a closed set with no drift between siblings.
+  which stamps these into wheel ``Requires-Dist`` so every sibling is
+  at the rc floor or newer.
 
 Names in both maps are PEP 503 normalized so the rewrite step matches
 ``unique-sdk``, ``unique_sdk`` and ``Unique.SDK`` to the same entry.
@@ -94,7 +93,7 @@ def resolve(
         raise SystemExit(f"invalid cycle: {cycle!r}")
 
     # Global max across every publishable package; one rc counter for the
-    # whole cut so sibling ``==`` pins always resolve consistently.
+    # whole cut so sibling ``>=`` pins always share the same floor.
     seen: list[int] = []
     for pkg in publishable:
         n = highest_rc_in_cycle(pkg["pypi_name"], cycle, pypi_base_url, fetcher=fetcher)
@@ -107,7 +106,7 @@ def resolve(
     dep_pins: dict[str, str] = {}
     for pkg in publishable:
         new_versions[pkg["id"]] = version
-        dep_pins[normalize(pkg["pypi_name"])] = f"=={version}"
+        dep_pins[normalize(pkg["pypi_name"])] = f">={version}"
 
     return new_versions, dep_pins, rc_n
 

--- a/.github/scripts/rewrite-pyproject-pre-release.py
+++ b/.github/scripts/rewrite-pyproject-pre-release.py
@@ -29,9 +29,9 @@ or ``resolve-rc-versions.py``:
   * Dev publish (``resolve-dev-versions.py``) emits ``>=<version>`` pins;
     siblings drift forward independently and ``pip install -U`` upgrades
     siblings that were not republished.
-  * RC publish (``resolve-rc-versions.py``) emits ``==<version>`` pins,
-    because every publishable package is republished at the same
-    ``{cycle}.0rcN`` for a fully reproducible cut.
+  * RC publish (``resolve-rc-versions.py``) emits ``>=<version>`` pins,
+    floored at the shared ``{cycle}.0rcN`` so customers can upgrade
+    freely to later rcs or the final stable.
 
 Non-AI dependencies are left untouched. ``project.name`` and ``[tool.*]``
 tables are never touched. Formatting and comments in the TOML file are
@@ -58,7 +58,7 @@ _REQ_RE = re.compile(r"^\s*([A-Za-z0-9_.\-]+)(\[[^\]]*\])?\s*(.*)$")
 _VERSION_RE = re.compile(r"^\d{4}\.\d{2}\.\d+(\.dev\d+|rc\d+)$")
 # Dep pins come from one of the two resolvers:
 #   >=<version>   from resolve-dev-versions.py (siblings drift forward)
-#   ==<version>   from resolve-rc-versions.py  (reproducible rc cut)
+#   >=<version>   from resolve-rc-versions.py  (floored at the rc cut)
 # Versions may be CalVer with a ``.devN``/``rcN`` suffix, or legacy
 # pre-CalVer dotted numerics (e.g. "0.3.3") for last-stable fallbacks.
 _PIN_RE = re.compile(r"^(>=|==)\d+(\.\d+)*(\.dev\d+|rc\d+)?$")

--- a/.github/scripts/tests/test_resolve_rc_versions.py
+++ b/.github/scripts/tests/test_resolve_rc_versions.py
@@ -124,15 +124,15 @@ class ResolveTests(unittest.TestCase):
         self.assertEqual(new_versions["toolkit"], "2026.20.0rc1")
         self.assertEqual(new_versions["sdk"], "2026.20.0rc1")
         self.assertEqual(new_versions["mcp"], "2026.20.0rc1")
-        # And every sibling dep is pinned with ``==`` to that same version.
-        self.assertEqual(dep_pins["unique-toolkit"], "==2026.20.0rc1")
-        self.assertEqual(dep_pins["unique-sdk"], "==2026.20.0rc1")
-        self.assertEqual(dep_pins["unique-mcp"], "==2026.20.0rc1")
+        # And every sibling dep is floored at that rc version.
+        self.assertEqual(dep_pins["unique-toolkit"], ">=2026.20.0rc1")
+        self.assertEqual(dep_pins["unique-sdk"], ">=2026.20.0rc1")
+        self.assertEqual(dep_pins["unique-mcp"], ">=2026.20.0rc1")
 
     def test_global_max_drives_shared_counter(self) -> None:
         # Different packages are at different rc counters on PyPI; the
         # next cut must use ``max + 1`` shared across the full set so
-        # ``==`` pins still resolve to one concrete release.
+        # all siblings are floored at the same rc.
         new_versions, dep_pins, rc_n = self._resolve(
             pypi={
                 "unique_toolkit": ["2026.20.0rc1", "2026.20.0rc2"],
@@ -144,7 +144,7 @@ class ResolveTests(unittest.TestCase):
         for pid in ("toolkit", "sdk", "mcp"):
             self.assertEqual(new_versions[pid], "2026.20.0rc5")
         for name in ("unique-toolkit", "unique-sdk", "unique-mcp"):
-            self.assertEqual(dep_pins[name], "==2026.20.0rc5")
+            self.assertEqual(dep_pins[name], ">=2026.20.0rc5")
 
     def test_publishable_without_rc_history_still_gets_shared_counter(self) -> None:
         # A brand-new package never published to PyPI must still land at
@@ -159,7 +159,7 @@ class ResolveTests(unittest.TestCase):
         )
         self.assertEqual(rc_n, 4)
         self.assertEqual(new_versions["sdk"], "2026.20.0rc4")
-        self.assertEqual(dep_pins["unique-sdk"], "==2026.20.0rc4")
+        self.assertEqual(dep_pins["unique-sdk"], ">=2026.20.0rc4")
 
     def test_pep503_normalization(self) -> None:
         # ``unique_toolkit`` and ``unique-mcp`` must both land under
@@ -202,7 +202,7 @@ class MainOutputFilesTests(unittest.TestCase):
             def fake_resolve(**_):
                 return (
                     {"toolkit": "2026.20.0rc1"},
-                    {"unique-toolkit": "==2026.20.0rc1"},
+                    {"unique-toolkit": ">=2026.20.0rc1"},
                     1,
                 )
 

--- a/.github/workflows/cd-publish-dev.yaml
+++ b/.github/workflows/cd-publish-dev.yaml
@@ -26,9 +26,9 @@ name: "[CD] Publish dev builds to PyPI"
 # =============================================
 #   Computed once in `resolve` and stamped into every wheel's
 #   Requires-Dist by `rewrite-pyproject-pre-release.py`:
-#     - dep IS publishing in this push          -> `==<its new_version>`
-#         (siblings are locked together so `pip install` always pulls a
-#          mutually-consistent set)
+#     - dep IS publishing in this push          -> `>=<its new_version>`
+#         (floor matches the co-published version; pip can still upgrade
+#          to a later dev or stable)
 #     - dep has a dev wheel in the current cycle -> `>=<highest dev>`
 #         (older locally-installed dev wheels do not satisfy the floor,
 #          so `pip install -U` correctly upgrades them)


### PR DESCRIPTION
## What

RC sibling dependencies were pinned with `==`, which forced customers installing an rc floor (e.g. `>=2026.20.0rc1`) to also explicitly pin every other package to the exact same rc. This PR switches `resolve-rc-versions.py` to emit `>=` pins, matching the existing behaviour of `resolve-dev-versions.py` for dev releases.

It also corrects an outdated comment in `cd-publish-dev.yaml` that incorrectly described co-published dev deps as `==` pins (the code has always used `>=`).

## Changes

- `resolve-rc-versions.py`: emit `>={cycle}.0rcN` instead of `=={cycle}.0rcN` for sibling deps; update docstring accordingly
- `rewrite-pyproject-pre-release.py`: update comment describing what rc pins look like
- `cd-publish-dev.yaml`: fix wrong `==` comment on dev co-publishing pins
- `test_resolve_rc_versions.py`: flip all `==` assertions to `>=`

## Why `>=` over `==`

`==` was originally chosen for reproducibility — every package in a cut lands at the exact same `rcN`. However it forces customers to pin *all* packages when they only want a floor. With `>=`, a customer can write `unique-toolkit>=2026.20.0rc1` and let pip resolve the rest naturally, including upgrading to later rcs or the eventual stable.

All 31 tests pass.

Made with [Cursor](https://cursor.com)