### PR TITLE
feat(sdk): rewrite blob upload URLs via INGESTION_UPLOAD_API_URL_INTERNAL

### DIFF
--- a/unique_sdk/tests/cli/test_config.py
+++ b/unique_sdk/tests/cli/test_config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Generator
 from unittest.mock import patch
 
 import pytest
@@ -12,6 +13,25 @@ from unique_sdk.cli.config import Config, load_config
 
 # Stable fake gateway root for UNIQUE_API_BASE tests (not a real hostname).
 _TEST_PUBLIC_CHAT_BASE = "https://test-api-base.example/public/chat-gen2"
+
+
+@pytest.fixture(autouse=True)
+def _reset_sdk_ingestion_setting() -> Generator[None, None, None]:
+    """Snapshot/restore ``unique_sdk.ingestion_upload_api_url_internal``
+    around every CLI config test.
+
+    ``load_config`` writes onto the SDK module global as a side effect
+    (same shape as ``unique_sdk.api_key`` / ``api_base`` /``app_id``).
+    Without a per-test reset, a test that exercises the env-var path
+    would leak its value into sibling tests that expect the global to
+    start at ``None``, producing order-dependent failures.
+    """
+    original = unique_sdk.ingestion_upload_api_url_internal
+    try:
+        unique_sdk.ingestion_upload_api_url_internal = None
+        yield
+    finally:
+        unique_sdk.ingestion_upload_api_url_internal = original
 
 
 class TestConfig:
@@ -28,6 +48,25 @@ class TestConfig:
         assert c.api_key == "key"
         assert c.app_id == "app"
         assert c.api_base == "https://example.com"
+        # Default for the new field — kwarg is optional and falls back
+        # to ``None`` so existing call sites that build a ``Config``
+        # without it continue to compile.
+        assert c.ingestion_upload_api_url_internal is None
+
+    def test_config_stores_ingestion_upload_url(self) -> None:
+        c = Config(
+            user_id="u1",
+            company_id="c1",
+            api_key="key",
+            app_id="app",
+            api_base="https://example.com",
+            ingestion_upload_api_url_internal=(
+                "http://node-ingestion.test.svc.cluster.local:8091/scoped/upload"
+            ),
+        )
+        assert c.ingestion_upload_api_url_internal == (
+            "http://node-ingestion.test.svc.cluster.local:8091/scoped/upload"
+        )
 
 
 class TestLoadConfig:
@@ -116,3 +155,107 @@ class TestLoadConfig:
     def test_all_vars_missing_exits(self) -> None:
         with pytest.raises(SystemExit):
             load_config()
+
+
+class TestLoadConfigIngestionUpload:
+    """``INGESTION_UPLOAD_API_URL_INTERNAL`` env var → SDK module global.
+
+    The CLI is the only place the env var is read; the SDK proper does
+    not auto-init from the environment (mirrors the way ``api_key`` is
+    surfaced — applications either set ``unique_sdk.api_key`` directly
+    or call ``load_config()`` to pull it from the env). These tests pin
+    that the wiring writes onto BOTH the returned ``Config`` and the
+    package-level ``unique_sdk.ingestion_upload_api_url_internal``
+    attribute, with the same empty/whitespace-disable semantics that
+    the consumer (``_apply_ingestion_upload_url_override``) uses on the
+    read side.
+    """
+
+    @patch.dict(
+        os.environ,
+        {
+            "UNIQUE_USER_ID": "user_test",
+            "UNIQUE_COMPANY_ID": "company_test",
+            "INGESTION_UPLOAD_API_URL_INTERNAL": (
+                "http://node-ingestion.test.svc.cluster.local:8091/scoped/upload"
+            ),
+        },
+        clear=True,
+    )
+    def test_env_var_is_wired_onto_sdk_global(self) -> None:
+        config = load_config()
+        expected = "http://node-ingestion.test.svc.cluster.local:8091/scoped/upload"
+        assert config.ingestion_upload_api_url_internal == expected
+        assert unique_sdk.ingestion_upload_api_url_internal == expected
+
+    @patch.dict(
+        os.environ,
+        {
+            "UNIQUE_USER_ID": "user_test",
+            "UNIQUE_COMPANY_ID": "company_test",
+        },
+        clear=True,
+    )
+    def test_unset_env_var_leaves_global_at_none(self) -> None:
+        config = load_config()
+        assert config.ingestion_upload_api_url_internal is None
+        assert unique_sdk.ingestion_upload_api_url_internal is None
+
+    @patch.dict(
+        os.environ,
+        {
+            "UNIQUE_USER_ID": "user_test",
+            "UNIQUE_COMPANY_ID": "company_test",
+            "INGESTION_UPLOAD_API_URL_INTERNAL": "",
+        },
+        clear=True,
+    )
+    def test_empty_env_var_collapses_to_none(self) -> None:
+        # Empty string in a Helm overlay is a deliberate "disable the
+        # rewrite" knob; the operator should not have to ``unset`` the
+        # env var entirely. ``load_config`` collapses it to ``None``
+        # so the consumer's ``if not base`` check fires.
+        config = load_config()
+        assert config.ingestion_upload_api_url_internal is None
+        assert unique_sdk.ingestion_upload_api_url_internal is None
+
+    @patch.dict(
+        os.environ,
+        {
+            "UNIQUE_USER_ID": "user_test",
+            "UNIQUE_COMPANY_ID": "company_test",
+            "INGESTION_UPLOAD_API_URL_INTERNAL": "   ",
+        },
+        clear=True,
+    )
+    def test_whitespace_env_var_collapses_to_none(self) -> None:
+        # Same contract as the empty-string case: whitespace-only is
+        # treated as "disabled" rather than as a literal URL fragment
+        # that would later 400 on the upload PUT.
+        config = load_config()
+        assert config.ingestion_upload_api_url_internal is None
+        assert unique_sdk.ingestion_upload_api_url_internal is None
+
+    @patch.dict(
+        os.environ,
+        {
+            "UNIQUE_USER_ID": "user_test",
+            "UNIQUE_COMPANY_ID": "company_test",
+            "INGESTION_UPLOAD_API_URL_INTERNAL": (
+                "  http://node-ingestion/upload  "
+            ),
+        },
+        clear=True,
+    )
+    def test_surrounding_whitespace_is_trimmed(self) -> None:
+        # Operators paste URLs with trailing newlines / spaces all the
+        # time; trimming on the wiring layer keeps the URL clean
+        # without forcing the override helper to do per-call cleanup.
+        config = load_config()
+        assert config.ingestion_upload_api_url_internal == (
+            "http://node-ingestion/upload"
+        )
+        assert (
+            unique_sdk.ingestion_upload_api_url_internal
+            == "http://node-ingestion/upload"
+        )

--- a/unique_sdk/tests/cli/test_config.py
+++ b/unique_sdk/tests/cli/test_config.py
@@ -241,9 +241,7 @@ class TestLoadConfigIngestionUpload:
         {
             "UNIQUE_USER_ID": "user_test",
             "UNIQUE_COMPANY_ID": "company_test",
-            "INGESTION_UPLOAD_API_URL_INTERNAL": (
-                "  http://node-ingestion/upload  "
-            ),
+            "INGESTION_UPLOAD_API_URL_INTERNAL": ("  http://node-ingestion/upload  "),
         },
         clear=True,
     )

--- a/unique_sdk/unique_sdk/__init__.py
+++ b/unique_sdk/unique_sdk/__init__.py
@@ -13,6 +13,7 @@ api_base: str = "https://gateway.unique.app/public/chat-gen2"
 api_version: str = ApiVersion.CURRENT
 api_verify_mode: bool = True
 default_http_client: "HTTPClient | None" = None
+ingestion_upload_api_url_internal: str | None = None
 
 # Set to either 'debug' or 'info', controls console logging
 log: Literal["debug", "info"] | None = None

--- a/unique_sdk/unique_sdk/cli/config.py
+++ b/unique_sdk/unique_sdk/cli/config.py
@@ -16,6 +16,7 @@ class Config:
     api_key: str
     app_id: str
     api_base: str
+    ingestion_upload_api_url_internal: str | None
 
     def __init__(
         self,
@@ -25,20 +26,30 @@ class Config:
         api_key: str,
         app_id: str,
         api_base: str,
+        ingestion_upload_api_url_internal: str | None = None,
     ) -> None:
         self.user_id = user_id
         self.company_id = company_id
         self.api_key = api_key
         self.app_id = app_id
         self.api_base = api_base
+        self.ingestion_upload_api_url_internal = ingestion_upload_api_url_internal
 
 
 def load_config() -> Config:
     """Load configuration from environment variables and wire into unique_sdk.
 
     Required env vars: UNIQUE_USER_ID, UNIQUE_COMPANY_ID.
-    Optional: UNIQUE_API_KEY, UNIQUE_APP_ID (not needed on localhost or in a
-    secured cluster), UNIQUE_API_BASE (defaults to the SDK default).
+    Optional:
+        * ``UNIQUE_API_KEY`` / ``UNIQUE_APP_ID`` (not needed on localhost
+          or in a secured cluster).
+        * ``UNIQUE_API_BASE`` (defaults to the SDK default).
+        * ``INGESTION_UPLOAD_API_URL_INTERNAL`` — when set, content
+          uploads via ``unique_sdk.utils.file_io.upload_file`` rewrite
+          the public ``writeUrl`` / ``pdfPreviewWriteUrl`` to this base
+          before the PUT, so blob uploads can travel over a private
+          cluster network. Empty / whitespace-only disables the rewrite
+          (treated identically to unset).
     """
     missing: list[str] = []
     for var in (
@@ -61,10 +72,17 @@ def load_config() -> Config:
     company_id = os.environ["UNIQUE_COMPANY_ID"]
     api_base = os.environ.get("UNIQUE_API_BASE", unique_sdk.api_base)
     api_base = api_base.strip().strip("'\"")
+    raw_ingestion_url = os.environ.get("INGESTION_UPLOAD_API_URL_INTERNAL")
+    ingestion_upload_api_url_internal = (
+        raw_ingestion_url.strip() or None
+        if isinstance(raw_ingestion_url, str)
+        else None
+    )
 
     unique_sdk.api_key = api_key
     unique_sdk.app_id = app_id
     unique_sdk.api_base = api_base
+    unique_sdk.ingestion_upload_api_url_internal = ingestion_upload_api_url_internal
 
     return Config(
         user_id=user_id,
@@ -72,4 +90,5 @@ def load_config() -> Config:
         api_key=api_key,
         app_id=app_id,
         api_base=api_base,
+        ingestion_upload_api_url_internal=ingestion_upload_api_url_internal,
     )

--- a/unique_sdk/unique_sdk/utils/file_io.py
+++ b/unique_sdk/unique_sdk/utils/file_io.py
@@ -3,6 +3,7 @@ import os
 import tempfile
 from pathlib import Path
 from typing import Any, TypedDict
+from urllib.parse import urlparse
 
 import requests
 
@@ -42,6 +43,31 @@ def download_file(url: str, filename: str):
 
 
 _PREVIEW_PDF_MIME_TYPE = "application/pdf"
+
+
+def _apply_ingestion_upload_url_override(write_url: str) -> str:
+    """Rewrite the host+path of *write_url* to the in-cluster ingestion
+    base when ``unique_sdk.ingestion_upload_api_url_internal`` is set.
+
+    The platform mints a public upload URL shaped like
+    ``<host>/scoped/ingestion/upload?key=<id>``. Pods running inside
+    the same cluster can short-circuit the public ingress by PUTting
+    to the in-cluster service URL instead — only the host+path swaps,
+    the original query string (which carries the upload ``key``) is
+    preserved verbatim because the service identifies the target blob
+    by that key.
+
+    A ``None`` or empty/whitespace override (the wiring layer in
+    ``cli/config.py`` already collapses those to ``None``, but we
+    re-check here so direct ``unique_sdk.ingestion_upload_api_url_internal = ""``
+    assignments outside the CLI also no-op) leaves *write_url*
+    unchanged.
+    """
+    base = unique_sdk.ingestion_upload_api_url_internal
+    if not base or not base.strip():
+        return write_url
+    query = urlparse(write_url).query
+    return f"{base}?{query}" if query else base
 
 
 def _put_preview_pdf(write_url: str, preview_pdf_path: str) -> None:
@@ -148,9 +174,14 @@ def upload_file(
     )
 
     # Step 2 — PUT the original bytes to the SAS URL minted by Step 1.
+    # When ``ingestion_upload_api_url_internal`` is configured, swap
+    # the public host+path for the in-cluster service URL while
+    # preserving the ``?key=...`` query string the server identifies
+    # the target blob by.
     uploadUrl = createdContent.writeUrl
     if uploadUrl is None:  # guard: writeUrl is Optional, basedpyright needs narrowing
         raise ValueError("createdContent.writeUrl is None")
+    uploadUrl = _apply_ingestion_upload_url_override(uploadUrl)
     with open(path_to_file, "rb") as file:
         requests.put(
             uploadUrl,
@@ -231,7 +262,10 @@ def upload_file(
                 "node-ingestion expose previewPdfFileName on the upsert "
                 "mutation."
             )
-        _put_preview_pdf(preview_write_url, preview_pdf_path)
+        _put_preview_pdf(
+            _apply_ingestion_upload_url_override(preview_write_url),
+            preview_pdf_path,
+        )
 
     return createdContent
 

--- a/unique_sdk/unique_sdk/utils/file_io.py
+++ b/unique_sdk/unique_sdk/utils/file_io.py
@@ -66,6 +66,12 @@ def _apply_ingestion_upload_url_override(write_url: str) -> str:
     base = unique_sdk.ingestion_upload_api_url_internal
     if not base or not base.strip():
         return write_url
+    # Strip trailing slashes so an operator who sets
+    # ``INGESTION_UPLOAD_API_URL_INTERNAL=http://node-ingestion/upload/``
+    # does not end up PUTting to ``…/upload/?key=…`` (which the
+    # ingestion service routes differently from ``…/upload?key=…``).
+    # Mirrors ``unique_toolkit.content.utils`` so SDK and toolkit agree.
+    base = base.rstrip("/")
     query = urlparse(write_url).query
     return f"{base}?{query}" if query else base
 


### PR DESCRIPTION
## 🚀 Summary
Refs: _no ticket_

Adds an opt-in URL rewrite so SDK callers running inside the same cluster as `node-ingestion` can PUT blob bytes through the in-cluster service URL instead of the public ingress — without changing any call sites.

## ✅ Changes

- [x] Added feature
  - `unique_sdk.ingestion_upload_api_url_internal` — new SDK module global, defaults to `None`.
  - `INGESTION_UPLOAD_API_URL_INTERNAL` — env var read by `unique_sdk.cli.config.load_config`, trimmed and collapsed to `None` when empty/whitespace, mirrored onto both the returned `Config` and the SDK module global.
  - `_apply_ingestion_upload_url_override` (private) in `unique_sdk.utils.file_io` — swaps the host+path of the server-minted upload URL while preserving the original query string (which carries the upload `key`). Applied to both `writeUrl` (Step 2) and `pdfPreviewWriteUrl` (Step 4) of `upload_file`.

## 🧪 Testing

- `uv run poe lint` — clean on touched files.
- `uv run pytest tests/test_file_io_preview_pdf.py tests/test_file_io_download_content.py tests/cli/test_config.py -q` → 28 passed.
- `uv run pytest tests/cli/ -q` → 351 passed.

## Risk / rollout

- Default is `None` → no behaviour change for existing callers.
- The CLI's `unique-cli upload <file>` and `unique_sdk.utils.chat_in_space` automatically inherit the rewrite because they route through the shared `upload_file`; no additional plumbing required.
- Empty / whitespace-only env var is treated as "disabled" so operators can no-op the override via Helm overlay without unsetting the variable entirely.

Made with [Cursor](https://cursor.com)