### PR TITLE
chore(ci): scope release-workflow App token to the ai repo explicitly

### DIFF
--- a/.github/workflows/cd-arm-version.yaml
+++ b/.github/workflows/cd-arm-version.yaml
@@ -53,6 +53,7 @@ jobs:
         with:
           app_id: ${{ vars.RELEASE_WORKFLOW_CLIENT_ID }}
           base64_encoded_private_key: ${{ secrets.RELEASE_WORKFLOW_APP_PRIVATE_KEY_B64 }}
+          repositories: ai
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/cd-publish-dev.yaml
+++ b/.github/workflows/cd-publish-dev.yaml
@@ -296,6 +296,7 @@ jobs:
         with:
           app_id: ${{ vars.RELEASE_WORKFLOW_CLIENT_ID }}
           base64_encoded_private_key: ${{ secrets.RELEASE_WORKFLOW_APP_PRIVATE_KEY_B64 }}
+          repositories: ai
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -388,6 +389,7 @@ jobs:
         with:
           app_id: ${{ vars.RELEASE_WORKFLOW_CLIENT_ID }}
           base64_encoded_private_key: ${{ secrets.RELEASE_WORKFLOW_APP_PRIVATE_KEY_B64 }}
+          repositories: ai
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/cd-publish-rc.yaml
+++ b/.github/workflows/cd-publish-rc.yaml
@@ -338,6 +338,7 @@ jobs:
         with:
           app_id: ${{ vars.RELEASE_WORKFLOW_CLIENT_ID }}
           base64_encoded_private_key: ${{ secrets.RELEASE_WORKFLOW_APP_PRIVATE_KEY_B64 }}
+          repositories: ai
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/cd-release.yaml
+++ b/.github/workflows/cd-release.yaml
@@ -77,6 +77,7 @@ jobs:
         with:
           app_id: ${{ vars.RELEASE_WORKFLOW_CLIENT_ID }}
           base64_encoded_private_key: ${{ secrets.RELEASE_WORKFLOW_APP_PRIVATE_KEY_B64 }}
+          repositories: ai
 
       - id: rp
         uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
@@ -113,6 +114,7 @@ jobs:
         with:
           app_id: ${{ vars.RELEASE_WORKFLOW_CLIENT_ID }}
           base64_encoded_private_key: ${{ secrets.RELEASE_WORKFLOW_APP_PRIVATE_KEY_B64 }}
+          repositories: ai
 
       - name: Find open release PR branch
         id: pr-info
@@ -192,6 +194,7 @@ jobs:
         with:
           app_id: ${{ vars.RELEASE_WORKFLOW_CLIENT_ID }}
           base64_encoded_private_key: ${{ secrets.RELEASE_WORKFLOW_APP_PRIVATE_KEY_B64 }}
+          repositories: ai
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary

Adds `repositories: ai` to all 7 `unique-ag/actions/github/app-token-create`
call sites in the release workflows.

## Why this is needed on top of #1593

[#1593](https://github.com/Unique-AG/ai/pull/1593) removed
`owner: ${{ github.repository_owner }}` from the call sites with the
intent of falling back to `GITHUB_REPOSITORY`. **It was a runtime
no-op.** The wrapper action declares its own `owner` input with
`default: ${{ github.repository_owner }}` and unconditionally forwards
it to `actions/create-github-app-token`:

```yaml
# unique-ag/actions/github/app-token-create/action.yml
inputs:
  owner:
    default: ${{ github.repository_owner }}
# ...
- uses: actions/create-github-app-token@…
  with:
    owner: ${{ inputs.owner }}
    repositories: ${{ inputs.repositories }}
```

So even after #1593, the inner action received `owner: Unique-AG` /
`repositories: ""` — the "all repositories owned by `Unique-AG`" path
that authenticates via `GET /users/Unique-AG/installation`. The post-#1593
run log confirms this:

> `Input 'repositories' is not set. Creating token for all repositories owned by Unique-AG.`
> `url: 'https://api.github.com/users/Unique-AG/installation'`

(see https://github.com/Unique-AG/ai/actions/runs/25313177425)

Setting `repositories: ai` overrides the wrapper default's branch:
with both `owner` and `repositories` populated, the inner action mints
a token scoped to `Unique-AG/ai` only and authenticates via
`GET /repos/Unique-AG/ai/installation`.

## Why hardcoded `ai`

These four workflows live in this repo and never run anywhere else.
Hardcoded `ai` is self-documenting and parallels how the
`image.repository: uniqueapp.azurecr.io/unique/ai` references next to
them are spelled. If the repo is ever renamed, this is the same
one-line update as those.

(`${{ github.event.repository.name }}` would be more portable but
costs readability for a configuration that never moves.)

## What this PR does *not* fix

Same as #1593 / #1592: this does not unblock the current
`A JSON web token could not be decoded` 401, which is a key/App
mismatch on `RELEASE_WORKFLOW_APP_PRIVATE_KEY_B64`. That's tracked in
UN-20383 and resolved by the key rotation, not by anything in CI.

## Test plan

- [ ] After merge + key rotation, trigger `cd-arm-version.yaml` via
      workflow_dispatch and confirm in the action log:
  - the line `Input 'repositories' is not set...` is gone
  - any failure URL points at `/repos/Unique-AG/ai/installation`,
    not `/users/Unique-AG/installation`
- [ ] `cd-publish-dev` continues to open its standing dev-bump PR (the
      App-authored push that defeats GitHub's anti-recursion CI rule).

Refs: UN-20383

Made with [Cursor](https://cursor.com)