### PR TITLE
chore(ci): bump app-token-create to validate PEM

### DIFF
--- a/.github/workflows/cd-arm-version.yaml
+++ b/.github/workflows/cd-arm-version.yaml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Generate GitHub App token
         id: app-token
-        uses: unique-ag/actions/github/app-token-create@df61dcf6fb84a7cad9c9b5f04924b40311cb016a
+        uses: unique-ag/actions/github/app-token-create@08cc24e926dda3254b05aa898c362790ec506a3d
         with:
           app_id: ${{ vars.RELEASE_WORKFLOW_CLIENT_ID }}
           base64_encoded_private_key: ${{ secrets.RELEASE_WORKFLOW_APP_PRIVATE_KEY_B64 }}

--- a/.github/workflows/cd-publish-dev.yaml
+++ b/.github/workflows/cd-publish-dev.yaml
@@ -292,7 +292,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: unique-ag/actions/github/app-token-create@df61dcf6fb84a7cad9c9b5f04924b40311cb016a
+        uses: unique-ag/actions/github/app-token-create@08cc24e926dda3254b05aa898c362790ec506a3d
         with:
           app_id: ${{ vars.RELEASE_WORKFLOW_CLIENT_ID }}
           base64_encoded_private_key: ${{ secrets.RELEASE_WORKFLOW_APP_PRIVATE_KEY_B64 }}
@@ -385,7 +385,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: unique-ag/actions/github/app-token-create@df61dcf6fb84a7cad9c9b5f04924b40311cb016a
+        uses: unique-ag/actions/github/app-token-create@08cc24e926dda3254b05aa898c362790ec506a3d
         with:
           app_id: ${{ vars.RELEASE_WORKFLOW_CLIENT_ID }}
           base64_encoded_private_key: ${{ secrets.RELEASE_WORKFLOW_APP_PRIVATE_KEY_B64 }}

--- a/.github/workflows/cd-publish-rc.yaml
+++ b/.github/workflows/cd-publish-rc.yaml
@@ -334,7 +334,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: unique-ag/actions/github/app-token-create@df61dcf6fb84a7cad9c9b5f04924b40311cb016a
+        uses: unique-ag/actions/github/app-token-create@08cc24e926dda3254b05aa898c362790ec506a3d
         with:
           app_id: ${{ vars.RELEASE_WORKFLOW_CLIENT_ID }}
           base64_encoded_private_key: ${{ secrets.RELEASE_WORKFLOW_APP_PRIVATE_KEY_B64 }}

--- a/.github/workflows/cd-release.yaml
+++ b/.github/workflows/cd-release.yaml
@@ -73,7 +73,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: unique-ag/actions/github/app-token-create@df61dcf6fb84a7cad9c9b5f04924b40311cb016a
+        uses: unique-ag/actions/github/app-token-create@08cc24e926dda3254b05aa898c362790ec506a3d
         with:
           app_id: ${{ vars.RELEASE_WORKFLOW_CLIENT_ID }}
           base64_encoded_private_key: ${{ secrets.RELEASE_WORKFLOW_APP_PRIVATE_KEY_B64 }}
@@ -110,7 +110,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: unique-ag/actions/github/app-token-create@df61dcf6fb84a7cad9c9b5f04924b40311cb016a
+        uses: unique-ag/actions/github/app-token-create@08cc24e926dda3254b05aa898c362790ec506a3d
         with:
           app_id: ${{ vars.RELEASE_WORKFLOW_CLIENT_ID }}
           base64_encoded_private_key: ${{ secrets.RELEASE_WORKFLOW_APP_PRIVATE_KEY_B64 }}
@@ -190,7 +190,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: unique-ag/actions/github/app-token-create@df61dcf6fb84a7cad9c9b5f04924b40311cb016a
+        uses: unique-ag/actions/github/app-token-create@08cc24e926dda3254b05aa898c362790ec506a3d
         with:
           app_id: ${{ vars.RELEASE_WORKFLOW_CLIENT_ID }}
           base64_encoded_private_key: ${{ secrets.RELEASE_WORKFLOW_APP_PRIVATE_KEY_B64 }}


### PR DESCRIPTION
## Summary

Bumps `unique-ag/actions/github/app-token-create` from
`df61dcf6fb84a7cad9c9b5f04924b40311cb016a` to
[`08cc24e`](https://github.com/unique-ag/actions/commit/08cc24e926dda3254b05aa898c362790ec506a3d)
across all four release workflows that authenticate as the
`release-workflow` GitHub App:

- `.github/workflows/cd-arm-version.yaml`
- `.github/workflows/cd-publish-dev.yaml` (×2)
- `.github/workflows/cd-publish-rc.yaml`
- `.github/workflows/cd-release.yaml` (×3)

## Why

The new SHA picks up [unique-ag/actions#8](https://github.com/unique-ag/actions/pull/8),
which adds two pre-flight checks to the wrapper:

1. **Empty input check** — if `base64_encoded_private_key` is unset/empty,
   the action fails immediately instead of forwarding an empty string to
   `actions/create-github-app-token`, which would otherwise sign a JWT
   against an empty key and produce a cryptic 401 from GitHub:

   > A JSON web token could not be decoded
   > GET https://api.github.com/users/<owner>/installation

2. **PEM-shape check** — `base64 -d` is permissive and silently produces
   garbage from common upload mistakes (raw PEM committed without
   encoding, Python `b'…'` repr, double-encoding, CRLF line-folding).
   The action now requires the decoded value to start with
   `-----BEGIN ` and end with `PRIVATE KEY-----`, and on failure points
   at the Infrastructure-as-Code runbook:

   > re-encode the App's `.pem` with `base64` on the command line and
   > commit the updated value to the infrastructure repo so it
   > reconciles back into the GitHub secret

That eliminates the multi-day forensic exercise we just hit on UN-20383
the next time a malformed key lands in `RELEASE_WORKFLOW_APP_PRIVATE_KEY_B64`.

No behavioral change on the happy path: when the secret is well-formed,
the new checks pass silently and `actions/create-github-app-token` runs
exactly as before.

## Test plan

- [ ] Trigger `cd-arm-version.yaml` via workflow_dispatch and confirm the
      "Generate GitHub App token" step still produces a token (i.e. the
      `release-workflow` secret is well-formed → checks pass silently).
- [ ] Confirm the next `cd-publish-dev.yaml` run on push reaches steps
      past token generation.
- [ ] If a future run fails, the error should now name the input and
      point at the IaC runbook instead of returning the GitHub 401.

Refs: UN-20383

Made with [Cursor](https://cursor.com)