### PR TITLE
chore(ci): add 2-week cooldown to dependabot github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 5
+    # 2-week stability window: skip releases newer than this. github-actions is
+    # not semver-graded by Dependabot, so default-days governs all bumps.
+    cooldown:
+      default-days: 14
     commit-message:
       prefix: chore(deps)
     labels:


### PR DESCRIPTION
## 🚀 Summary

Adds a 2-week stability window to the `github-actions` Dependabot config that landed in #1565, so we don't get pull requests for action releases that are less than 14 days old.

Dependabot's [`cooldown`](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/optimizing-pr-creation-version-updates#setting-up-a-cooldown-period-for-dependency-updates) feature (GA July 2025) is the supported way to do this. For ecosystems that aren't semver-graded by Dependabot — explicitly Docker and **GitHub Actions** per the docs — `default-days` governs every bump, so a single field is enough.

## ✅ Changes

- [x] `cooldown.default-days: 14` on the `github-actions` update entry

## 🧪 Testing

- YAML is structurally valid and matches the [Dependabot v2 schema](https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates#cooldown).
- Behaviour change at runtime: when Dependabot's daily scan finds a new action release, it will skip the bump until that release is ≥14 days old. Security updates are not affected by `cooldown`.
- No effect on already-pinned SHAs in workflows; the verify-pinned-actions check stays green.


Made with [Cursor](https://cursor.com)