### PR TITLE
refactor(pydantic-helpers): introduce list_of and dict_of for default factories

### DIFF
--- a/unique_toolkit/tests/_common/config_checker/test_differ.py
+++ b/unique_toolkit/tests/_common/config_checker/test_differ.py
@@ -7,6 +7,7 @@ from unique_toolkit._common.config_checker.differ import (
     ConfigDiffer,
     DefaultChangeReport,
 )
+from unique_toolkit._common.pydantic_helpers import list_of
 
 
 class SimpleConfig(BaseModel):
@@ -21,7 +22,7 @@ class NestedConfig(BaseModel):
 
 class ListConfig(BaseModel):
     items: list[str] = Field(default_factory=lambda: ["a", "b"])
-    tags: list[int] = Field(default_factory=list)
+    tags: list[int] = Field(default_factory=list_of(int))
 
 
 class DictConfig(BaseModel):

--- a/unique_toolkit/tests/_common/test_pydantic_helpers.py
+++ b/unique_toolkit/tests/_common/test_pydantic_helpers.py
@@ -13,8 +13,10 @@ from unique_toolkit._common.pydantic_helpers import (
     create_complement_model,
     create_intersection_model,
     create_union_model,
+    dict_of,
     field_title_generator,
     get_configuration_dict,
+    list_of,
     model_title_generator,
 )
 
@@ -469,11 +471,11 @@ class TestEdgeCases:
         class ModelA(BaseModel):
             simple_field: str
             optional_field: Optional[str] = None
-            list_field: list[str] = Field(default_factory=list)
+            list_field: list[str] = Field(default_factory=list_of(str))
 
         class ModelB(BaseModel):
             simple_field: str
-            dict_field: dict[str, int] = Field(default_factory=dict)
+            dict_field: dict[str, int] = Field(default_factory=dict_of(str, int))
 
         # Test union
         union_model = create_union_model(ModelA, ModelB, "ComplexUnion")
@@ -695,7 +697,9 @@ class TestNoneToDefault:
         from typing import Annotated
 
         class Model(BaseModel):
-            items: Annotated[list[str], NoneToDefault] = Field(default_factory=list)
+            items: Annotated[list[str], NoneToDefault] = Field(
+                default_factory=list_of(str)
+            )
 
         instance = Model(items=None)
 
@@ -782,7 +786,9 @@ class TestNoneToDefault:
         from typing import Annotated
 
         class Model(BaseModel):
-            items: Annotated[list[str], NoneToDefault] = Field(default_factory=list)
+            items: Annotated[list[str], NoneToDefault] = Field(
+                default_factory=list_of(str)
+            )
 
         a = Model(items=None)
         b = Model(items=None)

--- a/unique_toolkit/unique_toolkit/_common/config_checker/differ.py
+++ b/unique_toolkit/unique_toolkit/_common/config_checker/differ.py
@@ -9,6 +9,7 @@ from deepdiff import DeepDiff
 from pydantic import BaseModel, Field
 
 from unique_toolkit._common.config_checker.models import DefaultChange
+from unique_toolkit._common.pydantic_helpers import list_of
 
 logger = logging.getLogger(__name__)
 
@@ -17,7 +18,7 @@ class DefaultChangeReport(BaseModel):
     """Report of detected default changes."""
 
     config_name: str
-    changes: list[DefaultChange] = Field(default_factory=list)
+    changes: list[DefaultChange] = Field(default_factory=list_of(DefaultChange))
 
     def has_changes(self) -> bool:
         """Check if there are any changes."""

--- a/unique_toolkit/unique_toolkit/_common/config_checker/exporter.py
+++ b/unique_toolkit/unique_toolkit/_common/config_checker/exporter.py
@@ -15,6 +15,7 @@ from unique_toolkit._common.config_checker.models import (
     ConfigEntry,
     EnvironmentVarWarning,
 )
+from unique_toolkit._common.pydantic_helpers import list_of
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +25,9 @@ class ExportManifest(BaseModel):
 
     exported_count: int
     skipped_count: int
-    warnings: list[EnvironmentVarWarning] = Field(default_factory=list)
+    warnings: list[EnvironmentVarWarning] = Field(
+        default_factory=list_of(EnvironmentVarWarning)
+    )
     config_files: dict[str, str] = Field(
         default_factory=dict
     )  # config_name -> file_path

--- a/unique_toolkit/unique_toolkit/_common/config_checker/validator.py
+++ b/unique_toolkit/unique_toolkit/_common/config_checker/validator.py
@@ -15,6 +15,7 @@ from unique_toolkit._common.config_checker.models import (
 from unique_toolkit._common.config_checker.models import (
     ValidationError as ValidationErrorModel,
 )
+from unique_toolkit._common.pydantic_helpers import list_of
 
 logger = logging.getLogger(__name__)
 
@@ -25,7 +26,9 @@ class ValidationReport(BaseModel):
     total_configs: int
     valid_count: int
     invalid_count: int
-    results: list[ConfigValidationResult] = Field(default_factory=list)
+    results: list[ConfigValidationResult] = Field(
+        default_factory=list_of(ConfigValidationResult)
+    )
 
     def has_failures(self) -> bool:
         """Check if there are any validation failures."""

--- a/unique_toolkit/unique_toolkit/_common/endpoint_requestor.py
+++ b/unique_toolkit/unique_toolkit/_common/endpoint_requestor.py
@@ -16,6 +16,7 @@ from unique_toolkit._common.endpoint_builder import (
     QueryParamsType,
     ResponseType,
 )
+from unique_toolkit._common.pydantic_helpers import dict_of
 
 # Paramspecs
 CombinedParamsSpec = ParamSpec("CombinedParamsSpec")
@@ -29,7 +30,7 @@ ResponseT_co = TypeVar("ResponseT_co", bound=BaseModel, covariant=True)
 
 class RequestContext(BaseModel):
     base_url: str
-    headers: dict[str, str] = Field(default_factory=dict)
+    headers: dict[str, str] = Field(default_factory=dict_of(str, str))
 
 
 def _verify_url(url: str) -> None:

--- a/unique_toolkit/unique_toolkit/_common/experimental/endpoint_requestor.py
+++ b/unique_toolkit/unique_toolkit/_common/experimental/endpoint_requestor.py
@@ -16,6 +16,7 @@ from unique_toolkit._common.experimental.endpoint_builder import (
     QueryParamsType,
     ResponseType,
 )
+from unique_toolkit._common.pydantic_helpers import dict_of
 
 # Paramspecs
 CombinedParamsSpec = ParamSpec("CombinedParamsSpec")
@@ -29,7 +30,7 @@ ResponseT_co = TypeVar("ResponseT_co", bound=BaseModel, covariant=True)
 
 class RequestContext(BaseModel):
     base_url: str
-    headers: dict[str, str] = Field(default_factory=dict)
+    headers: dict[str, str] = Field(default_factory=dict_of(str, str))
 
 
 def _verify_url(url: str) -> None:

--- a/unique_toolkit/unique_toolkit/_common/pydantic_helpers.py
+++ b/unique_toolkit/unique_toolkit/_common/pydantic_helpers.py
@@ -1,6 +1,6 @@
 import logging
 import warnings
-from typing import Any, TypeVar, Unpack
+from typing import Any, Callable, TypeVar, Unpack
 
 import humps
 from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, create_model
@@ -9,6 +9,20 @@ from pydantic.fields import ComputedFieldInfo, FieldInfo
 from pydantic_core import PydanticUseDefault
 
 logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+
+K = TypeVar("K")
+V = TypeVar("V")
+
+
+def list_of(_t: type[T]) -> Callable[[], list[T]]:
+    return list  # type: ignore[return-value]
+
+
+def dict_of(_k: type[K], _v: type[V]) -> Callable[[], dict[K, V]]:
+    return dict  # type: ignore[return-value]
 
 
 def field_title_generator(

--- a/unique_toolkit/unique_toolkit/app/schemas.py
+++ b/unique_toolkit/unique_toolkit/app/schemas.py
@@ -12,6 +12,7 @@ from pydantic_settings import BaseSettings
 from typing_extensions import deprecated
 
 from unique_toolkit._common.exception import ConfigurationException
+from unique_toolkit._common.pydantic_helpers import list_of
 from unique_toolkit.app.chat_event_filter_options_settings import (
     CHAT_EVENT_FILTER_OPTIONS_SETTINGS,
 )
@@ -186,8 +187,12 @@ class ChatEventAdditionalParameters(BaseModel):
     translate_to_language: Optional[str] = None
     content_id_to_translate: Optional[str] = None
     user_space_instructions: str
-    uploaded_files: list[UploadedFileInfo] = Field(default_factory=list)
-    selected_uploaded_files: list[UploadedFileInfo] = Field(default_factory=list)
+    uploaded_files: list[UploadedFileInfo] = Field(
+        default_factory=list_of(UploadedFileInfo)
+    )
+    selected_uploaded_files: list[UploadedFileInfo] = Field(
+        default_factory=list_of(UploadedFileInfo)
+    )
 
     @property
     def uploaded_file_ids(self) -> list[str]:

--- a/unique_toolkit/unique_toolkit/content/smart_rules.py
+++ b/unique_toolkit/unique_toolkit/content/smart_rules.py
@@ -6,6 +6,8 @@ from typing import Any, Dict, List, Mapping, Self, Union
 from pydantic import AliasChoices, BaseModel, Field
 from pydantic.config import ConfigDict
 
+from unique_toolkit._common.pydantic_helpers import list_of
+
 
 class Operator(str, Enum):
     EQUALS = "equals"
@@ -58,7 +60,7 @@ class BaseStatement(BaseModel):
 class Statement(BaseStatement):
     operator: Operator
     value: Union[str, int, bool, list[str], "AndStatement", "OrStatement"]
-    path: List[str] = Field(default_factory=list)
+    path: List[str] = Field(default_factory=list_of(str))
 
     def _fill_in_variables(
         self,

--- a/unique_toolkit/unique_toolkit/experimental/components/content_tree/schemas.py
+++ b/unique_toolkit/unique_toolkit/experimental/components/content_tree/schemas.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Literal, Self
 
-from unique_toolkit._common.pydantic_helpers import dict_of, list_of
+from unique_toolkit._common.pydantic_helpers import list_of
 from unique_toolkit.content.schemas import ContentInfo
 
 MatchTarget = Literal["key", "path", "both"]
@@ -32,7 +32,8 @@ MatchTarget = Literal["key", "path", "both"]
 class PathTrieNode:
     """Nested directory structure; ``files`` are basenames in this directory."""
 
-    children: dict[str, Self] = field(default_factory=dict_of(str, Self))
+    # dict, not dict_of(str, Self): pyright does not treat Self as type[V] for dict_of.
+    children: dict[str, Self] = field(default_factory=dict)
     files: list[str] = field(default_factory=list_of(str))
 
     def walk_trie_nodes(self) -> list[PathTrieNode]:

--- a/unique_toolkit/unique_toolkit/experimental/components/content_tree/schemas.py
+++ b/unique_toolkit/unique_toolkit/experimental/components/content_tree/schemas.py
@@ -14,8 +14,9 @@ in the SDK/HTTP stack used by :mod:`unique_toolkit.experimental.components.conte
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Literal
+from typing import Literal, Self
 
+from unique_toolkit._common.pydantic_helpers import dict_of, list_of
 from unique_toolkit.content.schemas import ContentInfo
 
 MatchTarget = Literal["key", "path", "both"]
@@ -31,8 +32,8 @@ MatchTarget = Literal["key", "path", "both"]
 class PathTrieNode:
     """Nested directory structure; ``files`` are basenames in this directory."""
 
-    children: dict[str, PathTrieNode] = field(default_factory=dict)
-    files: list[str] = field(default_factory=list)
+    children: dict[str, Self] = field(default_factory=dict_of(str, Self))
+    files: list[str] = field(default_factory=list_of(str))
 
     def walk_trie_nodes(self) -> list[PathTrieNode]:
         out: list[PathTrieNode] = [self]

--- a/unique_toolkit/unique_toolkit/short_term_memory/schemas.py
+++ b/unique_toolkit/unique_toolkit/short_term_memory/schemas.py
@@ -4,6 +4,8 @@ from typing import Any
 from humps import camelize
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from unique_toolkit._common.pydantic_helpers import dict_of
+
 model_config = ConfigDict(
     alias_generator=camelize,
     populate_by_name=True,
@@ -21,7 +23,7 @@ class ShortTermMemory(BaseModel):
     data: str | dict[str, Any] | int | float | bool | list[Any] | None = Field(
         deprecated=True
     )
-    value: str | dict[str, Any] = Field(default_factory=dict)
+    value: str | dict[str, Any] = Field(default_factory=dict_of(str, Any))
 
     @model_validator(mode="after")
     def _data_to_value(self) -> "ShortTermMemory":

--- a/unique_toolkit/unique_toolkit/short_term_memory/schemas.py
+++ b/unique_toolkit/unique_toolkit/short_term_memory/schemas.py
@@ -4,8 +4,6 @@ from typing import Any
 from humps import camelize
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
-from unique_toolkit._common.pydantic_helpers import dict_of
-
 model_config = ConfigDict(
     alias_generator=camelize,
     populate_by_name=True,
@@ -23,7 +21,8 @@ class ShortTermMemory(BaseModel):
     data: str | dict[str, Any] | int | float | bool | list[Any] | None = Field(
         deprecated=True
     )
-    value: str | dict[str, Any] = Field(default_factory=dict_of(str, Any))
+    # dict, not dict_of(str, Any): pyright rejects type[Any] for dict_of's value parameter.
+    value: str | dict[str, Any] = Field(default_factory=dict)
 
     @model_validator(mode="after")
     def _data_to_value(self) -> "ShortTermMemory":


### PR DESCRIPTION
## Summary
- Add `list_of` and `dict_of` in `pydantic_helpers` as typed default factories for list/dict fields (cleaner than raw `list`/`dict` defaults where typing matters).
- Adopt these helpers across toolkit schemas and config-checker / endpoint code that uses `default_factory` for lists and dicts.
- Extend `test_pydantic_helpers` (and related tests) for the new helpers; minor type-checker noise cleanup in touched areas.

## Changes
- **`unique_toolkit/_common/pydantic_helpers.py`**: New `list_of` / `dict_of` helpers.
- **Schemas & models**: `app/schemas.py`, `content/smart_rules.py`, `experimental/components/content_tree/schemas.py`, `short_term_memory/schemas.py` — use the new factories where appropriate.
- **Infra-style modules**: `config_checker` (`differ`, `exporter`, `validator`), `endpoint_requestor` (stable + experimental) — aligned `default_factory` usage.
- **Tests**: `tests/_common/test_pydantic_helpers.py`, `tests/_common/config_checker/test_differ.py`.

## Test plan
- [ ] `uv run python -m pytest unique_toolkit/tests/_common/test_pydantic_helpers.py unique_toolkit/tests/_common/config_checker/test_differ.py` (or your usual toolkit test entrypoint)
- [ ] Optional: broader `unique_toolkit` test slice if you want extra confidence on schema imports.

## Risk / rollout
- Low: behavior-preserving refactor focused on typing and default-factory clarity; rollback is revert the single commit on this branch.