### PR TITLE
chore(ci): scope release-workflow App token to the current repo

### DIFF
--- a/.github/workflows/cd-arm-version.yaml
+++ b/.github/workflows/cd-arm-version.yaml
@@ -53,7 +53,6 @@ jobs:
         with:
           app_id: ${{ vars.RELEASE_WORKFLOW_CLIENT_ID }}
           base64_encoded_private_key: ${{ secrets.RELEASE_WORKFLOW_APP_PRIVATE_KEY_B64 }}
-          owner: ${{ github.repository_owner }}
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/cd-publish-dev.yaml
+++ b/.github/workflows/cd-publish-dev.yaml
@@ -296,7 +296,6 @@ jobs:
         with:
           app_id: ${{ vars.RELEASE_WORKFLOW_CLIENT_ID }}
           base64_encoded_private_key: ${{ secrets.RELEASE_WORKFLOW_APP_PRIVATE_KEY_B64 }}
-          owner: ${{ github.repository_owner }}
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -389,7 +388,6 @@ jobs:
         with:
           app_id: ${{ vars.RELEASE_WORKFLOW_CLIENT_ID }}
           base64_encoded_private_key: ${{ secrets.RELEASE_WORKFLOW_APP_PRIVATE_KEY_B64 }}
-          owner: ${{ github.repository_owner }}
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/cd-publish-rc.yaml
+++ b/.github/workflows/cd-publish-rc.yaml
@@ -338,7 +338,6 @@ jobs:
         with:
           app_id: ${{ vars.RELEASE_WORKFLOW_CLIENT_ID }}
           base64_encoded_private_key: ${{ secrets.RELEASE_WORKFLOW_APP_PRIVATE_KEY_B64 }}
-          owner: ${{ github.repository_owner }}
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/cd-release.yaml
+++ b/.github/workflows/cd-release.yaml
@@ -77,7 +77,6 @@ jobs:
         with:
           app_id: ${{ vars.RELEASE_WORKFLOW_CLIENT_ID }}
           base64_encoded_private_key: ${{ secrets.RELEASE_WORKFLOW_APP_PRIVATE_KEY_B64 }}
-          owner: ${{ github.repository_owner }}
 
       - id: rp
         uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
@@ -114,7 +113,6 @@ jobs:
         with:
           app_id: ${{ vars.RELEASE_WORKFLOW_CLIENT_ID }}
           base64_encoded_private_key: ${{ secrets.RELEASE_WORKFLOW_APP_PRIVATE_KEY_B64 }}
-          owner: ${{ github.repository_owner }}
 
       - name: Find open release PR branch
         id: pr-info
@@ -194,7 +192,6 @@ jobs:
         with:
           app_id: ${{ vars.RELEASE_WORKFLOW_CLIENT_ID }}
           base64_encoded_private_key: ${{ secrets.RELEASE_WORKFLOW_APP_PRIVATE_KEY_B64 }}
-          owner: ${{ github.repository_owner }}
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary

Drops `owner: ${{ github.repository_owner }}` from every
`unique-ag/actions/github/app-token-create` step in the release
workflows (7 sites across 4 files).

With `owner` set and `repositories` unset,
[`actions/create-github-app-token`](https://github.com/actions/create-github-app-token#usage)
mints a token covering **every** repo the App is installed on under
`Unique-AG` and authenticates via `GET /users/Unique-AG/installation`
(the URL visible in the recent failure logs:

> `Input 'repositories' is not set. Creating token for all repositories owned by Unique-AG.`
> `GET https://api.github.com/users/Unique-AG/installation`

).

With both inputs absent the underlying action falls back to
`GITHUB_REPOSITORY` and authenticates via
`GET /repos/Unique-AG/ai/installation` — exactly the scope these
workflows actually need.

## Why this is safe

I grep'd every consumer of `steps.app-token.outputs.token` in this
repo. Every one is a checkout / push / `gh` CLI call against the
calling repo (`Unique-AG/ai`):

- `actions/checkout` for `cd-arm-version`, `cd-publish-dev`,
  `cd-publish-rc`, `cd-release`
- `release-please-action` (operates on the calling repo)
- `gh pr create / pr edit / pr comment / release create` against
  `Unique-AG/ai`
- the `prepare-next-cycle.sh` script (commits to this repo)

No cross-repo writes. Narrowing scope strictly removes a permission
we never used.

## Relationship to #1592

Independent of [#1592](https://github.com/Unique-AG/ai/pull/1592)
(SHA bump for the PEM-validation hardening). The two PRs touch the
same `with:` blocks but on different lines (`uses:` vs an `owner:`
input), so they merge in either order without conflict. Neither this
PR nor #1592 fixes the current `A JSON web token could not be decoded`
401 — that's a key/App mismatch on the secret itself, tracked in
UN-20383.

## Test plan

- [ ] After merge + key rotation completes, trigger
      `cd-arm-version.yaml` via workflow_dispatch and confirm:
  - the action log no longer prints
    `Input 'repositories' is not set. Creating token for all repositories owned by Unique-AG.`
  - the URL in any failure trace is `/repos/Unique-AG/ai/installation`,
    not `/users/Unique-AG/installation`
- [ ] Confirm `cd-publish-dev.yaml` still opens its standing dev-bump
      PR with the App-authored push (anti-recursion CI trigger
      preserved).

Refs: UN-20383

Made with [Cursor](https://cursor.com)