### PR TITLE
feat(ci): cap CalVer dev sibling pins below first RC

### DIFF
--- a/.github/scripts/calver_dev_dependency_pin.py
+++ b/.github/scripts/calver_dev_dependency_pin.py
@@ -1,0 +1,42 @@
+"""CalVer sibling dependency pins for cycle ``*.devN`` builds.
+
+Under PEP 440, release candidates sort **above** developmental releases on the
+same patch line (``*.dev10 < *.rc1``). A floor like ``>=2026.20.0.dev6`` alone
+would therefore admit an older RC published for ``2026.20.0``, which breaks
+teams that RC from a divergent line.
+
+We constrain dev floors with an RC ceiling on the **same patch triple**:
+
+``>=YYYY.WW.P.devN,<YYYY.WW.Prc0``
+"""
+
+from __future__ import annotations
+
+import re
+
+_CALVER_PATCH_DEV_RE = re.compile(
+    r"^(?P<release>\d{4}\.\d{2}\.\d+)\.(?P<dev>dev\d+)$",
+)
+# Validates dep-pin strings passed into rewrite-pyproject-pre-release.py /
+# workflows: legacy ``>=/==VERSION`` siblings, or cycle dev sibling with RC cap.
+_PIN_LEGACY_OK = re.compile(r"^(>=|==)\d+(\.\d+)*(\.dev\d+|rc\d+)?$")
+_PIN_GE_DEV_RC_CAP = re.compile(
+    r"^>=(?P<rel>\d{4}\.\d{2}\.\d+)\.(?P<idev>dev\d+),\s*"
+    r"<(?P<cap>\d{4}\.\d{2}\.\d+)rc\d+$",
+)
+
+
+def is_valid_rewrite_dep_pin(pin: str) -> bool:
+    mc = _PIN_GE_DEV_RC_CAP.match(pin)
+    if mc:
+        return mc.group("rel") == mc.group("cap")
+    return bool(_PIN_LEGACY_OK.match(pin))
+
+
+def dev_dependency_pin(lower_version: str) -> str:
+    """Return a PEP 508 dependency suffix suitable for stamping into pyproject."""
+    suffix = f">={lower_version}"
+    m = _CALVER_PATCH_DEV_RE.match(lower_version)
+    if m:
+        suffix += f",<{m.group('release')}rc0"
+    return suffix

--- a/.github/scripts/resolve-dev-versions.py
+++ b/.github/scripts/resolve-dev-versions.py
@@ -16,11 +16,13 @@ From that we produce:
     (or ``dev0`` when nothing is in the cycle yet). Per-package
     contiguous counter, no gaps.
 
-  * ``dep_pins``: for every publishable AI package, the PEP 440 spec
+  * ``dep_pins``: for every publishable AI package, the PEP 508 spec
     suffix downstream wheels should use for it:
-      - package is a sibling in this push   -> ``>=<new version>``
-      - cycle already has a dev on PyPI     -> ``>={cycle}.0.dev<N>``
-      - otherwise                           -> ``>=<pyproject version>``
+      - CalVer cycle ``*.devN`` sibling     -> ``>=V,<YYY.WW.Prc0`` via
+        ``calver_dev_dependency_pin.dev_dependency_pin`` (excludes sibling RCs).
+      - package is a sibling in this push   -> pinned at new cycle dev floor
+      - cycle already has a dev on PyPI     -> pinned at highest existing ``dev<N>``
+      - otherwise (pyproject-stable)        -> ``>=<stable>`` unchanged
 
 Both maps key cross-package names by their PEP 503 normalized form so
 ``rewrite-pyproject-pre-release.py`` can match regardless of whether the
@@ -32,9 +34,16 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import sys
 import urllib.error
 import urllib.request
 from pathlib import Path
+
+_SCRIPT_DIR = Path(__file__).resolve().parent
+if str(_SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPT_DIR))
+
+from calver_dev_dependency_pin import dev_dependency_pin  # noqa: E402
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_PACKAGE_CONFIG = (
@@ -132,13 +141,13 @@ def resolve(
             next_n = 0 if dev_n is None else dev_n + 1
             version = f"{cycle}.0.dev{next_n}"
             new_versions[pkg["id"]] = version
-            dep_pins[key] = f">={version}"
+            dep_pins[key] = dev_dependency_pin(version)
             all_current_versions[pkg["id"]] = version
             if sh := pkg.get("shorthand"):
                 branch_parts.append(f"{sh}-{next_n}")
         elif dev_n is not None:
             version = f"{cycle}.0.dev{dev_n}"
-            dep_pins[key] = f">={version}"
+            dep_pins[key] = dev_dependency_pin(version)
             all_current_versions[pkg["id"]] = version
             if sh := pkg.get("shorthand"):
                 branch_parts.append(f"{sh}-{dev_n}")

--- a/.github/scripts/rewrite-pyproject-pre-release.py
+++ b/.github/scripts/rewrite-pyproject-pre-release.py
@@ -10,14 +10,14 @@ publish workflows. Two things happen in place:
    names another AI monorepo package is rewritten to use the pin
    supplied via ``--dep-pins``. For example, with::
 
-       --dep-pins '{"unique-sdk": ">=2026.18.0.dev3",
-                    "unique-toolkit": ">=2026.18.0.dev7"}'
+       --dep-pins '{"unique-sdk": ">=2026.18.0.dev3,<2026.18.0rc0",
+                    "unique-toolkit": ">=2026.18.0.dev7,<2026.18.0rc0"}'
 
    the rewriter produces::
 
-       "unique-sdk>=0.10.85,<0.12"  ->  "unique-sdk>=2026.18.0.dev3"
+       "unique-sdk>=0.10.85,<0.12"  ->  "unique-sdk>=2026.18.0.dev3,<2026.18.0rc0"
        "unique-toolkit[monitoring]>=1.69.6,<2"
-           ->  "unique-toolkit[monitoring]>=2026.18.0.dev7"
+           ->  "unique-toolkit[monitoring]>=2026.18.0.dev7,<2026.18.0rc0"
 
 Because the constraint explicitly contains a PEP 440 pre-release segment
 (``devN`` or ``rcN``), pip/uv resolves to pre-release versions without
@@ -26,9 +26,8 @@ Because the constraint explicitly contains a PEP 440 pre-release segment
 The pin map is computed upstream by either ``resolve-dev-versions.py``
 or ``resolve-rc-versions.py``:
 
-  * Dev publish (``resolve-dev-versions.py``) emits ``>=<version>`` pins;
-    siblings drift forward independently and ``pip install -U`` upgrades
-    siblings that were not republished.
+  * Dev publish (``resolve-dev-versions.py``) emits ``>=V,<YYY.WW.Prc0``
+    pins for CalVer ``*.devN`` siblings; legacy fallbacks stay ``>=`` only.
   * RC publish (``resolve-rc-versions.py``) emits ``>=<version>`` pins,
     floored at the shared ``{cycle}.0rcN`` so customers can upgrade
     freely to later rcs or the final stable.
@@ -47,21 +46,24 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import sys
 from pathlib import Path
 
 import tomlkit
+
+_SCRIPT_DIR = Path(__file__).resolve().parent
+if str(_SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPT_DIR))
+
+from calver_dev_dependency_pin import is_valid_rewrite_dep_pin  # noqa: E402
 
 _REQ_RE = re.compile(r"^\s*([A-Za-z0-9_.\-]+)(\[[^\]]*\])?\s*(.*)$")
 # Own version is always a CalVer pre-release — either ``.devN`` (dev
 # publish) or ``rcN`` (release-candidate publish). Stable CalVers are
 # stamped by release-please, never by this script.
 _VERSION_RE = re.compile(r"^\d{4}\.\d{2}\.\d+(\.dev\d+|rc\d+)$")
-# Dep pins come from one of the two resolvers:
-#   >=<version>   from resolve-dev-versions.py (siblings drift forward)
-#   >=<version>   from resolve-rc-versions.py  (floored at the rc cut)
-# Versions may be CalVer with a ``.devN``/``rcN`` suffix, or legacy
-# pre-CalVer dotted numerics (e.g. "0.3.3") for last-stable fallbacks.
-_PIN_RE = re.compile(r"^(>=|==)\d+(\.\d+)*(\.dev\d+|rc\d+)?$")
+# Dep pins from resolvers: ``>=`` with optional ``,<YYY.WW.Prc0`` for dev
+# siblings, ``==`` for rc cuts, or legacy ``>=`` only.
 
 
 def normalize(name: str) -> str:
@@ -114,7 +116,7 @@ def main(argv: list[str] | None = None) -> int:
 
     dep_pins: dict[str, str] = {}
     for name, pin in dep_pins_raw.items():
-        if not isinstance(pin, str) or not _PIN_RE.match(pin):
+        if not isinstance(pin, str) or not is_valid_rewrite_dep_pin(pin):
             raise SystemExit(f"invalid pin for {name!r}: {pin!r}")
         dep_pins[normalize(name)] = pin
 

--- a/.github/scripts/tests/test_resolve_dev_versions.py
+++ b/.github/scripts/tests/test_resolve_dev_versions.py
@@ -119,7 +119,7 @@ class ResolveTests(unittest.TestCase):
             on_disk={"unique_sdk": "0.11.6", "unique_mcp": "0.3.3"},
         )
         self.assertEqual(new_versions, {"toolkit": "2026.18.0.dev0"})
-        self.assertEqual(dep_pins["unique-toolkit"], ">=2026.18.0.dev0")
+        self.assertEqual(dep_pins["unique-toolkit"], ">=2026.18.0.dev0,<2026.18.0rc0")
         self.assertEqual(dep_pins["unique-sdk"], ">=0.11.6")
         self.assertEqual(dep_pins["unique-mcp"], ">=0.3.3")
         # all_current_versions
@@ -141,8 +141,8 @@ class ResolveTests(unittest.TestCase):
             on_disk={"unique_mcp": "0.3.3"},
         )
         self.assertEqual(new_versions, {"toolkit": "2026.18.0.dev4"})
-        self.assertEqual(dep_pins["unique-toolkit"], ">=2026.18.0.dev4")
-        self.assertEqual(dep_pins["unique-sdk"], ">=2026.18.0.dev2")
+        self.assertEqual(dep_pins["unique-toolkit"], ">=2026.18.0.dev4,<2026.18.0rc0")
+        self.assertEqual(dep_pins["unique-sdk"], ">=2026.18.0.dev2,<2026.18.0rc0")
         self.assertEqual(dep_pins["unique-mcp"], ">=0.3.3")
         self.assertEqual(all_current["toolkit"], "2026.18.0.dev4")
         self.assertEqual(all_current["sdk"], "2026.18.0.dev2")
@@ -161,8 +161,8 @@ class ResolveTests(unittest.TestCase):
         self.assertEqual(
             new_versions, {"toolkit": "2026.18.0.dev6", "sdk": "2026.18.0.dev10"}
         )
-        self.assertEqual(dep_pins["unique-toolkit"], ">=2026.18.0.dev6")
-        self.assertEqual(dep_pins["unique-sdk"], ">=2026.18.0.dev10")
+        self.assertEqual(dep_pins["unique-toolkit"], ">=2026.18.0.dev6,<2026.18.0rc0")
+        self.assertEqual(dep_pins["unique-sdk"], ">=2026.18.0.dev10,<2026.18.0rc0")
         self.assertEqual(dep_pins["unique-mcp"], ">=0.3.3")
         self.assertEqual(all_current["toolkit"], "2026.18.0.dev6")
         self.assertEqual(all_current["sdk"], "2026.18.0.dev10")

--- a/.github/scripts/tests/test_rewrite_pyproject_pre_release.py
+++ b/.github/scripts/tests/test_rewrite_pyproject_pre_release.py
@@ -75,18 +75,18 @@ class RewriteTests(unittest.TestCase):
     def test_rewrites_own_version_and_ai_deps(self) -> None:
         out = self._run(
             {
-                "unique-sdk": ">=2026.18.0.dev3",
-                "unique-orchestrator": ">=2026.18.0.dev1",
+                "unique-sdk": ">=2026.18.0.dev3,<2026.18.0rc0",
+                "unique-orchestrator": ">=2026.18.0.dev1,<2026.18.0rc0",
                 "unique-mcp": ">=2026.14.0",
             },
         )
         self.assertIn('version = "2026.18.0.dev7"', out)
-        self.assertIn('"unique-sdk>=2026.18.0.dev3"', out)
-        self.assertIn('"unique_orchestrator>=2026.18.0.dev1"', out)
+        self.assertIn('"unique-sdk>=2026.18.0.dev3,<2026.18.0rc0"', out)
+        self.assertIn('"unique_orchestrator>=2026.18.0.dev1,<2026.18.0rc0"', out)
         self.assertIn('"unique-mcp[extra]>=2026.14.0"', out)
 
     def test_leaves_non_ai_deps_alone(self) -> None:
-        out = self._run({"unique-sdk": ">=2026.18.0.dev3"})
+        out = self._run({"unique-sdk": ">=2026.18.0.dev3,<2026.18.0rc0"})
         self.assertIn('"pydantic>=2.0"', out)
         self.assertIn('"prometheus-client>=0.17"', out)
 
@@ -95,7 +95,7 @@ class RewriteTests(unittest.TestCase):
         # (e.g. unique-mcp 0.3.3). The rewriter must pass it through.
         out = self._run(
             {
-                "unique-sdk": ">=2026.18.0.dev3",
+                "unique-sdk": ">=2026.18.0.dev3,<2026.18.0rc0",
                 "unique-mcp": ">=0.3.3",
                 "unique-orchestrator": ">=1.22.2",
             }
@@ -104,7 +104,7 @@ class RewriteTests(unittest.TestCase):
         self.assertIn('"unique_orchestrator>=1.22.2"', out)
 
     def test_preserves_other_tool_tables(self) -> None:
-        out = self._run({"unique-sdk": ">=2026.18.0.dev3"})
+        out = self._run({"unique-sdk": ">=2026.18.0.dev3,<2026.18.0rc0"})
         self.assertIn("[tool.some-tool]", out)
         self.assertIn("keep_me = true", out)
 
@@ -113,12 +113,12 @@ class RewriteTests(unittest.TestCase):
         # the dep-pin map keys on the normalized "unique-orchestrator".
         out = self._run(
             {
-                "unique-orchestrator": ">=2026.18.0.dev2",
-                "unique-sdk": ">=2026.18.0.dev3",
+                "unique-orchestrator": ">=2026.18.0.dev2,<2026.18.0rc0",
+                "unique-sdk": ">=2026.18.0.dev3,<2026.18.0rc0",
                 "unique-mcp": ">=2026.14.0",
             }
         )
-        self.assertIn('"unique_orchestrator>=2026.18.0.dev2"', out)
+        self.assertIn('"unique_orchestrator>=2026.18.0.dev2,<2026.18.0rc0"', out)
 
     def test_rejects_unknown_dep_pin_format(self) -> None:
         with tempfile.TemporaryDirectory() as td:
@@ -132,6 +132,23 @@ class RewriteTests(unittest.TestCase):
                         "2026.18.0.dev7",
                         "--dep-pins",
                         json.dumps({"unique-sdk": "~=2026.18.0"}),
+                    ]
+                )
+
+    def test_rejects_mismatched_dev_rc_cap(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "pyproject.toml"
+            path.write_text(SAMPLE_PYPROJECT)
+            with self.assertRaises(SystemExit):
+                rppr.main(
+                    [
+                        str(path),
+                        "--own-version",
+                        "2026.18.0.dev7",
+                        "--dep-pins",
+                        json.dumps(
+                            {"unique-sdk": ">=2026.18.0.dev3,<2026.19.0rc0"}
+                        ),
                     ]
                 )
 

--- a/.github/workflows/cd-publish-dev.yaml
+++ b/.github/workflows/cd-publish-dev.yaml
@@ -26,13 +26,10 @@ name: "[CD] Publish dev builds to PyPI"
 # =============================================
 #   Computed once in `resolve` and stamped into every wheel's
 #   Requires-Dist by `rewrite-pyproject-pre-release.py`:
-#     - dep IS publishing in this push          -> `>=<its new_version>`
-#         (floor matches the co-published version; pip can still upgrade
-#          to a later dev or stable)
-#     - dep has a dev wheel in the current cycle -> `>=<highest dev>`
-#         (older locally-installed dev wheels do not satisfy the floor,
-#          so `pip install -U` correctly upgrades them)
-#     - otherwise                                -> `>=<last stable>`
+#     - CalVer cycle sibling ``*.devN`` (publishing now or existing on PyPI)
+#         ``>=V,<YYY.WW.Prc0`` — admits later dev builds on that patch triple
+#         but excludes sibling RC releases (they sort above dev under PEP 440).
+#     - legacy pyproject stable fallback (pre-CalVer packages) ``>=<stable>`` only.
 #         (a fresh cycle with no dev wheels yet; the dep has not changed
 #          since its last stable, so that is the honest floor)
 #


### PR DESCRIPTION
## Summary

CalVer **`.devN`** sibling dependency floors from `resolve-dev-versions` are now stamped as **`>=V,<YYY.WW.Prc0`** so pip/uv cannot resolve a **sibling RC** ahead of dev on the same patch triple (PEP 440 orders RC above dev).

### Changes

- New `calver_dev_dependency_pin.py` with `dev_dependency_pin()` and rewrite-time validation helpers.
- `rewrite-pyproject-pre-release.py` accepts the compound suffix and rejects mismatched caps.
- Workflow comment block in `cd-publish-dev.yaml` updated.
- Unit tests adjusted; added mismatched-cap rejection case.

Companion monorepo PR updates `sync-ai-versions` to emit the same pattern when syncing **`main`/dev-cut** floors.

## Testing

`uv run --with tomlkit --with pytest pytest .github/scripts/tests/test_resolve_dev_versions.py .github/scripts/tests/test_rewrite_pyproject_pre_release.py -q` (23 passed)

## AI assist

Medium — implementation and tests authored with AI assistance.

Made with [Cursor](https://cursor.com)