### PR TITLE
fix(toolkit): raise httpx timeouts for async KB blob uploads

### DIFF
--- a/unique_toolkit/tests/content/test_content_functions_unit.py
+++ b/unique_toolkit/tests/content/test_content_functions_unit.py
@@ -647,3 +647,118 @@ async def test_download_content_to_bytes_async__raises_error__when_response_not_
                 content_id="content123",
                 chat_id="chat123",
             )
+
+
+# ---------------------------------------------------------------------------
+# httpx timeout tests for _trigger_upload_content_async (UN-18453)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_trigger_upload_content_async_uses_generous_timeout(
+    sample_content_data,
+) -> None:
+    """
+    Purpose: Verify AsyncClient is created with read/write timeouts well above the 5 s default.
+    Why this matters: Large HTML files (~4 MB) reliably timeout at 5 s waiting for the Azure
+    Blob Storage commit response; without an explicit timeout the upload silently fails.
+    Setup summary: Patch _upsert_content_async and httpx.AsyncClient, call the private helper,
+    assert the timeout kwarg has read >= 60 and write >= 60.
+    """
+    import httpx
+
+    from unique_toolkit.content.functions import _trigger_upload_content_async
+
+    captured_timeout: httpx.Timeout | None = None
+
+    with patch(
+        "unique_toolkit.content.functions._upsert_content_async",
+        new_callable=AsyncMock,
+    ) as mock_upsert:
+        mock_upsert.return_value = sample_content_data
+
+        with patch(
+            "unique_toolkit.content.functions.httpx.AsyncClient"
+        ) as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_response = Mock()
+            mock_response.raise_for_status = Mock()
+            mock_client.put.return_value = mock_response
+            mock_client_cls.return_value = mock_client
+
+            def capture_timeout(*args, **kwargs):
+                nonlocal captured_timeout
+                captured_timeout = kwargs.get("timeout")
+                return mock_client
+
+            mock_client_cls.side_effect = capture_timeout
+
+            await _trigger_upload_content_async(
+                user_id="user123",
+                company_id="company123",
+                content=b"<html>large payload</html>",
+                content_name="dashboard.html",
+                mime_type="text/html",
+                chat_id="chat123",
+            )
+
+    assert captured_timeout is not None, (
+        "httpx.AsyncClient must receive a timeout= kwarg"
+    )
+    assert isinstance(captured_timeout, httpx.Timeout)
+    assert captured_timeout.read is not None and captured_timeout.read >= 60, (
+        f"read timeout {captured_timeout.read} must be >= 60 s to survive large blob uploads"
+    )
+    assert captured_timeout.write is not None and captured_timeout.write >= 60, (
+        f"write timeout {captured_timeout.write} must be >= 60 s to survive large blob uploads"
+    )
+
+
+@pytest.mark.asyncio
+async def test_trigger_upload_content_async_timeout_not_default_5s(
+    sample_content_data,
+) -> None:
+    """
+    Purpose: Guard against accidental regression back to the 5 s httpx default.
+    Why this matters: A plain httpx.AsyncClient() has read=write=5 s which causes ReadTimeout
+    for ~4 MB HTML artifacts (observed in production, chat chat_n2ww1gbf0bti31gh8dt95hox).
+    """
+    import httpx
+
+    from unique_toolkit.content.functions import _trigger_upload_content_async
+
+    with patch(
+        "unique_toolkit.content.functions._upsert_content_async",
+        new_callable=AsyncMock,
+    ) as mock_upsert:
+        mock_upsert.return_value = sample_content_data
+
+        with patch(
+            "unique_toolkit.content.functions.httpx.AsyncClient"
+        ) as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_response = Mock()
+            mock_response.raise_for_status = Mock()
+            mock_client.put.return_value = mock_response
+            mock_client_cls.return_value = mock_client
+
+            await _trigger_upload_content_async(
+                user_id="user123",
+                company_id="company123",
+                content=b"<html>large payload</html>",
+                content_name="dashboard.html",
+                mime_type="text/html",
+                chat_id="chat123",
+            )
+
+            call_kwargs = mock_client_cls.call_args[1]
+            timeout = call_kwargs.get("timeout")
+
+    assert timeout is not None, (
+        "timeout= must be passed explicitly to httpx.AsyncClient"
+    )
+    assert not isinstance(timeout, httpx.Timeout) or timeout.read != 5.0, (
+        "read timeout must not be the default 5 s"
+    )

--- a/unique_toolkit/unique_toolkit/content/functions.py
+++ b/unique_toolkit/unique_toolkit/content/functions.py
@@ -589,7 +589,12 @@ async def _trigger_upload_content_async(
         "X-Ms-Blob-Type": "BlockBlob",
     }
     # upload to azure blob storage SAS url uploadUrl the pdf file translatedFile make sure it is treated as a application/pdf
-    async with httpx.AsyncClient() as client:
+    # Use generous write/read timeouts: multi-MB HTML files (e.g. Plotly bundles) can
+    # exhaust the default 5 s ceiling while waiting for the Azure Blob commit response.
+    _blob_upload_timeout = httpx.Timeout(
+        connect=10.0, read=120.0, write=120.0, pool=10.0
+    )
+    async with httpx.AsyncClient(timeout=_blob_upload_timeout) as client:
         if isinstance(content, bytes):
             response = await client.put(
                 url=write_url,


### PR DESCRIPTION
## Summary

- Fixes **`httpx.ReadTimeout`** on the async knowledge-base upload path when pushing multi-megabyte bodies (for example code-interpreter HTML with an inlined Plotly bundle) to the Azure Blob Storage SAS URL.
- Root cause: `httpx.AsyncClient()` without `timeout=` uses a **5 s** default for read/write; the upload can finish sending the body but still time out waiting for the storage commit response.

**Ticket:** [UN-18453](https://unique-ch.atlassian.net/browse/UN-18453)  
**Branch:** `fix/toolkit/un-18453-kb-blob-upload-httpx-timeout`

## Changes

- **`unique_toolkit/content/functions.py`:** `_trigger_upload_content_async` now uses `httpx.Timeout(connect=10.0, read=120.0, write=120.0, pool=10.0)` on the blob `PUT` client.
- **`tests/content/test_content_functions_unit.py`:** Two unit tests assert the async client receives a generous timeout and is not left at the 5 s default.

## Test plan

- `cd unique_toolkit && poetry run pytest tests/content/test_content_functions_unit.py -k timeout -v`

## Risk / rollout

- Longer ceilings can mask genuine backend or network stalls; mitigated by keeping a fixed **120 s** cap (not unbounded). No public API or caller signature changes.

## Refs

- Jira: **UN-18453** — [UN-18453](https://unique-ch.atlassian.net/browse/UN-18453)


[UN-18453]: https://unique-ch.atlassian.net/browse/UN-18453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[UN-18453]: https://unique-ch.atlassian.net/browse/UN-18453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ