### PR TITLE
feat(web-search): redesign V3 as two-command (search / read_urls) tool

### DIFF
--- a/tool_packages/unique_web_search/src/unique_web_search/config.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/config.py
@@ -34,6 +34,7 @@ from unique_web_search.services.executors import (
     WebSearchModeConfig,
     WebSearchV1Config,
     WebSearchV2Config,
+    WebSearchV3Config,
     get_default_web_search_mode_config,
 )
 from unique_web_search.services.query_elicitation import QueryElicitationConfig
@@ -172,6 +173,11 @@ class WebSearchConfig(BaseToolConfig):
         title="Search Mode V2 Settings",
         description="Settings for the advanced AI-planned search mode (V2), including step limits and tool behavior.",
     )
+    web_search_mode_config_v3: WebSearchV3Config = Field(
+        default_factory=WebSearchV3Config,
+        title="Search Mode V3 Settings (Experimental)",
+        description="Settings for the agent-driven search mode (V3): the model itself chains snippet-only `search` calls with on-demand full-page `read_urls` calls per task.",
+    )
 
     # Todo [UN-17655] RJSF Tags don't function properly when using union + dscriminator
     search_engine_config: ActivatedSearchEngine = Field(  # type: ignore (This type is computed at runtime so pyright is not able to infer it)
@@ -253,6 +259,8 @@ class WebSearchConfig(BaseToolConfig):
     def web_search_mode_config(self) -> WebSearchModeConfig:
         if self.web_search_active_mode == WebSearchMode.V1:
             return self.web_search_mode_config_v1
+        if self.web_search_active_mode == WebSearchMode.V3:
+            return self.web_search_mode_config_v3
         return self.web_search_mode_config_v2
 
     @field_validator("web_search_active_mode", mode="before")

--- a/tool_packages/unique_web_search/src/unique_web_search/service.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/service.py
@@ -137,6 +137,11 @@ class WebSearchTool(Tool[WebSearchConfig]):
 
         tool_description = self.config.web_search_mode_config.tool_description
 
+        if self.config.web_search_mode_config.mode == WebSearchMode.V3:
+            tool_description = Template(tool_description).render(
+                tool_parameters_schema=WebSearchV3ToolParameters.schema_hint(),
+            )
+
         return LanguageModelToolDescription(
             name=self.name,
             description=tool_description,

--- a/tool_packages/unique_web_search/src/unique_web_search/service.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/service.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from datetime import datetime
 from time import time
 
@@ -34,6 +35,8 @@ from unique_web_search.services.executors import (
     WebSearchMode,
     WebSearchV1Executor,
     WebSearchV2Executor,
+    WebSearchV3Config,
+    WebSearchV3Executor,
 )
 from unique_web_search.services.executors.context import (
     ExecutorCallbacks,
@@ -42,6 +45,7 @@ from unique_web_search.services.executors.context import (
 )
 from unique_web_search.services.executors.v1.schema import WebSearchToolParameters
 from unique_web_search.services.executors.v2.schema import WebSearchPlan
+from unique_web_search.services.executors.v3.schema import WebSearchV3ToolParameters
 from unique_web_search.services.message_log import WebSearchMessageLogger
 from unique_web_search.services.query_elicitation import QueryElicitationService
 from unique_web_search.services.search_engine import (
@@ -123,10 +127,13 @@ class WebSearchTool(Tool[WebSearchConfig]):
                 self.config.web_search_mode_config.tool_parameters_description.date_restrict_description,
             )
         else:
-            engine_mode = self._resolve_search_engine_mode()
-            self.tool_parameter_calls = WebSearchPlan.with_search_engine_mode(
-                engine_mode
-            )
+            if self.config.web_search_mode_config.mode == WebSearchMode.V3:
+                self.tool_parameter_calls = WebSearchV3ToolParameters
+            else:
+                engine_mode = self._resolve_search_engine_mode()
+                self.tool_parameter_calls = WebSearchPlan.with_search_engine_mode(
+                    engine_mode
+                )
 
         tool_description = self.config.web_search_mode_config.tool_description
 
@@ -142,6 +149,11 @@ class WebSearchTool(Tool[WebSearchConfig]):
             return mode_config.tool_description_for_system_prompt
 
         template_str = mode_config.tool_description_for_system_prompt
+
+        if mode_config.mode == WebSearchMode.V3:
+            return Template(template_str).render(
+                date_string=datetime.now().strftime("%A %B %d, %Y"),
+            )
 
         # Backwards compatibility: V2 prompts persisted before the Jinja
         # migration use the legacy ``$max_steps`` placeholder. Jinja would
@@ -170,6 +182,8 @@ class WebSearchTool(Tool[WebSearchConfig]):
         )
 
     def tool_format_information_for_system_prompt(self) -> str:
+        if self.config.web_search_active_mode == WebSearchMode.V3:
+            return self.config.web_search_mode_config_v3.tool_format_information_for_system_prompt
         return self.config.tool_format_information_for_system_prompt
 
     def evaluation_check_list(self) -> list[EvaluationMetricName]:
@@ -190,7 +204,7 @@ class WebSearchTool(Tool[WebSearchConfig]):
 
         web_search_message_logger = WebSearchMessageLogger(
             message_step_logger=self._message_step_logger,
-            tool_display_name=self.display_name(),
+            tool_display_name=self._build_display_name(parameters),
         )
         executor = self._get_executor(
             tool_call, parameters, debug_info, web_search_message_logger
@@ -272,10 +286,10 @@ class WebSearchTool(Tool[WebSearchConfig]):
     def _get_executor(
         self,
         tool_call: LanguageModelFunction,
-        parameters: WebSearchPlan | WebSearchToolParameters,
+        parameters: WebSearchPlan | WebSearchToolParameters | WebSearchV3ToolParameters,
         debug_info: WebSearchDebugInfo,
         web_search_message_logger: WebSearchMessageLogger,
-    ) -> WebSearchV1Executor | WebSearchV2Executor:
+    ) -> WebSearchV1Executor | WebSearchV2Executor | WebSearchV3Executor:
         # Initialize query elicitation service and get callbacks
         elicitation_service = QueryElicitationService(
             chat_service=self._chat_service,
@@ -307,7 +321,17 @@ class WebSearchTool(Tool[WebSearchConfig]):
         )
 
         search_config = self.config.web_search_mode_config
+        if search_config.mode == WebSearchMode.V3:
+            assert isinstance(search_config, WebSearchV3Config)
+            assert isinstance(parameters, WebSearchV3ToolParameters)
 
+            return WebSearchV3Executor(
+                services=services,
+                config=config,
+                callbacks=callbacks,
+                tool_call=tool_call,
+                tool_parameters=parameters,
+            )
         if isinstance(parameters, WebSearchPlan):
             assert search_config.mode == WebSearchMode.V2
             return WebSearchV2Executor(
@@ -381,6 +405,23 @@ class WebSearchTool(Tool[WebSearchConfig]):
                 )
 
         return notify_from_tool_call
+
+    def _build_display_name(
+        self,
+        parameters: WebSearchPlan | WebSearchToolParameters | WebSearchV3ToolParameters,
+    ) -> str:
+        if not isinstance(parameters, WebSearchV3ToolParameters):
+            return self.display_name()
+
+        display_name = self.display_name()
+        # Remove "search" from the display name (case-insensitive, all occurrences).
+        display_name = re.sub(
+            r"\bsearch\b", "", display_name, flags=re.IGNORECASE
+        ).strip()
+
+        suffix = parameters.get_display_name_suffix()
+
+        return display_name + suffix
 
 
 ToolFactory.register_tool(WebSearchTool, WebSearchConfig)

--- a/tool_packages/unique_web_search/src/unique_web_search/services/executors/__init__.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/executors/__init__.py
@@ -17,10 +17,14 @@ from unique_web_search.services.executors.v2.config import WebSearchV2Config
 from unique_web_search.services.executors.v2.executor import (
     WebSearchV2Executor,
 )
+from unique_web_search.services.executors.v3.config import WebSearchV3Config
+from unique_web_search.services.executors.v3.executor import (
+    WebSearchV3Executor,
+)
 from unique_web_search.settings import env_settings
 
 _LOGGER = getLogger(__name__)
-WebSearchModeConfig = WebSearchV1Config | WebSearchV2Config
+WebSearchModeConfig = WebSearchV1Config | WebSearchV2Config | WebSearchV3Config
 
 
 def get_default_web_search_mode_config() -> WebSearchMode:
@@ -29,6 +33,8 @@ def get_default_web_search_mode_config() -> WebSearchMode:
             return WebSearchMode.V1
         case "v2":
             return WebSearchMode.V2
+        case "v3":
+            return WebSearchMode.V3
         case _:
             raise ValueError(f"Invalid web search mode: {env_settings.web_search_mode}")
 
@@ -37,11 +43,13 @@ __all__ = [
     "WebSearchModeConfig",
     "WebSearchV1Config",
     "WebSearchV2Config",
+    "WebSearchV3Config",
     "get_default_web_search_mode_config",
     "WebSearchMode",
     "RefineQueryMode",
     "WebSearchV1Executor",
     "WebSearchV2Executor",
+    "WebSearchV3Executor",
     "ExecutorServiceContext",
     "ExecutorConfiguration",
     "ExecutorCallbacks",

--- a/tool_packages/unique_web_search/src/unique_web_search/services/executors/base_config.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/executors/base_config.py
@@ -12,6 +12,7 @@ from unique_web_search.services.helpers import (
 class WebSearchMode(StrEnum):
     V1 = "v1"
     V2 = "v2"
+    V3 = "v3"
 
     @staticmethod
     def get_enum_names() -> list[str]:
@@ -22,6 +23,7 @@ class WebSearchMode(StrEnum):
         return [
             "V1 — Simple keyword searches with optional query refinement",
             "V2 — AI-planned multi-step research (search and read pages in sequence)",
+            "V3 (Experimental) — Agent-driven research: chains cheap snippet searches with on-demand full-page reads, deciding each step per task",
         ]
 
     @classmethod

--- a/tool_packages/unique_web_search/src/unique_web_search/services/executors/v3/__init__.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/executors/v3/__init__.py
@@ -1,0 +1,7 @@
+from unique_web_search.services.executors.v3.config import WebSearchV3Config
+from unique_web_search.services.executors.v3.executor import WebSearchV3Executor
+
+__all__ = [
+    "WebSearchV3Config",
+    "WebSearchV3Executor",
+]

--- a/tool_packages/unique_web_search/src/unique_web_search/services/executors/v3/config.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/executors/v3/config.py
@@ -1,0 +1,71 @@
+"""Configuration for Web Search V3 (search SERP + fetch URLs)."""
+
+from typing import Annotated, Literal
+
+from pydantic import Field, field_validator
+from pydantic.json_schema import SkipJsonSchema
+from unique_toolkit._common.pydantic.rjsf_tags import RJSFMetaTag
+from unique_toolkit.agentic.tools.config import get_configuration_dict
+
+from unique_web_search.prompts import (
+    DEFAULT_TOOL_FORMAT_INFORMATION_FOR_SYSTEM_PROMPT_V3,
+)
+from unique_web_search.services.executors.base_config import (
+    BaseWebSearchModeConfig,
+    WebSearchMode,
+)
+from unique_web_search.services.executors.v3.prompts import (
+    DEFAULT_TOOL_DESCRIPTION,
+    DEFAULT_TOOL_DESCRIPTION_FOR_SYSTEM_PROMPT,
+)
+from unique_web_search.services.helpers import clean_model_title_generator
+
+
+class WebSearchV3Config(BaseWebSearchModeConfig[WebSearchMode.V3]):
+    """V3 mode: ``search`` returns SERP rows as JSON chunks; ``fetch_urls`` crawls and processes pages."""
+
+    model_config = get_configuration_dict(
+        model_title_generator=clean_model_title_generator
+    )
+    mode: SkipJsonSchema[Literal[WebSearchMode.V3]] = WebSearchMode.V3
+
+    tool_description: Annotated[
+        str,
+        RJSFMetaTag.StringWidget.textarea(
+            rows=len(DEFAULT_TOOL_DESCRIPTION.split("\n"))
+        ),
+    ] = Field(
+        default=DEFAULT_TOOL_DESCRIPTION,
+        title="Tool Description",
+        description="Advanced: Description that helps the AI model decide when to use web search.",
+    )
+    tool_description_for_system_prompt: Annotated[
+        str,
+        RJSFMetaTag.StringWidget.textarea(
+            rows=int(len(DEFAULT_TOOL_DESCRIPTION_FOR_SYSTEM_PROMPT.split("\n")) / 2)
+        ),
+    ] = Field(
+        default=DEFAULT_TOOL_DESCRIPTION_FOR_SYSTEM_PROMPT,
+        title="Tool Description for System Prompt",
+        description="Advanced: Description that helps the AI model decide when to use web search (V3).",
+    )
+    tool_format_information_for_system_prompt: Annotated[
+        str,
+        RJSFMetaTag.StringWidget.textarea(
+            rows=int(
+                len(DEFAULT_TOOL_FORMAT_INFORMATION_FOR_SYSTEM_PROMPT_V3.split("\n"))
+                / 3
+            )
+        ),
+    ] = Field(
+        default=DEFAULT_TOOL_FORMAT_INFORMATION_FOR_SYSTEM_PROMPT_V3,
+        title="Tool Format Information For System Prompt",
+        description="Advanced: Instructions that tell the AI how to cite web search sources in its answers (V3 includes domain diversity requirements).",
+    )
+
+    @field_validator("mode", mode="before")
+    @classmethod
+    def validate_mode(cls, v: str) -> Literal["v3"]:
+        if "v3" in v.lower():
+            return "v3"
+        raise ValueError(f"Invalid mode: {v}")

--- a/tool_packages/unique_web_search/src/unique_web_search/services/executors/v3/executor.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/executors/v3/executor.py
@@ -1,0 +1,223 @@
+"""Web Search V3 executor: one command per invocation (``query`` search or ``urls`` fetch)."""
+
+from __future__ import annotations
+
+import json
+import logging
+from time import time
+
+from unidecode import unidecode
+from unique_toolkit.content import ContentChunk
+from unique_toolkit.language_model import LanguageModelFunction
+from unique_toolkit.monitoring import metric_scope
+
+from unique_web_search.metrics import (
+    crawl_duration,
+    crawl_errors,
+    search_duration,
+    search_errors,
+    search_total,
+)
+from unique_web_search.schema import StepDebugInfo
+from unique_web_search.services.executors.base_executor import BaseWebSearchExecutor
+from unique_web_search.services.executors.context import (
+    ExecutorCallbacks,
+    ExecutorConfiguration,
+    ExecutorServiceContext,
+)
+from unique_web_search.services.executors.v3.schema import (
+    FetchUrlsPayload,
+    SearchPayload,
+    WebSearchV3ToolParameters,
+)
+from unique_web_search.services.search_engine.schema import WebSearchResult
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class WebSearchV3Executor(BaseWebSearchExecutor[WebSearchV3ToolParameters]):
+    """Run either a ``query`` search (SERP-only JSON chunks) or a ``urls`` fetch (crawl + pipeline)."""
+
+    def __init__(
+        self,
+        services: ExecutorServiceContext,
+        config: ExecutorConfiguration,
+        callbacks: ExecutorCallbacks,
+        tool_call: LanguageModelFunction,
+        tool_parameters: WebSearchV3ToolParameters,
+    ):
+        super().__init__(
+            services=services,
+            config=config,
+            callbacks=callbacks,
+            tool_call=tool_call,
+            tool_parameters=tool_parameters,
+        )
+
+    async def run(self) -> list[ContentChunk]:
+        p = self.tool_parameters
+        if isinstance(p.payload, SearchPayload):
+            await self._message_log_callback.log_progress("_Executing Search_")
+            return await self._run_search(query=p.payload.query, objective=p.objective)
+        if isinstance(p.payload, FetchUrlsPayload):
+            await self._message_log_callback.log_progress("_Reading Web Pages_")
+            return await self._run_fetch_urls(
+                urls=p.payload.urls, objective=p.objective
+            )
+
+        msg = "WebSearchV3ToolParameters requires exactly one of 'query' or 'urls'."
+
+        raise ValueError(msg)
+
+    async def _run_search(
+        self,
+        *,
+        query: str,
+        objective: str,
+    ) -> list[ContentChunk]:
+        self.notify_name = "**Searching Web**"
+        self.notify_message = objective
+        await self.notify_callback()
+
+        elicited = await self._ff_elicitate_queries([query])
+        query = elicited[0]
+
+        self.debug_info.steps.append(
+            StepDebugInfo(
+                step_name="SEARCH",
+                execution_time=0,
+                config={
+                    "objective": objective,
+                    "query": query,
+                },
+            )
+        )
+
+        engine = self.search_service.config.search_engine_name.value
+        time_start = time()
+        _LOGGER.info(
+            "Company %s Searching with %s", self.company_id, self.search_service
+        )
+
+        await self._message_log_callback.log_queries([query])
+        with metric_scope(search_duration, search_errors, engine=engine):
+            search_total.labels(engine=engine).inc()
+            results = await self.search_service.search(query)
+        await self._message_log_callback.log_web_search_results(results)
+
+        delta_time = time() - time_start
+        self.debug_info.steps.append(
+            StepDebugInfo(
+                step_name="SEARCH.search",
+                execution_time=delta_time,
+                config=self.search_service.config.search_engine_name.name,
+                extra={
+                    "query": query,
+                    "number_of_results": len(results),
+                    "urls": [result.url for result in results],
+                },
+            )
+        )
+        _LOGGER.info("Searched with %s in %s seconds", self.search_service, delta_time)
+
+        chunks = self._serp_results_to_content_chunks(results)
+        return chunks
+
+    def _serp_results_to_content_chunks(
+        self, results: list[WebSearchResult]
+    ) -> list[ContentChunk]:
+        """One chunk per SERP row; ``text`` is JSON with url, domain, title, snippet."""
+        out: list[ContentChunk] = []
+        for i, r in enumerate(results):
+            payload = {
+                "url": r.url,
+                "domain": r.display_link,
+                "title": r.title,
+                "snippet": r.snippet,
+            }
+            if r.content:
+                payload["content"] = r.content
+
+            text = json.dumps(payload, ensure_ascii=False)
+
+            title_ascii = unidecode(r.title)
+            name = f'{r.display_link}: "{title_ascii}"'
+            out.append(
+                ContentChunk(
+                    id=name,
+                    text=text,
+                    order=i,
+                    start_page=None,
+                    end_page=None,
+                    key=name,
+                    chunk_id=str(i),
+                    url=r.url,
+                    title=name,
+                )
+            )
+        return out
+
+    async def _run_fetch_urls(
+        self,
+        *,
+        urls: list[str],
+        objective: str,
+    ) -> list[ContentChunk]:
+        self.notify_name = "**Reading Web Pages**"
+        self.notify_message = objective
+        await self.notify_callback()
+
+        self.debug_info.steps.append(
+            StepDebugInfo(
+                step_name="FETCH_URLS",
+                execution_time=0,
+                config={
+                    "objective": objective,
+                    "urls": list(urls),
+                },
+            )
+        )
+
+        urls = list(urls)
+        crawler = self.crawler_service.config.crawler_type.value
+        time_start = time()
+        _LOGGER.info("Company %s Crawling %s URLs", self.company_id, len(urls))
+
+        await self._message_log_callback.log_queries(urls)
+        with metric_scope(crawl_duration, crawl_errors, crawler=crawler):
+            contents = await self.crawler_service.crawl(urls)
+        delta_time = time() - time_start
+
+        results = [
+            WebSearchResult(url=u, content=c, snippet="", title="")
+            for u, c in zip(urls, contents)
+        ]
+        await self._message_log_callback.log_web_search_results(results)
+
+        self.debug_info.steps.append(
+            StepDebugInfo(
+                step_name="FETCH_URLS.crawl",
+                execution_time=delta_time,
+                config=self.crawler_service.config.crawler_type.name,
+                extra={"urls": urls, "number_of_results": len(results)},
+            )
+        )
+
+        self.notify_name = "**Analyzing Web Pages**"
+        self.notify_message = objective
+        await self.notify_callback()
+        await self._message_log_callback.log_progress("_Analyzing Web Pages_")
+
+        content_focus = objective
+        content_results = await self._content_processing(content_focus, results)
+
+        if self.chunk_relevancy_sort_config.enabled:
+            self.notify_name = "**Resorting Sources**"
+            self.notify_message = objective
+            await self.notify_callback()
+            await self._message_log_callback.log_progress("_Resorting Sources_")
+
+        flat_chunks = await self._select_relevant_sources(
+            content_focus, content_results
+        )
+        return flat_chunks

--- a/tool_packages/unique_web_search/src/unique_web_search/services/executors/v3/prompts/__init__.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/executors/v3/prompts/__init__.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+from unique_web_search.utils import load_template
+
+_PROMPTS_DIR = Path(__file__).parent
+
+DEFAULT_TOOL_DESCRIPTION: str = load_template(_PROMPTS_DIR, "tool_description.j2")
+DEFAULT_TOOL_DESCRIPTION_FOR_SYSTEM_PROMPT: str = load_template(
+    _PROMPTS_DIR, "tool_description_for_system_prompt.j2"
+)

--- a/tool_packages/unique_web_search/src/unique_web_search/services/executors/v3/prompts/tool_description.j2
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/executors/v3/prompts/tool_description.j2
@@ -1,0 +1,16 @@
+The WebSearch tool returns up-to-date information from the web. It exposes two capabilities, picked per call via `command`:
+
+- **Search** (`command: "search"`) — runs the configured search engine and returns SERP rows (URL, domain, title, snippet). Gives a high-level read of what relevant pages contain without crawling them. Useful for **exploration** and quick lookups when a snippet is enough to answer.
+- **Fetch** (`command: "read_urls"`) — crawls one or more URLs and returns full-page text. Useful for **deep dives** when the task is complex and needs exact figures, quotes, regulatory text, or specs, and when the user provides a URL directly.
+
+Each call performs **one** operation. Drive multi-part tasks by chaining calls.
+
+### Fields
+
+- **`command`** — `"search"` or `"read_urls"`.
+- **`objective`** — One concise sentence: what this call is meant to accomplish.
+- **`payload`** — Shape depends on `command`:
+  - For `"search"`: `{ "gap": <what this query is meant to fill>, "query": <search engine query> }`.
+  - For `"read_urls"`: `{ "urls": [<HTTP(S) URLs to crawl>] }`. Use only URLs returned by a prior search or pasted by the user — never invent URLs.
+
+For a deeper playbook on when to search vs fetch (snippet hedging, canonical-source topics, sub-question decomposition, URL-selection rules, anti-patterns), activate the `web-search-v3` skill before/while using this tool.

--- a/tool_packages/unique_web_search/src/unique_web_search/services/executors/v3/prompts/tool_description.j2
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/executors/v3/prompts/tool_description.j2
@@ -7,10 +7,8 @@ Each call performs **one** operation. Drive multi-part tasks by chaining calls.
 
 ### Fields
 
-- **`command`** — `"search"` or `"read_urls"`.
-- **`objective`** — One concise sentence: what this call is meant to accomplish.
-- **`payload`** — Shape depends on `command`:
-  - For `"search"`: `{ "gap": <what this query is meant to fill>, "query": <search engine query> }`.
-  - For `"read_urls"`: `{ "urls": [<HTTP(S) URLs to crawl>] }`. Use only URLs returned by a prior search or pasted by the user — never invent URLs.
+{{ tool_parameters_schema }}
+
+Never invent URLs.
 
 For a deeper playbook on when to search vs fetch (snippet hedging, canonical-source topics, sub-question decomposition, URL-selection rules, anti-patterns), activate the `web-search-v3` skill before/while using this tool.

--- a/tool_packages/unique_web_search/src/unique_web_search/services/executors/v3/prompts/tool_description_for_system_prompt.j2
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/executors/v3/prompts/tool_description_for_system_prompt.j2
@@ -27,14 +27,6 @@ Use it when:
 
 **Current date:** {{ date_string }}
 
-### Fields
-
-- **`command`** (string, per call) — `"search"` or `"read_urls"`.
-- **`objective`** (string, per call) — One concise sentence: what this call is meant to accomplish.
-- **`payload`** (object, per call) — Shape depends on `command`:
-  - For `"search"`: `{ "gap": <what this query is meant to fill>, "query": <focused 3-8 keyword query; query operators allowed> }`. For time-sensitive topics you may incorporate **{{ date_string }}** (year or month) in the query.
-  - For `"read_urls"`: `{ "urls": [<HTTP(S) URLs to crawl>] }`. Use only URLs returned by a prior search or pasted by the user — **never invent URLs**.
-
 ### Balance exploration and exploitation
 
 - **Explore first.** Start with `command: "search"` to get a cheap, high-level read of candidate pages. Cover one `gap` per call.

--- a/tool_packages/unique_web_search/src/unique_web_search/services/executors/v3/prompts/tool_description_for_system_prompt.j2
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/executors/v3/prompts/tool_description_for_system_prompt.j2
@@ -1,0 +1,48 @@
+Use `WebSearch` for up-to-date information from the web. It exposes two capabilities, picked per call via `command`. Each invocation performs **one** operation; complex user tasks are handled by **chaining** invocations.
+
+#### `command: "search"` — search the web
+
+Runs the configured search engine and returns SERP rows (URL, domain, title, snippet). It is **fast** and gives a **high-level read** of what relevant pages contain without paying the cost of crawling them.
+
+Use it when:
+
+- You need to **discover sources**: you don't yet have URLs and need the engine to surface candidates for a topic.
+- The user's question can be answered from **snippets alone** — a definition, a status, a current value, a short factual lookup.
+- You're at the **start of a complex task** and need to map out what's out there before deciding which pages are worth a deeper read.
+- You want to **scope or sanity-check** a topic cheaply (does this entity / event / product even exist? how recent is the latest coverage?).
+- You need to **cover a new gap / sub-question** in a multi-step task — issue another search rather than blindly fetching.
+
+#### `command: "read_urls"` — fetch full page content
+
+Crawls one or more URLs and returns the full-page text. It is **slower** than search but gives the **complete content** of the chosen pages, not just a snippet.
+
+Use it when:
+
+- The user **pasted a URL** or asked you to read a specific page — go straight here, do not search first.
+- The task is **complex / in-depth** and needs more than a snippet: exact figures, full quotes, regulatory text, contract language, statute numbers, API specs, version numbers.
+- The previous search returned **paraphrased / hedged snippets** ("around", "approximately", "is expected to", "reportedly") for a question that needs precision.
+- The topic is **canonical-source-driven** — financial filings (10-K, 10-Q, earnings releases), regulator publications, official product docs, peer-reviewed papers, primary press releases — where the page itself is the source of truth.
+- You found a **highly relevant** SERP hit but the title/snippet alone doesn't support the claim you want to make.
+- The snippets from the previous "search" commands are relevant but do not fully answer the question or fill the gap and fetching the full page is necessary.
+
+**Current date:** {{ date_string }}
+
+### Fields
+
+- **`command`** (string, per call) — `"search"` or `"read_urls"`.
+- **`objective`** (string, per call) — One concise sentence: what this call is meant to accomplish.
+- **`payload`** (object, per call) — Shape depends on `command`:
+  - For `"search"`: `{ "gap": <what this query is meant to fill>, "query": <focused 3-8 keyword query; query operators allowed> }`. For time-sensitive topics you may incorporate **{{ date_string }}** (year or month) in the query.
+  - For `"read_urls"`: `{ "urls": [<HTTP(S) URLs to crawl>] }`. Use only URLs returned by a prior search or pasted by the user — **never invent URLs**.
+
+### Balance exploration and exploitation
+
+- **Explore first.** Start with `command: "search"` to get a cheap, high-level read of candidate pages. Cover one `gap` per call.
+- **Refine, don't escalate prematurely.** If the first search did not fill the `gap`, issue another `command: "search"` with a refined query (different keywords, narrower entity, different timeframe) before reaching for `read_urls`.
+- **Exploit when snippets aren't enough.** Switch to `command: "read_urls"` when snippets paraphrase / hedge, or the task needs exact figures, quotes, regulatory text, specs, or canonical-source content. Pick **1-3 high-signal URLs** from the most recent SERP — complementary domains preferred.
+- **User-provided URLs go straight to fetch.** If the user pasted URL(s), the first call should be `command: "read_urls"`. Do not "search" for a URL the user already supplied.
+- **Latency is a fair trade.** `read_urls` takes longer than `search`. That latency is acceptable on complex queries where the user expects depth — give them the answer that's actually grounded. Don't fetch when a snippet already answers the question; don't refuse to fetch when the snippet doesn't.
+
+For the deeper explore-then-exploit playbook (snippet hedging triggers, canonical-source topics, sub-question decomposition, URL-selection rules, anti-patterns, worked examples), activate the `web-search-v3` skill before/while using this tool.
+
+Tool arguments are defined by the tool schema; the live JSON schema comes from the tool definition.

--- a/tool_packages/unique_web_search/src/unique_web_search/services/executors/v3/schema.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/executors/v3/schema.py
@@ -1,0 +1,51 @@
+"""V3 WebSearch tool parameters: a flat schema with exactly one of ``query`` or ``urls`` per call."""
+
+from enum import StrEnum
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class Command(StrEnum):
+    SEARCH = "search"
+    FETCH_URLS = "read_urls"
+
+
+class SearchPayload(BaseModel):
+    gap: str = Field(
+        description="A brief description of the gap that the query is meant to fill"
+    )
+    query: str = Field(
+        description="Search query for the configured search engine. Query must be fixed for the entire rounds."
+    )
+
+
+class FetchUrlsPayload(BaseModel):
+    urls: list[str] = Field(
+        description="HTTP(S) URLs to crawl for full-page text. Use only URLs returned by a prior search or pasted by the user."
+    )
+
+
+class WebSearchV3ToolParameters(BaseModel):
+    """Root JSON for the V3 WebSearch tool: set exactly one of ``query`` or ``urls``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    command: Command = Field(
+        description="The command to execute. Must be either 'search' or 'read_urls'."
+    )
+
+    objective: str = Field(
+        description="One concise sentence: what this call is meant to accomplish."
+    )
+
+    payload: SearchPayload | FetchUrlsPayload = Field(
+        description="The payload of the command. Must be either a SearchPayload or a FetchUrlsPayload."
+    )
+
+    def get_display_name_suffix(self) -> str:
+        if self.command == Command.SEARCH:
+            return " - Searching"
+        elif self.command == Command.FETCH_URLS:
+            return " - Reading Pages"
+        else:
+            raise ValueError(f"Invalid command: {self.command}")

--- a/tool_packages/unique_web_search/src/unique_web_search/services/executors/v3/schema.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/executors/v3/schema.py
@@ -1,5 +1,6 @@
 """V3 WebSearch tool parameters: a flat schema with exactly one of ``query`` or ``urls`` per call."""
 
+import typing
 from enum import StrEnum
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -41,6 +42,45 @@ class WebSearchV3ToolParameters(BaseModel):
     payload: SearchPayload | FetchUrlsPayload = Field(
         description="The payload of the command. Must be either a SearchPayload or a FetchUrlsPayload."
     )
+
+    @classmethod
+    def schema_hint(cls) -> str:
+        """Return a markdown-bulleted hint mirroring the field descriptions of this model.
+
+        Mirrors the legacy hand-written prompt block: one bullet per top-level
+        field, with the ``payload`` bullet expanded into one inline JSON sketch
+        per ``command`` value (since ``payload`` is a discriminated union).
+        Field descriptions are inlined as ``<...>`` placeholders so the prompt
+        stays in sync with the Pydantic model.
+        """
+
+        def _inline_json(payload_model: type[BaseModel]) -> str:
+            parts: list[str] = []
+            for name, field in payload_model.model_fields.items():
+                placeholder = f"<{field.description or name}>"
+                if typing.get_origin(field.annotation) is list:
+                    placeholder = f"[{placeholder}]"
+                parts.append(f'"{name}": {placeholder}')
+            return "{ " + ", ".join(parts) + " }"
+
+        lines: list[str] = []
+        for name, field in cls.model_fields.items():
+            if name == "command":
+                choices = " or ".join(f'`"{c.value}"`' for c in Command)
+                lines.append(f"- **`{name}`** — {choices}.")
+            elif name == "payload":
+                continue
+            else:
+                lines.append(f"- **`{name}`** — {field.description or name}")
+
+        lines.append("- **`payload`** — Shape depends on `command`:")
+        for cmd, payload_model in (
+            (Command.SEARCH, SearchPayload),
+            (Command.FETCH_URLS, FetchUrlsPayload),
+        ):
+            lines.append(f'  - For `"{cmd.value}"`: `{_inline_json(payload_model)}`.')
+
+        return "\n".join(lines)
 
     def get_display_name_suffix(self) -> str:
         if self.command == Command.SEARCH:

--- a/tool_packages/unique_web_search/src/unique_web_search/skills/web-search-v3.md
+++ b/tool_packages/unique_web_search/src/unique_web_search/skills/web-search-v3.md
@@ -1,0 +1,261 @@
+---
+name: web-search
+description: >-
+  Use this skill when the WebSearch tool is being used and the task is
+  non-trivial. Explains how to balance the `search` capability (SERP
+  snippets, cheap exploration) against the `read_urls` capability
+  (full-page fetch, deeper but slower) based on snippet hedging,
+  canonical-source topics, and sub-question coverage.
+---
+
+# WebSearch — Explore → Exploit Playbook
+
+Use the `WebSearch` tool for up-to-date information from the web. It exposes
+two capabilities, picked per call via `command`:
+
+- **Search** (`command: "search"`) — runs the search engine and returns SERP
+  rows (URL, domain, title, snippet). High-level read of what relevant pages
+  contain without crawling them. Useful for **exploration** and quick
+  lookups.
+- **Fetch** (`command: "read_urls"`) — crawls one or more URLs and returns
+  full-page text. Useful for **deep dives** when the task is complex and
+  needs exact figures, quotes, regulatory text, or specs, and when the user
+  provides a URL directly.
+
+Each invocation performs **one** operation. Complex user tasks are handled
+by **chaining** invocations.
+
+## Decision flow
+
+```mermaid
+flowchart TD
+    Start[User task] --> HasUrl{User pasted URL?}
+    HasUrl -- yes --> Fetch["command: read_urls<br/>payload.urls"]
+    HasUrl -- no --> Search["command: search<br/>payload.gap + payload.query"]
+    Search --> Check{Snippets fill the gap?}
+    Check -- "yes, more gaps remain" --> Search
+    Check -- "yes, all covered" --> Answer[Answer]
+    Check -- "no (hedged / exact text / canonical source)" --> Fetch
+    Fetch --> Answer
+```
+
+## Tool fields
+
+- **`command`** (string, per call) — `"search"` or `"read_urls"`.
+- **`objective`** (string, per call) — One concise sentence: what this call
+  is meant to accomplish.
+- **`payload`** (object, per call) — Shape depends on `command`:
+  - For `"search"`:
+    - **`gap`** — A brief description of what this query is meant to fill
+      (the specific missing fact / facet / sub-question).
+    - **`query`** — One focused search query (3-8 keywords; query operators
+      allowed). For time-sensitive topics you may incorporate the current
+      year or month to improve recall.
+  - For `"read_urls"`:
+    - **`urls`** — HTTP(S) URLs to crawl for full-page text. Use only URLs
+      returned by a prior `search` call or pasted by the user — **never
+      invent URLs**.
+
+## Step 1 — Decide complexity (in your head, not in the tool args)
+
+Read the user task and silently classify it:
+
+- **Simple** when the task fits ALL of:
+  - One concrete fact, definition, value, status, or short list to look up.
+  - One entity (one company, one person, one product, one place, one document).
+  - One timeframe (one date, one quarter, one year — or timeless).
+  - One ask (no comparison, no "and", no "vs", no "compared to", no "across").
+- **Complex** when ANY of the following hold:
+  - Multiple distinct facts the user wants in one answer.
+  - Comparison or contrast across ≥2 entities, products, jurisdictions, or vendors.
+  - Multiple time windows (e.g. "in 2023 vs 2024", "before and after the IPO").
+  - Composite reasoning that needs sub-answers chained together.
+  - Vague / multi-faceted topics the user expects you to cover broadly.
+
+For complex tasks, decompose into 2-5 self-contained sub-questions and run
+**one `command: "search"` per sub-question** (and follow-up
+`command: "read_urls"` calls as needed). Each sub-question should:
+
+- Be answerable on its own by one focused search (and possibly one fetch
+  follow-up).
+- Not depend on the answer of another sub-question.
+- Cover a distinct entity / facet / timeframe — no overlap.
+
+## Step 2 — Execute one operation per call
+
+- Use **`command: "search"`** when you need the search engine to discover
+  sources or craft a query. Set `payload.gap` to the specific gap you're
+  trying to fill and `payload.query` to one focused 3-8 keyword string. For
+  time-sensitive topics, include the current year or month in the query.
+- Use **`command: "read_urls"`** when the URL(s) to read are already known:
+  the user pasted them, asked you to read a specific page, **or** a
+  previous `search` call returned them and snippets are not enough. Pass
+  the URL(s) from the `url` fields of those snippet chunks — do not invent
+  or paraphrase URLs.
+
+If the user pasted URL(s) at the start of the task, your **first** call
+should use `command: "read_urls"`. Do not run a search to "find" a URL the
+user already supplied.
+
+## Step 3 — Sufficiency check after every search
+
+Before deciding the next call, judge the snippets you just received against
+the current `objective` and `gap`:
+
+- Do they contain the **specific** number, quote, date, or name the
+  `objective` requires? (Snippets often paraphrase or truncate.)
+- Are there **≥2 corroborating domains** for fact-style claims, when
+  accuracy matters?
+- Is the **freshness** consistent with the question?
+- Are key entities / context disambiguated (right company, right region,
+  right version)?
+
+Decide:
+
+- **Snippets sufficient** + still uncovered sub-questions ⇒ next call is
+  another `command: "search"` for the next sub-question.
+- **Snippets sufficient** + all sub-questions covered (or task was simple)
+  ⇒ stop calling and answer.
+- **Snippets insufficient** ⇒ go to Step 4.
+
+### Triggers that mean snippets are not sufficient
+
+Follow up with `command: "read_urls"` (1-3 high-signal URLs from the SERP
+just returned) whenever any of these holds:
+
+- Snippets **paraphrase** or **hedge** ("reportedly", "around",
+  "approximately", "is expected to") and the task wants exact figures,
+  quotes, or names.
+- The task needs **exact text** — quotations, regulatory clauses, contract
+  language, statute numbers, API specs, exam syllabus, version numbers.
+- The topic is **canonical-source-driven**: financial filings (10-K, 10-Q,
+  earnings releases), regulator publications (SEC, FINMA, ESMA, EU), official
+  product documentation, peer-reviewed papers, court rulings, primary press
+  releases. Snippets summarize these; the page is the source of truth.
+- A hit is **highly relevant** but the title/snippet alone cannot support
+  the claim you want to make.
+
+Fetching takes longer than searching. That latency is a fair trade on
+complex queries where the user expects depth — don't refuse to fetch when
+the snippet doesn't actually answer the question. Conversely, don't fetch
+just to "be thorough" when a snippet already answers cleanly.
+
+## Step 4 — Fetch follow-up (when snippets aren't enough)
+
+Issue a follow-up call with:
+
+- `command: "read_urls"`.
+- An `objective` like "Read full article X to extract <missing detail> for
+  <sub-question Y>".
+- `payload.urls` set to a **small, high-signal** subset (typically 1-3
+  URLs; pick complementary domains) of URLs from the `url` fields of the
+  SERP JSON you already received.
+
+Once the page text comes back, do another sufficiency check. If the task is
+complex and more sub-questions remain, continue with the next
+`command: "search"`; otherwise, answer.
+
+### URL-selection rules
+
+- Pick URLs from the **`url` fields of recent SERP chunks** only — never
+  type, paraphrase, or guess a URL.
+- Prefer the **smallest set** that fills the gap (1-3 URLs is usually
+  enough). If you need many pages, issue **additional**
+  `command: "read_urls"` calls rather than one giant list.
+- Prefer **complementary domains** (e.g. one official source + one
+  independent corroborator) over multiple URLs from the same domain.
+- For canonical-source topics, prioritize the **issuer's own page** (the
+  regulator, the company, the standards body) over secondary coverage.
+
+## Anti-patterns (do not do these)
+
+- Packing several sub-questions into one bloated `query`. Split them across
+  calls instead, one `gap` per call.
+- Running `command: "search"` "just in case" before reading a URL the user
+  already provided.
+- Calling `command: "read_urls"` with paraphrased or invented URLs — only
+  URLs surfaced by a prior search (or pasted by the user) are valid.
+- Refetching pages already crawled in this task.
+- Re-deciding mid-task whether the task is simple or complex — keep the
+  plan stable for the whole task.
+- Setting a `payload` shape that doesn't match `command` (e.g. `urls` under
+  a `"search"` command, or `query` under a `"read_urls"` command).
+
+## Worked examples
+
+### Simple — one search is enough
+
+User: "What is the current US Fed funds target rate?"
+
+```json
+{
+  "command": "search",
+  "objective": "Look up the current Fed funds target rate range.",
+  "payload": {
+    "gap": "Current Fed funds target rate range and effective date.",
+    "query": "current Fed funds target rate"
+  }
+}
+```
+
+If the snippets clearly state the range with a recent date, answer. If they
+hedge ("around", "expected to"), follow up with `command: "read_urls"` on
+the top SERP hit.
+
+### Simple — user pasted a URL, go straight to fetch
+
+User: "Read https://example.com/policy.pdf and summarize."
+
+```json
+{
+  "command": "read_urls",
+  "objective": "Read the user-provided policy document and summarize it.",
+  "payload": {
+    "urls": ["https://example.com/policy.pdf"]
+  }
+}
+```
+
+### Complex — one search per sub-question
+
+User: "Compare Stripe and Adyen on cross-border fees, settlement times, and
+EU PSD2 compliance."
+
+Decomposed sub-questions (kept in your head, not in the tool args):
+
+1. Stripe cross-border fees and pricing for international card transactions
+2. Adyen cross-border fees and pricing for international card transactions
+3. Stripe settlement and payout times by region
+4. Adyen settlement and payout times by region
+5. Stripe and Adyen positioning under EU PSD2 / SCA requirements
+
+First call (cover sub-question 1):
+
+```json
+{
+  "command": "search",
+  "objective": "Cover sub-question 1: Stripe cross-border fees and pricing.",
+  "payload": {
+    "gap": "Stripe cross-border / international card transaction fee percentages.",
+    "query": "Stripe cross-border international card transaction fees pricing"
+  }
+}
+```
+
+### Complex follow-up — weak snippets, fetch the source page
+
+After call 1 above, the snippets paraphrase Stripe's pricing instead of
+giving exact percentages. Follow up:
+
+```json
+{
+  "command": "read_urls",
+  "objective": "Read Stripe's official pricing page to extract exact cross-border fee percentages.",
+  "payload": {
+    "urls": ["https://stripe.com/pricing"]
+  }
+}
+```
+
+Then resume with the next sub-question (`command: "search"` for Adyen
+cross-border fees), and so on.

--- a/tool_packages/unique_web_search/tests/test_config.py
+++ b/tool_packages/unique_web_search/tests/test_config.py
@@ -16,6 +16,7 @@ from unique_web_search.config import (
 )
 from unique_web_search.prompts import (
     DEFAULT_TOOL_FORMAT_INFORMATION_FOR_SYSTEM_PROMPT,
+    DEFAULT_TOOL_FORMAT_INFORMATION_FOR_SYSTEM_PROMPT_V3,
 )
 from unique_web_search.services.crawlers.base import CrawlerType
 from unique_web_search.services.crawlers.basic import BasicCrawlerConfig
@@ -27,8 +28,7 @@ from unique_web_search.services.executors.v1.config import (
     WebSearchV1Config,
 )
 from unique_web_search.services.executors.v2.config import WebSearchV2Config
-
-# from unique_web_search.services.executors.v3.config import WebSearchV3Config
+from unique_web_search.services.executors.v3.config import WebSearchV3Config
 from unique_web_search.services.search_engine.base import SearchEngineType
 from unique_web_search.services.search_engine.google import GoogleConfig
 
@@ -201,9 +201,9 @@ class TestWebSearchV2Config:
             WebSearchV2Config(mode="v1")
         assert "Invalid mode" in str(exc_info.value)
 
-        # with pytest.raises(ValidationError) as exc_info:
-        #     WebSearchV2Config(mode="v3")
-        # assert "Invalid mode" in str(exc_info.value)
+        with pytest.raises(ValidationError) as exc_info:
+            WebSearchV2Config(mode="v3")
+        assert "Invalid mode" in str(exc_info.value)
 
         with pytest.raises(ValidationError) as exc_info:
             WebSearchV2Config(mode="invalid")
@@ -226,20 +226,20 @@ class TestExperimentalFeatures:
         assert config.tool_response_system_reminder.get_reminder_prompt == ""
 
 
-# class TestWebSearchV3Config:
-#     """Test cases for WebSearchV3Config."""
+class TestWebSearchV3Config:
+    """Test cases for WebSearchV3Config."""
 
-#     def test_web_search_v3_config_tool_format_information_default(self) -> None:
-#         """V3 citation instructions default to the full V3 template including domain diversity."""
-#         config = WebSearchV3Config()
+    def test_web_search_v3_config_tool_format_information_default(self) -> None:
+        """V3 citation instructions default to the full V3 template including domain diversity."""
+        config = WebSearchV3Config()
 
-#         assert (
-#             config.tool_format_information_for_system_prompt
-#             == DEFAULT_TOOL_FORMAT_INFORMATION_FOR_SYSTEM_PROMPT_V3
-#         )
-#         assert "Domain Diversity Requirement" in (
-#             config.tool_format_information_for_system_prompt
-#         )
+        assert (
+            config.tool_format_information_for_system_prompt
+            == DEFAULT_TOOL_FORMAT_INFORMATION_FOR_SYSTEM_PROMPT_V3
+        )
+        assert "Domain Diversity Requirement" in (
+            config.tool_format_information_for_system_prompt
+        )
 
 
 class TestQueryRefinementConfig:
@@ -640,11 +640,11 @@ class TestWebSearchConfig:
         )
         assert config_v1.web_search_active_mode == WebSearchMode.V1
 
-        # config_v3 = WebSearchConfig(
-        #     language_model=mock_language_model_info,
-        #     web_search_active_mode="v3",
-        # )
-        # assert config_v3.web_search_active_mode == WebSearchMode.V3
+        config_v3 = WebSearchConfig(
+            language_model=mock_language_model_info,
+            web_search_active_mode="v3",
+        )
+        assert config_v3.web_search_active_mode == WebSearchMode.V3
 
         config_invalid = WebSearchConfig(
             language_model=mock_language_model_info,

--- a/tool_packages/unique_web_search/tests/test_executors.py
+++ b/tool_packages/unique_web_search/tests/test_executors.py
@@ -17,16 +17,15 @@ from unique_web_search.services.executors.v2.executor import (
     WebSearchV2Executor,
 )
 from unique_web_search.services.executors.v2.schema import Step, StepType, WebSearchPlan
-
-# from unique_web_search.services.executors.v3.executor import (
-#     WebSearchV3Executor,
-# )
-# from unique_web_search.services.executors.v3.schema import (
-#     Command,
-#     FetchUrlsPayload,
-#     SearchPayload,
-#     WebSearchV3ToolParameters,
-# )
+from unique_web_search.services.executors.v3.executor import (
+    WebSearchV3Executor,
+)
+from unique_web_search.services.executors.v3.schema import (
+    Command,
+    FetchUrlsPayload,
+    SearchPayload,
+    WebSearchV3ToolParameters,
+)
 from unique_web_search.services.search_engine.schema import WebSearchResult
 
 
@@ -720,196 +719,196 @@ class TestWebSearchV2ExecutorExecuteSearchStep:
         ].log_web_search_results.assert_called()
 
 
-# class TestWebSearchV3ExecutorSearch:
-#     """Tests for WebSearchV3Executor ``search`` (SERP-only JSON chunks)."""
+class TestWebSearchV3ExecutorSearch:
+    """Tests for WebSearchV3Executor ``search`` (SERP-only JSON chunks)."""
 
-#     @pytest.mark.ai
-#     @pytest.mark.asyncio
-#     async def test_run_search__returns_json_chunks_without_crawl(
-#         self,
-#         executor_context_objects: dict,
-#         mock_executor_dependencies: dict,
-#     ) -> None:
-#         """V3 search maps SERP rows to ContentChunks with JSON bodies; no crawl or judge."""
-#         import json
+    @pytest.mark.ai
+    @pytest.mark.asyncio
+    async def test_run_search__returns_json_chunks_without_crawl(
+        self,
+        executor_context_objects: dict,
+        mock_executor_dependencies: dict,
+    ) -> None:
+        """V3 search maps SERP rows to ContentChunks with JSON bodies; no crawl or judge."""
+        import json
 
-#         tool_parameters = WebSearchV3ToolParameters.model_validate(
-#             {
-#                 "command": "search",
-#                 "objective": "Find recent search hits about NVIDIA coverage",
-#                 "payload": {
-#                     "gap": "Need fresh NVIDIA press coverage",
-#                     "query": "nvidia coverage",
-#                 },
-#             }
-#         )
+        tool_parameters = WebSearchV3ToolParameters.model_validate(
+            {
+                "command": "search",
+                "objective": "Find recent search hits about NVIDIA coverage",
+                "payload": {
+                    "gap": "Need fresh NVIDIA press coverage",
+                    "query": "nvidia coverage",
+                },
+            }
+        )
 
-#         serp = [
-#             WebSearchResult(
-#                 url="https://example.com/page1",
-#                 title="Page 1",
-#                 snippet="Snippet 1",
-#                 content="",
-#             ),
-#             WebSearchResult(
-#                 url="https://example.com/page2",
-#                 title="Page 2",
-#                 snippet="Snippet 2",
-#                 content="",
-#             ),
-#         ]
-#         mock_executor_dependencies["search_service"].search = AsyncMock(
-#             return_value=serp
-#         )
-#         mock_executor_dependencies[
-#             "search_service"
-#         ].config.search_engine_name.name = "TEST"
-#         mock_executor_dependencies["crawler_service"].crawl = AsyncMock()
+        serp = [
+            WebSearchResult(
+                url="https://example.com/page1",
+                title="Page 1",
+                snippet="Snippet 1",
+                content="",
+            ),
+            WebSearchResult(
+                url="https://example.com/page2",
+                title="Page 2",
+                snippet="Snippet 2",
+                content="",
+            ),
+        ]
+        mock_executor_dependencies["search_service"].search = AsyncMock(
+            return_value=serp
+        )
+        mock_executor_dependencies[
+            "search_service"
+        ].config.search_engine_name.name = "TEST"
+        mock_executor_dependencies["crawler_service"].crawl = AsyncMock()
 
-#         executor = WebSearchV3Executor(
-#             services=executor_context_objects["services"],
-#             config=executor_context_objects["config"],
-#             callbacks=executor_context_objects["callbacks"],
-#             tool_call=mock_executor_dependencies["tool_call"],
-#             tool_parameters=tool_parameters,
-#         )
-#         result = await executor.run()
+        executor = WebSearchV3Executor(
+            services=executor_context_objects["services"],
+            config=executor_context_objects["config"],
+            callbacks=executor_context_objects["callbacks"],
+            tool_call=mock_executor_dependencies["tool_call"],
+            tool_parameters=tool_parameters,
+        )
+        result = await executor.run()
 
-#         mock_executor_dependencies["crawler_service"].crawl.assert_not_called()
-#         assert len(result) == 2
-#         first = json.loads(result[0].text)
-#         assert first["url"] == "https://example.com/page1"
-#         assert first["domain"] == "example.com"
-#         assert first["title"] == "Page 1"
-#         assert first["snippet"] == "Snippet 1"
-
-
-# class TestWebSearchV3ExecutorFetchUrls:
-#     """Tests for WebSearchV3Executor ``read_urls`` (crawl + content pipeline)."""
-
-#     @pytest.mark.ai
-#     @pytest.mark.asyncio
-#     async def test_run_fetch_urls__invokes_crawler_not_search(
-#         self,
-#         executor_context_objects: dict,
-#         mock_executor_dependencies: dict,
-#     ) -> None:
-#         """V3 read_urls calls the crawler with the supplied URLs and skips the search engine."""
-#         urls = [
-#             "https://example.com/page1",
-#             "https://example.com/page2",
-#         ]
-#         tool_parameters = WebSearchV3ToolParameters.model_validate(
-#             {
-#                 "command": "read_urls",
-#                 "objective": "Read the linked articles for full text",
-#                 "payload": {"urls": urls},
-#             }
-#         )
-
-#         mock_executor_dependencies["crawler_service"].crawl = AsyncMock(
-#             return_value=["content1", "content2"]
-#         )
-#         mock_executor_dependencies["crawler_service"].config.crawler_type.name = "TEST"
-#         mock_executor_dependencies["content_processor"].run = AsyncMock(return_value=[])
-#         mock_executor_dependencies["chunk_relevancy_sort_config"].enabled = False
-#         mock_executor_dependencies["content_reducer"].return_value = []
-
-#         executor = WebSearchV3Executor(
-#             services=executor_context_objects["services"],
-#             config=executor_context_objects["config"],
-#             callbacks=executor_context_objects["callbacks"],
-#             tool_call=mock_executor_dependencies["tool_call"],
-#             tool_parameters=tool_parameters,
-#         )
-#         result = await executor.run()
-
-#         mock_executor_dependencies["crawler_service"].crawl.assert_called_once_with(
-#             urls
-#         )
-#         mock_executor_dependencies["search_service"].search.assert_not_called()
-#         mock_executor_dependencies["content_processor"].run.assert_awaited_once()
-#         assert isinstance(result, list)
+        mock_executor_dependencies["crawler_service"].crawl.assert_not_called()
+        assert len(result) == 2
+        first = json.loads(result[0].text)
+        assert first["url"] == "https://example.com/page1"
+        assert first["domain"] == "example.com"
+        assert first["title"] == "Page 1"
+        assert first["snippet"] == "Snippet 1"
 
 
-# class TestWebSearchV3ToolParametersValidation:
-#     """Validators on the V3 tool parameter schema (``command``/``objective``/``payload``)."""
+class TestWebSearchV3ExecutorFetchUrls:
+    """Tests for WebSearchV3Executor ``read_urls`` (crawl + content pipeline)."""
 
-#     @pytest.mark.ai
-#     def test_search_command_with_search_payload_parses(self) -> None:
-#         """``command='search'`` with a ``SearchPayload`` validates and round-trips."""
-#         params = WebSearchV3ToolParameters.model_validate(
-#             {
-#                 "command": "search",
-#                 "objective": "Look up the current Fed funds target rate.",
-#                 "payload": {
-#                     "gap": "Need the current target rate",
-#                     "query": "fed funds rate",
-#                 },
-#             }
-#         )
-#         assert params.command == Command.SEARCH
-#         assert isinstance(params.payload, SearchPayload)
-#         assert params.payload.query == "fed funds rate"
+    @pytest.mark.ai
+    @pytest.mark.asyncio
+    async def test_run_fetch_urls__invokes_crawler_not_search(
+        self,
+        executor_context_objects: dict,
+        mock_executor_dependencies: dict,
+    ) -> None:
+        """V3 read_urls calls the crawler with the supplied URLs and skips the search engine."""
+        urls = [
+            "https://example.com/page1",
+            "https://example.com/page2",
+        ]
+        tool_parameters = WebSearchV3ToolParameters.model_validate(
+            {
+                "command": "read_urls",
+                "objective": "Read the linked articles for full text",
+                "payload": {"urls": urls},
+            }
+        )
 
-#     @pytest.mark.ai
-#     def test_read_urls_command_with_fetch_urls_payload_parses(self) -> None:
-#         """``command='read_urls'`` with a ``FetchUrlsPayload`` validates and round-trips."""
-#         params = WebSearchV3ToolParameters.model_validate(
-#             {
-#                 "command": "read_urls",
-#                 "objective": "Read the linked SEC filing for exact figures.",
-#                 "payload": {
-#                     "urls": [
-#                         "https://www.sec.gov/Archives/edgar/data/foo/10-k.htm",
-#                     ],
-#                 },
-#             }
-#         )
-#         assert params.command == Command.FETCH_URLS
-#         assert isinstance(params.payload, FetchUrlsPayload)
-#         assert params.payload.urls == [
-#             "https://www.sec.gov/Archives/edgar/data/foo/10-k.htm",
-#         ]
+        mock_executor_dependencies["crawler_service"].crawl = AsyncMock(
+            return_value=["content1", "content2"]
+        )
+        mock_executor_dependencies["crawler_service"].config.crawler_type.name = "TEST"
+        mock_executor_dependencies["content_processor"].run = AsyncMock(return_value=[])
+        mock_executor_dependencies["chunk_relevancy_sort_config"].enabled = False
+        mock_executor_dependencies["content_reducer"].return_value = []
 
-#     @pytest.mark.ai
-#     def test_extra_fields_are_rejected(self) -> None:
-#         """Top-level ``extra='forbid'`` rejects unknown keys (no legacy fields allowed)."""
-#         with pytest.raises(ValueError):
-#             WebSearchV3ToolParameters.model_validate(
-#                 {
-#                     "command": "search",
-#                     "objective": "Anything",
-#                     "payload": {"gap": "g", "query": "q"},
-#                     "task_complexity": "simple",
-#                 }
-#             )
+        executor = WebSearchV3Executor(
+            services=executor_context_objects["services"],
+            config=executor_context_objects["config"],
+            callbacks=executor_context_objects["callbacks"],
+            tool_call=mock_executor_dependencies["tool_call"],
+            tool_parameters=tool_parameters,
+        )
+        result = await executor.run()
 
-#     @pytest.mark.ai
-#     def test_command_enum_values(self) -> None:
-#         """The ``Command`` enum exposes exactly ``search`` and ``read_urls``."""
-#         assert Command("search") is Command.SEARCH
-#         assert Command("read_urls") is Command.FETCH_URLS
+        mock_executor_dependencies["crawler_service"].crawl.assert_called_once_with(
+            urls
+        )
+        mock_executor_dependencies["search_service"].search.assert_not_called()
+        mock_executor_dependencies["content_processor"].run.assert_awaited_once()
+        assert isinstance(result, list)
 
-#     @pytest.mark.ai
-#     def test_get_display_name_suffix_per_command(self) -> None:
-#         """Display-name suffix differs per command for UI clarity."""
-#         search_params = WebSearchV3ToolParameters.model_validate(
-#             {
-#                 "command": "search",
-#                 "objective": "Search obj",
-#                 "payload": {"gap": "g", "query": "q"},
-#             }
-#         )
-#         fetch_params = WebSearchV3ToolParameters.model_validate(
-#             {
-#                 "command": "read_urls",
-#                 "objective": "Fetch obj",
-#                 "payload": {"urls": ["https://example.com/a"]},
-#             }
-#         )
-#         assert search_params.get_display_name_suffix() == " - Searching"
-#         assert fetch_params.get_display_name_suffix() == " - Reading Pages"
+
+class TestWebSearchV3ToolParametersValidation:
+    """Validators on the V3 tool parameter schema (``command``/``objective``/``payload``)."""
+
+    @pytest.mark.ai
+    def test_search_command_with_search_payload_parses(self) -> None:
+        """``command='search'`` with a ``SearchPayload`` validates and round-trips."""
+        params = WebSearchV3ToolParameters.model_validate(
+            {
+                "command": "search",
+                "objective": "Look up the current Fed funds target rate.",
+                "payload": {
+                    "gap": "Need the current target rate",
+                    "query": "fed funds rate",
+                },
+            }
+        )
+        assert params.command == Command.SEARCH
+        assert isinstance(params.payload, SearchPayload)
+        assert params.payload.query == "fed funds rate"
+
+    @pytest.mark.ai
+    def test_read_urls_command_with_fetch_urls_payload_parses(self) -> None:
+        """``command='read_urls'`` with a ``FetchUrlsPayload`` validates and round-trips."""
+        params = WebSearchV3ToolParameters.model_validate(
+            {
+                "command": "read_urls",
+                "objective": "Read the linked SEC filing for exact figures.",
+                "payload": {
+                    "urls": [
+                        "https://www.sec.gov/Archives/edgar/data/foo/10-k.htm",
+                    ],
+                },
+            }
+        )
+        assert params.command == Command.FETCH_URLS
+        assert isinstance(params.payload, FetchUrlsPayload)
+        assert params.payload.urls == [
+            "https://www.sec.gov/Archives/edgar/data/foo/10-k.htm",
+        ]
+
+    @pytest.mark.ai
+    def test_extra_fields_are_rejected(self) -> None:
+        """Top-level ``extra='forbid'`` rejects unknown keys (no legacy fields allowed)."""
+        with pytest.raises(ValueError):
+            WebSearchV3ToolParameters.model_validate(
+                {
+                    "command": "search",
+                    "objective": "Anything",
+                    "payload": {"gap": "g", "query": "q"},
+                    "task_complexity": "simple",
+                }
+            )
+
+    @pytest.mark.ai
+    def test_command_enum_values(self) -> None:
+        """The ``Command`` enum exposes exactly ``search`` and ``read_urls``."""
+        assert Command("search") is Command.SEARCH
+        assert Command("read_urls") is Command.FETCH_URLS
+
+    @pytest.mark.ai
+    def test_get_display_name_suffix_per_command(self) -> None:
+        """Display-name suffix differs per command for UI clarity."""
+        search_params = WebSearchV3ToolParameters.model_validate(
+            {
+                "command": "search",
+                "objective": "Search obj",
+                "payload": {"gap": "g", "query": "q"},
+            }
+        )
+        fetch_params = WebSearchV3ToolParameters.model_validate(
+            {
+                "command": "read_urls",
+                "objective": "Fetch obj",
+                "payload": {"urls": ["https://example.com/a"]},
+            }
+        )
+        assert search_params.get_display_name_suffix() == " - Searching"
+        assert fetch_params.get_display_name_suffix() == " - Reading Pages"
 
 
 class TestWebSearchV2ExecutorExecuteReadUrlStep:

--- a/tool_packages/unique_web_search/tests/test_service.py
+++ b/tool_packages/unique_web_search/tests/test_service.py
@@ -6,8 +6,7 @@ import pytest
 from unique_web_search.service import WebSearchTool
 from unique_web_search.services.executors.v1.schema import WebSearchToolParameters
 from unique_web_search.services.executors.v2.schema import WebSearchPlan
-
-# from unique_web_search.services.executors.v3.schema import WebSearchV3ToolParameters
+from unique_web_search.services.executors.v3.schema import WebSearchV3ToolParameters
 
 
 class TestWebSearchToolDescription:
@@ -181,38 +180,38 @@ class TestWebSearchToolDescriptionForSystemPrompt:
         assert "must not exceed 5 steps" in result
         assert "$max_steps" not in result
 
-    # @pytest.mark.ai
-    # def test_tool_description_for_system_prompt__renders_jinja__when_mode_is_v3(
-    #     self,
-    #     mock_web_search_config_v3: Mock,
-    #     mocker: Any,
-    # ) -> None:
-    #     """
-    #     Purpose: Verify tool_description_for_system_prompt renders Jinja placeholders for V3.
-    #     Why this matters: V3 uses dynamic date in the system prompt template.
-    #     Setup summary: Mock WebSearchTool with V3 config containing Jinja placeholders.
-    #     """
-    #     from unique_web_search.services.search_engine.base import SearchEngineType
+    @pytest.mark.ai
+    def test_tool_description_for_system_prompt__renders_jinja__when_mode_is_v3(
+        self,
+        mock_web_search_config_v3: Mock,
+        mocker: Any,
+    ) -> None:
+        """
+        Purpose: Verify tool_description_for_system_prompt renders Jinja placeholders for V3.
+        Why this matters: V3 uses dynamic date in the system prompt template.
+        Setup summary: Mock WebSearchTool with V3 config containing Jinja placeholders.
+        """
+        from unique_web_search.services.search_engine.base import SearchEngineType
 
-    #     mocker.patch("unique_web_search.service.get_search_engine_service")
-    #     mocker.patch("unique_web_search.service.get_crawler_service")
-    #     mocker.patch("unique_web_search.service.ChunkRelevancySorter")
-    #     mocker.patch("unique_web_search.service.ContentProcessor")
-    #     mocker.patch.object(
-    #         WebSearchTool, "__init__", lambda self, config, *args, **kwargs: None
-    #     )
+        mocker.patch("unique_web_search.service.get_search_engine_service")
+        mocker.patch("unique_web_search.service.get_crawler_service")
+        mocker.patch("unique_web_search.service.ChunkRelevancySorter")
+        mocker.patch("unique_web_search.service.ContentProcessor")
+        mocker.patch.object(
+            WebSearchTool, "__init__", lambda self, config, *args, **kwargs: None
+        )
 
-    #     tool = WebSearchTool.__new__(WebSearchTool)
-    #     tool.config = mock_web_search_config_v3
-    #     mock_engine = Mock()
-    #     mock_engine.config.search_engine_name = SearchEngineType.GOOGLE
-    #     tool.search_engine_service = mock_engine
+        tool = WebSearchTool.__new__(WebSearchTool)
+        tool.config = mock_web_search_config_v3
+        mock_engine = Mock()
+        mock_engine.config.search_engine_name = SearchEngineType.GOOGLE
+        tool.search_engine_service = mock_engine
 
-    #     result: str = tool.tool_description_for_system_prompt()
+        result: str = tool.tool_description_for_system_prompt()
 
-    #     assert isinstance(result, str)
-    #     assert result.startswith("V3 system prompt with ")
-    #     assert "{{ date_string }}" not in result
+        assert isinstance(result, str)
+        assert result.startswith("V3 system prompt with ")
+        assert "{{ date_string }}" not in result
 
 
 class TestWebSearchToolFormatInformation:
@@ -245,33 +244,33 @@ class TestWebSearchToolFormatInformation:
         assert isinstance(result, str)
         assert result == "Test format info"
 
-    # @pytest.mark.ai
-    # def test_tool_format_information_for_system_prompt__returns_v3_nested_value(
-    #     self,
-    #     mock_web_search_config_v3: Mock,
-    #     mocker: Any,
-    # ) -> None:
-    #     """
-    #     Purpose: Verify V3 citation instructions come from Search Mode V3 settings, not root + append.
-    #     Why this matters: V3 has a single configured prompt without runtime concatenation.
-    #     """
-    #     mocker.patch("unique_web_search.service.get_search_engine_service")
-    #     mocker.patch("unique_web_search.service.get_crawler_service")
-    #     mocker.patch("unique_web_search.service.ChunkRelevancySorter")
-    #     mocker.patch("unique_web_search.service.ContentProcessor")
-    #     mocker.patch.object(
-    #         WebSearchTool, "__init__", lambda self, config, *args, **kwargs: None
-    #     )
+    @pytest.mark.ai
+    def test_tool_format_information_for_system_prompt__returns_v3_nested_value(
+        self,
+        mock_web_search_config_v3: Mock,
+        mocker: Any,
+    ) -> None:
+        """
+        Purpose: Verify V3 citation instructions come from Search Mode V3 settings, not root + append.
+        Why this matters: V3 has a single configured prompt without runtime concatenation.
+        """
+        mocker.patch("unique_web_search.service.get_search_engine_service")
+        mocker.patch("unique_web_search.service.get_crawler_service")
+        mocker.patch("unique_web_search.service.ChunkRelevancySorter")
+        mocker.patch("unique_web_search.service.ContentProcessor")
+        mocker.patch.object(
+            WebSearchTool, "__init__", lambda self, config, *args, **kwargs: None
+        )
 
-    #     tool = WebSearchTool.__new__(WebSearchTool)
-    #     tool.config = mock_web_search_config_v3
+        tool = WebSearchTool.__new__(WebSearchTool)
+        tool.config = mock_web_search_config_v3
 
-    #     result: str = tool.tool_format_information_for_system_prompt()
+        result: str = tool.tool_format_information_for_system_prompt()
 
-    #     assert result == (
-    #         mock_web_search_config_v3.web_search_mode_config_v3.tool_format_information_for_system_prompt
-    #     )
-    #     assert "Domain Diversity Requirement" in result
+        assert result == (
+            mock_web_search_config_v3.web_search_mode_config_v3.tool_format_information_for_system_prompt
+        )
+        assert "Domain Diversity Requirement" in result
 
 
 class TestWebSearchToolEvaluationCheckList:
@@ -742,86 +741,86 @@ class TestWebSearchToolRun:
 
         assert result.system_reminder == ""
 
-    # @pytest.mark.ai
-    # @pytest.mark.asyncio
-    # async def test_run__system_reminder_uses_experimental_prompt__when_enabled_for_v3(
-    #     self,
-    #     mock_web_search_config_v3: Mock,
-    #     sample_content_chunks: list,
-    #     mocker: Any,
-    # ) -> None:
-    #     """
-    #     Purpose: Verify run sets system_reminder from experimental features when enabled (V3).
-    #     Why this matters: Tool response reminder is independent of system-prompt citation instructions.
-    #     """
-    #     rem = mock_web_search_config_v3.experimental_features.tool_response_system_reminder
-    #     rem.enable_system_reminder = True
-    #     rem.system_reminder_prompt = (
-    #         "Test format info\n\n## Domain Diversity Requirement\n\n"
-    #         "When the current WebSearch tool response"
-    #     )
-    #     rem.get_reminder_prompt = rem.system_reminder_prompt
-    #     mock_executor = AsyncMock()
-    #     mock_executor.run = AsyncMock(return_value=sample_content_chunks)
-    #     mock_executor.notify_name = "test-name"
-    #     mock_executor.notify_message = "test-message"
+    @pytest.mark.ai
+    @pytest.mark.asyncio
+    async def test_run__system_reminder_uses_experimental_prompt__when_enabled_for_v3(
+        self,
+        mock_web_search_config_v3: Mock,
+        sample_content_chunks: list,
+        mocker: Any,
+    ) -> None:
+        """
+        Purpose: Verify run sets system_reminder from experimental features when enabled (V3).
+        Why this matters: Tool response reminder is independent of system-prompt citation instructions.
+        """
+        rem = mock_web_search_config_v3.experimental_features.tool_response_system_reminder
+        rem.enable_system_reminder = True
+        rem.system_reminder_prompt = (
+            "Test format info\n\n## Domain Diversity Requirement\n\n"
+            "When the current WebSearch tool response"
+        )
+        rem.get_reminder_prompt = rem.system_reminder_prompt
+        mock_executor = AsyncMock()
+        mock_executor.run = AsyncMock(return_value=sample_content_chunks)
+        mock_executor.notify_name = "test-name"
+        mock_executor.notify_message = "test-message"
 
-    #     mocker.patch("unique_web_search.service.get_search_engine_service")
-    #     mocker.patch("unique_web_search.service.get_crawler_service")
-    #     mocker.patch("unique_web_search.service.ChunkRelevancySorter")
-    #     mocker.patch("unique_web_search.service.ContentProcessor")
+        mocker.patch("unique_web_search.service.get_search_engine_service")
+        mocker.patch("unique_web_search.service.get_crawler_service")
+        mocker.patch("unique_web_search.service.ChunkRelevancySorter")
+        mocker.patch("unique_web_search.service.ContentProcessor")
 
-    #     mock_debug_info_class = Mock()
-    #     mock_debug_info_instance = Mock()
-    #     mock_debug_info_instance.model_dump.return_value = {"test": "debug_info"}
-    #     mock_debug_info_instance.num_chunks_in_final_prompts = None
-    #     mock_debug_info_instance.execution_time = None
-    #     mock_debug_info_class.return_value = mock_debug_info_instance
-    #     mocker.patch(
-    #         "unique_web_search.service.WebSearchDebugInfo", mock_debug_info_class
-    #     )
+        mock_debug_info_class = Mock()
+        mock_debug_info_instance = Mock()
+        mock_debug_info_instance.model_dump.return_value = {"test": "debug_info"}
+        mock_debug_info_instance.num_chunks_in_final_prompts = None
+        mock_debug_info_instance.execution_time = None
+        mock_debug_info_class.return_value = mock_debug_info_instance
+        mocker.patch(
+            "unique_web_search.service.WebSearchDebugInfo", mock_debug_info_class
+        )
 
-    #     mock_message_logger = Mock()
-    #     mock_message_logger.finished = AsyncMock()
-    #     mock_message_logger.failed = AsyncMock()
-    #     mocker.patch(
-    #         "unique_web_search.service.WebSearchMessageLogger",
-    #         return_value=mock_message_logger,
-    #     )
+        mock_message_logger = Mock()
+        mock_message_logger.finished = AsyncMock()
+        mock_message_logger.failed = AsyncMock()
+        mocker.patch(
+            "unique_web_search.service.WebSearchMessageLogger",
+            return_value=mock_message_logger,
+        )
 
-    #     mocker.patch.object(
-    #         WebSearchTool, "__init__", lambda self, config, *args, **kwargs: None
-    #     )
-    #     mocker.patch.object(WebSearchTool, "_get_executor", return_value=mock_executor)
+        mocker.patch.object(
+            WebSearchTool, "__init__", lambda self, config, *args, **kwargs: None
+        )
+        mocker.patch.object(WebSearchTool, "_get_executor", return_value=mock_executor)
 
-    #     tool = WebSearchTool.__new__(WebSearchTool)
-    #     tool.config = mock_web_search_config_v3
-    #     tool.tool_parameter_calls = WebSearchV3ToolParameters
-    #     tool.logger = Mock()
-    #     tool._message_step_logger = Mock()
-    #     tool._tool_progress_reporter = None
-    #     tool._display_name = "WebSearch"
-    #     tool.company_id = "test-company"
-    #     tool.debug = False
-    #     tool.name = "WebSearch"
-    #     tool.settings = Mock()
-    #     tool.settings.display_name = "WebSearch"
-    #     tool._get_argument_screening_service_if_ff_enabled = AsyncMock(
-    #         return_value=None
-    #     )
+        tool = WebSearchTool.__new__(WebSearchTool)
+        tool.config = mock_web_search_config_v3
+        tool.tool_parameter_calls = WebSearchV3ToolParameters
+        tool.logger = Mock()
+        tool._message_step_logger = Mock()
+        tool._tool_progress_reporter = None
+        tool._display_name = "WebSearch"
+        tool.company_id = "test-company"
+        tool.debug = False
+        tool.name = "WebSearch"
+        tool.settings = Mock()
+        tool.settings.display_name = "WebSearch"
+        tool._get_argument_screening_service_if_ff_enabled = AsyncMock(
+            return_value=None
+        )
 
-    #     tool_call = Mock()
-    #     tool_call.id = "test-id"
-    #     tool_call.arguments = {
-    #         "command": "search",
-    #         "objective": "Test sub-goal for this search",
-    #         "payload": {"gap": "Test gap to fill", "query": "test"},
-    #     }
+        tool_call = Mock()
+        tool_call.id = "test-id"
+        tool_call.arguments = {
+            "command": "search",
+            "objective": "Test sub-goal for this search",
+            "payload": {"gap": "Test gap to fill", "query": "test"},
+        }
 
-    #     result = await tool.run(tool_call)
+        result = await tool.run(tool_call)
 
-    #     assert "Test format info" in result.system_reminder
-    #     assert "Domain Diversity Requirement" in result.system_reminder
+        assert "Test format info" in result.system_reminder
+        assert "Domain Diversity Requirement" in result.system_reminder
 
     @pytest.mark.ai
     @pytest.mark.asyncio

--- a/tool_packages/unique_web_search/tests/test_web_search_mode.py
+++ b/tool_packages/unique_web_search/tests/test_web_search_mode.py
@@ -43,15 +43,15 @@ class TestWebSearchModeEnum:
         mode = WebSearchMode("v2")
         assert mode == WebSearchMode.V2
 
-    # def test_web_search_mode_v3_value(self):
-    #     """Test WebSearchMode.V3 has correct value."""
-    #     assert WebSearchMode.V3 == "v3"
-    #     assert WebSearchMode.V3.value == "v3"
+    def test_web_search_mode_v3_value(self):
+        """Test WebSearchMode.V3 has correct value."""
+        assert WebSearchMode.V3 == "v3"
+        assert WebSearchMode.V3.value == "v3"
 
-    # def test_web_search_mode_from_string_v3(self):
-    #     """Test creating WebSearchMode from string 'v3'."""
-    #     mode = WebSearchMode("v3")
-    #     assert mode == WebSearchMode.V3
+    def test_web_search_mode_from_string_v3(self):
+        """Test creating WebSearchMode from string 'v3'."""
+        mode = WebSearchMode("v3")
+        assert mode == WebSearchMode.V3
 
     def test_web_search_mode_missing_alias_v2_beta_lowercase(self):
         """Test WebSearchMode._missing_ handles 'v2 (beta)' alias correctly."""
@@ -87,10 +87,10 @@ class TestWebSearchModeEnum:
         """Labels must align with JSON schema enum order (V1, V2, V3)."""
         names = WebSearchMode.get_enum_names()
         members = list(WebSearchMode)
-        assert members == [WebSearchMode.V1, WebSearchMode.V2]
+        assert members == [WebSearchMode.V1, WebSearchMode.V2, WebSearchMode.V3]
         assert names[0].startswith("V1")
         assert names[1].startswith("V2")
-        # assert names[2].startswith("V3")
+        assert names[2].startswith("V3")
 
 
 class TestGetDefaultWebSearchModeConfig:
@@ -114,14 +114,14 @@ class TestGetDefaultWebSearchModeConfig:
             result = get_default_web_search_mode_config()
             assert result == WebSearchMode.V2
 
-    # def test_get_default_returns_v3_when_env_is_v3(self):
-    #     """Test get_default_web_search_mode_config returns V3 when env is 'v3'."""
-    #     with patch(
-    #         "unique_web_search.services.executors.env_settings"
-    #     ) as mock_settings:
-    #         mock_settings.web_search_mode = "v3"
-    #         result = get_default_web_search_mode_config()
-    #         assert result == WebSearchMode.V3
+    def test_get_default_returns_v3_when_env_is_v3(self):
+        """Test get_default_web_search_mode_config returns V3 when env is 'v3'."""
+        with patch(
+            "unique_web_search.services.executors.env_settings"
+        ) as mock_settings:
+            mock_settings.web_search_mode = "v3"
+            result = get_default_web_search_mode_config()
+            assert result == WebSearchMode.V3
 
     def test_get_default_raises_error_for_invalid_mode(self):
         """Test get_default_web_search_mode_config raises ValueError for invalid mode."""
@@ -247,15 +247,15 @@ class TestWebSearchConfigDefaultMode:
         )
         assert config.web_search_mode_config.mode == WebSearchMode.V2
 
-    # def test_web_search_config_mode_selects_correct_config_v3(
-    #     self, mock_language_model_info
-    # ):
-    #     """Test WebSearchConfig.web_search_mode_config returns V3 config when mode is V3."""
-    #     config = WebSearchConfig(
-    #         language_model=mock_language_model_info,
-    #         web_search_active_mode=WebSearchMode.V3,
-    #     )
-    #     assert config.web_search_mode_config.mode == WebSearchMode.V3
+    def test_web_search_config_mode_selects_correct_config_v3(
+        self, mock_language_model_info
+    ):
+        """Test WebSearchConfig.web_search_mode_config returns V3 config when mode is V3."""
+        config = WebSearchConfig(
+            language_model=mock_language_model_info,
+            web_search_active_mode=WebSearchMode.V3,
+        )
+        assert config.web_search_mode_config.mode == WebSearchMode.V3
 
     def test_web_search_config_accepts_string_mode(self, mock_language_model_info):
         """Test WebSearchConfig accepts string values for web_search_active_mode."""
@@ -273,21 +273,21 @@ class TestWebSearchConfigDefaultMode:
         )
         assert config.web_search_active_mode == WebSearchMode.V2
 
-    # def test_web_search_config_accepts_v3_string(self, mock_language_model_info):
-    #     """Test WebSearchConfig accepts 'v3' for web_search_active_mode."""
-    #     config = WebSearchConfig(
-    #         language_model=mock_language_model_info,
-    #         web_search_active_mode="v3",  # type: ignore
-    #     )
-    #     assert config.web_search_active_mode == WebSearchMode.V3
+    def test_web_search_config_accepts_v3_string(self, mock_language_model_info):
+        """Test WebSearchConfig accepts 'v3' for web_search_active_mode."""
+        config = WebSearchConfig(
+            language_model=mock_language_model_info,
+            web_search_active_mode="v3",  # type: ignore
+        )
+        assert config.web_search_active_mode == WebSearchMode.V3
 
-    # def test_web_search_config_accepts_v3_beta_alias(self, mock_language_model_info):
-    #     """Test WebSearchConfig accepts 'v3 (beta)' alias for web_search_active_mode."""
-    #     config = WebSearchConfig(
-    #         language_model=mock_language_model_info,
-    #         web_search_active_mode="v3 (beta)",  # type: ignore
-    #     )
-    #     assert config.web_search_active_mode == WebSearchMode.V3
+    def test_web_search_config_accepts_v3_beta_alias(self, mock_language_model_info):
+        """Test WebSearchConfig accepts 'v3 (beta)' alias for web_search_active_mode."""
+        config = WebSearchConfig(
+            language_model=mock_language_model_info,
+            web_search_active_mode="v3 (beta)",  # type: ignore
+        )
+        assert config.web_search_active_mode == WebSearchMode.V3
 
     def test_web_search_config_rejects_invalid_mode(self, mock_language_model_info):
         """Test WebSearchConfig defaults to v1 for invalid web_search_active_mode values."""
@@ -375,11 +375,11 @@ class TestWebSearchModeIntegration:
         )
         assert config_v2.web_search_mode_config == config_v2.web_search_mode_config_v2
 
-        # config_v3 = WebSearchConfig(
-        #     language_model=mock_language_model_info,
-        #     web_search_active_mode=WebSearchMode.V3,
-        # )
-        # assert config_v3.web_search_mode_config == config_v3.web_search_mode_config_v3
+        config_v3 = WebSearchConfig(
+            language_model=mock_language_model_info,
+            web_search_active_mode=WebSearchMode.V3,
+        )
+        assert config_v3.web_search_mode_config == config_v3.web_search_mode_config_v3
 
 
 class TestWebSearchModeEdgeCases:


### PR DESCRIPTION
## 🚀 Summary
Ref: UN-19831

- **V3 redesigned as a two-command tool.** Each call performs **one** operation, picked via `command`:
  - `command: "search"` — runs the search engine and returns SERP rows (URL, domain, title, snippet) as JSON `ContentChunk`s. No crawl, no LLM judge.
  - `command: "read_urls"` — crawls the chosen URLs and runs them through the standard content pipeline.
  Multi-step research is driven by the LLM chaining calls; the new `web-search-v3` agent skill (`skills/web-search-v3.md`) ships the explore-then-exploit playbook.
- **V3 schema simplified** to `command` + `objective` + a discriminated `payload` (`SearchPayload{gap, query}` or `FetchUrlsPayload{urls}`). The old `user_intent` / `task_complexity` / `sub_questions` / `action` / `search` / `fetch_urls` fields are gone.
- **V3 mode label** in `WebSearchMode.get_enum_names()` updated to describe the new design (was still describing the old snippet-judge pipeline).