### PR TITLE
ci(release): tighten dev-cut PR cleanup after stable cut

### DIFF
--- a/.github/workflows/cd-release.yaml
+++ b/.github/workflows/cd-release.yaml
@@ -210,33 +210,43 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: ./.github/scripts/prepare-next-cycle.sh
 
-      # A stable release commits new dev floors via update-dep-floors.py,
-      # which makes any open `chore: pin dev-cut <SHA>` PR (opened by
-      # cd-publish-dev.yaml against `main`) obsolete: its floors are
-      # strictly older than the floors that just landed on `main`.
-      # Close them so they don't accumulate cycle after cycle.
-      - name: Close stale dev bump PRs
+      # cd-publish-dev.yaml already closes the prior dev-bump PR every time
+      # it opens a new one, so at most one `chore: pin dev-cut <SHA>` PR is
+      # ever open. After a stable cut, update-dep-floors.py has just
+      # persisted strictly newer floors on `main`, making that single open
+      # PR obsolete. Close it now instead of waiting for the next dev
+      # publish to supersede it (the next dev publish may not happen for
+      # hours/days, and a "previous-cycle" dev-cut PR sitting open is
+      # confusing for reviewers).
+      - name: Close stale dev bump PR
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
+          # Use a loop anyway in case the invariant ever slips and more than
+          # one ends up open.
           PR_NUMBERS=$(gh pr list \
             --repo "${{ github.repository }}" \
             --state open \
             --base main \
-            --search "chore: pin dev-cut in:title" \
+            --label "dev-version-bump" \
             --json number \
             --jq '.[].number')
 
           if [[ -z "$PR_NUMBERS" ]]; then
-            echo "No open dev bump PRs found."
+            echo "No open dev bump PR found."
             exit 0
           fi
 
+          # `|| true` keeps the post-release job green if the PR is already
+          # closed (race with cd-publish-dev.yaml's own cleanup) or if the
+          # API call hits a transient error — this is best-effort cleanup,
+          # not a release-blocking step.
           for PR in $PR_NUMBERS; do
             echo "Closing dev bump PR #${PR}"
             gh pr close "$PR" \
               --repo "${{ github.repository }}" \
-              --comment "Superseded by stable release: dev-cut floors were just persisted to \`main\`."
+              --comment "Superseded by stable release: dev-cut floors were just persisted to \`main\`." \
+              || true
           done
 
       - name: Summary
@@ -245,6 +255,6 @@ jobs:
             echo "### Post-release actions"
             echo "- Cut \`release/\` branch from the tagged release commit (App token bypasses branch protection on \`release-branches\` ruleset)"
             echo "- Pushed \`Release-As\` trailer to \`main\` to arm the next CalVer cycle (App token bypasses branch protection on \`main-branch\` ruleset)"
-            echo "- Closed any open \`chore: pin dev-cut …\` PRs (superseded by the stable floors that just landed on \`main\`)"
+            echo "- Closed the open \`chore: pin dev-cut …\` PR (superseded by the stable floors that just landed on \`main\`)"
             echo "- \`cd-publish.yaml\` will fire on the \`release:published\` event created by release-please's App-token-authored release"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/contributing/release-process.md
+++ b/docs/contributing/release-process.md
@@ -160,7 +160,7 @@ flowchart TD
    ```
    Because this PR is opened by the bot, it only requires your approval — you can approve and merge it yourself without a second reviewer.
 4. release-please bumps all `pyproject.toml` versions and `CHANGELOG.md` entries, then tags and creates a GitHub Release.
-5. `cd-release.yaml`'s post-release job pushes the new `release/YYYY.WW` branch from the tagged commit (the Release Workflow App is a bypass actor on the `release-branches` ruleset), arms the next cycle on `main` — see [Arming a cycle](#arming-a-cycle) — and closes any open `chore: pin dev-cut <SHA>` PRs, since their floors are now superseded by the stable floors that just landed on `main`.
+5. `cd-release.yaml`'s post-release job pushes the new `release/YYYY.WW` branch from the tagged commit (the Release Workflow App is a bypass actor on the `release-branches` ruleset), arms the next cycle on `main` — see [Arming a cycle](#arming-a-cycle) — and closes the currently-open `chore: pin dev-cut <SHA>` PR if one exists (`cd-publish-dev.yaml` keeps at most one open at a time; after a stable cut its floors are strictly older than what just landed on `main`).
 6. The GitHub Release that release-please just published natively triggers `cd-publish.yaml`, which builds and publishes every changed package to PyPI. Dependencies in the stable wheels are pinned with `>=` (updated by `update-dep-floors.py` at release time).
 7. Propagating the new stable versions to the monorepo is [documented in the monorepo](https://github.com/Unique-AG/monorepo/blob/master/docs/uniqueai/release-process/index.md#sync-ai-versions-workflow).
 


### PR DESCRIPTION
## Summary

Follow-up cleanup on the `Close stale dev bump PR` step that landed in #1554. Three small fixes — none of them affect what packages get published or when.

## Changes

### `.github/workflows/cd-release.yaml`

- **Honest comment.** The previous wording said we close the dev-cut PR "so they don't accumulate cycle after cycle." That's not actually possible: `cd-publish-dev.yaml::open-dev-bump-pr` already closes the prior `dev-version-bump` PR every time it opens a new one (`gh pr list --label dev-version-bump | xargs gh pr close`). At most one is ever open. The real motivation for closing it on the stable cut is faster cleanup — without this step the previous-cycle PR sits open until the next dev publish supersedes it (could be hours, could be days), and that's confusing for reviewers.
- **Label-based PR query.** Switched `--search "chore: pin dev-cut in:title"` to `--label "dev-version-bump"`, matching how `cd-publish-dev.yaml` itself finds these PRs. Title substring matching is fragile — a future rename of the title pattern would silently make the query miss PRs.
- **`|| true` on `gh pr close`.** Bugbot finding: with `set -e`, a failed close (race with `cd-publish-dev.yaml`'s own cleanup, or a transient GitHub API blip) would fail the post-release job and skip the Summary step — even though closing the PR is best-effort cleanup, not a release-blocking action. Added `|| true` plus an inline comment explaining why.

### `docs/contributing/release-process.md`

Updated the matching cadence step to reflect the at-most-one invariant ("closes the currently-open `chore: pin dev-cut <SHA>` PR if one exists") instead of the misleading "any open PRs".

## Test plan

- [ ] Stable Release PR merged on `main` with one open dev-cut PR → that PR is closed with the superseded comment, post-release job stays green.
- [ ] Stable Release PR merged with no open dev-cut PR → step prints `No open dev bump PR found.` and exits 0.
- [ ] Simulate a race (close the dev-cut PR manually right before the post-release job runs) → `gh pr close` returns non-zero, the step still succeeds, Summary still emits.

Refs: #1554

Made with [Cursor](https://cursor.com)