### PR TITLE
refactor(unique_toolkit): split ChatEvent and MagicTableEvent webhook types

### DIFF
--- a/tool_packages/unique_internal_search/tests/test_service.py
+++ b/tool_packages/unique_internal_search/tests/test_service.py
@@ -1205,47 +1205,6 @@ class TestInternalSearchTool:
         assert tool.chat_id == "parent_chat_456"
 
     @pytest.mark.ai
-    @patch("unique_internal_search.service.ContentService")
-    @patch("unique_internal_search.service.ChunkRelevancySorter")
-    def test_tool__initializes__with_base_event(
-        self,
-        mock_chunk_relevancy_sorter_class: Any,
-        mock_content_service_class: Any,
-        base_internal_search_config: InternalSearchConfig,
-        mock_base_event: Any,
-        mock_logger: Any,
-    ) -> None:
-        """
-        Purpose: Verify InternalSearchTool initializes correctly with BaseEvent (no chat_id).
-        Why this matters: Ensures tool works with non-chat events that don't have chat_id.
-        Setup summary: Mock ContentService and ChunkRelevancySorter from_event, verify chat_id is None.
-        """
-        # Arrange
-        mock_content_service = Mock(spec=ContentService)
-        mock_content_service._metadata_filter = None
-        mock_content_service_class.from_event.return_value = mock_content_service
-
-        mock_sorter = Mock()
-        mock_chunk_relevancy_sorter_class.from_event.return_value = mock_sorter
-
-        # Act
-        def setup_tool(self, configuration, event, *args, **kwargs):
-            # Set attributes that Tool base class expects
-            setattr(self, "_event", event)
-            setattr(self, "logger", mock_logger)
-            setattr(self, "_message_step_logger", None)
-
-        with patch("unique_internal_search.service.Tool.__init__", setup_tool):
-            tool = InternalSearchTool(
-                configuration=base_internal_search_config,
-                event=mock_base_event,
-            )
-
-        # Assert
-        assert tool.config == base_internal_search_config
-        assert tool.chat_id is None
-
-    @pytest.mark.ai
     @pytest.mark.asyncio
     async def test_post_progress_message__notifies_reporter__when_reporter_exists(
         self,

--- a/tool_packages/unique_internal_search/unique_internal_search/service.py
+++ b/tool_packages/unique_internal_search/unique_internal_search/service.py
@@ -21,7 +21,7 @@ from unique_toolkit.agentic.tools.names import INTERNAL_SEARCH_TOOL_NAME
 from unique_toolkit.agentic.tools.schemas import ToolCallResponse
 from unique_toolkit.agentic.tools.tool import Tool
 from unique_toolkit.agentic.tools.tool_progress_reporter import ProgressState
-from unique_toolkit.app.schemas import BaseEvent, ChatEvent, Event
+from unique_toolkit.app.schemas import ChatEvent
 from unique_toolkit.chat.service import LanguageModelToolDescription
 from unique_toolkit.content.schemas import Content, ContentChunk
 from unique_toolkit.content.service import ContentService
@@ -361,7 +361,7 @@ class InternalSearchTool(Tool[InternalSearchConfig], InternalSearchService):
     def __init__(
         self,
         configuration: InternalSearchConfig,
-        event: BaseEvent,
+        event: ChatEvent,
         *args,
         **kwargs,
     ):
@@ -370,13 +370,10 @@ class InternalSearchTool(Tool[InternalSearchConfig], InternalSearchService):
         content_service = ContentService.from_event(self.event)
         chunk_relevancy_sorter = ChunkRelevancySorter.from_event(self.event)
         selected_uploaded_file_ids = extract_selected_uploaded_file_ids(self.event)
-        if isinstance(self.event, (ChatEvent, Event)):
-            if self.event.payload.correlation:
-                chat_id = self.event.payload.correlation.parent_chat_id
-            else:
-                chat_id = self.event.payload.chat_id
+        if self.event.payload.correlation:
+            chat_id = self.event.payload.correlation.parent_chat_id
         else:
-            chat_id = None
+            chat_id = self.event.payload.chat_id
         self._display_name = kwargs.get("display_name", "Internal Search")
         InternalSearchService.__init__(
             self,

--- a/tool_packages/unique_internal_search/unique_internal_search/uploaded_search/service.py
+++ b/tool_packages/unique_internal_search/unique_internal_search/uploaded_search/service.py
@@ -14,7 +14,7 @@ from unique_toolkit.agentic.tools.tool_progress_reporter import (
     ProgressState,
     ToolProgressReporter,
 )
-from unique_toolkit.app.schemas import BaseEvent, ChatEvent
+from unique_toolkit.app.schemas import ChatEvent
 from unique_toolkit.chat.service import LanguageModelToolDescription
 from unique_toolkit.content import Content
 from unique_toolkit.language_model.schemas import (
@@ -33,7 +33,7 @@ class UploadedSearchTool(Tool[UploadedSearchConfig]):
     def __init__(
         self,
         config: UploadedSearchConfig,
-        event: BaseEvent,
+        event: ChatEvent,
         tool_progress_reporter: ToolProgressReporter,
         *args,
         **kwargs,
@@ -48,10 +48,7 @@ class UploadedSearchTool(Tool[UploadedSearchConfig]):
         )
         self._internal_search_tool._display_name = self._display_name
         self._selected_uploaded_files = extract_selected_uploaded_file_ids(event)
-        if isinstance(event, ChatEvent):
-            self._user_query = event.payload.user_message.text
-        else:
-            self._user_query = None
+        self._user_query = event.payload.user_message.text
 
         # This blocking API call should be avoided.
         # However, we don't have an easy way to pass user uploaded files to the tool currently

--- a/unique_toolkit/docs/agentic_table/index.md
+++ b/unique_toolkit/docs/agentic_table/index.md
@@ -18,19 +18,26 @@ The `unique_toolkit.agentic_table` module provides:
 
 The Agentic Table module triggers the following events when specific actions are performed. Each event contains the necessary payload to perform the action. All payload schemas are defined in the `unique_toolkit.agentic_table.schemas` module.
 
-All payloads inherit from `MagicTableBasePayload` which includes the following base attributes:
+All payloads inherit from `MagicTableBasePayload`, which extends the shared
+`BaseEventPayload` envelope from `unique_toolkit.app.schemas` and adds
+magic-table-specific fields. Chat-only fields such as `user_message` and
+`assistant_message` live on `ChatEventPayload`, not on magic-table payloads.
 
-- `name: str` - The name of the module
-- `sheet_name: str` - The name of the sheet
-- `action: MagicTableAction` - The action being performed
+**From `BaseEventPayload`:**
+
+- `name: str` - The module / action name driving the event
 - `chat_id: str` - The chat ID
 - `assistant_id: str` - The assistant ID
-- `table_id: str` - The table ID
-- `user_message: ChatEventUserMessage` - The user message that triggered the event
-- `assistant_message: ChatEventAssistantMessage` - The assistant message associated with the event
 - `configuration: dict[str, Any]` - Configuration dictionary
-- `metadata: T` - Metadata specific to the payload type (varies by event)
 - `metadata_filter: dict[str, Any] | None` - Optional metadata filter
+- `correlation: Correlation | None` - Optional link to a parent chat message
+
+**Additional fields on `MagicTableBasePayload`:**
+
+- `sheet_name: str` - The name of the sheet
+- `action: MagicTableAction` - The action being performed
+- `table_id: str` - The table ID
+- `metadata: T` - Metadata specific to the payload type (varies by event)
 
 | Event Name | Description | Payload Type | Payload Structure |
 |------------|-------------|--------------|-------------------|

--- a/unique_toolkit/tests/agentic/tools/test_run_context.py
+++ b/unique_toolkit/tests/agentic/tools/test_run_context.py
@@ -1,0 +1,52 @@
+from unique_toolkit.agentic.tools.run_context import ToolRunContext
+from unique_toolkit.app.schemas import (
+    ChatEvent,
+    ChatEventAssistantMessage,
+    ChatEventPayload,
+    ChatEventUserMessage,
+    EventName,
+)
+
+
+def _chat_event(tool_choices: list[str], disabled_tools: list[str]) -> ChatEvent:
+    return ChatEvent(
+        id="evt-1",
+        event=EventName.EXTERNAL_MODULE_CHOSEN,
+        user_id="user-1",
+        company_id="company-1",
+        payload=ChatEventPayload(
+            name="module",
+            description="desc",
+            chat_id="chat-1",
+            assistant_id="asst-1",
+            configuration={},
+            user_message=ChatEventUserMessage(
+                id="umsg-1",
+                text="hi",
+                created_at="2021-01-01T00:00:00Z",
+                language="EN",
+                original_text="hi",
+            ),
+            assistant_message=ChatEventAssistantMessage(
+                id="amsg-1",
+                created_at="2021-01-01T00:00:00Z",
+            ),
+            tool_choices=tool_choices,
+            disabled_tools=disabled_tools,
+        ),
+    )
+
+
+def test_from_chat_event__copies_tool_filter_fields() -> None:
+    event = _chat_event(["search"], ["upload"])
+    ctx = ToolRunContext.from_chat_event(event)
+    assert ctx.tool_choices == ["search"]
+    assert ctx.disabled_tools == ["upload"]
+    assert ctx.tool_init_event is event
+
+
+def test_run_context__defaults_to_empty_lists() -> None:
+    ctx = ToolRunContext()
+    assert ctx.tool_choices == []
+    assert ctx.disabled_tools == []
+    assert ctx.tool_init_event is None

--- a/unique_toolkit/tests/agentic_table/test_synthetic_chat_event.py
+++ b/unique_toolkit/tests/agentic_table/test_synthetic_chat_event.py
@@ -1,0 +1,49 @@
+"""Tests for build_synthetic_chat_event."""
+
+import pytest
+
+from unique_toolkit.agentic_table.schemas import (
+    DDMetadata,
+    MagicTableAction,
+    MagicTableEvent,
+    MagicTableEventTypes,
+    MagicTableUpdateCellPayload,
+)
+from unique_toolkit.agentic_table.synthetic_chat_event import (
+    build_synthetic_chat_event,
+)
+from unique_toolkit.app.schemas import EventName
+
+
+def _make_event(*, chat_id: str) -> MagicTableEvent:
+    return MagicTableEvent(
+        id="evt-1",
+        event=MagicTableEventTypes.UPDATE_CELL,
+        user_id="user-1",
+        company_id="company-1",
+        payload=MagicTableUpdateCellPayload(
+            name="rfp-agent",
+            sheet_name="sheet-1",
+            action=MagicTableAction.UPDATE_CELL,
+            chat_id=chat_id,
+            assistant_id="assistant-1",
+            table_id="table-1",
+            column_order=0,
+            row_order=0,
+            data="cell",
+            metadata=DDMetadata(),
+        ),
+    )
+
+
+def test_build_synthetic_chat_event__uses_placeholder_message_ids() -> None:
+    synthetic = build_synthetic_chat_event(_make_event(chat_id="chat-1"))
+    assert synthetic.event == EventName.EXTERNAL_MODULE_CHOSEN
+    assert synthetic.payload.chat_id == "chat-1"
+    assert synthetic.payload.user_message.id == "magic-table-streaming-user"
+    assert synthetic.payload.assistant_message.id == "magic-table-streaming-assistant"
+
+
+def test_build_synthetic_chat_event__requires_chat_id() -> None:
+    with pytest.raises(ValueError, match="missing chat_id"):
+        build_synthetic_chat_event(_make_event(chat_id=""))

--- a/unique_toolkit/tests/app/test_unique_settings.py
+++ b/unique_toolkit/tests/app/test_unique_settings.py
@@ -1323,6 +1323,7 @@ class TestUniqueContext:
             == MAGIC_TABLE_STREAMING_ASSISTANT_MESSAGE_ID
         )
         assert ctx.chat.last_user_message_id == MAGIC_TABLE_STREAMING_USER_MESSAGE_ID
+        assert ctx.chat.last_user_message_text == ""
 
     @pytest.mark.ai
     def test_from_magic_table_event__raises_without_chat_id(self) -> None:

--- a/unique_toolkit/tests/app/test_unique_settings.py
+++ b/unique_toolkit/tests/app/test_unique_settings.py
@@ -3,7 +3,14 @@ from pathlib import Path
 
 import pytest
 from pydantic import SecretStr
+from unique_sdk.api_resources._agentic_table import MagicTableAction
 
+from unique_toolkit.agentic_table.schemas import (
+    DDMetadata,
+    MagicTableEvent,
+    MagicTableEventTypes,
+    MagicTableUpdateCellPayload,
+)
 from unique_toolkit.app.schemas import (
     BaseEvent,
     ChatEvent,
@@ -14,6 +21,8 @@ from unique_toolkit.app.schemas import (
     EventName,
 )
 from unique_toolkit.app.unique_settings import (
+    MAGIC_TABLE_STREAMING_ASSISTANT_MESSAGE_ID,
+    MAGIC_TABLE_STREAMING_USER_MESSAGE_ID,
     AuthContext,
     ChatContext,
     EnvFileNotFoundError,
@@ -1294,3 +1303,56 @@ class TestUniqueContext:
         )
         ctx = UniqueContext.from_event(event)
         assert ctx.chat is None
+
+    @pytest.mark.ai
+    def test_from_magic_table_event__maps_auth_and_chat(self) -> None:
+        event = _make_magic_table_event(
+            company_id="company-mt",
+            user_id="user-mt",
+            chat_id="chat-mt",
+            assistant_id="asst-mt",
+        )
+        ctx = UniqueContext.from_magic_table_event(event)
+        assert ctx.auth.get_confidential_company_id() == "company-mt"
+        assert ctx.auth.get_confidential_user_id() == "user-mt"
+        assert ctx.chat is not None
+        assert ctx.chat.chat_id == "chat-mt"
+        assert ctx.chat.assistant_id == "asst-mt"
+        assert (
+            ctx.chat.last_assistant_message_id
+            == MAGIC_TABLE_STREAMING_ASSISTANT_MESSAGE_ID
+        )
+        assert ctx.chat.last_user_message_id == MAGIC_TABLE_STREAMING_USER_MESSAGE_ID
+
+    @pytest.mark.ai
+    def test_from_magic_table_event__raises_without_chat_id(self) -> None:
+        event = _make_magic_table_event(chat_id="")
+        with pytest.raises(ValueError, match="missing chat_id"):
+            UniqueContext.from_magic_table_event(event)
+
+
+def _make_magic_table_event(
+    *,
+    user_id: str = "user-1",
+    company_id: str = "company-1",
+    chat_id: str = "chat-1",
+    assistant_id: str = "asst-1",
+) -> MagicTableEvent:
+    return MagicTableEvent(
+        id="evt-mt-1",
+        event=MagicTableEventTypes.UPDATE_CELL,
+        user_id=user_id,
+        company_id=company_id,
+        payload=MagicTableUpdateCellPayload(
+            name="agentic-table",
+            sheet_name="sheet-1",
+            action=MagicTableAction.UPDATE_CELL,
+            chat_id=chat_id,
+            assistant_id=assistant_id,
+            table_id="table-1",
+            column_order=0,
+            row_order=0,
+            data="cell",
+            metadata=DDMetadata(),
+        ),
+    )

--- a/unique_toolkit/tests/content/test_content_service_unit.py
+++ b/unique_toolkit/tests/content/test_content_service_unit.py
@@ -1083,3 +1083,31 @@ class TestGetDocumentsUploadedToChatAsync:
         assert len(result) == 2
         returned_ids = {c.id for c in result}
         assert returned_ids == {"file_a", "file_b"}
+
+
+class TestContentServiceFromContext:
+    @pytest.mark.ai
+    def test_from_context__uses_parent_chat_when_correlated(self) -> None:
+        from pydantic import SecretStr
+
+        from unique_toolkit.app.unique_settings import (
+            AuthContext,
+            ChatContext,
+            UniqueContext,
+        )
+
+        ctx = UniqueContext(
+            auth=AuthContext(
+                company_id=SecretStr("company-1"),
+                user_id=SecretStr("user-1"),
+            ),
+            chat=ChatContext(
+                chat_id="sub-chat",
+                assistant_id="asst-1",
+                parent_chat_id="parent-chat",
+                metadata_filter={"k": "v"},
+            ),
+        )
+        service = ContentService.from_context(ctx)
+        assert service._chat_id == "parent-chat"
+        assert service._metadata_filter == {"k": "v"}

--- a/unique_toolkit/tests/services/test_factory.py
+++ b/unique_toolkit/tests/services/test_factory.py
@@ -549,3 +549,21 @@ class TestDefaultRegistrations:
         """
         with pytest.raises(ServiceNotRegisteredError):
             UniqueServiceFactory.create("Identity", settings=settings)
+
+    @pytest.mark.ai
+    def test_content_service__registered(
+        self, settings_with_chat: UniqueSettings
+    ) -> None:
+        from unique_toolkit.content.service import ContentService
+
+        svc = UniqueServiceFactory.create(ContentService, settings=settings_with_chat)
+        assert isinstance(svc, ContentService)
+        assert svc._chat_id == "chat-1"
+
+    @pytest.mark.ai
+    def test_language_model_service__registered(self, settings: UniqueSettings) -> None:
+        from unique_toolkit.language_model.service import LanguageModelService
+
+        svc = UniqueServiceFactory.create(LanguageModelService, settings=settings)
+        assert isinstance(svc, LanguageModelService)
+        assert svc._company_id == "company-1"

--- a/unique_toolkit/unique_toolkit/_common/chunk_relevancy_sorter/service.py
+++ b/unique_toolkit/unique_toolkit/_common/chunk_relevancy_sorter/service.py
@@ -71,7 +71,7 @@ class ChunkRelevancySorter:
         company_id: str | None = None,
         user_id: str | None = None,
     ):
-        if isinstance(event, (ChatEvent, BaseEvent)):
+        if isinstance(event, BaseEvent):
             self.chunk_relevancy_evaluator = ContextRelevancyEvaluator.from_event(event)
         else:
             [company_id, user_id] = validate_required_values([company_id, user_id])

--- a/unique_toolkit/unique_toolkit/agentic/evaluation/context_relevancy/service.py
+++ b/unique_toolkit/unique_toolkit/agentic/evaluation/context_relevancy/service.py
@@ -81,7 +81,7 @@ class ContextRelevancyEvaluator:
         company_id: str | None = None,
         user_id: str | None = None,
     ):
-        if isinstance(event, (ChatEvent, BaseEvent)):
+        if isinstance(event, BaseEvent):
             self.language_model_service = LanguageModelService.from_event(event)
         else:
             [company_id, user_id] = validate_required_values([company_id, user_id])

--- a/unique_toolkit/unique_toolkit/agentic/tools/a2a/manager.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/a2a/manager.py
@@ -21,8 +21,15 @@ class A2AManager:
     def get_all_sub_agents(
         self,
         tool_configs: list[ToolBuildConfig],
-        event: ChatEvent,
+        event: ChatEvent | None,
     ) -> tuple[list[ToolBuildConfig], list[SubAgentTool]]:
+        if event is None:
+            return [
+                tool_config
+                for tool_config in tool_configs
+                if not tool_config.is_sub_agent
+            ], []
+
         sub_agents = []
 
         for tool_config in tool_configs:

--- a/unique_toolkit/unique_toolkit/agentic/tools/a2a/manager.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/a2a/manager.py
@@ -21,19 +21,19 @@ class A2AManager:
     def get_all_sub_agents(
         self,
         tool_configs: list[ToolBuildConfig],
-        event: ChatEvent | None,
+        event: ChatEvent,
     ) -> tuple[list[ToolBuildConfig], list[SubAgentTool]]:
-        if event is None:
-            return [
-                tool_config
-                for tool_config in tool_configs
-                if not tool_config.is_sub_agent
-            ], []
-
         sub_agents = []
 
         for tool_config in tool_configs:
             if not tool_config.is_sub_agent:
+                continue
+
+            if not tool_config.is_enabled:
+                self._logger.info(
+                    "Skipping disabled sub-agent '%s'",
+                    tool_config.name,
+                )
                 continue
 
             if not isinstance(tool_config.configuration, SubAgentToolConfig):
@@ -44,16 +44,23 @@ class A2AManager:
 
             sub_agent_tool_config = tool_config.configuration
 
-            sub_agents.append(
-                SubAgentTool(
-                    configuration=sub_agent_tool_config,
-                    event=event,
-                    tool_progress_reporter=self._tool_progress_reporter,
-                    name=tool_config.name,
-                    display_name=tool_config.display_name,
-                    response_watcher=self._response_watcher,
+            try:
+                sub_agents.append(
+                    SubAgentTool(
+                        configuration=sub_agent_tool_config,
+                        event=event,
+                        tool_progress_reporter=self._tool_progress_reporter,
+                        name=tool_config.name,
+                        display_name=tool_config.display_name,
+                        response_watcher=self._response_watcher,
+                    )
                 )
-            )
+            except Exception:
+                self._logger.warning(
+                    "Skipping sub-agent '%s' due to initialization failure.",
+                    tool_config.name,
+                    exc_info=True,
+                )
 
         filtered_tool_config = [
             tool_config for tool_config in tool_configs if not tool_config.is_sub_agent

--- a/unique_toolkit/unique_toolkit/agentic/tools/factory.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/factory.py
@@ -38,6 +38,27 @@ class ToolFactory:
         return tool
 
     @classmethod
+    def build_tool_with_services(
+        cls,
+        tool_name: str,
+        settings: "ToolBuildConfig",
+        *,
+        chat_service: Any,
+        language_model_service: Any,
+        tool_progress_reporter: Any | None = None,
+        event: Any | None = None,
+    ) -> Tool[BaseToolConfig]:
+        tool = cls.tool_map[tool_name](
+            settings.configuration,
+            chat_service=chat_service,
+            language_model_service=language_model_service,
+            tool_progress_reporter=tool_progress_reporter,
+            event=event,
+        )
+        tool.settings = settings
+        return tool
+
+    @classmethod
     def build_tool_config(cls, tool_name: str, **kwargs) -> BaseToolConfig:
         if tool_name not in cls.tool_config_map:
             raise ValueError(f"Tool {tool_name} not found")

--- a/unique_toolkit/unique_toolkit/agentic/tools/run_context.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/run_context.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from typing_extensions import Self
+
+from unique_toolkit.app.schemas import ChatEvent
+
+
+@dataclass(frozen=True)
+class ToolRunContext:
+    """Tool-manager runtime state decoupled from a raw :class:`ChatEvent`."""
+
+    tool_choices: list[str] = field(default_factory=list)
+    disabled_tools: list[str] = field(default_factory=list)
+    tool_init_event: ChatEvent | None = None
+
+    @classmethod
+    def from_chat_event(cls, event: ChatEvent) -> Self:
+        return cls(
+            tool_choices=list(event.payload.tool_choices),
+            disabled_tools=list(event.payload.disabled_tools),
+            tool_init_event=event,
+        )

--- a/unique_toolkit/unique_toolkit/agentic/tools/tool.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/tool.py
@@ -18,7 +18,8 @@ from unique_toolkit.app.schemas import ChatEvent
 from unique_toolkit.language_model import LanguageModelToolDescription
 
 if TYPE_CHECKING:
-    pass
+    from unique_toolkit.language_model.service import LanguageModelService
+    from unique_toolkit.services.chat_service import ChatService
 from unique_toolkit.language_model.schemas import (
     LanguageModelFunction,
 )
@@ -176,17 +177,33 @@ class Tool(ABC, Generic[ConfigType]):
         tool_progress_reporter: ToolProgressReporter | None = ...,
     ) -> None: ...
 
+    @overload
+    def __init__(
+        self,
+        config: ConfigType,
+        *,
+        chat_service: ChatService,
+        language_model_service: LanguageModelService,
+        tool_progress_reporter: ToolProgressReporter | None = ...,
+        event: ChatEvent | None = ...,
+    ) -> None: ...
+
     def __init__(
         self,
         config: ConfigType,
         event: ChatEvent | None = None,
         tool_progress_reporter: ToolProgressReporter | None = None,
+        *,
+        chat_service: ChatService | None = None,
+        language_model_service: LanguageModelService | None = None,
     ) -> None:
         """Initialize the tool.
 
-        Preferred (decoupled): `Tool(config)` — configuration only.
+        Preferred (decoupled): ``Tool(config)`` — configuration only.
 
-        Backward compatible: `Tool(config, event, tool_progress_reporter)` — creates
+        Service injection: ``Tool(config, chat_service=..., language_model_service=...)``.
+
+        Backward compatible: ``Tool(config, event, tool_progress_reporter)`` — creates
         deprecated chat_service, language_model_service, message_step_logger for
         legacy subclasses.
         """
@@ -199,6 +216,20 @@ class Tool(ABC, Generic[ConfigType]):
         module_name = "default overwrite for module name"
         self.logger = getLogger(f"{module_name}.{__name__}")
         self.debug_info: dict[str, Any] = {}
+
+        if chat_service is not None and language_model_service is not None:
+            from unique_toolkit.agentic.message_log_manager.service import (
+                MessageStepLogger,
+            )
+
+            self._event = event
+            self._tool_progress_reporter = tool_progress_reporter
+            self._chat_service = chat_service
+            self._language_model_service = language_model_service
+            self._message_step_logger = MessageStepLogger(
+                chat_service=self._chat_service,
+            )
+            return
 
         if event is not None:
             from unique_toolkit.agentic.message_log_manager.service import (

--- a/unique_toolkit/unique_toolkit/agentic/tools/tool_manager.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/tool_manager.py
@@ -12,6 +12,7 @@ from openai.types.responses import (
     response_create_params,
 )
 from pydantic import BaseModel, Field
+from typing_extensions import Self
 
 from unique_toolkit._common.execution import (
     Result,
@@ -31,6 +32,7 @@ from unique_toolkit.agentic.tools.openai_builtin.base import (
     OpenAIBuiltInToolName,
 )
 from unique_toolkit.agentic.tools.openai_builtin.manager import OpenAIBuiltInToolManager
+from unique_toolkit.agentic.tools.run_context import ToolRunContext
 from unique_toolkit.agentic.tools.schemas import ToolCallResponse, ToolPrompts
 from unique_toolkit.agentic.tools.tool import Tool
 from unique_toolkit.agentic.tools.tool_progress_reporter import ToolProgressReporter
@@ -89,12 +91,61 @@ class _ToolManager(Generic[_ApiMode]):
         api_mode: _ApiMode,
         builtin_tool_manager: OpenAIBuiltInToolManager | None = None,
     ) -> None:
+        self._setup(
+            logger=logger,
+            config=config,
+            run_context=ToolRunContext.from_chat_event(event),
+            tool_progress_reporter=tool_progress_reporter,
+            mcp_manager=mcp_manager,
+            a2a_manager=a2a_manager,
+            api_mode=api_mode,
+            builtin_tool_manager=builtin_tool_manager,
+        )
+
+    @classmethod
+    def from_run_context(
+        cls,
+        logger: Logger,
+        config: ToolManagerConfig,
+        *,
+        run_context: ToolRunContext,
+        tool_progress_reporter: ToolProgressReporter,
+        mcp_manager: MCPManager,
+        a2a_manager: A2AManager,
+        api_mode: _ApiMode,
+        builtin_tool_manager: OpenAIBuiltInToolManager | None = None,
+    ) -> Self:
+        instance = cls.__new__(cls)
+        instance._setup(
+            logger=logger,
+            config=config,
+            run_context=run_context,
+            tool_progress_reporter=tool_progress_reporter,
+            mcp_manager=mcp_manager,
+            a2a_manager=a2a_manager,
+            api_mode=api_mode,
+            builtin_tool_manager=builtin_tool_manager,
+        )
+        return instance
+
+    def _setup(
+        self,
+        *,
+        logger: Logger,
+        config: ToolManagerConfig,
+        run_context: ToolRunContext,
+        tool_progress_reporter: ToolProgressReporter,
+        mcp_manager: MCPManager,
+        a2a_manager: A2AManager,
+        api_mode: _ApiMode,
+        builtin_tool_manager: OpenAIBuiltInToolManager | None,
+    ) -> None:
         self._logger = logger
         self._config = config
         self._tool_progress_reporter = tool_progress_reporter
         self._tools: list[Tool[Any] | OpenAIBuiltInTool[Any]] = []
-        self._tool_choices = event.payload.tool_choices
-        self._disabled_tools = event.payload.disabled_tools
+        self._tool_choices = run_context.tool_choices
+        self._disabled_tools = run_context.disabled_tools
         self._exclusive_tools = [
             tool.name for tool in self._config.tools if tool.is_exclusive
         ]
@@ -104,16 +155,16 @@ class _ToolManager(Generic[_ApiMode]):
         self._a2a_manager = a2a_manager
         self._builtin_tool_manager = builtin_tool_manager
         self._api_mode = api_mode
-        self._init__tools(event)
+        self._init__tools(run_context.tool_init_event)
 
-    def _init__tools(self, event: ChatEvent) -> None:
+    def _init__tools(self, tool_init_event: ChatEvent | None) -> None:
         tool_choices = self._tool_choices
         tool_configs = self._config.tools
         self._logger.info("Initializing tool definitions...")
         self._logger.info(f"Tool choices: {tool_choices}")
 
         tool_configs, sub_agents = self._a2a_manager.get_all_sub_agents(
-            tool_configs, event
+            tool_configs, tool_init_event
         )
         self._sub_agents = sub_agents
 
@@ -133,18 +184,24 @@ class _ToolManager(Generic[_ApiMode]):
         registered_tool_names.update(t.name for t in self._mcp_tools)
 
         # Build internal tools from configurations
-        self._internal_tools = [
-            ToolFactory.build_tool_with_settings(
-                t.name,
-                t,
-                t.configuration,
-                event,
-                tool_progress_reporter=self._tool_progress_reporter,
-            )
-            for t in tool_configs
-            if t.name not in registered_tool_names  # Skip already handled tools
-            and t.name not in OpenAIBuiltInToolName  # Safeguard
-        ]
+        self._internal_tools = []
+        for t in tool_configs:
+            if t.name in registered_tool_names:
+                continue
+            if t.name in OpenAIBuiltInToolName:
+                continue
+            if tool_init_event is not None:
+                built_tool = ToolFactory.build_tool_with_settings(
+                    t.name,
+                    t,
+                    t.configuration,
+                    tool_init_event,
+                    tool_progress_reporter=self._tool_progress_reporter,
+                )
+            else:
+                built_tool = ToolFactory.tool_map[t.name](t.configuration)
+                built_tool.settings = t
+            self._internal_tools.append(built_tool)
 
         # Combine all types of tools
         self.available_tools = (
@@ -607,6 +664,28 @@ class ToolManager(_ToolManager[Literal["completions"]]):
             builtin_tool_manager=None,
         )
 
+    @classmethod
+    def from_run_context(
+        cls,
+        logger: Logger,
+        config: ToolManagerConfig,
+        *,
+        run_context: ToolRunContext,
+        tool_progress_reporter: ToolProgressReporter,
+        mcp_manager: MCPManager,
+        a2a_manager: A2AManager,
+    ) -> Self:
+        return super().from_run_context(
+            logger=logger,
+            config=config,
+            run_context=run_context,
+            tool_progress_reporter=tool_progress_reporter,
+            mcp_manager=mcp_manager,
+            a2a_manager=a2a_manager,
+            api_mode="completions",
+            builtin_tool_manager=None,
+        )
+
 
 class ResponsesApiToolManager(_ToolManager[Literal["responses"]]):
     def __init__(
@@ -630,6 +709,32 @@ class ResponsesApiToolManager(_ToolManager[Literal["responses"]]):
             api_mode="responses",
             builtin_tool_manager=builtin_tool_manager,
         )
+
+    @classmethod
+    def from_run_context(
+        cls,
+        logger: Logger,
+        config: ToolManagerConfig,
+        *,
+        run_context: ToolRunContext,
+        tool_progress_reporter: ToolProgressReporter,
+        mcp_manager: MCPManager,
+        a2a_manager: A2AManager,
+        builtin_tool_manager: OpenAIBuiltInToolManager,
+    ) -> Self:
+        instance = cls.__new__(cls)
+        instance._builtin_tool_manager = builtin_tool_manager
+        instance._setup(
+            logger=logger,
+            config=config,
+            run_context=run_context,
+            tool_progress_reporter=tool_progress_reporter,
+            mcp_manager=mcp_manager,
+            a2a_manager=a2a_manager,
+            api_mode="responses",
+            builtin_tool_manager=builtin_tool_manager,
+        )
+        return instance
 
     def get_required_include_params(self) -> list[ResponseIncludable]:
         """Return Responses API include params required by all active built-in tools."""

--- a/unique_toolkit/unique_toolkit/agentic/tools/tool_manager.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/tool_manager.py
@@ -163,9 +163,18 @@ class _ToolManager(Generic[_ApiMode]):
         self._logger.info("Initializing tool definitions...")
         self._logger.info(f"Tool choices: {tool_choices}")
 
-        tool_configs, sub_agents = self._a2a_manager.get_all_sub_agents(
-            tool_configs, tool_init_event
-        )
+        if tool_init_event is not None:
+            tool_configs, sub_agents = self._a2a_manager.get_all_sub_agents(
+                tool_configs,
+                tool_init_event,
+            )
+        else:
+            tool_configs = [
+                tool_config
+                for tool_config in tool_configs
+                if not tool_config.is_sub_agent
+            ]
+            sub_agents = []
         self._sub_agents = sub_agents
 
         registered_tool_names = set(t.name for t in self._sub_agents)

--- a/unique_toolkit/unique_toolkit/agentic_table/schemas.py
+++ b/unique_toolkit/unique_toolkit/agentic_table/schemas.py
@@ -22,11 +22,10 @@ from unique_sdk.api_resources._agentic_table import (
 
 from unique_toolkit._common.pydantic_helpers import get_configuration_dict
 from unique_toolkit.app.schemas import (
-    ChatEvent,
-    ChatEventAssistantMessage,
-    ChatEventUserMessage,
-    Correlation,
+    AssistantWebhookEvent,
+    BaseEventPayload,
 )
+from unique_toolkit.app.unique_settings import UniqueChatEventFilterOptions
 from unique_toolkit.language_model.schemas import (
     LanguageModelMessageRole,
     LanguageModelMessages,
@@ -112,27 +111,25 @@ A = TypeVar("A", bound=MagicTableAction)
 T = TypeVar("T", bound=BaseMetadata)
 
 
-class MagicTableBasePayload(BaseModel, Generic[A, T]):
-    model_config = get_configuration_dict()
-    name: str = Field(description="The name of the module")
-    sheet_name: str
+class MagicTableBasePayload(BaseEventPayload, Generic[A, T]):
+    """Magic-table-specific payload.
 
+    Inherits the common envelope fields (``name``, ``chat_id``, ``assistant_id``,
+    ``configuration``, ``metadata_filter``, ``correlation``) from
+    :class:`BaseEventPayload` and adds magic-table-only fields.
+
+    Note: previously this carried stub-empty ``user_message`` /
+    ``assistant_message`` defaults so that ``MagicTableEvent`` could pose as
+    a ``ChatEvent``. That coupling is gone; magic-table flows that need a
+    chat context should construct a :class:`UniqueContext` explicitly.
+    """
+
+    model_config = get_configuration_dict()
+
+    sheet_name: str
     action: A
-    chat_id: str
-    assistant_id: str
     table_id: str
-    user_message: ChatEventUserMessage = Field(
-        default=ChatEventUserMessage(
-            id="", text="", original_text="", created_at="", language=""
-        )
-    )
-    assistant_message: ChatEventAssistantMessage = Field(
-        default=ChatEventAssistantMessage(id="", created_at="")
-    )
-    configuration: dict[str, Any] = {}
     metadata: T
-    metadata_filter: dict[str, Any] | None = None
-    correlation: Correlation | None = None
 
 
 ########### Specialized Payload definitions ###########
@@ -263,10 +260,18 @@ PayloadTypes = (
 MagicTablePayloadTypes = Annotated[PayloadTypes, Field(discriminator="action")]
 
 
-class MagicTableEvent(ChatEvent):
-    # TODO(UN-19532): investigate making ChatEvent generic to avoid these overrides
+class MagicTableEvent(
+    AssistantWebhookEvent[UniqueChatEventFilterOptions, MagicTablePayloadTypes]
+):
+    """Magic-table webhook event, sibling of :class:`ChatEvent`.
+
+    No longer extends ``ChatEvent``; both events are siblings under
+    :class:`AssistantWebhookEvent`. This makes ``isinstance(magic_table_event,
+    ChatEvent)`` correctly return ``False`` and prevents silently passing a
+    magic-table event to services that require chat-only fields.
+    """
+
     event: MagicTableEventTypes  # pyright: ignore[reportIncompatibleVariableOverride]
-    payload: MagicTablePayloadTypes  # pyright: ignore[reportIncompatibleVariableOverride]
 
 
 class LogDetail(BaseModel):

--- a/unique_toolkit/unique_toolkit/agentic_table/schemas.py
+++ b/unique_toolkit/unique_toolkit/agentic_table/schemas.py
@@ -1,5 +1,5 @@
 from enum import StrEnum
-from typing import Annotated, Any, Generic, Literal, TypeVar
+from typing import Annotated, Any, Generic, Literal, TypeVar, override
 
 from pydantic import (
     AliasChoices,
@@ -20,6 +20,7 @@ from unique_sdk.api_resources._agentic_table import (
     SheetType,
 )
 
+from unique_toolkit._common.exception import ConfigurationException
 from unique_toolkit._common.pydantic_helpers import get_configuration_dict
 from unique_toolkit.app.schemas import (
     AssistantWebhookEvent,
@@ -272,6 +273,36 @@ class MagicTableEvent(
     """
 
     event: MagicTableEventTypes  # pyright: ignore[reportIncompatibleVariableOverride]
+
+    @override
+    def filter_event(
+        self, *, filter_options: UniqueChatEventFilterOptions | None = None
+    ) -> bool:
+        if filter_options is None:
+            return False
+
+        if not filter_options.assistant_ids and not filter_options.references_in_code:
+            raise ConfigurationException(
+                "No filter options provided, all events will be filtered! \n"
+                "Please define: \n"
+                " - 'UNIQUE_CHAT_EVENT_FILTER_OPTIONS_ASSISTANT_IDS' \n"
+                " - 'UNIQUE_CHAT_EVENT_FILTER_OPTIONS_REFERENCES_IN_CODE' \n"
+                "in your environment variables."
+            )
+
+        if (
+            filter_options.assistant_ids
+            and self.payload.assistant_id not in filter_options.assistant_ids
+        ):
+            return True
+
+        if (
+            filter_options.references_in_code
+            and self.payload.name not in filter_options.references_in_code
+        ):
+            return True
+
+        return super().filter_event(filter_options=filter_options)
 
 
 class LogDetail(BaseModel):

--- a/unique_toolkit/unique_toolkit/agentic_table/synthetic_chat_event.py
+++ b/unique_toolkit/unique_toolkit/agentic_table/synthetic_chat_event.py
@@ -1,0 +1,63 @@
+"""Synthetic :class:`ChatEvent` for magic-table runs with chat-typed toolkit APIs."""
+
+from unique_toolkit.agentic_table.schemas import MagicTableEvent
+from unique_toolkit.app.schemas import (
+    ChatEvent,
+    ChatEventAssistantMessage,
+    ChatEventPayload,
+    ChatEventUserMessage,
+    EventName,
+)
+from unique_toolkit.app.unique_settings import (
+    MAGIC_TABLE_STREAMING_ASSISTANT_MESSAGE_ID,
+    MAGIC_TABLE_STREAMING_USER_MESSAGE_ID,
+)
+
+_MAGIC_TABLE_STREAMING_MESSAGE_CREATED_AT = "1970-01-01T00:00:00Z"
+
+
+def build_synthetic_chat_event(
+    event: MagicTableEvent,
+    *,
+    event_id: str | None = None,
+    description: str = "magic-table",
+) -> ChatEvent:
+    """Build a :class:`ChatEvent` for evaluators/tools that still require chat typing.
+
+    Magic-table runs create messages dynamically; placeholder message ids are
+    sufficient for search tooling and hallucination evaluation scoping.
+    """
+    payload = event.payload
+    chat_id = payload.chat_id
+    if not chat_id:
+        msg = (
+            "Magic-table event is missing chat_id; "
+            "chat-scoped services cannot be built."
+        )
+        raise ValueError(msg)
+    return ChatEvent(
+        id=event_id or event.id,
+        event=EventName.EXTERNAL_MODULE_CHOSEN,
+        user_id=event.user_id,
+        company_id=event.company_id,
+        payload=ChatEventPayload(
+            name=payload.name,
+            chat_id=chat_id,
+            assistant_id=payload.assistant_id,
+            description=description,
+            configuration=payload.configuration,
+            metadata_filter=payload.metadata_filter,
+            correlation=payload.correlation,
+            user_message=ChatEventUserMessage(
+                id=MAGIC_TABLE_STREAMING_USER_MESSAGE_ID,
+                text="",
+                original_text="",
+                created_at=_MAGIC_TABLE_STREAMING_MESSAGE_CREATED_AT,
+                language="EN",
+            ),
+            assistant_message=ChatEventAssistantMessage(
+                id=MAGIC_TABLE_STREAMING_ASSISTANT_MESSAGE_ID,
+                created_at=_MAGIC_TABLE_STREAMING_MESSAGE_CREATED_AT,
+            ),
+        ),
+    )

--- a/unique_toolkit/unique_toolkit/app/schemas.py
+++ b/unique_toolkit/unique_toolkit/app/schemas.py
@@ -250,14 +250,36 @@ class ChatEventSkill(BaseModel):
 SkillReference = ChatEventSkill
 
 
-class ChatEventPayload(BaseModel):
+class BaseEventPayload(BaseModel):
+    """Common payload fields shared by all assistant-context webhook events.
+
+    Both :class:`ChatEventPayload` and :class:`MagicTableBasePayload` extend
+    this. Services that only need the common envelope (``chat_id``,
+    ``assistant_id``, ``metadata_filter``, ``correlation``, ...) should
+    accept :class:`AssistantWebhookEvent` and read the payload off this
+    shared shape; services that need chat-only fields (``user_message``,
+    ``assistant_message``) must accept :class:`ChatEvent` explicitly.
+    """
+
     model_config = model_config
 
-    name: str
-    description: str
-    configuration: dict[str, Any]
+    name: str = Field(description="The module / action name driving the event.")
     chat_id: str
     assistant_id: str
+    configuration: dict[str, Any] = Field(default_factory=dict)
+    # Default is None as empty dict triggers error in `backend-ingestion`
+    metadata_filter: dict[str, Any] | None = Field(
+        default=None,
+        description="Metadata filter compiled after module selection function calling and scope rules.",
+    )
+    correlation: Correlation | None = Field(
+        default=None,
+        description="The correlation to parent message in another chat.",
+    )
+
+
+class ChatEventPayload(BaseEventPayload):
+    description: str
     user_message: ChatEventUserMessage
     assistant_message: ChatEventAssistantMessage
     text: str | None = None
@@ -296,11 +318,6 @@ class ChatEventPayload(BaseModel):
         default_factory=dict,
         description="Parameters extracted from module selection function calling the tool.",
     )
-    # Default is None as empty dict triggers error in `backend-ingestion`
-    metadata_filter: dict[str, Any] | None = Field(
-        default=None,
-        description="Metadata filter compiled after module selection function calling and scope rules.",
-    )
     raw_scope_rules: UniqueQL | None = Field(
         default=None,
         description="Raw UniqueQL rule that can be compiled to a metadata filter.",
@@ -316,10 +333,6 @@ class ChatEventPayload(BaseModel):
     session_config: JsonValue | None = Field(
         default=None,
         description="The session configuration for the chat session.",
-    )
-    correlation: Correlation | None = Field(
-        default=None,
-        description="The correlation to parent message in another chat.",
     )
 
     @field_validator("raw_scope_rules", mode="before")
@@ -341,12 +354,37 @@ class EventPayload(ChatEventPayload):
     # additional_parameters: Optional[EventAdditionalParameters] = None
 
 
-class ChatEvent(BaseEvent[UniqueChatEventFilterOptions]):
+PayloadT_co = TypeVar("PayloadT_co", bound=BaseEventPayload, covariant=True)
+
+
+class AssistantWebhookEvent(
+    BaseEvent[FilterOptionsT], Generic[FilterOptionsT, PayloadT_co]
+):
+    """Umbrella envelope for webhook events that carry assistant/chat context.
+
+    The payload is constrained to :class:`BaseEventPayload`, giving consumers
+    a typed view of the shared envelope fields (``chat_id``, ``assistant_id``,
+    ``metadata_filter``, ``correlation``, ...). Concrete events specialize
+    the payload type:
+
+    * :class:`ChatEvent` → :class:`ChatEventPayload`
+    * ``MagicTableEvent`` → ``MagicTablePayloadTypes`` (discriminated union)
+
+    ``PayloadT_co`` is covariant so that ``AssistantWebhookEvent[..., ChildPayload]``
+    is a subtype of ``AssistantWebhookEvent[..., ParentPayload]``. This lets a
+    service signature accept *any* assistant-context event while still
+    accessing the common ``BaseEventPayload`` shape in a type-checked way.
+    """
+
     model_config = model_config
 
-    payload: ChatEventPayload
+    payload: PayloadT_co
     created_at: Optional[int] = None
     version: Optional[str] = None
+
+
+class ChatEvent(AssistantWebhookEvent[UniqueChatEventFilterOptions, ChatEventPayload]):
+    model_config = model_config
 
     class FilterOptions(BaseSettings):
         assistant_ids: list[str] = Field(

--- a/unique_toolkit/unique_toolkit/app/schemas.py
+++ b/unique_toolkit/unique_toolkit/app/schemas.py
@@ -378,7 +378,8 @@ class AssistantWebhookEvent(
 
     model_config = model_config
 
-    payload: PayloadT_co
+    # Covariant payload must stay read-only; reassignment through a widened type is unsound.
+    payload: PayloadT_co = Field(frozen=True)
     created_at: Optional[int] = None
     version: Optional[str] = None
 

--- a/unique_toolkit/unique_toolkit/app/unique_settings.py
+++ b/unique_toolkit/unique_toolkit/app/unique_settings.py
@@ -25,7 +25,12 @@ from unique_toolkit.app.feature_flags import UNIQUE_TOOLKIT_FEATURE_FLAGS
 from unique_toolkit.app.find_env_file import EnvFileNotFoundError, find_env_file
 
 if TYPE_CHECKING:
+    from unique_toolkit.agentic_table.schemas import MagicTableEvent
     from unique_toolkit.app.schemas import BaseEvent, ChatEvent
+
+# Placeholder message ids for magic-table runs that create messages dynamically.
+MAGIC_TABLE_STREAMING_ASSISTANT_MESSAGE_ID = "magic-table-streaming-assistant"
+MAGIC_TABLE_STREAMING_USER_MESSAGE_ID = "magic-table-streaming-user"
 
 
 logger = getLogger(__name__)
@@ -459,6 +464,38 @@ class UniqueContext:
         return cls(
             auth=AuthContext.from_event(event),
             chat=ChatContext.from_chat_event(event),
+        )
+
+    @classmethod
+    def from_magic_table_event(cls, event: MagicTableEvent) -> Self:
+        """Build auth + chat context from a magic-table webhook event.
+
+        Magic-table payloads carry ``chat_id`` and ``assistant_id`` but no live
+        user/assistant message objects. Placeholder message ids are used so
+        chat-scoped services (e.g. :class:`ChatService`) can be constructed via
+        :meth:`from_context`; do not use this context for short-term memory
+        writes that require a real message id.
+        """
+        payload = event.payload
+        if not payload.chat_id:
+            msg = (
+                "Magic-table event is missing chat_id; "
+                "chat-scoped services cannot be built."
+            )
+            raise ValueError(msg)
+        parent_chat_id = (
+            payload.correlation.parent_chat_id if payload.correlation else None
+        )
+        return cls(
+            auth=AuthContext.from_event(event),
+            chat=ChatContext(
+                chat_id=payload.chat_id,
+                assistant_id=payload.assistant_id,
+                last_assistant_message_id=MAGIC_TABLE_STREAMING_ASSISTANT_MESSAGE_ID,
+                last_user_message_id=MAGIC_TABLE_STREAMING_USER_MESSAGE_ID,
+                metadata_filter=payload.metadata_filter,
+                parent_chat_id=parent_chat_id,
+            ),
         )
 
     @classmethod

--- a/unique_toolkit/unique_toolkit/app/unique_settings.py
+++ b/unique_toolkit/unique_toolkit/app/unique_settings.py
@@ -493,6 +493,7 @@ class UniqueContext:
                 assistant_id=payload.assistant_id,
                 last_assistant_message_id=MAGIC_TABLE_STREAMING_ASSISTANT_MESSAGE_ID,
                 last_user_message_id=MAGIC_TABLE_STREAMING_USER_MESSAGE_ID,
+                last_user_message_text="",
                 metadata_filter=payload.metadata_filter,
                 parent_chat_id=parent_chat_id,
             ),

--- a/unique_toolkit/unique_toolkit/content/service.py
+++ b/unique_toolkit/unique_toolkit/content/service.py
@@ -1,10 +1,10 @@
 import logging
 from pathlib import Path
-from typing import Any, overload
+from typing import TYPE_CHECKING, Any, overload
 
 import unique_sdk
 from requests import Response
-from typing_extensions import deprecated
+from typing_extensions import Self, deprecated
 
 from unique_toolkit._common.utils.files import is_file_content, is_image_content
 from unique_toolkit._common.validate_required_values import validate_required_values
@@ -32,6 +32,9 @@ from unique_toolkit.content.schemas import (
     ContentRerankerConfig,
     ContentSearchType,
 )
+
+if TYPE_CHECKING:
+    from unique_toolkit.app.unique_settings import UniqueContext
 
 logger = logging.getLogger(f"toolkit.{DOMAIN_NAME}.{__name__}")
 
@@ -161,10 +164,40 @@ class ContentService:
         )
 
     @classmethod
+    def from_context(
+        cls,
+        context: UniqueContext,
+        *,
+        metadata_filter: dict[str, Any] | None = None,
+    ) -> Self:
+        """Create a ContentService from a :class:`UniqueContext`.
+
+        When ``context.chat.parent_chat_id`` is set (subagent correlation),
+        content operations are scoped to the parent chat.
+        """
+        if context.chat is None:
+            msg = "ContentService requires chat context (context.chat is None)"
+            raise ValueError(msg)
+        chat = context.chat
+        effective_filter = (
+            metadata_filter if metadata_filter is not None else chat.metadata_filter
+        )
+        chat_id = (
+            chat.parent_chat_id if chat.parent_chat_id is not None else chat.chat_id
+        )
+        return cls(
+            company_id=context.auth.get_confidential_company_id(),
+            user_id=context.auth.get_confidential_user_id(),
+            chat_id=chat_id,
+            metadata_filter=effective_filter,
+        )
+
+    @classmethod
     def from_settings(
         cls,
         settings: UniqueSettings | str | None = None,
         metadata_filter: dict[str, Any] | None = None,
+        **kwargs: Any,
     ):
         """
         Initialize the ContentService with a settings object and metadata filter.
@@ -174,6 +207,12 @@ class ContentService:
             settings = UniqueSettings.from_env_auto_with_sdk_init()
         elif isinstance(settings, str):
             settings = UniqueSettings.from_env_auto_with_sdk_init(filename=settings)
+
+        if settings.context.chat is not None:
+            return cls.from_context(
+                settings.context,
+                metadata_filter=metadata_filter,
+            )
 
         return cls(
             company_id=settings.auth.company_id.get_secret_value(),

--- a/unique_toolkit/unique_toolkit/content/service.py
+++ b/unique_toolkit/unique_toolkit/content/service.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, overload
+from typing import Any, overload
 
 import unique_sdk
 from requests import Response
@@ -9,7 +9,7 @@ from typing_extensions import Self, deprecated
 from unique_toolkit._common.utils.files import is_file_content, is_image_content
 from unique_toolkit._common.validate_required_values import validate_required_values
 from unique_toolkit.app.schemas import BaseEvent, Correlation
-from unique_toolkit.app.unique_settings import UniqueSettings
+from unique_toolkit.app.unique_settings import UniqueContext, UniqueSettings
 from unique_toolkit.content import DOMAIN_NAME
 from unique_toolkit.content.constants import DEFAULT_SEARCH_LANGUAGE
 from unique_toolkit.content.functions import (
@@ -32,9 +32,6 @@ from unique_toolkit.content.schemas import (
     ContentRerankerConfig,
     ContentSearchType,
 )
-
-if TYPE_CHECKING:
-    from unique_toolkit.app.unique_settings import UniqueContext
 
 logger = logging.getLogger(f"toolkit.{DOMAIN_NAME}.{__name__}")
 

--- a/unique_toolkit/unique_toolkit/content/service.py
+++ b/unique_toolkit/unique_toolkit/content/service.py
@@ -8,7 +8,7 @@ from typing_extensions import deprecated
 
 from unique_toolkit._common.utils.files import is_file_content, is_image_content
 from unique_toolkit._common.validate_required_values import validate_required_values
-from unique_toolkit.app.schemas import BaseEvent, ChatEvent, Correlation, Event
+from unique_toolkit.app.schemas import BaseEvent, ChatEvent, Correlation
 from unique_toolkit.app.unique_settings import UniqueSettings
 from unique_toolkit.content import DOMAIN_NAME
 from unique_toolkit.content.constants import DEFAULT_SEARCH_LANGUAGE
@@ -46,7 +46,7 @@ class ContentService:
         "Use __init__ with company_id, user_id and chat_id instead or use the classmethod `from_event`"
     )
     @overload
-    def __init__(self, event: Event | ChatEvent | BaseEvent[Any]): ...
+    def __init__(self, event: BaseEvent[Any]): ...
 
     """
         Initialize the ContentService with an event (deprecated)
@@ -68,7 +68,7 @@ class ContentService:
 
     def __init__(
         self,
-        event: Event | BaseEvent[Any] | None = None,
+        event: BaseEvent[Any] | None = None,
         company_id: str | None = None,
         user_id: str | None = None,
         chat_id: str | None = None,
@@ -83,7 +83,7 @@ class ContentService:
         if event:
             self._company_id: str = event.company_id
             self._user_id: str = event.user_id
-            if isinstance(event, (ChatEvent, Event)):
+            if isinstance(event, ChatEvent):
                 self._metadata_filter = event.payload.metadata_filter
                 self._chat_id: str | None = event.payload.chat_id
         else:
@@ -94,7 +94,7 @@ class ContentService:
             self._metadata_filter = metadata_filter
 
     @classmethod
-    def from_event(cls, event: Event | ChatEvent | BaseEvent[Any]):
+    def from_event(cls, event: BaseEvent[Any]):
         """Initialize the ContentService with an event.
 
         When the event has a correlation (e.g. subagent run), delegates to
@@ -109,24 +109,17 @@ class ContentService:
             ContentService: Instance scoped to the event's chat or, when
                 correlation is present, the parent chat.
         """
-        if (
-            isinstance(event, (ChatEvent, Event))
-            and getattr(event.payload, "correlation", None) is not None
-        ):
-            if event.payload.correlation is None:
-                raise ValueError(
-                    "correlation attribute is not defined in the event payload"
-                )
+        if isinstance(event, ChatEvent) and event.payload.correlation is not None:
             return cls.from_correlation(
                 event.company_id,
                 event.user_id,
                 event.payload.correlation,
-                metadata_filter=getattr(event.payload, "metadata_filter", None),
+                metadata_filter=event.payload.metadata_filter,
             )
         chat_id = None
         metadata_filter = None
 
-        if isinstance(event, (ChatEvent | Event)):
+        if isinstance(event, ChatEvent):
             chat_id = event.payload.chat_id
             metadata_filter = event.payload.metadata_filter
 
@@ -192,7 +185,7 @@ class ContentService:
     @deprecated(
         "The event property is deprecated and will be removed in a future version."
     )
-    def event(self) -> Event | BaseEvent[Any] | None:
+    def event(self) -> BaseEvent[Any] | None:
         """
         Get the event object (deprecated).
 

--- a/unique_toolkit/unique_toolkit/content/service.py
+++ b/unique_toolkit/unique_toolkit/content/service.py
@@ -8,7 +8,7 @@ from typing_extensions import Self, deprecated
 
 from unique_toolkit._common.utils.files import is_file_content, is_image_content
 from unique_toolkit._common.validate_required_values import validate_required_values
-from unique_toolkit.app.schemas import BaseEvent, ChatEvent, Correlation
+from unique_toolkit.app.schemas import BaseEvent, Correlation
 from unique_toolkit.app.unique_settings import UniqueSettings
 from unique_toolkit.content import DOMAIN_NAME
 from unique_toolkit.content.constants import DEFAULT_SEARCH_LANGUAGE
@@ -81,20 +81,22 @@ class ContentService:
         Initialize the ContentService with a company_id, user_id and chat_id.
         """
 
-        self._event = event  # Changed to protected attribute
+        if event is not None:
+            delegated = type(self).from_event(event)
+            self._event = event
+            self._company_id = delegated._company_id
+            self._user_id = delegated._user_id
+            self._chat_id = delegated._chat_id
+            self._metadata_filter = delegated._metadata_filter
+            return
+
+        self._event = None
         self._metadata_filter = None
-        if event:
-            self._company_id: str = event.company_id
-            self._user_id: str = event.user_id
-            if isinstance(event, ChatEvent):
-                self._metadata_filter = event.payload.metadata_filter
-                self._chat_id: str | None = event.payload.chat_id
-        else:
-            [company_id, user_id] = validate_required_values([company_id, user_id])
-            self._company_id = company_id
-            self._user_id = user_id
-            self._chat_id = chat_id
-            self._metadata_filter = metadata_filter
+        [company_id, user_id] = validate_required_values([company_id, user_id])
+        self._company_id = company_id
+        self._user_id = user_id
+        self._chat_id = chat_id
+        self._metadata_filter = metadata_filter
 
     @classmethod
     def from_event(cls, event: BaseEvent[Any]):
@@ -112,25 +114,20 @@ class ContentService:
             ContentService: Instance scoped to the event's chat or, when
                 correlation is present, the parent chat.
         """
-        if isinstance(event, ChatEvent) and event.payload.correlation is not None:
+        payload = event.payload
+        if payload.correlation is not None:
             return cls.from_correlation(
                 event.company_id,
                 event.user_id,
-                event.payload.correlation,
-                metadata_filter=event.payload.metadata_filter,
+                payload.correlation,
+                metadata_filter=payload.metadata_filter,
             )
-        chat_id = None
-        metadata_filter = None
-
-        if isinstance(event, ChatEvent):
-            chat_id = event.payload.chat_id
-            metadata_filter = event.payload.metadata_filter
 
         return cls(
             company_id=event.company_id,
             user_id=event.user_id,
-            chat_id=chat_id,
-            metadata_filter=metadata_filter,
+            chat_id=payload.chat_id,
+            metadata_filter=payload.metadata_filter,
         )
 
     @classmethod

--- a/unique_toolkit/unique_toolkit/language_model/service.py
+++ b/unique_toolkit/unique_toolkit/language_model/service.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel
 from typing_extensions import deprecated
 
 from unique_toolkit._common.validate_required_values import validate_required_values
-from unique_toolkit.app.schemas import BaseEvent, ChatEvent, Event
+from unique_toolkit.app.schemas import BaseEvent, ChatEvent
 from unique_toolkit.app.unique_settings import UniqueSettings
 from unique_toolkit.content.schemas import ContentChunk
 from unique_toolkit.language_model.constants import (
@@ -40,7 +40,7 @@ class LanguageModelService:
         "Use __init__ with company_id and user_id instead or use the classmethod `from_event`"
     )
     @overload
-    def __init__(self, event: Event | ChatEvent | BaseEvent[Any]): ...
+    def __init__(self, event: BaseEvent[Any]): ...
 
     """
         Initialize the LanguageModelService with an event (deprecated)
@@ -55,12 +55,12 @@ class LanguageModelService:
 
     def __init__(
         self,
-        event: Event | ChatEvent | BaseEvent[Any] | None = None,
+        event: BaseEvent[Any] | None = None,
         company_id: str | None = None,
         user_id: str | None = None,
         **kwargs: dict[str, Any],  # only here for backward compatibility
     ):
-        if isinstance(event, (ChatEvent, Event)):
+        if isinstance(event, ChatEvent):
             self._event = event
             self._chat_id = event.payload.chat_id
             self._assistant_id = event.payload.assistant_id
@@ -106,7 +106,7 @@ class LanguageModelService:
     @deprecated(
         "The event property is deprecated and will be removed in a future version."
     )
-    def event(self) -> Event | BaseEvent[Any] | None:
+    def event(self) -> BaseEvent[Any] | None:
         """
         Get the event object (deprecated).
 

--- a/unique_toolkit/unique_toolkit/language_model/service.py
+++ b/unique_toolkit/unique_toolkit/language_model/service.py
@@ -88,7 +88,7 @@ class LanguageModelService:
         return cls(company_id=event.company_id, user_id=event.user_id)
 
     @classmethod
-    def from_settings(cls, settings: UniqueSettings | str | None = None):
+    def from_settings(cls, settings: UniqueSettings | str | None = None, **kwargs: Any):
         """
         Initialize the LanguageModelService with a settings object.
         """

--- a/unique_toolkit/unique_toolkit/language_model/service.py
+++ b/unique_toolkit/unique_toolkit/language_model/service.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel
 from typing_extensions import deprecated
 
 from unique_toolkit._common.validate_required_values import validate_required_values
-from unique_toolkit.app.schemas import BaseEvent, ChatEvent
+from unique_toolkit.app.schemas import BaseEvent
 from unique_toolkit.app.unique_settings import UniqueSettings
 from unique_toolkit.content.schemas import ContentChunk
 from unique_toolkit.language_model.constants import (
@@ -60,25 +60,22 @@ class LanguageModelService:
         user_id: str | None = None,
         **kwargs: dict[str, Any],  # only here for backward compatibility
     ):
-        if isinstance(event, ChatEvent):
+        if event is not None:
+            auth_scoped = type(self).from_event(event)
+            self._company_id = auth_scoped._company_id
+            self._user_id = auth_scoped._user_id
             self._event = event
-            self._chat_id = event.payload.chat_id
-            self._assistant_id = event.payload.assistant_id
-            self._company_id = event.company_id
-            self._user_id = event.user_id
-        elif isinstance(event, BaseEvent):
-            self._event = event
-            self._company_id = event.company_id
-            self._user_id = event.user_id
-            self._chat_id = None
-            self._assistant_id = None
-        else:
-            [company_id, user_id] = validate_required_values([company_id, user_id])
-            self._event = None
-            self._company_id: str = company_id
-            self._user_id: str = user_id
-            self._chat_id: str | None = None
-            self._assistant_id: str | None = None
+            payload = event.payload
+            self._chat_id = getattr(payload, "chat_id", None)
+            self._assistant_id = getattr(payload, "assistant_id", None)
+            return
+
+        [company_id, user_id] = validate_required_values([company_id, user_id])
+        self._event = None
+        self._company_id: str = company_id
+        self._user_id: str = user_id
+        self._chat_id: str | None = None
+        self._assistant_id: str | None = None
 
     @classmethod
     def from_event(cls, event: BaseEvent[Any]):

--- a/unique_toolkit/unique_toolkit/services/factory.py
+++ b/unique_toolkit/unique_toolkit/services/factory.py
@@ -14,6 +14,8 @@ if TYPE_CHECKING:
     from unique_toolkit._common.chunk_relevancy_sorter.service import (
         ChunkRelevancySorter,
     )
+    from unique_toolkit.content.service import ContentService
+    from unique_toolkit.language_model.service import LanguageModelService
 
 
 class ServiceProtocol(Protocol):
@@ -102,6 +104,20 @@ class UniqueServiceFactory:
         """Create a :class:`KnowledgeBaseService` using the pre-bound context."""
         return self.get(KnowledgeBaseService, **kwargs)
 
+    def content_service(self, **kwargs: Any) -> ContentService:
+        """Create a :class:`ContentService` using the pre-bound context."""
+        from unique_toolkit.content.service import ContentService as _ContentService
+
+        return self.get(_ContentService, **kwargs)
+
+    def language_model_service(self, **kwargs: Any) -> LanguageModelService:
+        """Create a :class:`LanguageModelService` using the pre-bound context."""
+        from unique_toolkit.language_model.service import (
+            LanguageModelService as _LanguageModelService,
+        )
+
+        return self.get(_LanguageModelService, **kwargs)
+
     def chunk_relevancy_sorter(self) -> ChunkRelevancySorter:
         """Create a :class:`ChunkRelevancySorter` using the pre-bound context."""
         # issue with circular imports - need to use this
@@ -138,7 +154,8 @@ class UniqueServiceFactory:
     def register_known_services(cls) -> None:
         """Register the stable toolkit services with the factory.
 
-        Currently registers :class:`KnowledgeBaseService` and :class:`ChatService`.
+        Currently registers :class:`KnowledgeBaseService`, :class:`ChatService`,
+        :class:`ContentService`, and :class:`LanguageModelService`.
         :class:`ChunkRelevancySorter` is intentionally excluded to avoid circular
         imports at package init time — use the ``chunk_relevancy_sorter()``
         convenience method instead.
@@ -149,10 +166,17 @@ class UniqueServiceFactory:
         example, :meth:`Identity.from_settings`) so that the experimental
         dependency is visible at every call site.
         """
+        from unique_toolkit.content.service import ContentService
+        from unique_toolkit.language_model.service import LanguageModelService
         from unique_toolkit.services.chat_service import ChatService
         from unique_toolkit.services.knowledge_base import KnowledgeBaseService
 
-        for service_class in [KnowledgeBaseService, ChatService]:
+        for service_class in [
+            KnowledgeBaseService,
+            ChatService,
+            ContentService,
+            LanguageModelService,
+        ]:
             if service_class.__name__ not in cls._registry:
                 cls.register(service_class=service_class)
 

--- a/unique_toolkit/unique_toolkit/services/knowledge_base.py
+++ b/unique_toolkit/unique_toolkit/services/knowledge_base.py
@@ -16,7 +16,7 @@ from unique_toolkit._common.metadata_filter_scope import (
     merge_scope_clause_into_metadata_filter,
 )
 from unique_toolkit._common.validate_required_values import validate_required_values
-from unique_toolkit.app.schemas import BaseEvent, ChatEvent, Event
+from unique_toolkit.app.schemas import BaseEvent, ChatEvent
 from unique_toolkit.app.unique_settings import UniqueSettings
 from unique_toolkit.content.constants import (
     DEFAULT_SEARCH_LANGUAGE,
@@ -93,7 +93,7 @@ class KnowledgeBaseService:
         """
         metadata_filter = None
 
-        if isinstance(event, (ChatEvent | Event)):
+        if isinstance(event, ChatEvent):
             metadata_filter = event.payload.metadata_filter
 
         return cls(

--- a/unique_toolkit/unique_toolkit/short_term_memory/service.py
+++ b/unique_toolkit/unique_toolkit/short_term_memory/service.py
@@ -52,23 +52,33 @@ class ShortTermMemoryService:
         chat_id: str | None = None,
         message_id: str | None = None,
     ):
-        self._event = event
-        if event:
-            self._company_id: str = event.company_id
-            self._user_id: str = event.user_id
+        if event is not None:
             if isinstance(event, ChatEvent):
-                self._chat_id = event.payload.chat_id
-                self._message_id = event.payload.user_message.id
-        else:
-            [company_id, user_id] = validate_required_values([company_id, user_id])
+                delegated = type(self).from_event(event)
+                self._event = event
+                self._company_id = delegated._company_id
+                self._user_id = delegated._user_id
+                self._chat_id = delegated._chat_id
+                self._message_id = delegated._message_id
+                return
 
-            if not (chat_id or message_id):
-                raise ValueError("Chat_id or message_id must be provided")
+            self._event = event
+            self._company_id = event.company_id
+            self._user_id = event.user_id
+            self._chat_id = None
+            self._message_id = None
+            return
 
-            self._company_id = company_id
-            self._user_id = user_id
-            self._chat_id = chat_id
-            self._message_id = message_id
+        self._event = None
+        [company_id, user_id] = validate_required_values([company_id, user_id])
+
+        if not (chat_id or message_id):
+            raise ValueError("Chat_id or message_id must be provided")
+
+        self._company_id = company_id
+        self._user_id = user_id
+        self._chat_id = chat_id
+        self._message_id = message_id
 
     @classmethod
     def from_event(cls, event: ChatEvent):

--- a/unique_toolkit/unique_toolkit/short_term_memory/service.py
+++ b/unique_toolkit/unique_toolkit/short_term_memory/service.py
@@ -56,7 +56,7 @@ class ShortTermMemoryService:
         if event:
             self._company_id: str = event.company_id
             self._user_id: str = event.user_id
-            if isinstance(event, (ChatEvent, Event)):
+            if isinstance(event, ChatEvent):
                 self._chat_id = event.payload.chat_id
                 self._message_id = event.payload.user_message.id
         else:


### PR DESCRIPTION
## Summary

Refs: [UN-19308](https://unique-ch.atlassian.net/browse/UN-19308)

- Introduces `BaseEventPayload` / `ChatEventPayload` and `AssistantWebhookEvent[FilterOptionsT, PayloadT_co]` so payload types specialize without unsound `payload` overrides.
- `ChatEvent` and `MagicTableEvent` are sibling specializations of `AssistantWebhookEvent` (shared webhook envelope + payload union).
- Chat-scoped toolkit services (`ChatService`, `ContentService`, `LanguageModelService`, …) now require `ChatEvent` where they read chat-only fields; `internal_search` tools follow the same rule.
- `AssistantWebhookEvent.payload` is `Field(frozen=True)` so covariant `PayloadT_co` stays read-only and reassignment through a widened type cannot corrupt a narrowed event.
- `get_initial_debug_info` lives on `ChatEvent` only; service call sites still use `BaseEvent[Any]` plus `isinstance(event, ChatEvent)` at the edge.

**Follow-up (out of scope):** `event` is still `str` on `BaseEvent`; `MagicTableEvent.event` still needs a `# pyright: ignore`. Literal event-name discriminators and a top-level `ChatEvent | MagicTableEvent` parse union would be a separate change.

## Type safety

- **Payload axis:** `PayloadT_co` is covariant; services that only need the common envelope can accept `AssistantWebhookEvent[..., BaseEventPayload]` and read `chat_id`, `assistant_id`, `metadata_filter`, etc. type-safely.
- **Event-kind separation:** `isinstance(magic_table_event, ChatEvent)` is now correctly `False`; chat service `isinstance` guards are sound.
- **Frozen payload:** closes the latent covariance hole (assigning a `BaseEventPayload` through a widened reference while still reading `ChatEventPayload` fields elsewhere).
- **Not yet closed:** event-name generics, discriminated parsing by `event`, and replacing `BaseEvent[Any]` service signatures with `AssistantWebhookEvent[..., BaseEventPayload]` where appropriate.

## Compatibility

**For the common case — anyone receiving a real `ChatEvent` webhook — this is fully backward compatible at runtime.** The only true breakage hits code that relied on `MagicTableEvent` *being* a `ChatEvent`.

### What stays safe

- **`ChatEvent` deserialization is unchanged.** The payload split into `BaseEventPayload` (common: `name`, `chat_id`, `assistant_id`, `configuration`, `metadata_filter`, `correlation`) + `ChatEventPayload(BaseEventPayload)` (chat-only: `description`, `user_message`, `assistant_message`, …) is purely structural. Because `ChatEventPayload` inherits the common fields, the wire shape and every field name/default is identical — no migration needed for webhook parsing.
- **The legacy `Event` alias still works.** `Event` still subclasses `ChatEvent`, so `isinstance(event, ChatEvent)` remains `True` and every narrowed service still accepts it.
- **Chat-scoped service constructors accept the same inputs at runtime.** `ChatService`, `ContentService`, `LanguageModelService`, `ShortTermMemoryService`, `KnowledgeBaseService` still take a real `ChatEvent`/`Event` and behave identically.

### What breaks

- **`MagicTableEvent` is no longer a subclass of `ChatEvent`** (`isinstance(magic_table_event, ChatEvent)` is now **`False`**, was `True`). Passing a magic-table event into a chat-scoped service (`ChatService(event)`, `LanguageModelService(event)`, …) no longer picks up `chat_id`/`message_id` and now raises via `validate_required_values`. Build a `UniqueContext` (or synthetic `ChatEvent`) explicitly instead. Use `isinstance(event, AssistantWebhookEvent)` when you only need the common ancestor covering both flows.
- **`MagicTableBasePayload` dropped the stub-empty `user_message` / `assistant_message` defaults.** Code reading `magic_table_event.payload.user_message.id` (previously `""`) now raises `AttributeError`.
- **`get_initial_debug_info()` is defined only on `ChatEvent`**; calling it on other event types (e.g. `MagicTableEvent`) raises `AttributeError`.
- **Reassigning `event.payload` on real webhook models now fails** (`Field(frozen=True)` on `AssistantWebhookEvent.payload`). Production code should not do this; tests using `Mock(spec=ChatEvent)` are unaffected.
- **Type-checker-only tightening (no runtime effect):** several service signatures narrowed from `Event | ChatEvent | BaseEvent` unions to `BaseEvent[Any]` / `ChatEvent`. Consumers running `pyright`/`mypy` against these signatures may surface new type errors even where runtime is fine.

### Who is affected

- **External customers:** only those consuming `MagicTableEvent`/agentic-table events through toolkit services, or typed against the removed union signatures. Standard chat-assistant customers: **no impact**.
- **Internal monorepo:** the legacy direct calls (`magic_table_dd/app.py`, `rfp_agent/service_container.py`) are handled by the agentic-table `service_context.py` bridge in monorepo#24666.

---

BREAKING CHANGE: MagicTableEvent no longer subclasses ChatEvent—use AssistantWebhookEvent for the shared envelope; get_initial_debug_info is ChatEvent-only (AttributeError otherwise). MagicTableBasePayload no longer carries stub user_message/assistant_message defaults.

## AI assist

Medium AI assist on structure, typings, compatibility notes, and type-safety review.

## Testing

- `pytest tests/app/test_schemas.py` (13 passed)
- `basedpyright unique_toolkit/app/schemas.py` (0 errors)
- CI on push

Made with [Cursor](https://cursor.com)


[UN-19308]: https://unique-ch.atlassian.net/browse/UN-19308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ