### PR TITLE
docs(release): align dev pin docs with RC ceiling semantics

### DIFF
--- a/.github/scripts/calver_dev_dependency_pin.py
+++ b/.github/scripts/calver_dev_dependency_pin.py
@@ -18,8 +18,8 @@ _CALVER_PATCH_DEV_RE = re.compile(
     r"^(?P<release>\d{4}\.\d{2}\.\d+)\.(?P<dev>dev\d+)$",
 )
 # Validates dep-pin strings passed into rewrite-pyproject-pre-release.py /
-# workflows: legacy ``>=/==VERSION`` siblings, or cycle dev sibling with RC cap.
-_PIN_LEGACY_OK = re.compile(r"^(>=|==)\d+(\.\d+)*(\.dev\d+|rc\d+)?$")
+# workflows: plain ``>=`` / ``==`` specs, or cycle ``*.devN`` sibling with RC cap.
+_PIN_SIMPLE_SPEC = re.compile(r"^(>=|==)\d+(\.\d+)*(\.dev\d+|rc\d+)?$")
 _PIN_GE_DEV_RC_CAP = re.compile(
     r"^>=(?P<rel>\d{4}\.\d{2}\.\d+)\.(?P<idev>dev\d+),\s*"
     r"<(?P<cap>\d{4}\.\d{2}\.\d+)rc\d+$",
@@ -30,7 +30,7 @@ def is_valid_rewrite_dep_pin(pin: str) -> bool:
     mc = _PIN_GE_DEV_RC_CAP.match(pin)
     if mc:
         return mc.group("rel") == mc.group("cap")
-    return bool(_PIN_LEGACY_OK.match(pin))
+    return bool(_PIN_SIMPLE_SPEC.match(pin))
 
 
 def dev_dependency_pin(lower_version: str) -> str:

--- a/.github/scripts/resolve-dev-versions.py
+++ b/.github/scripts/resolve-dev-versions.py
@@ -22,7 +22,7 @@ From that we produce:
         ``calver_dev_dependency_pin.dev_dependency_pin`` (excludes sibling RCs).
       - package is a sibling in this push   -> pinned at new cycle dev floor
       - cycle already has a dev on PyPI     -> pinned at highest existing ``dev<N>``
-      - otherwise (pyproject-stable)        -> ``>=<stable>`` unchanged
+      - otherwise (no ``*.devN`` in this cycle for that package yet) -> ``>=<stable>`` unchanged
 
 Both maps key cross-package names by their PEP 503 normalized form so
 ``rewrite-pyproject-pre-release.py`` can match regardless of whether the

--- a/.github/scripts/rewrite-pyproject-pre-release.py
+++ b/.github/scripts/rewrite-pyproject-pre-release.py
@@ -27,7 +27,8 @@ The pin map is computed upstream by either ``resolve-dev-versions.py``
 or ``resolve-rc-versions.py``:
 
   * Dev publish (``resolve-dev-versions.py``) emits ``>=V,<YYY.WW.Prc0``
-    pins for CalVer ``*.devN`` siblings; legacy fallbacks stay ``>=`` only.
+    pins for cycle ``*.devN`` siblings; when there is no cycle dev yet,
+    pins stay a plain ``>=`` floor at last stable.
   * RC publish (``resolve-rc-versions.py``) emits ``>=<version>`` pins,
     floored at the shared ``{cycle}.0rcN`` so customers can upgrade
     freely to later rcs or the final stable.
@@ -63,7 +64,7 @@ _REQ_RE = re.compile(r"^\s*([A-Za-z0-9_.\-]+)(\[[^\]]*\])?\s*(.*)$")
 # stamped by release-please, never by this script.
 _VERSION_RE = re.compile(r"^\d{4}\.\d{2}\.\d+(\.dev\d+|rc\d+)$")
 # Dep pins from resolvers: ``>=`` with optional ``,<YYY.WW.Prc0`` for dev
-# siblings, ``==`` for rc cuts, or legacy ``>=`` only.
+# siblings, ``==`` for rc cuts, or plain ``>=`` only (stable floor).
 
 
 def normalize(name: str) -> str:

--- a/.github/scripts/tests/test_rewrite_pyproject_pre_release.py
+++ b/.github/scripts/tests/test_rewrite_pyproject_pre_release.py
@@ -90,9 +90,8 @@ class RewriteTests(unittest.TestCase):
         self.assertIn('"pydantic>=2.0"', out)
         self.assertIn('"prometheus-client>=0.17"', out)
 
-    def test_accepts_legacy_stable_fallback_pin(self) -> None:
-        # Last-stable fallback for unchanged deps may be pre-CalVer
-        # (e.g. unique-mcp 0.3.3). The rewriter must pass it through.
+    def test_accepts_stable_only_fallback_pin(self) -> None:
+        # Last-stable fallback for unchanged deps: plain ``>=`` floor only.
         out = self._run(
             {
                 "unique-sdk": ">=2026.18.0.dev3,<2026.18.0rc0",

--- a/.github/workflows/cd-publish-dev.yaml
+++ b/.github/workflows/cd-publish-dev.yaml
@@ -29,9 +29,8 @@ name: "[CD] Publish dev builds to PyPI"
 #     - CalVer cycle sibling ``*.devN`` (publishing now or existing on PyPI)
 #         ``>=V,<YYY.WW.Prc0`` — admits later dev builds on that patch triple
 #         but excludes sibling RC releases (they sort above dev under PEP 440).
-#     - legacy pyproject stable fallback (pre-CalVer packages) ``>=<stable>`` only.
-#         (a fresh cycle with no dev wheels yet; the dep has not changed
-#          since its last stable, so that is the honest floor)
+#     - stable-only floor when no ``*.devN`` exists in this cycle yet for that
+#         package: ``>=<stable>`` only (dep unchanged since last stable).
 #
 # Serialization
 # =============

--- a/docs/contributing/release-process.md
+++ b/docs/contributing/release-process.md
@@ -50,8 +50,8 @@ On each qualifying push the workflow:
 1. Detects which packages changed (same logic as PR CI).
 2. Queries PyPI for the highest `.devN` already published for each changed package in the current cycle, increments, and emits `YYYY.WW.0.dev(N+1)`.
 3. Rewrites cross-package AI dependencies in each wheel's `Requires-Dist` (via `rewrite-pyproject-pre-release.py` and pins from `resolve-dev-versions.py`):
-   - **CalVer cycle sibling** (`YYYY.WW.P.devN`) — ``>=V,<YYY.WW.Prc0``: admits later `.dev*` builds on the same patch triple but excludes sibling **RC** releases (PEP 440 ranks RC above dev on that line).
-   - **Legacy pyproject fallback** (no cycle dev yet, pre-CalVer or stable-only floor) → ``>=<last stable>`` only.
+   - **Cycle dev sibling** (`YYYY.WW.P.devN`) — ``>=V,<YYY.WW.Prc0``: admits later `.dev*` builds on the same patch triple but excludes sibling **RC** releases (PEP 440 ranks RC above dev on that line).
+   - **No cycle dev yet** for that package (unchanged since last stable; honest floor is still the stable line) → ``>=<last stable>`` only.
 4. Builds and publishes to PyPI under the `publish-prerelease` concurrency group (serialized, no races).
 5. Tags the head SHA as `dev-cut-<SHORT_SHA>` and creates a GitHub pre-release listing every package version produced.
 

--- a/docs/contributing/release-process.md
+++ b/docs/contributing/release-process.md
@@ -49,10 +49,9 @@ On each qualifying push the workflow:
 
 1. Detects which packages changed (same logic as PR CI).
 2. Queries PyPI for the highest `.devN` already published for each changed package in the current cycle, increments, and emits `YYYY.WW.0.dev(N+1)`.
-3. Rewrites cross-package AI dependencies in each wheel's `Requires-Dist`:
-   - Co-publishing sibling → `>=<its new dev version>`
-   - Existing dev version in this cycle → `>=<highest dev>`
-   - No dev yet in this cycle → `>=<last stable>`
+3. Rewrites cross-package AI dependencies in each wheel's `Requires-Dist` (via `rewrite-pyproject-pre-release.py` and pins from `resolve-dev-versions.py`):
+   - **CalVer cycle sibling** (`YYYY.WW.P.devN`) — ``>=V,<YYY.WW.Prc0``: admits later `.dev*` builds on the same patch triple but excludes sibling **RC** releases (PEP 440 ranks RC above dev on that line).
+   - **Legacy pyproject fallback** (no cycle dev yet, pre-CalVer or stable-only floor) → ``>=<last stable>`` only.
 4. Builds and publishes to PyPI under the `publish-prerelease` concurrency group (serialized, no races).
 5. Tags the head SHA as `dev-cut-<SHORT_SHA>` and creates a GitHub pre-release listing every package version produced.
 
@@ -76,7 +75,7 @@ After every successful dev publish the workflow opens (or updates) a pull reques
 chore: pin dev-cut <SHORT_SHA>
 ```
 
-This PR rewrites every publishable package's `pyproject.toml` so its `version` and AI cross-package dep floors match the dev wheels just published to PyPI. **You only need to merge it when you are mixing freshly-published dev wheels with locally-checked-out AI packages** — for example, when developing in a worktree where one package is a path source and a sibling is consumed as a wheel. Without this, `uv`'s version-solver fails because the local clone still advertises the previous cycle version while the wheel `Requires-Dist` floor is `>= <current dev>`.
+This PR rewrites every publishable package's `pyproject.toml` so its `version` and AI cross-package dep floors match the dev wheels just published to PyPI (cycle dev deps use the same ``>=V,<YYY.WW.Prc0`` pattern as `Requires-Dist`). **You only need to merge it when you are mixing freshly-published dev wheels with locally-checked-out AI packages** — for example, when developing in a worktree where one package is a path source and a sibling is consumed as a wheel. Without this, `uv`'s version-solver fails because the local clone still advertises the previous cycle version while the wheel constraint floor is newer.
 
 In the typical flow the PR can sit untouched: it is automatically superseded by the next dev publish (the workflow closes the previous one before opening the new one).
 


### PR DESCRIPTION
## Summary

Follow-up to [#1582](https://github.com/Unique-AG/ai/pull/1582) (already merged): bring `docs/contributing/release-process.md` and inline CI/script comments in sync with CalVer `*.devN` sibling pins using `>=V,<YYY.WW.Prc0`, and remove stale pre-CalVer / legacy migration wording.

Refs: (none — doc-only follow-up to #1582)

## Changes

- [x] Updated docs
- [x] Refactored code / cleaned up (comments, `_PIN_SIMPLE_SPEC` rename in `calver_dev_dependency_pin.py`, test name)

## Testing

- `uv run --with tomlkit --with pytest python -m pytest .github/scripts/tests/test_rewrite_pyproject_pre_release.py .github/scripts/tests/test_resolve_dev_versions.py -q` (23 passed)

Made with [Cursor](https://cursor.com)