### PR TITLE
feat(sdk): allow download_content to write to caller-specified target_path

### DIFF
--- a/unique_sdk/docs/utilities/file_io.md
+++ b/unique_sdk/docs/utilities/file_io.md
@@ -78,26 +78,31 @@ The File I/O utilities simplify:
 
 ??? example "`unique_sdk.utils.file_io.download_content` - Download files from knowledge base"
 
-    Download a file from the knowledge base and save it to a temporary directory.
+    Download a file from the knowledge base. By default the bytes are written to a fresh `/tmp/<rand>/<filename>` path; pass `target_path` to control the destination explicitly.
 
     **Parameters:**
 
     - `companyId` (required) - Company ID
     - `userId` (required) - User ID
     - `content_id` (required) - Content ID to download
-    - `filename` (required) - Filename to save as
+    - `filename` (required) - Filename used when falling back to the auto-generated `/tmp` directory; ignored when `target_path` is set
     - `chat_id` (optional) - Chat ID if file is in a chat
+    - `target_path` (optional) - `str | Path` destination; parent directories are created on demand. When omitted, the bytes land in `/tmp/<rand>/<filename>` (legacy behaviour)
 
     **Returns:**
 
-    - `Path` object pointing to the downloaded file in `/tmp`
+    - `Path` object pointing to the downloaded file (either `target_path` or the `/tmp` fallback)
+
+    **Raises:**
+
+    - `Exception` if the HTTP response is non-200. The destination is only created after a successful response, so a 404/5xx never leaves a half-written file behind when `target_path` is supplied.
 
     **Example:**
 
     ```python
     from unique_sdk.utils.file_io import download_content
 
-    # Download from scope
+    # Download from scope (legacy /tmp fallback)
     file_path = download_content(
         companyId=company_id,
         userId=user_id,
@@ -106,7 +111,6 @@ The File I/O utilities simplify:
     )
 
     print(f"Downloaded to: {file_path}")
-    # Use the file
     with open(file_path, "rb") as f:
         content = f.read()
     ```
@@ -120,6 +124,20 @@ The File I/O utilities simplify:
         content_id="cont_xyz789",
         filename="document.pdf",
         chat_id="chat_abc123"
+    )
+    ```
+
+    **Example - Caller-controlled destination:**
+
+    ```python
+    from pathlib import Path
+
+    file_path = download_content(
+        companyId=company_id,
+        userId=user_id,
+        content_id="cont_abc123",
+        filename="report.pdf",  # ignored, ``target_path`` wins
+        target_path=Path("/var/data/reports/report.pdf"),
     )
     ```
 

--- a/unique_sdk/tests/test_file_io_download_content.py
+++ b/unique_sdk/tests/test_file_io_download_content.py
@@ -1,0 +1,329 @@
+"""Unit tests for ``unique_sdk.utils.file_io.download_content``.
+
+These tests pin the contract of the SDK download helper:
+
+* The new ``target_path`` kwarg routes the bytes to a caller-controlled
+  destination, creating any missing parent directories. This unblocks
+  callers that need the file at a specific location (e.g. inside a
+  per-skill bundle directory in ``swappable_intelligence``) instead of
+  the historic ``/tmp/<rand>/<filename>`` fallback.
+* Omitting ``target_path`` keeps the legacy behaviour so every existing
+  caller in the SDK ecosystem keeps working unchanged.
+* HTTP failures are surfaced *before* we materialise the destination.
+  This matters for the ``target_path`` branch: a 4xx/5xx must never
+  leave a half-created directory or empty file behind on the caller's
+  filesystem.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from unique_sdk.utils import file_io
+
+
+def _fake_response(status_code: int = 200, content: bytes = b"hello") -> MagicMock:
+    response = MagicMock()
+    response.status_code = status_code
+    response.content = content
+    return response
+
+
+@pytest.fixture(autouse=True)
+def _sdk_globals() -> Any:
+    """Make ``download_content`` self-contained: stub the package globals
+    it reads so the function can build the URL/headers without needing
+    real credentials. Restores them afterwards so tests stay isolated."""
+    with (
+        patch.object(file_io.unique_sdk, "api_base", "https://api.test"),
+        patch.object(file_io.unique_sdk, "api_version", "2023-12-06"),
+        patch.object(file_io.unique_sdk, "app_id", "app_test"),
+        patch.object(file_io.unique_sdk, "api_key", "ukey_test"),
+    ):
+        yield
+
+
+@pytest.mark.ai
+@pytest.mark.unit
+class TestDownloadContentTargetPath:
+    def test_target_path_writes_bytes_to_caller_destination(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        Purpose: Verify ``target_path`` routes the downloaded bytes to
+            the exact caller-controlled path.
+        Why this matters: Callers like ``swappable_intelligence`` need
+            file_io to write into a per-skill bundle directory. The
+            legacy ``/tmp/<rand>/<filename>`` fallback forced a second
+            ``shutil.move`` step and was incompatible with sandboxed
+            filesystems where ``/tmp`` is unavailable or unwritable.
+        Setup summary: Stub ``requests.get`` with a 200 response and
+            assert the bytes land at the supplied path (and not in
+            ``/tmp``).
+        """
+        get_mock = MagicMock(return_value=_fake_response(content=b"payload"))
+        target = tmp_path / "out" / "report.pdf"
+
+        with patch.object(file_io.requests, "get", get_mock):
+            result = file_io.download_content(
+                companyId="company-1",
+                userId="user-1",
+                content_id="cont_test",
+                filename="ignored.pdf",
+                target_path=target,
+            )
+
+        assert result == target
+        assert target.read_bytes() == b"payload"
+
+    def test_target_path_creates_missing_parents(self, tmp_path: Path) -> None:
+        """
+        Purpose: Confirm parent directories are created on demand when
+            ``target_path`` points into a not-yet-existing tree.
+        Why this matters: Forcing callers to ``mkdir -p`` ahead of every
+            download would push the same boilerplate into every
+            consumer (and silently regress when one forgets). The SDK
+            should make the destination usable.
+        Setup summary: Pass a deeply nested ``target_path`` whose
+            parents do not exist; assert the file is written and the
+            tree is materialised.
+        """
+        get_mock = MagicMock(return_value=_fake_response(content=b"x"))
+        nested = tmp_path / "a" / "b" / "c" / "file.bin"
+
+        with patch.object(file_io.requests, "get", get_mock):
+            result = file_io.download_content(
+                companyId="company-1",
+                userId="user-1",
+                content_id="cont_test",
+                filename="ignored.bin",
+                target_path=str(nested),
+            )
+
+        assert Path(result) == nested
+        assert nested.parent.is_dir()
+        assert nested.read_bytes() == b"x"
+
+    def test_target_path_accepts_path_and_str(self, tmp_path: Path) -> None:
+        """
+        Purpose: Ensure both ``str`` and ``Path`` are accepted for
+            ``target_path``.
+        Why this matters: Callers compose paths with both ``os.path``
+            and ``pathlib``; rejecting one type would force ad-hoc
+            conversions at every call site.
+        Setup summary: Run the same download twice — once with a
+            ``Path`` and once with an equivalent ``str`` — and assert
+            both succeed and return ``Path`` objects.
+        """
+        get_mock = MagicMock(return_value=_fake_response(content=b"abc"))
+
+        path_target = tmp_path / "as_path.bin"
+        str_target = tmp_path / "as_str.bin"
+
+        with patch.object(file_io.requests, "get", get_mock):
+            result_path = file_io.download_content(
+                companyId="company-1",
+                userId="user-1",
+                content_id="cont_test",
+                filename="ignored.bin",
+                target_path=path_target,
+            )
+            result_str = file_io.download_content(
+                companyId="company-1",
+                userId="user-1",
+                content_id="cont_test",
+                filename="ignored.bin",
+                target_path=str(str_target),
+            )
+
+        assert isinstance(result_path, Path) and isinstance(result_str, Path)
+        assert result_path == path_target
+        assert result_str == str_target
+
+
+@pytest.mark.ai
+@pytest.mark.unit
+class TestDownloadContentLegacyFallback:
+    def test_no_target_path_falls_back_to_tmp(self, tmp_path: Path) -> None:
+        """
+        Purpose: Without ``target_path``, the SDK keeps using a fresh
+            ``mkdtemp`` directory and writes ``filename`` inside it.
+        Why this matters: Every existing caller in the SDK ecosystem
+            depends on this fallback (CLI ``download`` command,
+            toolkit's ``download_content_to_file_by_id``, integration
+            tests). A regression here would silently break them.
+        Setup summary: Redirect ``mkdtemp`` to ``tmp_path`` so we can
+            assert the returned path lives under it; verify the bytes
+            land in ``<tmp_path>/<some-dir>/<filename>``.
+        """
+        get_mock = MagicMock(return_value=_fake_response(content=b"legacy"))
+        mkdtemp_mock = MagicMock(return_value=str(tmp_path / "rand"))
+        (tmp_path / "rand").mkdir()
+
+        with (
+            patch.object(file_io.requests, "get", get_mock),
+            patch.object(file_io.tempfile, "mkdtemp", mkdtemp_mock),
+        ):
+            result = file_io.download_content(
+                companyId="company-1",
+                userId="user-1",
+                content_id="cont_test",
+                filename="legacy.pdf",
+            )
+
+        mkdtemp_mock.assert_called_once_with(dir="/tmp")
+        assert result == tmp_path / "rand" / "legacy.pdf"
+        assert result.read_bytes() == b"legacy"
+
+
+@pytest.mark.ai
+@pytest.mark.unit
+class TestDownloadContentErrors:
+    def test_non_string_content_id_raises_before_request(self, tmp_path: Path) -> None:
+        """
+        Purpose: A non-string ``content_id`` is a programmer mistake
+            and must fail fast before we hit the network.
+        Why this matters: Without the guard the f-string would
+            silently coerce ``None`` into the string ``"None"``, hiding
+            the bug behind an opaque 404 from the gateway.
+        Setup summary: Pass an integer ``content_id`` and assert
+            ``ValueError`` is raised; ``requests.get`` must not be
+            called.
+        """
+        get_mock = MagicMock()
+
+        with (
+            patch.object(file_io.requests, "get", get_mock),
+            pytest.raises(ValueError, match="content_id must be a string"),
+        ):
+            file_io.download_content(
+                companyId="company-1",
+                userId="user-1",
+                content_id=123,  # pyright: ignore[reportArgumentType]
+                filename="ignored.pdf",
+                target_path=tmp_path / "out.pdf",
+            )
+
+        get_mock.assert_not_called()
+
+    def test_http_error_does_not_create_target_directory(self, tmp_path: Path) -> None:
+        """
+        Purpose: When the server returns a non-200 status, the SDK
+            must raise *before* materialising the destination.
+        Why this matters: Otherwise a 404/5xx would leave behind a
+            half-created directory tree (and on the legacy fallback,
+            even a stray ``mkdtemp`` directory) for callers who passed
+            ``target_path``. That manifests as orphan empty folders in
+            production.
+        Setup summary: Stub the response with status 500, point
+            ``target_path`` at a not-yet-existing nested path, expect
+            the exception, and assert no parent directory was created.
+        """
+        get_mock = MagicMock(return_value=_fake_response(status_code=500))
+        target = tmp_path / "should_not_exist" / "file.bin"
+
+        with (
+            patch.object(file_io.requests, "get", get_mock),
+            pytest.raises(Exception, match="Status code 500"),
+        ):
+            file_io.download_content(
+                companyId="company-1",
+                userId="user-1",
+                content_id="cont_test",
+                filename="ignored.bin",
+                target_path=target,
+            )
+
+        assert not target.exists()
+        assert not target.parent.exists()
+
+    def test_http_error_skips_legacy_tmp_directory_creation(self) -> None:
+        """
+        Purpose: On a non-200 response in the legacy code path, we
+            must not even allocate a fresh ``mkdtemp`` directory.
+        Why this matters: The user-reported bug was that errors used
+            to be raised *after* ``mkdtemp`` ran, leaving stray empty
+            directories under ``/tmp`` on every failed download. The
+            new ordering must avoid that side effect for both branches.
+        Setup summary: Stub the response with 404 and assert
+            ``tempfile.mkdtemp`` is never called.
+        """
+        get_mock = MagicMock(return_value=_fake_response(status_code=404))
+        mkdtemp_mock = MagicMock()
+
+        with (
+            patch.object(file_io.requests, "get", get_mock),
+            patch.object(file_io.tempfile, "mkdtemp", mkdtemp_mock),
+            pytest.raises(Exception, match="Status code 404"),
+        ):
+            file_io.download_content(
+                companyId="company-1",
+                userId="user-1",
+                content_id="cont_test",
+                filename="ignored.bin",
+            )
+
+        mkdtemp_mock.assert_not_called()
+
+
+@pytest.mark.ai
+@pytest.mark.unit
+class TestDownloadContentRequestShape:
+    def test_chat_id_is_appended_as_query_param(self, tmp_path: Path) -> None:
+        """
+        Purpose: Pinning the URL contract — when ``chat_id`` is given,
+            it must be forwarded as a ``chatId`` query parameter so the
+            backend resolves chat-scoped content correctly.
+        Why this matters: The backend uses different ACLs for
+            chat-scoped vs scope-scoped content; dropping ``chatId``
+            would silently 404 on chat attachments.
+        Setup summary: Capture the URL passed to ``requests.get`` and
+            assert it contains ``?chatId=chat-1``.
+        """
+        get_mock = MagicMock(return_value=_fake_response())
+
+        with patch.object(file_io.requests, "get", get_mock):
+            file_io.download_content(
+                companyId="company-1",
+                userId="user-1",
+                content_id="cont_test",
+                filename="x.bin",
+                chat_id="chat-1",
+                target_path=tmp_path / "x.bin",
+            )
+
+        url = get_mock.call_args.args[0]
+        assert url.endswith("/content/cont_test/file?chatId=chat-1")
+
+    def test_auth_headers_are_forwarded(self, tmp_path: Path) -> None:
+        """
+        Purpose: The SDK must forward ``x-app-id``, ``x-user-id``,
+            ``x-company-id``, ``x-api-version`` and ``Authorization``
+            headers verbatim from ``unique_sdk`` globals + arguments.
+        Why this matters: A regression here would surface as 401/403
+            from the gateway and is hard to spot from a stack trace.
+        Setup summary: Inspect the kwargs passed to ``requests.get``
+            and assert each expected header is present with the value
+            we'd expect from the test fixture.
+        """
+        get_mock = MagicMock(return_value=_fake_response())
+
+        with patch.object(file_io.requests, "get", get_mock):
+            file_io.download_content(
+                companyId="company-1",
+                userId="user-1",
+                content_id="cont_test",
+                filename="x.bin",
+                target_path=tmp_path / "x.bin",
+            )
+
+        headers = get_mock.call_args.kwargs["headers"]
+        assert headers["x-app-id"] == "app_test"
+        assert headers["x-user-id"] == "user-1"
+        assert headers["x-company-id"] == "company-1"
+        assert headers["x-api-version"] == "2023-12-06"
+        assert headers["Authorization"] == "Bearer ukey_test"

--- a/unique_sdk/unique_sdk/utils/file_io.py
+++ b/unique_sdk/unique_sdk/utils/file_io.py
@@ -242,7 +242,34 @@ def download_content(
     content_id: str,
     filename: str,
     chat_id: str | None = None,
-):
+    target_path: str | Path | None = None,
+) -> Path:
+    """Download a Knowledge Base content row to disk.
+
+    Args:
+        companyId: Tenant id.
+        userId: Acting user id.
+        content_id: Knowledge Base content id to download.
+        filename: Filename used when falling back to the auto-generated
+            ``/tmp`` directory. Ignored when ``target_path`` is set.
+        chat_id: Optional chat id (forwarded as the ``chatId`` query
+            parameter so chat-scoped content is resolvable).
+        target_path: Optional caller-controlled destination path. When
+            provided, the file is written there (parent directories are
+            created on demand) and that path is returned. When ``None``
+            (the default), we fall back to ``/tmp/<rand>/<filename>`` to
+            preserve backwards compatibility with existing callers.
+
+    Returns:
+        Absolute path the bytes were written to.
+
+    Raises:
+        ValueError: ``content_id`` is not a string.
+        Exception: HTTP response was non-200. We surface this *before*
+            creating the destination so a 404/5xx never leaves a
+            half-written file behind for callers that pass
+            ``target_path``.
+    """
     # Guard for callers without a type checker: f-string would silently coerce None to "None" otherwise.
     if not isinstance(content_id, str):  # pyright: ignore[reportUnnecessaryIsInstance]
         raise ValueError("content_id must be a string.")  # pyright: ignore[reportUnreachable]
@@ -250,13 +277,6 @@ def download_content(
     if chat_id:
         url = f"{url}?chatId={chat_id}"
 
-    # Create a random directory inside /tmp
-    random_dir = tempfile.mkdtemp(dir="/tmp")
-
-    # Create the full file path
-    file_path = Path(random_dir) / filename
-
-    # Download the file and save it to the random directory
     headers = {
         "x-api-version": unique_sdk.api_version,
         "x-app-id": unique_sdk.app_id,
@@ -265,12 +285,22 @@ def download_content(
         "Authorization": "Bearer %s" % (unique_sdk.api_key,),
     }
 
+    # Issue the request before resolving the destination. A non-200
+    # response should never leave a half-created directory or empty
+    # file behind for callers who supplied ``target_path``.
     response = requests.get(url, headers=headers)
-    if response.status_code == 200:
-        with open(file_path, "wb") as file:
-            file.write(response.content)
-    else:
+    if response.status_code != 200:
         raise Exception(f"Error downloading file: Status code {response.status_code}")
+
+    if target_path is not None:
+        file_path = Path(target_path)
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+    else:
+        random_dir = tempfile.mkdtemp(dir="/tmp")
+        file_path = Path(random_dir) / filename
+
+    with open(file_path, "wb") as file:
+        file.write(response.content)
 
     return file_path
 


### PR DESCRIPTION
## Summary

- Adds an optional `target_path: str | Path | None` kwarg to `unique_sdk.utils.file_io.download_content` so callers can route the downloaded bytes to an explicit destination (parents are created on demand) instead of the historic `/tmp/<rand>/<filename>` fallback.
- Reorders the request handling so HTTP errors are surfaced *before* the destination is materialised — previously a 404/5xx still left an empty `mkdtemp` directory behind on the caller's filesystem.
- Fully backwards compatible: every existing caller (CLI `download`, `unique_toolkit.content.functions.download_content_to_file_by_id`, integration tests) keeps working unchanged because `target_path` defaults to `None`.

## Why

Today `download_content` hard-codes the destination to `tempfile.mkdtemp(dir="/tmp")`, forcing callers to do a follow-up `shutil.move` and breaking on sandboxed filesystems where `/tmp` is unavailable or unwritable. Consumers like `swappable_intelligence` need to land downloaded content directly inside a per-skill bundle directory; this patch gives them that knob without changing any other call site.

## Changes

- `unique_sdk/unique_sdk/utils/file_io.py`
  - New `target_path: str | Path | None = None` parameter on `download_content`.
  - Branch: when supplied, writes to `Path(target_path)` and `mkdir(parents=True, exist_ok=True)` for the parent.
  - HTTP status check moved above the destination resolution so a non-200 never half-creates a directory.
  - Added Google-style docstring covering args, return value, and raises.
- `unique_sdk/docs/utilities/file_io.md`
  - Documents the new `target_path` kwarg, the failure-before-write guarantee, and an example using a caller-controlled destination.
- `unique_sdk/tests/test_file_io_download_content.py` (new)
  - Pins the new contract: `target_path` (Path + str + nested parents), legacy `/tmp` fallback, HTTP-error-before-write for both branches, `chatId` query param + auth headers shape.

## Out of scope (deliberately)

The user-facing message also mentioned two optional improvements; both are deferred to follow-up PRs to keep this one minimal and reviewable:

- Streaming download via `requests.get(stream=True)` + `iter_content` for large bundles (today the whole body lives in memory before write).
- An async sibling (`download_content_async` using `httpx.AsyncClient`) for callers that don't want `asyncio.to_thread`. The existing `await asyncio.to_thread(file_io.upload_file, ...)` pattern in `swappable_intelligence` already covers downloads via the same wrapper.

Neither of those is required to unblock the original consumer.

## Test plan

- [x] `cd unique_sdk && uv run poe lint` — clean
- [x] `cd unique_sdk && uv run poe typecheck` — 0 errors, 0 warnings
- [x] `cd unique_sdk && uv run poe test` — 464 passed, 39 skipped (integration tests gated on credentials)
- [x] `cd unique_sdk && uv run poe depcheck` — clean
- [x] New file `tests/test_file_io_download_content.py` — 9 tests covering target_path / legacy fallback / HTTP error ordering / request shape

## Risk / rollout

- Pure additive change: new optional kwarg + reordered error handling. No existing call site loses functionality.
- The reordered error path means callers who were relying on the side-effect of an empty `/tmp/<rand>` directory being created on a failed download will no longer see it. That side effect was unintentional and undocumented — verified no caller in this monorepo depends on it (CLI/toolkit/integration tests all consume the returned `Path`, never inspect `/tmp` directly).

Made with [Cursor](https://cursor.com)