### PR TITLE
ci(release): wire Release Workflow App through full release flow

### DIFF
--- a/.github/scripts/prepare-next-cycle.sh
+++ b/.github/scripts/prepare-next-cycle.sh
@@ -1,13 +1,29 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Arms the next stable release by opening a PR that carries an empty
-# `Release-As: YYYY.WW.0` commit. Once merged, release-please rewrites its
-# standing Release PR on `main` to target that version.
+# Arms the next stable release by pushing an empty `Release-As: YYYY.WW.0`
+# commit directly onto the base branch (default `main`). Once the commit
+# lands, release-please rewrites its standing Release PR to target that
+# version on the next workflow run.
 #
-# The commit lands on a side branch (`chore/arm-YYYY.WW.0`) and is merged via
-# the normal merge queue. This avoids needing a branch-protection bypass for
-# direct pushes to `main`.
+# How the push works
+# ==================
+#   The caller is expected to authenticate `git`/`gh` as the Release
+#   Workflow GitHub App, which is a bypass actor on `main-branch` and
+#   `release-branches` rulesets. That makes the push to `main` legal and
+#   makes the resulting commit's `push:` event fire other workflows
+#   (GITHUB_TOKEN-authored pushes are blocked by GitHub's anti-recursion
+#   rule). cd-release.yaml's global concurrency group serializes the
+#   re-trigger behind any in-flight cd-release run.
+#
+# Race handling
+# =============
+#   Two arm runs aimed at the same `main` could race (e.g. concurrent
+#   cd-release runs after a long-tailed PR merge). The script handles
+#   that with a rebase+retry loop: if the push is rejected as
+#   non-fast-forward, refetch the base branch, reset the working tree
+#   to the new tip, recreate the empty commit, and try again. The
+#   commit is empty so nothing else can conflict.
 #
 # Inputs (via flags):
 #   --year-week YYYY.WW  Explicit target cycle (e.g. 2026.20). Optional.
@@ -15,15 +31,15 @@ set -euo pipefail
 #                        .release-please-manifest.json (manifest + 2 weeks,
 #                        fallback: next even ISO week).
 #   --remote NAME        Remote to push to. Default: origin.
-#   --branch NAME        Base branch (PR target). Default: main.
+#   --branch NAME        Base branch to push to. Default: main.
 #
-# Idempotent: exits 0 without opening a PR if the Release-As trailer is
-# already on the base branch, or if an arm PR for the same version is already
-# open.
+# Idempotent: exits 0 without pushing if the Release-As trailer is
+# already on the base branch.
 
 REMOTE="origin"
 BRANCH="main"
 YEAR_WEEK=""
+MAX_ATTEMPTS=5
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -60,64 +76,72 @@ if ! git config user.email >/dev/null 2>&1; then
   git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 fi
 
-git fetch --no-tags "$REMOTE" "$BRANCH"
-
 # Escape regex metachars in VERSION (dots) so the BRE below matches literally,
 # while keeping `^`/`$` as line anchors. `--fixed-strings` can't be used here
 # because it would also neuter the anchors and cause false positives for
 # versions that share a numeric prefix (e.g. 2026.20.0 vs 2026.20.0.dev1).
 ESCAPED_VERSION="${VERSION//./\\.}"
 
-# Limit the idempotency scan to commits made after the latest release tag so
-# we don't walk the entire branch history on every run.
-SINCE_FLAG=()
-LAST_TAG_DATE=$(git log -1 --format=%aI \
-  "$(git tag --list --sort=-version:refname 'unique-toolkit-v[0-9]*.[0-9]*.0' \
-     | head -1)" 2>/dev/null || true)
-if [[ -n "$LAST_TAG_DATE" ]]; then
-  SINCE_FLAG=(--since="$LAST_TAG_DATE")
-fi
+already_armed() {
+  # Limit the idempotency scan to commits made after the latest release tag
+  # so we don't walk the entire branch history on every run.
+  local since_flag=()
+  local last_tag_date
+  last_tag_date=$(git log -1 --format=%aI \
+    "$(git tag --list --sort=-version:refname 'unique-toolkit-v[0-9]*.[0-9]*.0' \
+       | head -1)" 2>/dev/null || true)
+  if [[ -n "$last_tag_date" ]]; then
+    since_flag=(--since="$last_tag_date")
+  fi
 
-if git log "${REMOTE}/${BRANCH}" "${SINCE_FLAG[@]}" \
-      --grep "^Release-As: ${ESCAPED_VERSION}$" \
-      -n 1 --format=%H | grep -q .; then
+  git log "${REMOTE}/${BRANCH}" "${since_flag[@]}" \
+        --grep "^Release-As: ${ESCAPED_VERSION}$" \
+        -n 1 --format=%H | grep -q .
+}
+
+git fetch --no-tags "$REMOTE" "$BRANCH"
+
+if already_armed; then
   echo "Release-As: ${VERSION} already present on ${REMOTE}/${BRANCH}; nothing to do."
   exit 0
 fi
 
-CYCLE_BRANCH="chore/arm-${VERSION}"
+# Rebase+retry loop: anchor on the latest remote tip, build the empty
+# commit, push. If the push is rejected because someone else advanced
+# the branch in between, refetch, re-anchor, retry. Empty commit means
+# there is never a real conflict to resolve — the only failure mode is
+# the non-fast-forward race.
+attempt=1
+while (( attempt <= MAX_ATTEMPTS )); do
+  echo "Attempt ${attempt}/${MAX_ATTEMPTS}: anchoring on ${REMOTE}/${BRANCH}"
+  git fetch --no-tags "$REMOTE" "$BRANCH"
+  git reset --hard "${REMOTE}/${BRANCH}"
 
-OPEN_PRS=$(gh pr list \
-  --base "$BRANCH" \
-  --head "$CYCLE_BRANCH" \
-  --state open \
-  --json number \
-  --jq 'length' 2>/dev/null || echo "0")
-if [[ "$OPEN_PRS" != "0" ]]; then
-  echo "Arm PR for ${VERSION} already open on ${CYCLE_BRANCH}; nothing to do."
-  exit 0
-fi
+  # Re-check after the fetch — another arm run could have landed
+  # the same Release-As trailer between attempts.
+  if already_armed; then
+    echo "Release-As: ${VERSION} just landed on ${REMOTE}/${BRANCH}; nothing to do."
+    exit 0
+  fi
 
-git commit --allow-empty \
-  -m "chore: arm release ${VERSION}" \
-  -m "Release-As: ${VERSION}"
+  git commit --allow-empty \
+    -m "chore: arm release ${VERSION}" \
+    -m "Release-As: ${VERSION}"
 
-# Populate the local tracking ref so --force-with-lease has something to
-# compare against. Without this fetch, --force-with-lease treats a missing
-# tracking ref as "expect the remote branch not to exist" and rejects the push
-# when the branch already exists (e.g. branch pushed but gh pr create failed,
-# or a previously closed arm PR). The || true handles the case where the branch
-# does not yet exist on the remote.
-git fetch --no-tags "$REMOTE" \
-  "refs/heads/${CYCLE_BRANCH}:refs/remotes/${REMOTE}/${CYCLE_BRANCH}" 2>/dev/null || true
-git push --force-with-lease "$REMOTE" "HEAD:refs/heads/${CYCLE_BRANCH}"
+  if git push "$REMOTE" "HEAD:refs/heads/${BRANCH}"; then
+    echo "Pushed Release-As: ${VERSION} to ${REMOTE}/${BRANCH}."
+    echo "release-please will retarget the standing Release PR on the next cd-release run."
+    exit 0
+  fi
 
-gh pr create \
-  --base "$BRANCH" \
-  --head "$CYCLE_BRANCH" \
-  --title "chore: arm release ${VERSION}" \
-  --body "Arms the next CalVer cycle. Once merged, release-please will retarget the standing Release PR to \`${VERSION}\`.
+  # Push failed. Most likely cause: another commit landed on the base
+  # branch between our fetch and our push (non-fast-forward). Back off
+  # a couple seconds with jitter and try again.
+  sleep_secs=$(( (RANDOM % 4) + 2 ))
+  echo "::warning::Push to ${REMOTE}/${BRANCH} rejected; refetching and retrying in ${sleep_secs}s..."
+  sleep "$sleep_secs"
+  attempt=$(( attempt + 1 ))
+done
 
-Release-As: ${VERSION}"
-
-echo "Opened arm PR for ${VERSION}. Release-please will update the ${BRANCH} Release PR once it is merged."
+echo "::error::Failed to push Release-As: ${VERSION} to ${REMOTE}/${BRANCH} after ${MAX_ATTEMPTS} attempts." >&2
+exit 1

--- a/.github/workflows/cd-arm-version.yaml
+++ b/.github/workflows/cd-arm-version.yaml
@@ -14,12 +14,16 @@ name: "[CD] Release · Arm Version"
 #   - shipping off-cadence (e.g. cut 2026.19.0 a week early),
 #   - correcting a miscomputed CalVer.
 #
-# It pushes an empty `Release-As: YYYY.WW.0` commit to `main`. Each
-# trailer overrides the previous one; no cleanup is needed.
+# It pushes an empty `Release-As: YYYY.WW.0` commit directly to `main`.
+# Each trailer overrides the previous one; no cleanup is needed.
+#
+# Runs on gh-static-ip-slim under the `release-workflow` environment so
+# `prepare-next-cycle.sh` can authenticate as the Release Workflow App,
+# which is a bypass actor on the main-branch ruleset and the only
+# identity allowed to push directly to `main`.
 
 permissions:
   contents: write
-  pull-requests: write
 
 on:
   workflow_dispatch:
@@ -31,7 +35,8 @@ on:
 
 jobs:
   arm:
-    runs-on: ubuntu-latest
+    runs-on: gh-static-ip-slim
+    environment: release-workflow
     timeout-minutes: 5
     steps:
       - name: Ensure workflow runs from main
@@ -42,16 +47,24 @@ jobs:
             exit 1
           fi
 
+      - name: Generate GitHub App token
+        id: app-token
+        uses: unique-ag/actions/github/app-token-create@df61dcf6fb84a7cad9c9b5f04924b40311cb016a
+        with:
+          app_id: ${{ vars.RELEASE_WORKFLOW_CLIENT_ID }}
+          base64_encoded_private_key: ${{ secrets.RELEASE_WORKFLOW_APP_PRIVATE_KEY_B64 }}
+          owner: ${{ github.repository_owner }}
+
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Arm cycle
         env:
           YEAR_WEEK: ${{ inputs.year_week }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           if [[ -n "$YEAR_WEEK" ]]; then
             ./.github/scripts/prepare-next-cycle.sh --year-week "$YEAR_WEEK"

--- a/.github/workflows/cd-publish-dev.yaml
+++ b/.github/workflows/cd-publish-dev.yaml
@@ -281,21 +281,33 @@ jobs:
     # plus the matching GitHub pre-release lock down what the cut actually
     # contained — which packages were rebuilt, at what versions, and with
     # which sibling pins — without anyone having to scrape PyPI by date.
+    #
+    # Runs on gh-static-ip-slim: the Release Workflow GitHub App is
+    # IP-origin-bound and only accepts requests from this runner's static IP.
     needs: [resolve, publish]
     if: needs.publish.result == 'success'
-    runs-on: ubuntu-latest
+    runs-on: gh-static-ip-slim
     permissions:
       contents: write
     outputs:
       short: ${{ steps.tag.outputs.short }}
       tag: ${{ steps.tag.outputs.tag }}
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: unique-ag/actions/github/app-token-create@df61dcf6fb84a7cad9c9b5f04924b40311cb016a
+        with:
+          app_id: ${{ vars.RELEASE_WORKFLOW_APP_ID }}
+          base64_encoded_private_key: ${{ secrets.RELEASE_WORKFLOW_APP_PRIVATE_KEY_B64 }}
+          owner: ${{ github.repository_owner }}
+
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           # Tag and notes target the commit the dev wheels were built from,
           # not whatever main looks like by the time this job runs.
           ref: ${{ github.sha }}
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Tag dev cut
         env:
@@ -313,7 +325,7 @@ jobs:
 
       - name: Create GitHub pre-release for cut
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           NEW_VERSIONS: ${{ needs.resolve.outputs.new_versions }}
           DEP_PINS: ${{ needs.resolve.outputs.dep_pins }}
           CYCLE: ${{ needs.resolve.outputs.cycle }}
@@ -358,9 +370,14 @@ jobs:
     # (e.g. chore/bump-dev-2026.18-tk-5-sdk-4-orch-3) so each publish run
     # creates a unique, auditable branch.  Any older open dev-bump PR is
     # closed first to avoid stale branches accumulating.
+    #
+    # Uses the Release Workflow GitHub App token so that the opened PR
+    # triggers pull_request: CI workflows. GITHUB_TOKEN-created PRs are
+    # subject to GitHub's anti-recursion rule and do not fire CI.
+    # Runs on gh-static-ip-slim: the App is IP-origin-bound.
     needs: [resolve, publish, tag-cut]
     if: needs.publish.result == 'success' && needs.tag-cut.result == 'success'
-    runs-on: ubuntu-latest
+    runs-on: gh-static-ip-slim
     permissions:
       contents: write
       pull-requests: write
@@ -368,9 +385,18 @@ jobs:
       BRANCH: chore/bump-dev-${{ needs.resolve.outputs.cycle }}-${{ needs.resolve.outputs.branch_suffix }}
       CYCLE: ${{ needs.resolve.outputs.cycle }}
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: unique-ag/actions/github/app-token-create@df61dcf6fb84a7cad9c9b5f04924b40311cb016a
+        with:
+          app_id: ${{ vars.RELEASE_WORKFLOW_APP_ID }}
+          base64_encoded_private_key: ${{ secrets.RELEASE_WORKFLOW_APP_PRIVATE_KEY_B64 }}
+          owner: ${{ github.repository_owner }}
+
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: main
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
@@ -379,7 +405,7 @@ jobs:
 
       - name: Ensure dev-version-bump label exists
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           gh label create "dev-version-bump" \
             --description "Automated PR that bumps dev version pins for local development" \
@@ -388,7 +414,7 @@ jobs:
 
       - name: Close previous dev-bump PRs
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           gh pr list --state open --label "dev-version-bump" --json number \
             | jq -r '.[].number' \
@@ -441,7 +467,7 @@ jobs:
       - name: Open PR
         if: steps.commit.outputs.pushed == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           ALL_CURRENT_VERSIONS: ${{ needs.resolve.outputs.all_current_versions }}
         run: |
           BODY_FILE="$(mktemp)"

--- a/.github/workflows/cd-publish-dev.yaml
+++ b/.github/workflows/cd-publish-dev.yaml
@@ -287,6 +287,7 @@ jobs:
     needs: [resolve, publish]
     if: needs.publish.result == 'success'
     runs-on: gh-static-ip-slim
+    environment: release-workflow
     permissions:
       contents: write
     outputs:
@@ -297,7 +298,7 @@ jobs:
         id: app-token
         uses: unique-ag/actions/github/app-token-create@df61dcf6fb84a7cad9c9b5f04924b40311cb016a
         with:
-          app_id: ${{ vars.RELEASE_WORKFLOW_APP_ID }}
+          app_id: ${{ vars.RELEASE_WORKFLOW_CLIENT_ID }}
           base64_encoded_private_key: ${{ secrets.RELEASE_WORKFLOW_APP_PRIVATE_KEY_B64 }}
           owner: ${{ github.repository_owner }}
 
@@ -378,6 +379,7 @@ jobs:
     needs: [resolve, publish, tag-cut]
     if: needs.publish.result == 'success' && needs.tag-cut.result == 'success'
     runs-on: gh-static-ip-slim
+    environment: release-workflow
     permissions:
       contents: write
       pull-requests: write
@@ -389,7 +391,7 @@ jobs:
         id: app-token
         uses: unique-ag/actions/github/app-token-create@df61dcf6fb84a7cad9c9b5f04924b40311cb016a
         with:
-          app_id: ${{ vars.RELEASE_WORKFLOW_APP_ID }}
+          app_id: ${{ vars.RELEASE_WORKFLOW_CLIENT_ID }}
           base64_encoded_private_key: ${{ secrets.RELEASE_WORKFLOW_APP_PRIVATE_KEY_B64 }}
           owner: ${{ github.repository_owner }}
 

--- a/.github/workflows/cd-publish-rc.yaml
+++ b/.github/workflows/cd-publish-rc.yaml
@@ -319,12 +319,27 @@ jobs:
     # cut SHA with the rc version and create the matching GitHub
     # pre-release. We do not block on tag-release for PyPI: even if
     # tagging fails, the wheels are already shipped.
+    #
+    # Runs on gh-static-ip-slim under the `release-workflow` environment
+    # so the tag and pre-release are authored by the Release Workflow
+    # App. App-authored tags / releases are not subject to GitHub's
+    # anti-recursion rule, which keeps the rc tag visible to any
+    # downstream automation that listens on `release: prereleased`.
     needs: [resolve, publish]
     if: needs.publish.result == 'success'
-    runs-on: ubuntu-latest
+    runs-on: gh-static-ip-slim
+    environment: release-workflow
     permissions:
       contents: write
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: unique-ag/actions/github/app-token-create@df61dcf6fb84a7cad9c9b5f04924b40311cb016a
+        with:
+          app_id: ${{ vars.RELEASE_WORKFLOW_CLIENT_ID }}
+          base64_encoded_private_key: ${{ secrets.RELEASE_WORKFLOW_APP_PRIVATE_KEY_B64 }}
+          owner: ${{ github.repository_owner }}
+
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           # Same SHA the dev wheels were built from. Tag goes on this
@@ -332,6 +347,7 @@ jobs:
           ref: ${{ needs.resolve.outputs.cut_sha }}
           fetch-depth: 0
           fetch-tags: true
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Tag rc release
         env:
@@ -348,7 +364,7 @@ jobs:
 
       - name: Create GitHub pre-release for rc cut
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           NEW_VERSIONS: ${{ needs.resolve.outputs.new_versions }}
           DEP_PINS: ${{ needs.resolve.outputs.dep_pins }}
           CYCLE: ${{ needs.resolve.outputs.cycle }}

--- a/.github/workflows/cd-release.yaml
+++ b/.github/workflows/cd-release.yaml
@@ -1,16 +1,47 @@
 name: "[CD] Release Pipeline"
 
 # Single entry point for the full release pipeline. One workflow so the
-# three post-release steps (cut branch, kick ci-publish, arm next cycle)
-# chain deterministically after release-please without racing it for
-# freshly-created tags.
+# post-release steps (cut branch, arm next cycle) chain deterministically
+# after release-please without racing it for freshly-created tags.
 #
 # Triggers:
 #   push: main          standing Release PR + post-release side effects
 #   push: release/*     per-cycle hotfix Release PR + hotfix publishes
-#   workflow_dispatch   manual kick after GITHUB_TOKEN-pushed commits
-#                       (see `cut-and-arm` — GitHub's anti-recursion rule
-#                       means those pushes can't re-trigger us via push)
+#   workflow_dispatch   manual kick (rarely needed)
+#
+# Tokens
+# ======
+#   release-please, the lockfile updater and cut-and-arm all run with the
+#   Release Workflow GitHub App token. Two reasons:
+#     1. Bypass: the App is a bypass actor on `main-branch` and
+#        `release-branches` rulesets, so `prepare-next-cycle.sh` can push
+#        directly to `main` and `cut-release-branch.sh` can create the
+#        new `release/YYYY.WW` branch despite branch protection.
+#     2. Trigger downstream CI: GitHub's anti-recursion rule prevents
+#        commits / releases produced by GITHUB_TOKEN from firing other
+#        workflows. App-token-authored events are NOT subject to that
+#        rule, so:
+#          - lockfile commits on the standing Release PR re-run PR CI,
+#          - the GitHub Release that release-please publishes natively
+#            triggers `cd-publish.yaml` (we don't need a `gh workflow run`
+#            shim),
+#          - the new `release/YYYY.WW` branch push triggers `cd-release`
+#            and `ci-pull-request.yaml` like any human-authored push.
+#
+#   Jobs that need the App token declare `environment: release-workflow`
+#   so the env-scoped credentials resolve, and run on `gh-static-ip-slim`
+#   because the App is IP-origin-bound to that runner pool.
+#
+# Concurrency
+# ===========
+#   A single global `cd-release` group serializes every run of this
+#   workflow regardless of branch. That keeps `prepare-next-cycle.sh`
+#   safe (the script pushes empty Release-As trailers to main; the very
+#   next push triggers another cd-release run, which we want to queue
+#   behind the current one) and keeps two parallel pushes to main from
+#   stomping each other's release-please updates. Hotfix pushes on
+#   release/* serialize against main runs too — they're rare enough
+#   that the extra waiting is fine.
 
 on:
   push:
@@ -24,15 +55,34 @@ permissions:
   pull-requests: write
   actions: write
 
+concurrency:
+  group: cd-release
+  cancel-in-progress: false
+
 jobs:
   release-please:
-    runs-on: ubuntu-latest
+    # Runs with the App token so the release commit, tag, and GitHub
+    # Release are authored by the App. That makes the `release:published`
+    # event fire `cd-publish.yaml` natively (no `gh workflow run` shim
+    # needed) and lets the App's bypass rights cover the tag push on
+    # protected branches.
+    runs-on: gh-static-ip-slim
+    environment: release-workflow
     outputs:
       releases_created: ${{ steps.rp.outputs.releases_created }}
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: unique-ag/actions/github/app-token-create@df61dcf6fb84a7cad9c9b5f04924b40311cb016a
+        with:
+          app_id: ${{ vars.RELEASE_WORKFLOW_CLIENT_ID }}
+          base64_encoded_private_key: ${{ secrets.RELEASE_WORKFLOW_APP_PRIVATE_KEY_B64 }}
+          owner: ${{ github.repository_owner }}
+
       - id: rp
         uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
         with:
+          token: ${{ steps.app-token.outputs.token }}
           config-file: ${{ startsWith(github.ref_name, 'release/') && 'release-please-config.release.json' || 'release-please-config.json' }}
           manifest-file: .release-please-manifest.json
           target-branch: ${{ github.ref_name }}
@@ -47,15 +97,29 @@ jobs:
   # run. Commits that don't trigger a version bump (docs, chore) leave `prs`
   # empty even though an open release PR exists. Querying by label is reliable
   # regardless of what release-please did in the current run.
+  #
+  # Why the App token? The lockfile commit needs to fire pull_request: CI
+  # on the standing Release PR. A push by GITHUB_TOKEN would be silently
+  # ignored by GitHub's anti-recursion rule and the PR would sit with no
+  # CI status against its newest commit.
   update-release-lockfile:
     needs: release-please
     if: needs.release-please.outputs.releases_created != 'true'
-    runs-on: ubuntu-latest
+    runs-on: gh-static-ip-slim
+    environment: release-workflow
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: unique-ag/actions/github/app-token-create@df61dcf6fb84a7cad9c9b5f04924b40311cb016a
+        with:
+          app_id: ${{ vars.RELEASE_WORKFLOW_CLIENT_ID }}
+          base64_encoded_private_key: ${{ secrets.RELEASE_WORKFLOW_APP_PRIVATE_KEY_B64 }}
+          owner: ${{ github.repository_owner }}
+
       - name: Find open release PR branch
         id: pr-info
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           BASE_BRANCH: ${{ github.ref_name }}
         run: |
           branch=$(gh pr list \
@@ -72,7 +136,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ steps.pr-info.outputs.branch }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup uv
         if: steps.pr-info.outputs.branch != ''
@@ -108,33 +172,6 @@ jobs:
           git add -A
           git commit -m "chore: update dependency floors and regenerate uv.lock for release"
           git push
-
-  # Dispatch cd-publish.yaml for stable wheels. Works for both main
-  # (YYYY.WW.0) and release/* (YYYY.WW.PATCH) since both flows land tags
-  # the same way. Runs on a separate runner so it doesn't block
-  # cut-and-arm.
-  #
-  # Why dispatch instead of relying on `release:published`? The release
-  # action just ran with the default GITHUB_TOKEN, and GitHub's
-  # anti-recursion rule means release events produced by GITHUB_TOKEN do
-  # not fire `release:` triggers on other workflows. `gh workflow run`
-  # bypasses that by invoking ci-publish as a workflow_dispatch.
-  publish-stable:
-    needs: release-please
-    if: needs.release-please.outputs.releases_created == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Kick ci-publish for stable wheels
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REF_NAME: ${{ github.ref_name }}
-          REF_SHA: ${{ github.sha }}
-        run: |
-          gh workflow run cd-publish.yaml \
-            --repo "${{ github.repository }}" \
-            --ref "$REF_NAME" \
-            -f package=all \
-            -f ref="$REF_SHA"
 
   # Main-only post-release chores. Skipped on release/* because hotfix
   # cycles don't cut a new branch and don't advance the next CalVer.
@@ -177,7 +214,7 @@ jobs:
         run: |
           {
             echo "### Post-release actions"
-            echo "- Cut \`release/\` branch from the tagged release commit"
-            echo "- Kicked \`cd-publish.yaml\` (package=all) via \`publish-stable\` job"
-            echo "- Opened arm PR on \`main\` to arm the next CalVer cycle"
+            echo "- Cut \`release/\` branch from the tagged release commit (App token bypasses branch protection on \`release-branches\` ruleset)"
+            echo "- Pushed \`Release-As\` trailer to \`main\` to arm the next CalVer cycle (App token bypasses branch protection on \`main-branch\` ruleset)"
+            echo "- \`cd-publish.yaml\` will fire on the \`release:published\` event created by release-please's App-token-authored release"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/cd-release.yaml
+++ b/.github/workflows/cd-release.yaml
@@ -141,19 +141,21 @@ jobs:
   #
   # Runs on gh-static-ip-slim: the Release Workflow GitHub App is
   # IP-origin-bound and only accepts requests from this runner's static IP.
+  # The `release-workflow` environment scopes the App credentials.
   cut-and-arm:
     needs: release-please
     if: >-
       needs.release-please.outputs.releases_created == 'true'
       && github.ref == 'refs/heads/main'
     runs-on: gh-static-ip-slim
+    environment: release-workflow
     timeout-minutes: 5
     steps:
       - name: Generate GitHub App token
         id: app-token
         uses: unique-ag/actions/github/app-token-create@df61dcf6fb84a7cad9c9b5f04924b40311cb016a
         with:
-          app_id: ${{ vars.RELEASE_WORKFLOW_APP_ID }}
+          app_id: ${{ vars.RELEASE_WORKFLOW_CLIENT_ID }}
           base64_encoded_private_key: ${{ secrets.RELEASE_WORKFLOW_APP_PRIVATE_KEY_B64 }}
           owner: ${{ github.repository_owner }}
 

--- a/.github/workflows/cd-release.yaml
+++ b/.github/workflows/cd-release.yaml
@@ -138,26 +138,37 @@ jobs:
 
   # Main-only post-release chores. Skipped on release/* because hotfix
   # cycles don't cut a new branch and don't advance the next CalVer.
+  #
+  # Runs on gh-static-ip-slim: the Release Workflow GitHub App is
+  # IP-origin-bound and only accepts requests from this runner's static IP.
   cut-and-arm:
     needs: release-please
     if: >-
       needs.release-please.outputs.releases_created == 'true'
       && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
+    runs-on: gh-static-ip-slim
     timeout-minutes: 5
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: unique-ag/actions/github/app-token-create@df61dcf6fb84a7cad9c9b5f04924b40311cb016a
+        with:
+          app_id: ${{ vars.RELEASE_WORKFLOW_APP_ID }}
+          base64_encoded_private_key: ${{ secrets.RELEASE_WORKFLOW_APP_PRIVATE_KEY_B64 }}
+          owner: ${{ github.repository_owner }}
+
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Cut release branch from tagged commit
         run: ./.github/scripts/cut-release-branch.sh
 
       - name: Arm next cycle on main
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: ./.github/scripts/prepare-next-cycle.sh
 
       - name: Summary


### PR DESCRIPTION
## Summary

Wires the Release Workflow GitHub App (provisioned by [infrastructure#2377](https://github.com/Unique-AG/infrastructure/pull/2377)) through every job in the release pipeline that needs to bypass branch protection or trigger downstream CI, and removes the workarounds those constraints previously forced.

## Why

The default `GITHUB_TOKEN` has two limitations that shaped the previous flow:

1. **Branch protection.** It cannot push to `main` or to the `release/*` namespace, so the original `prepare-next-cycle.sh` opened an arm PR on a side branch and merged it through the merge queue.
2. **Anti-recursion.** Commits, tags, and releases authored by `GITHUB_TOKEN` do not fire other workflows. So:
   - the standing Release PR's lockfile commits did not re-run `pull_request:` CI,
   - `release-please`'s `release: published` event did not fire `cd-publish.yaml`, requiring a `publish-stable` shim that ran `gh workflow run cd-publish.yaml`,
   - the dev-bump PR opened by `cd-publish-dev.yaml` did not run CI without manual nudging.

The Release Workflow App fixes both: it is a bypass actor on `main-branch` and `release-branches` rulesets, and its events are not subject to the anti-recursion rule. Credentials are environment-scoped to `release-workflow` and the App is IP-origin-bound, so jobs that use it must declare `environment: release-workflow` and `runs-on: gh-static-ip-slim`.

## Changes

- **`cd-release.yaml`**
  - `release-please`, `update-release-lockfile`, and `cut-and-arm` all run with the App token under `environment: release-workflow` on `gh-static-ip-slim`.
  - Drop the `publish-stable` job; the App-authored release event triggers `cd-publish.yaml` natively.
  - Add a global `cd-release` concurrency group so push-driven runs serialize regardless of branch — needed now that `prepare-next-cycle.sh` pushes directly to `main` and re-triggers this same workflow.
- **`prepare-next-cycle.sh`**
  - Replaces the side-branch + arm PR workaround with a direct push to `main`.
  - Push uses a rebase+retry loop bounded at 5 attempts so concurrent arm runs cannot lose each other's empty `Release-As` commits to a non-fast-forward race. The commit is empty by design — the only failure mode is the race itself, never a real conflict.
  - Idempotency check (Release-As trailer already on base branch) is preserved and re-run inside the loop after every refetch.
- **`cd-arm-version.yaml`** — manual escape hatch for `prepare-next-cycle.sh`. Now uses the App token + `gh-static-ip-slim` so it can push directly to `main` like the automated path.
- **`cd-publish-rc.yaml`** — `tag-release` now authors the rc tag and pre-release as the App for consistency with the rest of the release flow.
- **`cd-publish-dev.yaml`** + **`cd-release.yaml::cut-and-arm`** (existing commits) — fix the App-token wiring to use `vars.RELEASE_WORKFLOW_CLIENT_ID` and `environment: release-workflow`. Without this fix, those jobs would fail at runtime: the AI repo's App credentials are scoped to the `release-workflow` GitHub Environment (not repo-level), and the variable exposed is the App's `client_id`, not a numeric `app_id`.

## Test plan

- [ ] Wait for QA / staging pipeline (no CI changes that affect runtime correctness, only orchestration)
- [ ] Trigger `cd-arm-version.yaml` manually on `main` once merged; confirm the empty `Release-As` commit lands directly on `main` with no PR involved
- [ ] On the next stable release, confirm:
  - `cd-publish.yaml` fires from the App-authored `release: published` event with no `publish-stable` shim run
  - The new `release/YYYY.WW` branch push from `cut-release-branch.sh` triggers `cd-release` and `ci-pull-request.yaml` like any other push
- [ ] On the next dev publish, confirm the dev-bump PR opens with passing PR CI (was previously CI-less)

Refs: UN-20151