### PR TITLE
docs+ci(release): document release process and clean up stale dev-cut PRs

### DIFF
--- a/.github/workflows/cd-release.yaml
+++ b/.github/workflows/cd-release.yaml
@@ -210,11 +210,41 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: ./.github/scripts/prepare-next-cycle.sh
 
+      # A stable release commits new dev floors via update-dep-floors.py,
+      # which makes any open `chore: pin dev-cut <SHA>` PR (opened by
+      # cd-publish-dev.yaml against `main`) obsolete: its floors are
+      # strictly older than the floors that just landed on `main`.
+      # Close them so they don't accumulate cycle after cycle.
+      - name: Close stale dev bump PRs
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          PR_NUMBERS=$(gh pr list \
+            --repo "${{ github.repository }}" \
+            --state open \
+            --base main \
+            --search "chore: pin dev-cut in:title" \
+            --json number \
+            --jq '.[].number')
+
+          if [[ -z "$PR_NUMBERS" ]]; then
+            echo "No open dev bump PRs found."
+            exit 0
+          fi
+
+          for PR in $PR_NUMBERS; do
+            echo "Closing dev bump PR #${PR}"
+            gh pr close "$PR" \
+              --repo "${{ github.repository }}" \
+              --comment "Superseded by stable release: dev-cut floors were just persisted to \`main\`."
+          done
+
       - name: Summary
         run: |
           {
             echo "### Post-release actions"
             echo "- Cut \`release/\` branch from the tagged release commit (App token bypasses branch protection on \`release-branches\` ruleset)"
             echo "- Pushed \`Release-As\` trailer to \`main\` to arm the next CalVer cycle (App token bypasses branch protection on \`main-branch\` ruleset)"
+            echo "- Closed any open \`chore: pin dev-cut …\` PRs (superseded by the stable floors that just landed on \`main\`)"
             echo "- \`cd-publish.yaml\` will fire on the \`release:published\` event created by release-please's App-token-authored release"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/contributing/release-process.md
+++ b/docs/contributing/release-process.md
@@ -59,18 +59,39 @@ On each qualifying push the workflow:
 !!! note "Why only changed packages?"
     Dev releases are incremental. Only packages that actually changed are republished; unchanged siblings keep their last dev (or stable) version.
 
----
-
-## Dev cuts
+### Dev cuts
 
 A **dev cut** is the unit of promotion. It is defined by:
 
 - A single Git SHA on `main`
 - The set of `(package, devN version)` pairs produced from that push
 
-Every successful dev publish creates a `dev-cut-<SHORT_SHA>` tag (visible on the [GitHub tags page](https://github.com/Unique-AG/ai/tags)) and a matching GitHub pre-release that lists every package version in the cut.
+Every successful dev publish creates a `dev-cut-<SHORT_SHA>` tag (visible on the [GitHub tags page](https://github.com/Unique-AG/ai/tags)) and a matching GitHub pre-release that lists every package version in the cut. A dev cut is the only thing the [RC workflow](#rc-releases) accepts as input — you promote a specific cut, never "the latest dev".
 
-You can promote a specific dev cut to an RC — see [RC releases](#rc-releases) below.
+### Dev bump PR
+
+After every successful dev publish the workflow opens (or updates) a pull request **in the AI repo** with title:
+
+```
+chore: pin dev-cut <SHORT_SHA>
+```
+
+This PR rewrites every publishable package's `pyproject.toml` so its `version` and AI cross-package dep floors match the dev wheels just published to PyPI. **You only need to merge it when you are mixing freshly-published dev wheels with locally-checked-out AI packages** — for example, when developing in a worktree where one package is a path source and a sibling is consumed as a wheel. Without this, `uv`'s version-solver fails because the local clone still advertises the previous cycle version while the wheel `Requires-Dist` floor is `>= <current dev>`.
+
+In the typical flow the PR can sit untouched: it is automatically superseded by the next dev publish (the workflow closes the previous one before opening the new one).
+
+!!! tip "One-person merge"
+    Because the PR is opened by the Release Workflow App, it only requires your approval — you can approve and merge it yourself without a second reviewer. The PR also runs `pull_request:` CI normally, since the App-authored push is not subject to GitHub's anti-recursion rule.
+
+### Flow
+
+```mermaid
+flowchart TD
+    A[Push to main] -->|cd-publish-dev.yaml| B[dev publish<br/>YYYY.WW.0.devN<br/>changed packages only]
+    B --> C[dev-cut-SHORT_SHA tag<br/>+ GitHub pre-release<br/>listing all package versions]
+    B -->|open/update PR| E[Dev bump PR in AI repo<br/>chore: pin dev-cut SHORT_SHA]
+    C -.input to RC.-> R[cd-publish-rc.yaml]
+```
 
 ---
 
@@ -111,22 +132,15 @@ unique-toolkit>=2026.20.0rc1
 
 `pip` will resolve this to the latest compatible version — either a later RC or the eventual `2026.20.0` stable.
 
----
+### Flow
 
-## Dev bump PR
-
-After every successful dev publish the workflow opens (or updates) a pull request **in the AI repo** with title:
-
+```mermaid
+flowchart TD
+    DC[dev-cut-SHORT_SHA tag] -->|manual workflow_dispatch<br/>ref = dev-cut tag| RC[cd-publish-rc.yaml]
+    RC --> A1[ancestor check<br/>vs previous rc in cycle]
+    A1 --> P[RC publish<br/>YYYY.WW.0rcN<br/>all packages]
+    P --> T[rc-YYYY.WW.0rcN tag<br/>+ GitHub pre-release<br/>auto-generated notes]
 ```
-chore: pin dev-cut <SHORT_SHA>
-```
-
-This PR rewrites every publishable package's `pyproject.toml` so its `version` and AI cross-package dep floors match the dev wheels just published to PyPI. **You only need to merge it when you are mixing freshly-published dev wheels with locally-checked-out AI packages** — for example, when developing in a worktree where one package is a path source and a sibling is consumed as a wheel. Without this, `uv`'s version-solver fails because the local clone still advertises the previous cycle version while the wheel `Requires-Dist` floor is `>= <current dev>`.
-
-In the typical flow the PR can sit untouched: it is automatically superseded by the next dev publish (the workflow closes the previous one before opening the new one).
-
-!!! tip "One-person merge"
-    Because the PR is opened by the Release Workflow App, it only requires your approval — you can approve and merge it yourself without a second reviewer. The PR also runs `pull_request:` CI normally, since the App-authored push is not subject to GitHub's anti-recursion rule.
 
 ---
 
@@ -148,7 +162,7 @@ In the typical flow the PR can sit untouched: it is automatically superseded by 
 4. release-please bumps all `pyproject.toml` versions and `CHANGELOG.md` entries, then tags and creates a GitHub Release.
 5. `cd-release.yaml`'s post-release job pushes the new `release/YYYY.WW` branch from the tagged commit (the Release Workflow App is a bypass actor on the `release-branches` ruleset) and arms the next cycle on `main` — see [Arming a cycle](#arming-a-cycle).
 6. The GitHub Release that release-please just published natively triggers `cd-publish.yaml`, which builds and publishes every changed package to PyPI. Dependencies in the stable wheels are pinned with `>=` (updated by `update-dep-floors.py` at release time).
-7. `uniqueai-sync-ai-versions.yaml` (monorepo) automatically syncs the new stable versions to `master` with `==` pins.
+7. To propagate the new stable versions to monorepo `master`, run [`uniqueai-sync-ai-versions.yaml`](#sync-ai-versions-workflow) manually with `target=master`, `ai_source_branch=release/YYYY.WW`. The workflow rewrites every monorepo `pyproject.toml` to pin on the new versions with `==` (the pin operator is driven by `ai_source_branch`, not `target` — see [Pin operator rules](#pin-operator-rules)).
 
 ### Arming a cycle
 
@@ -163,6 +177,21 @@ Use the manual escape hatch when the automation can't run on its own (bootstrap,
 | Input | Default | Description |
 |-------|---------|-------------|
 | `year_week` | computed from manifest | Override target cycle, e.g. `2026.22` |
+
+### Flow
+
+```mermaid
+flowchart TD
+    ARM[cd-arm-version.yaml<br/>or auto post-release] -->|direct push to main<br/>Release-As: trailer| MAIN[main]
+    MAIN -->|release-please updates| RPR[Standing Release PR<br/>chore: stable release X]
+    MAIN -->|cd-release.yaml| LOCK[regenerate uv.lock<br/>push onto PR branch<br/>PR CI runs]
+    LOCK --> RPR
+    RPR -->|merge| TAG[release-please tags<br/>+ creates GitHub Release]
+    TAG -->|release: published| PUB[cd-publish.yaml<br/>biweekly stable publish<br/>YYYY.WW.0]
+    TAG --> CUT[cut release/YYYY.WW branch<br/>from tagged commit]
+    TAG --> NEXT[arm next cycle on main<br/>direct push]
+    TAG -.manual dispatch.-> SYNC[uniqueai-sync-ai-versions.yaml<br/>target=master<br/>source=release/YYYY.WW<br/>Sync == versions to monorepo master]
+```
 
 ---
 
@@ -182,6 +211,17 @@ Use the manual escape hatch when the automation can't run on its own (bootstrap,
 4. release-please tags the commit and creates a GitHub Release. The release event (authored by the Release Workflow App) natively triggers `cd-publish.yaml`.
 5. `cd-publish.yaml` publishes the patched packages to PyPI.
 6. Run `uniqueai-sync-ai-versions.yaml` manually (target `release`, source `release/YYYY.WW`) to sync the patch versions to the matching monorepo release branch.
+
+### Flow
+
+```mermaid
+flowchart TD
+    F[Fix PR on release/YYYY.WW] -->|merge| RB[release/YYYY.WW]
+    RB -->|release-please opens| HPR[Hotfix Release PR<br/>chore: hotfix release/YYYY.WW to X]
+    HPR -->|merge| TAG[release-please tags<br/>+ creates GitHub Release<br/>YYYY.WW.P]
+    TAG -->|release: published| PUB[cd-publish.yaml<br/>hotfix publish]
+    TAG -.manual.-> SYNC[uniqueai-sync-ai-versions.yaml<br/>target=release<br/>Sync == versions]
+```
 
 ---
 
@@ -208,25 +248,3 @@ Syncs AI package version floors from the AI repo into the monorepo. Runs automat
 
 !!! warning "Dev releases cannot be synced to monorepo release branches"
     The workflow rejects any run where `target=release` and `ai_source_branch=main`. Dev versions are not suitable for release branches.
-
----
-
-## Flow overview
-
-```mermaid
-flowchart TD
-    A[Push to main] -->|cd-publish-dev| B[dev publish\nYYYY.WW.0.devN]
-    B --> C[dev-cut-SHA tag\n+ GitHub pre-release]
-    C -->|manual cd-publish-rc| D[RC publish\nYYYY.WW.0rcN\nall packages]
-    B -->|open/update PR| E[Dev bump PR in AI repo\nchore: pin dev-cut SHA]
-
-    F[Merge Release PR on main] -->|cd-release| G[cut release/YYYY.WW branch\ncreate GitHub Release]
-    G -->|cd-publish| H[biweekly stable publish\nYYYY.WW.0\nchanged packages]
-    G -->|uniqueai-sync-ai-versions| I[Sync == versions\nto monorepo master]
-
-    J[Fix on release/YYYY.WW] -->|cd-release| K[create GitHub Release\nYYYY.WW.P]
-    K -->|cd-publish| L[hotfix publish]
-    K -->|manual uniqueai-sync-ai-versions| M[Sync == versions\nto monorepo release branch]
-
-    N[cd-arm-version\nmanual escape hatch] --> F
-```

--- a/docs/contributing/release-process.md
+++ b/docs/contributing/release-process.md
@@ -162,7 +162,7 @@ flowchart TD
 4. release-please bumps all `pyproject.toml` versions and `CHANGELOG.md` entries, then tags and creates a GitHub Release.
 5. `cd-release.yaml`'s post-release job pushes the new `release/YYYY.WW` branch from the tagged commit (the Release Workflow App is a bypass actor on the `release-branches` ruleset) and arms the next cycle on `main` — see [Arming a cycle](#arming-a-cycle).
 6. The GitHub Release that release-please just published natively triggers `cd-publish.yaml`, which builds and publishes every changed package to PyPI. Dependencies in the stable wheels are pinned with `>=` (updated by `update-dep-floors.py` at release time).
-7. To propagate the new stable versions to monorepo `master`, manually dispatch the [Sync AI Versions workflow](https://github.com/Unique-AG/monorepo/blob/master/docs/uniqueai/release-process/index.md#sync-ai-versions-workflow) in the monorepo with `target=master`, `ai_source_branch=release/YYYY.WW`. It rewrites the monorepo `pyproject.toml` files to pin the new stable versions with `==`.
+7. Propagating the new stable versions to the monorepo is [documented in the monorepo](https://github.com/Unique-AG/monorepo/blob/master/docs/uniqueai/release-process/index.md#sync-ai-versions-workflow).
 
 ### Arming a cycle
 
@@ -210,7 +210,7 @@ flowchart TD
    where `<version>` is `YYYY.WW.1` (or `.2`, etc.). Because this PR is opened by the bot, it only requires your approval — you can approve and merge it yourself without a second reviewer.
 4. release-please tags the commit and creates a GitHub Release. The release event (authored by the Release Workflow App) natively triggers `cd-publish.yaml`.
 5. `cd-publish.yaml` publishes the patched packages to PyPI.
-6. To propagate the patch versions to the matching monorepo release branch, manually dispatch the [Sync AI Versions workflow](https://github.com/Unique-AG/monorepo/blob/master/docs/uniqueai/release-process/index.md#sync-ai-versions-workflow) in the monorepo with `target=release`, `release_branch=release/YYYY.WW`.
+6. Propagating the patch versions to the matching monorepo release branch is [documented in the monorepo](https://github.com/Unique-AG/monorepo/blob/master/docs/uniqueai/release-process/index.md#sync-ai-versions-workflow).
 
 ### Flow
 
@@ -227,8 +227,4 @@ flowchart TD
 
 ## Syncing AI versions to the monorepo
 
-The monorepo consumes AI packages via `python/assistants/bundles/core/src/pyproject.toml` and `python/assistants/bundles/agentic-table/pyproject.toml`. Propagation is handled entirely on the monorepo side by the **Sync AI Versions** workflow — the AI repo never pushes to the monorepo.
-
-For inputs, pin-operator rules, triggers, and use cases (hotfix re-pin, stable-back-to-master, dev-floor bump) see the monorepo docs:
-
-→ [Sync AI Versions workflow (monorepo docs)](https://github.com/Unique-AG/monorepo/blob/master/docs/uniqueai/release-process/index.md#sync-ai-versions-workflow)
+Syncing AI package versions into the monorepo is [documented in the monorepo](https://github.com/Unique-AG/monorepo/blob/master/docs/uniqueai/release-process/index.md#sync-ai-versions-workflow).

--- a/docs/contributing/release-process.md
+++ b/docs/contributing/release-process.md
@@ -25,6 +25,20 @@ Pre-release suffixes follow PEP 440 ordering (`dev < rc < final`):
 
 ---
 
+## Automation identity
+
+All write operations performed by release workflows (creating/updating release-please PRs, pushing lockfile updates, tagging commits, creating GitHub Releases, opening dev-bump PRs, cutting `release/*` branches, arming the next cycle) authenticate as the **Release Workflow App**, a GitHub App provisioned in the [`infrastructure`](https://github.com/Unique-AG/infrastructure) repo and shared with the monorepo.
+
+Why it matters:
+
+- **Bypasses branch protection** — the App is registered as a bypass actor on the `main-branch` and `release-branches` rulesets, so the arm-next-cycle commit can be pushed directly to `main` and the cut step can push the new `release/YYYY.WW` branch without going through a PR.
+- **Triggers downstream CI** — pushes, tags, and releases authored by the App are *not* covered by GitHub's anti-recursion rule (which suppresses follow-up workflows for `GITHUB_TOKEN`-authored events). This is what makes lockfile commits on the Release PR run PR CI, and what makes the `release: published` event natively fan out to `cd-publish.yaml`.
+- **IP-origin-bound** — the App's installation token is only usable from the static-IP runner pool, so any job that mints one must declare `runs-on: gh-static-ip-slim` and `environment: release-workflow`.
+
+You should never need to interact with the App directly; this section exists so the references throughout the rest of this document make sense.
+
+---
+
 ## Dev releases
 
 **Trigger:** every push to `main` that touches a publishable package.
@@ -101,16 +115,18 @@ unique-toolkit>=2026.20.0rc1
 
 ## Dev bump PR
 
-After every successful dev publish the workflow opens (or updates) a pull request in the **monorepo** with title:
+After every successful dev publish the workflow opens (or updates) a pull request **in the AI repo** with title:
 
 ```
 chore: pin dev-cut <SHORT_SHA>
 ```
 
-This PR bumps the AI package version floors in the monorepo to the latest dev versions. **You only need to merge it when you are actively mixing dev AI dependencies with local monorepo sources** — for example, when developing a monorepo feature that depends on unreleased AI changes. In the typical development flow the PR can be left open and will be superseded by the next stable release sync.
+This PR rewrites every publishable package's `pyproject.toml` so its `version` and AI cross-package dep floors match the dev wheels just published to PyPI. **You only need to merge it when you are mixing freshly-published dev wheels with locally-checked-out AI packages** — for example, when developing in a worktree where one package is a path source and a sibling is consumed as a wheel. Without this, `uv`'s version-solver fails because the local clone still advertises the previous cycle version while the wheel `Requires-Dist` floor is `>= <current dev>`.
+
+In the typical flow the PR can sit untouched: it is automatically superseded by the next dev publish (the workflow closes the previous one before opening the new one).
 
 !!! tip "One-person merge"
-    Because the PR is opened by the bot, it only requires your approval — you can approve and merge it yourself without a second reviewer.
+    Because the PR is opened by the Release Workflow App, it only requires your approval — you can approve and merge it yourself without a second reviewer. The PR also runs `pull_request:` CI normally, since the App-authored push is not subject to GitHub's anti-recursion rule.
 
 ---
 
@@ -123,28 +139,30 @@ This PR bumps the AI package version floors in the monorepo to the latest dev ve
 ### Cadence
 
 1. **Arm the cycle** (usually automated, manual escape hatch available — see [Arming a cycle](#arming-a-cycle)).
-2. Developers merge features to `main`. Each merge triggers a dev publish (see above) and keeps the standing Release PR up to date.
+2. Developers merge features to `main`. Each merge triggers a dev publish (see above) and keeps the standing Release PR up to date. Whenever release-please rewrites the PR, `cd-release.yaml` regenerates `uv.lock` in the same workflow run and pushes the result back onto the PR branch — that push runs PR CI like any other commit, so the PR's status is always against the actual lockfile that will land.
 3. When ready to ship, **merge the Release PR** on `main`. Its title is:
    ```
    chore: stable release <version>
    ```
    Because this PR is opened by the bot, it only requires your approval — you can approve and merge it yourself without a second reviewer.
-4. release-please bumps all `pyproject.toml` versions and `CHANGELOG.md` entries.
-5. `cd-release.yaml` cuts the `release/YYYY.WW` branch, creates a GitHub Release, and triggers `cd-publish.yaml`.
-6. `cd-publish.yaml` builds and publishes every changed package to PyPI. Dependencies in the stable wheels are pinned with `>=` (updated by `update-dep-floors.py` at release time).
+4. release-please bumps all `pyproject.toml` versions and `CHANGELOG.md` entries, then tags and creates a GitHub Release.
+5. `cd-release.yaml`'s post-release job pushes the new `release/YYYY.WW` branch from the tagged commit (the Release Workflow App is a bypass actor on the `release-branches` ruleset) and arms the next cycle on `main` — see [Arming a cycle](#arming-a-cycle).
+6. The GitHub Release that release-please just published natively triggers `cd-publish.yaml`, which builds and publishes every changed package to PyPI. Dependencies in the stable wheels are pinned with `>=` (updated by `update-dep-floors.py` at release time).
 7. `uniqueai-sync-ai-versions.yaml` (monorepo) automatically syncs the new stable versions to `master` with `==` pins.
 
 ### Arming a cycle
 
-In steady state `cd-release.yaml` arms the next cycle automatically after cutting a release. Use the manual escape hatch when needed:
+In steady state `cd-release.yaml` arms the next cycle automatically after cutting a release: the same job that cuts `release/YYYY.WW` then runs `prepare-next-cycle.sh`, which pushes an empty `chore: arm release YYYY.WW.0` commit (with a `Release-As:` trailer) **directly onto `main`**. The Release Workflow App is a bypass actor on the `main-branch` ruleset, so the push is allowed despite branch protection. release-please picks the trailer up on the next workflow run and retargets the standing Release PR to that version.
+
+There is no arm PR, no side branch, and no merge queue involvement — the trailer commit lands on `main` immediately. If two arm runs race for the same `main`, `prepare-next-cycle.sh` retries with a refetch+re-anchor loop (bounded at 5 attempts) so a non-fast-forward rejection is recovered automatically.
+
+Use the manual escape hatch when the automation can't run on its own (bootstrap, skipped cycle, off-cadence release, miscomputed CalVer):
 
 **Workflow:** `.github/workflows/cd-arm-version.yaml` — triggered manually via `workflow_dispatch`.
 
 | Input | Default | Description |
 |-------|---------|-------------|
 | `year_week` | computed from manifest | Override target cycle, e.g. `2026.22` |
-
-The workflow pushes an empty `Release-As: YYYY.WW.0` footer commit to `main`. release-please picks this up and retargets the standing Release PR.
 
 ---
 
@@ -161,8 +179,8 @@ The workflow pushes an empty `Release-As: YYYY.WW.0` footer commit to `main`. re
    chore: hotfix release/YYYY.WW to <version>
    ```
    where `<version>` is `YYYY.WW.1` (or `.2`, etc.). Because this PR is opened by the bot, it only requires your approval — you can approve and merge it yourself without a second reviewer.
-4. release-please cuts a GitHub Release and triggers `cd-publish.yaml`.
-5. `cd-publish.yaml` publishes the patched packages.
+4. release-please tags the commit and creates a GitHub Release. The release event (authored by the Release Workflow App) natively triggers `cd-publish.yaml`.
+5. `cd-publish.yaml` publishes the patched packages to PyPI.
 6. Run `uniqueai-sync-ai-versions.yaml` manually (target `release`, source `release/YYYY.WW`) to sync the patch versions to the matching monorepo release branch.
 
 ---
@@ -200,7 +218,7 @@ flowchart TD
     A[Push to main] -->|cd-publish-dev| B[dev publish\nYYYY.WW.0.devN]
     B --> C[dev-cut-SHA tag\n+ GitHub pre-release]
     C -->|manual cd-publish-rc| D[RC publish\nYYYY.WW.0rcN\nall packages]
-    B -->|open/update PR| E[Dev bump PR in monorepo\nchore: pin dev-cut SHA]
+    B -->|open/update PR| E[Dev bump PR in AI repo\nchore: pin dev-cut SHA]
 
     F[Merge Release PR on main] -->|cd-release| G[cut release/YYYY.WW branch\ncreate GitHub Release]
     G -->|cd-publish| H[biweekly stable publish\nYYYY.WW.0\nchanged packages]

--- a/docs/contributing/release-process.md
+++ b/docs/contributing/release-process.md
@@ -160,7 +160,7 @@ flowchart TD
    ```
    Because this PR is opened by the bot, it only requires your approval — you can approve and merge it yourself without a second reviewer.
 4. release-please bumps all `pyproject.toml` versions and `CHANGELOG.md` entries, then tags and creates a GitHub Release.
-5. `cd-release.yaml`'s post-release job pushes the new `release/YYYY.WW` branch from the tagged commit (the Release Workflow App is a bypass actor on the `release-branches` ruleset) and arms the next cycle on `main` — see [Arming a cycle](#arming-a-cycle).
+5. `cd-release.yaml`'s post-release job pushes the new `release/YYYY.WW` branch from the tagged commit (the Release Workflow App is a bypass actor on the `release-branches` ruleset), arms the next cycle on `main` — see [Arming a cycle](#arming-a-cycle) — and closes any open `chore: pin dev-cut <SHA>` PRs, since their floors are now superseded by the stable floors that just landed on `main`.
 6. The GitHub Release that release-please just published natively triggers `cd-publish.yaml`, which builds and publishes every changed package to PyPI. Dependencies in the stable wheels are pinned with `>=` (updated by `update-dep-floors.py` at release time).
 7. Propagating the new stable versions to the monorepo is [documented in the monorepo](https://github.com/Unique-AG/monorepo/blob/master/docs/uniqueai/release-process/index.md#sync-ai-versions-workflow).
 
@@ -190,6 +190,7 @@ flowchart TD
     TAG -->|release: published| PUB[cd-publish.yaml<br/>biweekly stable publish<br/>YYYY.WW.0]
     TAG --> CUT[cut release/YYYY.WW branch<br/>from tagged commit]
     TAG --> NEXT[arm next cycle on main<br/>direct push]
+    TAG --> CLOSE[close stale<br/>chore: pin dev-cut PRs]
     TAG -.manual dispatch.-> SYNC[uniqueai-sync-ai-versions.yaml<br/>target=master<br/>source=release/YYYY.WW<br/>Sync == versions to monorepo master]
 ```
 

--- a/docs/contributing/release-process.md
+++ b/docs/contributing/release-process.md
@@ -162,7 +162,7 @@ flowchart TD
 4. release-please bumps all `pyproject.toml` versions and `CHANGELOG.md` entries, then tags and creates a GitHub Release.
 5. `cd-release.yaml`'s post-release job pushes the new `release/YYYY.WW` branch from the tagged commit (the Release Workflow App is a bypass actor on the `release-branches` ruleset) and arms the next cycle on `main` — see [Arming a cycle](#arming-a-cycle).
 6. The GitHub Release that release-please just published natively triggers `cd-publish.yaml`, which builds and publishes every changed package to PyPI. Dependencies in the stable wheels are pinned with `>=` (updated by `update-dep-floors.py` at release time).
-7. To propagate the new stable versions to monorepo `master`, run [`uniqueai-sync-ai-versions.yaml`](#sync-ai-versions-workflow) manually with `target=master`, `ai_source_branch=release/YYYY.WW`. The workflow rewrites every monorepo `pyproject.toml` to pin on the new versions with `==` (the pin operator is driven by `ai_source_branch`, not `target` — see [Pin operator rules](#pin-operator-rules)).
+7. To propagate the new stable versions to monorepo `master`, manually dispatch the [Sync AI Versions workflow](https://github.com/Unique-AG/monorepo/blob/master/docs/uniqueai/release-process/index.md#sync-ai-versions-workflow) in the monorepo with `target=master`, `ai_source_branch=release/YYYY.WW`. It rewrites the monorepo `pyproject.toml` files to pin the new stable versions with `==`.
 
 ### Arming a cycle
 
@@ -210,7 +210,7 @@ flowchart TD
    where `<version>` is `YYYY.WW.1` (or `.2`, etc.). Because this PR is opened by the bot, it only requires your approval — you can approve and merge it yourself without a second reviewer.
 4. release-please tags the commit and creates a GitHub Release. The release event (authored by the Release Workflow App) natively triggers `cd-publish.yaml`.
 5. `cd-publish.yaml` publishes the patched packages to PyPI.
-6. Run `uniqueai-sync-ai-versions.yaml` manually (target `release`, source `release/YYYY.WW`) to sync the patch versions to the matching monorepo release branch.
+6. To propagate the patch versions to the matching monorepo release branch, manually dispatch the [Sync AI Versions workflow](https://github.com/Unique-AG/monorepo/blob/master/docs/uniqueai/release-process/index.md#sync-ai-versions-workflow) in the monorepo with `target=release`, `release_branch=release/YYYY.WW`.
 
 ### Flow
 
@@ -225,26 +225,10 @@ flowchart TD
 
 ---
 
-## `sync-ai-versions` workflow
+## Syncing AI versions to the monorepo
 
-**Location:** monorepo `.github/workflows/uniqueai-sync-ai-versions.yaml`
+The monorepo consumes AI packages via `python/assistants/bundles/core/src/pyproject.toml` and `python/assistants/bundles/agentic-table/pyproject.toml`. Propagation is handled entirely on the monorepo side by the **Sync AI Versions** workflow — the AI repo never pushes to the monorepo.
 
-Syncs AI package version floors from the AI repo into the monorepo. Runs automatically after a stable release cuts a new `release/YYYY.WW` branch, and can be triggered manually for hotfixes or dev baseline updates.
+For inputs, pin-operator rules, triggers, and use cases (hotfix re-pin, stable-back-to-master, dev-floor bump) see the monorepo docs:
 
-### Manual inputs
-
-| Input | Required | Values | Notes |
-|-------|----------|--------|-------|
-| `target` | yes | `master` / `release` | Monorepo branch to update |
-| `release_branch` | if `release` | e.g. `release/2026.18` | Required when `target=release` |
-| `ai_source_branch` | no | `main` or `release/YYYY.WW` | Defaults: `main` (master target), same as `release_branch` (release target) |
-
-### Pin operator rules
-
-| AI source branch | Pin operator | Use case |
-|-----------------|-------------|---------|
-| `main` | `>=` | Dev baseline bump on monorepo `master` |
-| `release/YYYY.WW` | `==` | Exact stable or hotfix sync |
-
-!!! warning "Dev releases cannot be synced to monorepo release branches"
-    The workflow rejects any run where `target=release` and `ai_source_branch=main`. Dev versions are not suitable for release branches.
+→ [Sync AI Versions workflow (monorepo docs)](https://github.com/Unique-AG/monorepo/blob/master/docs/uniqueai/release-process/index.md#sync-ai-versions-workflow)

--- a/docs/contributing/release-process.md
+++ b/docs/contributing/release-process.md
@@ -1,0 +1,209 @@
+# Release Process
+
+This page documents the full lifecycle of AI package releases — from a developer pushing to `main` through stable weekly releases, hotfixes, and the optional RC path for pre-shipping to a specific customer.
+
+---
+
+## Version scheme
+
+All packages use **CalVer**: `YYYY.WW.PATCH`.
+
+| Segment | Meaning |
+|---------|---------|
+| `YYYY` | Calendar year |
+| `WW` | Next even ISO week number (the target release week) |
+| `PATCH` | `0` for weekly releases; `1`, `2`, … for hotfixes on the same branch |
+
+Pre-release suffixes follow PEP 440 ordering (`dev < rc < final`):
+
+| Suffix | Example | Published by |
+|--------|---------|--------------|
+| `.devN` | `2026.20.0.dev3` | Every push to `main` (automated) |
+| `rcN` | `2026.20.0rc2` | Manual promotion of a dev cut |
+| *(none)* | `2026.20.0` | Weekly release (automated via release-please) |
+| `.N` (hotfix) | `2026.20.1` | Patch on a `release/YYYY.WW` branch |
+
+---
+
+## Dev releases
+
+**Trigger:** every push to `main` that touches a publishable package.
+
+**Workflow:** `.github/workflows/cd-publish-dev.yaml`
+
+On each qualifying push the workflow:
+
+1. Detects which packages changed (same logic as PR CI).
+2. Queries PyPI for the highest `.devN` already published for each changed package in the current cycle, increments, and emits `YYYY.WW.0.dev(N+1)`.
+3. Rewrites cross-package AI dependencies in each wheel's `Requires-Dist`:
+   - Co-publishing sibling → `>=<its new dev version>`
+   - Existing dev version in this cycle → `>=<highest dev>`
+   - No dev yet in this cycle → `>=<last stable>`
+4. Builds and publishes to PyPI under the `publish-prerelease` concurrency group (serialized, no races).
+5. Tags the head SHA as `dev-cut-<SHORT_SHA>` and creates a GitHub pre-release listing every package version produced.
+
+!!! note "Why only changed packages?"
+    Dev releases are incremental. Only packages that actually changed are republished; unchanged siblings keep their last dev (or stable) version.
+
+---
+
+## Dev cuts
+
+A **dev cut** is the unit of promotion. It is defined by:
+
+- A single Git SHA on `main`
+- The set of `(package, devN version)` pairs produced from that push
+
+Every successful dev publish creates a `dev-cut-<SHORT_SHA>` tag (visible on the [GitHub tags page](https://github.com/Unique-AG/ai/tags)) and a matching GitHub pre-release that lists every package version in the cut.
+
+You can promote a specific dev cut to an RC — see [RC releases](#rc-releases) below.
+
+---
+
+## RC releases
+
+**Use case:** shipping a tested snapshot to a customer between two weekly releases, without using a dev version (which some package managers treat specially) and without conflicting with the upcoming weekly or future hotfixes.
+
+**Workflow:** `.github/workflows/cd-publish-rc.yaml` — triggered manually via `workflow_dispatch`.
+
+### Inputs
+
+| Input | Required | Description |
+|-------|----------|-------------|
+| `ref` | yes | A `dev-cut-<SHORT_SHA>` tag identifying the exact cut to promote |
+| `force_non_linear` | no | Skip the ancestor check (escape hatch, off by default) |
+
+### What happens
+
+1. Checks out the exact SHA from the `dev-cut` tag.
+2. Derives the CalVer cycle from `.release-please-manifest.json` at that SHA.
+3. Queries PyPI for the highest `rcN` already published in this cycle across all packages.
+4. Assigns `{cycle}.0rc(N+1)` to **every** publishable package (rc cuts always republish the full set).
+5. Rewrites cross-package AI dependencies to `>={cycle}.0rcN` (floor at this rc; customers can upgrade to later rcs or the final stable).
+6. Builds and publishes all packages to PyPI under the `publish-prerelease` concurrency group.
+7. Tags the commit as `rc-{cycle}.0rc(N+1)` and creates a GitHub pre-release with auto-generated notes covering commits since the previous rc (or stable) in this cycle.
+
+### RC monotonicity
+
+By default the workflow checks that the chosen dev cut is a descendant of any previous RC SHA in the same cycle. This ensures RC 2 is always a superset of RC 1. Use `force_non_linear: true` only when intentionally releasing a parallel cut.
+
+### Customer pinning
+
+A customer who wants to floor at an RC can write:
+
+```
+unique-toolkit>=2026.20.0rc1
+```
+
+`pip` will resolve this to the latest compatible version — either a later RC or the eventual `2026.20.0` stable.
+
+---
+
+## Dev bump PR
+
+After every successful dev publish the workflow opens (or updates) a pull request in the **monorepo** with title:
+
+```
+chore: pin dev-cut <SHORT_SHA>
+```
+
+This PR bumps the AI package version floors in the monorepo to the latest dev versions, allowing monorepo developers to test against the newest AI packages. It is **not** a release artifact — merge it at your discretion.
+
+---
+
+## Stable weekly releases
+
+**Trigger:** a Release PR is merged on `main`.
+
+**Workflow:** `.github/workflows/cd-release.yaml` (release-please) + `.github/workflows/cd-publish.yaml`
+
+### Cadence
+
+1. **Arm the cycle** (usually automated, manual escape hatch available — see [Arming a cycle](#arming-a-cycle)).
+2. Developers merge features to `main`. Each merge triggers a dev publish (see above) and keeps the standing Release PR up to date.
+3. When ready to ship, **merge the Release PR** on `main`. Its title is:
+   ```
+   chore: stable release <version>
+   ```
+4. release-please bumps all `pyproject.toml` versions and `CHANGELOG.md` entries.
+5. `cd-release.yaml` cuts the `release/YYYY.WW` branch, creates a GitHub Release, and triggers `cd-publish.yaml`.
+6. `cd-publish.yaml` builds and publishes every changed package to PyPI. Dependencies in the stable wheels are pinned with `>=` (updated by `update-dep-floors.py` at release time).
+7. `uniqueai-sync-ai-versions.yaml` (monorepo) automatically syncs the new stable versions to `master` with `==` pins.
+
+### Arming a cycle
+
+In steady state `cd-release.yaml` arms the next cycle automatically after cutting a release. Use the manual escape hatch when needed:
+
+**Workflow:** `.github/workflows/cd-arm-version.yaml` — triggered manually via `workflow_dispatch`.
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `year_week` | computed from manifest | Override target cycle, e.g. `2026.22` |
+
+The workflow pushes an empty `Release-As: YYYY.WW.0` footer commit to `main`. release-please picks this up and retargets the standing Release PR.
+
+---
+
+## Hotfix releases
+
+**Use case:** a critical fix that must ship on a release branch without waiting for the next weekly cycle.
+
+**Workflow:** `.github/workflows/cd-release.yaml` (running on a `release/*` branch) + `cd-publish.yaml`
+
+1. Branch off `release/YYYY.WW` and cherry-pick or commit the fix.
+2. release-please opens a PR on the release branch with title:
+   ```
+   chore: hotfix release/YYYY.WW to <version>
+   ```
+   where `<version>` is `YYYY.WW.1` (or `.2`, etc.).
+3. Merge the PR. release-please cuts a GitHub Release and triggers `cd-publish.yaml`.
+4. `cd-publish.yaml` publishes the patched packages.
+5. Run `uniqueai-sync-ai-versions.yaml` manually (target `release`, source `release/YYYY.WW`) to sync the patch versions to the matching monorepo release branch.
+
+---
+
+## `sync-ai-versions` workflow
+
+**Location:** monorepo `.github/workflows/uniqueai-sync-ai-versions.yaml`
+
+Syncs AI package version floors from the AI repo into the monorepo. Runs automatically after a stable release cuts a new `release/YYYY.WW` branch, and can be triggered manually for hotfixes or dev baseline updates.
+
+### Manual inputs
+
+| Input | Required | Values | Notes |
+|-------|----------|--------|-------|
+| `target` | yes | `master` / `release` | Monorepo branch to update |
+| `release_branch` | if `release` | e.g. `release/2026.18` | Required when `target=release` |
+| `ai_source_branch` | no | `main` or `release/YYYY.WW` | Defaults: `main` (master target), same as `release_branch` (release target) |
+
+### Pin operator rules
+
+| AI source branch | Pin operator | Use case |
+|-----------------|-------------|---------|
+| `main` | `>=` | Dev baseline bump on monorepo `master` |
+| `release/YYYY.WW` | `==` | Exact stable or hotfix sync |
+
+!!! warning "Dev releases cannot be synced to monorepo release branches"
+    The workflow rejects any run where `target=release` and `ai_source_branch=main`. Dev versions are not suitable for release branches.
+
+---
+
+## Flow overview
+
+```mermaid
+flowchart TD
+    A[Push to main] -->|cd-publish-dev| B[dev publish\nYYYY.WW.0.devN]
+    B --> C[dev-cut-SHA tag\n+ GitHub pre-release]
+    C -->|manual cd-publish-rc| D[RC publish\nYYYY.WW.0rcN\nall packages]
+    B -->|open/update PR| E[Dev bump PR in monorepo\nchore: pin dev-cut SHA]
+
+    F[Merge Release PR on main] -->|cd-release| G[cut release/YYYY.WW branch\ncreate GitHub Release]
+    G -->|cd-publish| H[stable publish\nYYYY.WW.0\nchanged packages]
+    G -->|uniqueai-sync-ai-versions| I[Sync == versions\nto monorepo master]
+
+    J[Fix on release/YYYY.WW] -->|cd-release| K[create GitHub Release\nYYYY.WW.P]
+    K -->|cd-publish| L[hotfix publish]
+    K -->|manual uniqueai-sync-ai-versions| M[Sync == versions\nto monorepo release branch]
+
+    N[cd-arm-version\nmanual escape hatch] --> F
+```

--- a/docs/contributing/release-process.md
+++ b/docs/contributing/release-process.md
@@ -1,6 +1,6 @@
 # Release Process
 
-This page documents the full lifecycle of AI package releases — from a developer pushing to `main` through stable weekly releases, hotfixes, and the optional RC path for pre-shipping to a specific customer.
+This page documents the full lifecycle of AI package releases — from a developer pushing to `main` through stable biweekly releases, hotfixes, and the optional RC path for pre-shipping to a specific customer.
 
 ---
 
@@ -12,7 +12,7 @@ All packages use **CalVer**: `YYYY.WW.PATCH`.
 |---------|---------|
 | `YYYY` | Calendar year |
 | `WW` | Next even ISO week number (the target release week) |
-| `PATCH` | `0` for weekly releases; `1`, `2`, … for hotfixes on the same branch |
+| `PATCH` | `0` for biweekly releases; `1`, `2`, … for hotfixes on the same branch |
 
 Pre-release suffixes follow PEP 440 ordering (`dev < rc < final`):
 
@@ -20,7 +20,7 @@ Pre-release suffixes follow PEP 440 ordering (`dev < rc < final`):
 |--------|---------|--------------|
 | `.devN` | `2026.20.0.dev3` | Every push to `main` (automated) |
 | `rcN` | `2026.20.0rc2` | Manual promotion of a dev cut |
-| *(none)* | `2026.20.0` | Weekly release (automated via release-please) |
+| *(none)* | `2026.20.0` | Biweekly release (automated via release-please) |
 | `.N` (hotfix) | `2026.20.1` | Patch on a `release/YYYY.WW` branch |
 
 ---
@@ -62,7 +62,7 @@ You can promote a specific dev cut to an RC — see [RC releases](#rc-releases) 
 
 ## RC releases
 
-**Use case:** shipping a tested snapshot to a customer between two weekly releases, without using a dev version (which some package managers treat specially) and without conflicting with the upcoming weekly or future hotfixes.
+**Use case:** shipping a tested snapshot to a customer between two biweekly releases, without using a dev version (which some package managers treat specially) and without conflicting with the upcoming biweekly or future hotfixes.
 
 **Workflow:** `.github/workflows/cd-publish-rc.yaml` — triggered manually via `workflow_dispatch`.
 
@@ -107,11 +107,14 @@ After every successful dev publish the workflow opens (or updates) a pull reques
 chore: pin dev-cut <SHORT_SHA>
 ```
 
-This PR bumps the AI package version floors in the monorepo to the latest dev versions, allowing monorepo developers to test against the newest AI packages. It is **not** a release artifact — merge it at your discretion.
+This PR bumps the AI package version floors in the monorepo to the latest dev versions. **You only need to merge it when you are actively mixing dev AI dependencies with local monorepo sources** — for example, when developing a monorepo feature that depends on unreleased AI changes. In the typical development flow the PR can be left open and will be superseded by the next stable release sync.
+
+!!! tip "One-person merge"
+    Because the PR is opened by the bot, it only requires your approval — you can approve and merge it yourself without a second reviewer.
 
 ---
 
-## Stable weekly releases
+## Stable biweekly releases
 
 **Trigger:** a Release PR is merged on `main`.
 
@@ -125,6 +128,7 @@ This PR bumps the AI package version floors in the monorepo to the latest dev ve
    ```
    chore: stable release <version>
    ```
+   Because this PR is opened by the bot, it only requires your approval — you can approve and merge it yourself without a second reviewer.
 4. release-please bumps all `pyproject.toml` versions and `CHANGELOG.md` entries.
 5. `cd-release.yaml` cuts the `release/YYYY.WW` branch, creates a GitHub Release, and triggers `cd-publish.yaml`.
 6. `cd-publish.yaml` builds and publishes every changed package to PyPI. Dependencies in the stable wheels are pinned with `>=` (updated by `update-dep-floors.py` at release time).
@@ -146,19 +150,20 @@ The workflow pushes an empty `Release-As: YYYY.WW.0` footer commit to `main`. re
 
 ## Hotfix releases
 
-**Use case:** a critical fix that must ship on a release branch without waiting for the next weekly cycle.
+**Use case:** a critical fix that must ship on a release branch without waiting for the next biweekly cycle.
 
 **Workflow:** `.github/workflows/cd-release.yaml` (running on a `release/*` branch) + `cd-publish.yaml`
 
-1. Branch off `release/YYYY.WW` and cherry-pick or commit the fix.
-2. release-please opens a PR on the release branch with title:
+1. Create a branch off `release/YYYY.WW`, commit or cherry-pick the fix, and open a PR targeting `release/YYYY.WW`.
+2. Get the PR reviewed and merged normally (standard review process applies).
+3. release-please opens a second PR on the release branch with title:
    ```
    chore: hotfix release/YYYY.WW to <version>
    ```
-   where `<version>` is `YYYY.WW.1` (or `.2`, etc.).
-3. Merge the PR. release-please cuts a GitHub Release and triggers `cd-publish.yaml`.
-4. `cd-publish.yaml` publishes the patched packages.
-5. Run `uniqueai-sync-ai-versions.yaml` manually (target `release`, source `release/YYYY.WW`) to sync the patch versions to the matching monorepo release branch.
+   where `<version>` is `YYYY.WW.1` (or `.2`, etc.). Because this PR is opened by the bot, it only requires your approval — you can approve and merge it yourself without a second reviewer.
+4. release-please cuts a GitHub Release and triggers `cd-publish.yaml`.
+5. `cd-publish.yaml` publishes the patched packages.
+6. Run `uniqueai-sync-ai-versions.yaml` manually (target `release`, source `release/YYYY.WW`) to sync the patch versions to the matching monorepo release branch.
 
 ---
 
@@ -198,7 +203,7 @@ flowchart TD
     B -->|open/update PR| E[Dev bump PR in monorepo\nchore: pin dev-cut SHA]
 
     F[Merge Release PR on main] -->|cd-release| G[cut release/YYYY.WW branch\ncreate GitHub Release]
-    G -->|cd-publish| H[stable publish\nYYYY.WW.0\nchanged packages]
+    G -->|cd-publish| H[biweekly stable publish\nYYYY.WW.0\nchanged packages]
     G -->|uniqueai-sync-ai-versions| I[Sync == versions\nto monorepo master]
 
     J[Fix on release/YYYY.WW] -->|cd-release| K[create GitHub Release\nYYYY.WW.P]

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -41,6 +41,7 @@ theme:
 nav:
   - Home: 'index.md'
   - Implementation Guidelines: 'usecase_realization_guidelines.md'
+  - Release Process: 'contributing/release-process.md'
   - Unique SDK: https://unique-ag.github.io/ai/unique-sdk/latest/
   - Unique Toolkit: https://unique-ag.github.io/ai/unique-toolkit/latest/
   - Tutorials: '!include ./tutorials/mkdocs.yaml'


### PR DESCRIPTION
## Summary

Two related changes around the AI repo's CalVer release lifecycle:

1. **`docs/contributing/release-process.md`** — the missing operator manual for releases. A single page covering dev / RC / stable / hotfix flows, wired into the MkDocs nav after **Implementation Guidelines**.
2. **`cd-release.yaml::cut-and-arm`** — closes stale `chore: pin dev-cut <SHA>` PRs after a stable release, so they don't accumulate cycle after cycle.

## Changes

### `docs/contributing/release-process.md` + `mkdocs.yaml`

A from-scratch reference page covering the AI release lifecycle end to end:

- **CalVer scheme** (`YYYY.WW.PATCH`) with `.devN` / `rcN` / final / `.PATCH` examples.
- **Automation identity** — Release Workflow GitHub App, `gh-static-ip-slim` runner, bypass actor on `main-branch` and `release-branches` rulesets, why GitHub's anti-recursion rule forces us to use the App token for events that must trigger downstream CI.
- **Dev releases** — per-push `.devN` publish, change detection, `>=` floors.
- **Dev cuts** — what a `dev-cut-<SHA>` tag is, how to find it on the GitHub Releases page, and how it makes RC promotion reproducible.
- **`chore: pin dev-cut <SHA>` PR** — when it's safe to leave open and when you should merge it (mixing dev wheels with locally-checked-out path sources).
- **RC releases** — manual `cd-publish-rc.yaml` dispatch, full-set republish, `>=` cross-package floors, monotonicity guard, and a customer pinning example.
- **Stable biweekly releases** — Release PR flow, arming, cut-and-arm side effects (release branch, `Release-As` trailer, dev-cut PR cleanup), `cd-publish.yaml` triggered natively by the App-authored release event.
- **Hotfix releases** — branch off `release/YYYY.WW`, cherry-pick + PR, hotfix Release PR title pattern (`chore: hotfix release/YYYY.WW to <version>`), manual sync into the matching monorepo release branch.
- **Per-stage Mermaid diagrams** for Dev / RC / Stable / Hotfix.
- **Sync to monorepo** — single pointer to the [monorepo docs](https://github.com/Unique-AG/monorepo/blob/master/docs/uniqueai/release-process/index.md#sync-ai-versions-workflow); no duplicated detail.

### `.github/workflows/cd-release.yaml`

New `Close stale dev bump PRs` step in the `cut-and-arm` job. The job already gates on `releases_created == true && refs/heads/main`, so the step only fires on an actual stable cut. Implementation:

- Uses the App token already available in this job (no extra secret plumbing).
- `gh pr list --base main --search "chore: pin dev-cut in:title"` finds every open dev-cut bump PR.
- `gh pr close --comment "Superseded by stable release: dev-cut floors were just persisted to main"` closes each one.

After a stable cut, `update-dep-floors.py` has just persisted new floors to every `pyproject.toml` on `main`. Any open dev-cut PR's floors are strictly older — keeping them open just produces stale, conflict-prone PRs that never get merged. The summary block is updated to mention the cleanup.

## Test plan

- [ ] Stable Release PR merged on `main` → next `cd-release` run cuts the release branch, arms the next cycle, **and** closes every open `chore: pin dev-cut <SHA>` PR with the superseded comment.
- [ ] Stable cut with no open dev-cut PRs → step prints `No open dev bump PRs found.` and exits 0.
- [ ] Hotfix Release PR merged on `release/YYYY.WW` → `cut-and-arm` is skipped (branch gate), no PRs are closed.
- [ ] `mkdocs serve` renders the new page in the navigation between **Implementation Guidelines** and the rest, with all per-stage diagrams visible.