### PR TITLE
chore(ci): enable dependabot for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+# Keeps GitHub Actions used in workflows and composite actions up to date.
+# Dependabot preserves the existing SHA-pin + version-comment style enforced
+# by .github/workflows/github.policies.verify.pinned-actions.yaml.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore(deps)
+    labels:
+      - dependencies
+      - github-actions
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: weekly
+      interval: daily
     open-pull-requests-limit: 5
     commit-message:
       prefix: chore(deps)


### PR DESCRIPTION
## 🚀 Summary

Adds a `.github/dependabot.yml` entry for the `github-actions` ecosystem so that all action references in `.github/workflows/**` and `.github/actions/**` are kept up to date.

Today the repo only receives Dependabot **security updates** (enabled at the repo level via the infrastructure repo's Terraform: `dependabot_security_updates: true` in `providers/github/unique-ag/repos/ai.yaml`). Security updates only fire on advisories — they don't routinely bump action versions. The version-update behaviour is configured per-repo via `.github/dependabot.yml`, which was missing.

## ✅ Changes

- [x] Add `.github/dependabot.yml` covering `package-ecosystem: github-actions` at `/` (Dependabot scans `.github/workflows/**` and `.github/actions/*/action.yml` from this single root entry)
- [x] Schedule: `daily`
- [x] Group all updates into a single PR per cycle (`groups.github-actions: "*"`) to avoid PR spam
- [x] `open-pull-requests-limit: 5` as a safety ceiling
- [x] Commit prefix `chore(deps)` to match the conventional-commit style and what existing Dependabot PRs in this repo already use

## 🧪 Testing

- YAML is structurally valid and follows the [Dependabot v2 schema](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference).
- After merge, Dependabot will run on the configured schedule. The first scheduled run produces a single grouped PR proposing updates to currently outdated actions.
- Pinning style is preserved: Dependabot for `github-actions` updates SHA-pinned references and the trailing version comment together, so the existing `unique-ag/actions/github/policies/verify-pinned-actions` check will keep passing.

## Notes

- No change is needed in the infrastructure repo. Repo-level toggles (`vulnerability_alerts`, `dependabot_security_updates`) are already managed there; the version-update config has to live in this repo's default branch.


Made with [Cursor](https://cursor.com)