### PR TITLE
fix(ci): use repo-level RELEASE_WORKFLOW_APP_ID for App token

### DIFF
--- a/.github/workflows/cd-arm-version.yaml
+++ b/.github/workflows/cd-arm-version.yaml
@@ -17,10 +17,11 @@ name: "[CD] Release · Arm Version"
 # It pushes an empty `Release-As: YYYY.WW.0` commit directly to `main`.
 # Each trailer overrides the previous one; no cleanup is needed.
 #
-# Runs on gh-static-ip-slim under the `release-workflow` environment so
-# `prepare-next-cycle.sh` can authenticate as the Release Workflow App,
-# which is a bypass actor on the main-branch ruleset and the only
-# identity allowed to push directly to `main`.
+# Runs on gh-static-ip-slim because the Release Workflow App is
+# IP-origin-bound to that runner pool. `prepare-next-cycle.sh`
+# authenticates as the Release Workflow App, which is a bypass actor on
+# the main-branch ruleset and the only identity allowed to push directly
+# to `main`.
 
 permissions:
   contents: write
@@ -36,7 +37,6 @@ on:
 jobs:
   arm:
     runs-on: gh-static-ip-slim
-    environment: release-workflow
     timeout-minutes: 5
     steps:
       - name: Ensure workflow runs from main
@@ -51,7 +51,7 @@ jobs:
         id: app-token
         uses: unique-ag/actions/github/app-token-create@08cc24e926dda3254b05aa898c362790ec506a3d
         with:
-          app_id: ${{ vars.RELEASE_WORKFLOW_CLIENT_ID }}
+          app_id: ${{ vars.RELEASE_WORKFLOW_APP_ID }}
           base64_encoded_private_key: ${{ secrets.RELEASE_WORKFLOW_APP_PRIVATE_KEY_B64 }}
           repositories: ai
 

--- a/.github/workflows/cd-publish-dev.yaml
+++ b/.github/workflows/cd-publish-dev.yaml
@@ -283,7 +283,6 @@ jobs:
     needs: [resolve, publish]
     if: needs.publish.result == 'success'
     runs-on: gh-static-ip-slim
-    environment: release-workflow
     permissions:
       contents: write
     outputs:
@@ -294,7 +293,7 @@ jobs:
         id: app-token
         uses: unique-ag/actions/github/app-token-create@08cc24e926dda3254b05aa898c362790ec506a3d
         with:
-          app_id: ${{ vars.RELEASE_WORKFLOW_CLIENT_ID }}
+          app_id: ${{ vars.RELEASE_WORKFLOW_APP_ID }}
           base64_encoded_private_key: ${{ secrets.RELEASE_WORKFLOW_APP_PRIVATE_KEY_B64 }}
           repositories: ai
 
@@ -375,7 +374,6 @@ jobs:
     needs: [resolve, publish, tag-cut]
     if: needs.publish.result == 'success' && needs.tag-cut.result == 'success'
     runs-on: gh-static-ip-slim
-    environment: release-workflow
     permissions:
       contents: write
       pull-requests: write
@@ -387,7 +385,7 @@ jobs:
         id: app-token
         uses: unique-ag/actions/github/app-token-create@08cc24e926dda3254b05aa898c362790ec506a3d
         with:
-          app_id: ${{ vars.RELEASE_WORKFLOW_CLIENT_ID }}
+          app_id: ${{ vars.RELEASE_WORKFLOW_APP_ID }}
           base64_encoded_private_key: ${{ secrets.RELEASE_WORKFLOW_APP_PRIVATE_KEY_B64 }}
           repositories: ai
 

--- a/.github/workflows/cd-publish-rc.yaml
+++ b/.github/workflows/cd-publish-rc.yaml
@@ -320,15 +320,14 @@ jobs:
     # pre-release. We do not block on tag-release for PyPI: even if
     # tagging fails, the wheels are already shipped.
     #
-    # Runs on gh-static-ip-slim under the `release-workflow` environment
-    # so the tag and pre-release are authored by the Release Workflow
-    # App. App-authored tags / releases are not subject to GitHub's
-    # anti-recursion rule, which keeps the rc tag visible to any
-    # downstream automation that listens on `release: prereleased`.
+    # Runs on gh-static-ip-slim (the Release Workflow App is
+    # IP-origin-bound) so the tag and pre-release are authored by the
+    # Release Workflow App. App-authored tags / releases are not subject
+    # to GitHub's anti-recursion rule, which keeps the rc tag visible to
+    # any downstream automation that listens on `release: prereleased`.
     needs: [resolve, publish]
     if: needs.publish.result == 'success'
     runs-on: gh-static-ip-slim
-    environment: release-workflow
     permissions:
       contents: write
     steps:
@@ -336,7 +335,7 @@ jobs:
         id: app-token
         uses: unique-ag/actions/github/app-token-create@08cc24e926dda3254b05aa898c362790ec506a3d
         with:
-          app_id: ${{ vars.RELEASE_WORKFLOW_CLIENT_ID }}
+          app_id: ${{ vars.RELEASE_WORKFLOW_APP_ID }}
           base64_encoded_private_key: ${{ secrets.RELEASE_WORKFLOW_APP_PRIVATE_KEY_B64 }}
           repositories: ai
 

--- a/.github/workflows/cd-release.yaml
+++ b/.github/workflows/cd-release.yaml
@@ -28,9 +28,11 @@ name: "[CD] Release Pipeline"
 #          - the new `release/YYYY.WW` branch push triggers `cd-release`
 #            and `ci-pull-request.yaml` like any human-authored push.
 #
-#   Jobs that need the App token declare `environment: release-workflow`
-#   so the env-scoped credentials resolve, and run on `gh-static-ip-slim`
-#   because the App is IP-origin-bound to that runner pool.
+#   Jobs that need the App token run on `gh-static-ip-slim` because the
+#   App is IP-origin-bound to that runner pool. They read the App
+#   credentials from the repo-level `RELEASE_WORKFLOW_APP_ID` variable
+#   and `RELEASE_WORKFLOW_APP_PRIVATE_KEY_B64` secret (managed by
+#   Infra-as-Code).
 #
 # Concurrency
 # ===========
@@ -67,7 +69,6 @@ jobs:
     # needed) and lets the App's bypass rights cover the tag push on
     # protected branches.
     runs-on: gh-static-ip-slim
-    environment: release-workflow
     outputs:
       releases_created: ${{ steps.rp.outputs.releases_created }}
     steps:
@@ -75,7 +76,7 @@ jobs:
         id: app-token
         uses: unique-ag/actions/github/app-token-create@08cc24e926dda3254b05aa898c362790ec506a3d
         with:
-          app_id: ${{ vars.RELEASE_WORKFLOW_CLIENT_ID }}
+          app_id: ${{ vars.RELEASE_WORKFLOW_APP_ID }}
           base64_encoded_private_key: ${{ secrets.RELEASE_WORKFLOW_APP_PRIVATE_KEY_B64 }}
           repositories: ai
 
@@ -106,13 +107,12 @@ jobs:
     needs: release-please
     if: needs.release-please.outputs.releases_created != 'true'
     runs-on: gh-static-ip-slim
-    environment: release-workflow
     steps:
       - name: Generate GitHub App token
         id: app-token
         uses: unique-ag/actions/github/app-token-create@08cc24e926dda3254b05aa898c362790ec506a3d
         with:
-          app_id: ${{ vars.RELEASE_WORKFLOW_CLIENT_ID }}
+          app_id: ${{ vars.RELEASE_WORKFLOW_APP_ID }}
           base64_encoded_private_key: ${{ secrets.RELEASE_WORKFLOW_APP_PRIVATE_KEY_B64 }}
           repositories: ai
 
@@ -178,21 +178,19 @@ jobs:
   #
   # Runs on gh-static-ip-slim: the Release Workflow GitHub App is
   # IP-origin-bound and only accepts requests from this runner's static IP.
-  # The `release-workflow` environment scopes the App credentials.
   cut-and-arm:
     needs: release-please
     if: >-
       needs.release-please.outputs.releases_created == 'true'
       && github.ref == 'refs/heads/main'
     runs-on: gh-static-ip-slim
-    environment: release-workflow
     timeout-minutes: 5
     steps:
       - name: Generate GitHub App token
         id: app-token
         uses: unique-ag/actions/github/app-token-create@08cc24e926dda3254b05aa898c362790ec506a3d
         with:
-          app_id: ${{ vars.RELEASE_WORKFLOW_CLIENT_ID }}
+          app_id: ${{ vars.RELEASE_WORKFLOW_APP_ID }}
           base64_encoded_private_key: ${{ secrets.RELEASE_WORKFLOW_APP_PRIVATE_KEY_B64 }}
           repositories: ai
 


### PR DESCRIPTION
## Summary

The release workflows were reading App credentials from the `release-workflow` environment overlay (`vars.RELEASE_WORKFLOW_CLIENT_ID` and the env-scoped `RELEASE_WORKFLOW_APP_PRIVATE_KEY_B64` secret), which still points at an abandoned AI-specific App that was never finished being created. The repo was switched in IaC ([Unique-AG/infrastructure@554a8a1](https://github.com/Unique-AG/infrastructure/commit/554a8a18)) to reuse the existing shared release-workflow App (App ID `2324764`, the same App the monorepo uses) at the repo level, but the workflows kept reading the broken env overlay — so every App-token step failed with `A JSON web token could not be decoded`, even after [#2427](https://github.com/Unique-AG/infrastructure/pull/2427) rotated the env-scoped key.

Fix the workflows to match the monorepo pattern:

- Read the App ID from the repo-level `RELEASE_WORKFLOW_APP_ID` variable (= `2324764`) instead of the orphaned `RELEASE_WORKFLOW_CLIENT_ID` env var.
- Drop `environment: release-workflow` from every affected job so the wrong env-scoped secret stops shadowing the correct repo-level one.

The `release-workflow` environment carries no protection rules (`protection_rules: []`, `deployment_branch_policy: null`), so removing the `environment:` declaration changes nothing else. The `gh-static-ip-slim` runner is preserved because the App is IP-origin-bound to that pool. Comment headers updated to match.

## Why the env overlay went stale
- `06ba1b58` (Apr 25) added env-scoped placeholders for a planned AI-specific App.
- `554a8a18` (Apr 28) "reuse existing release workflow app for ai repo" replaced the placeholders at the **repo** level (`RELEASE_WORKFLOW_APP_ID = 2324764`) but left the env-scoped overlay in place.
- The workflows kept reading `vars.RELEASE_WORKFLOW_CLIENT_ID` from the env overlay, which still resolves to the abandoned App.

## Follow-up
Once this is merged and the dev/release pipelines go green, follow up in `Unique-AG/infrastructure` by deleting the now-orphaned `environments.release-workflow` block from `providers/github/unique-ag/repos/ai.yaml` so GitHub stops carrying the stale env-scoped vars/secrets. Tracked in UN-20383.

## Test plan
- [ ] Re-run the failing `cd-publish-dev` workflow and confirm the App-token step succeeds.
- [ ] Re-run `cd-release` (release-please) once a release-relevant commit lands; confirm release-please commits are authored by the App.
- [ ] `cd-arm-version` manual dispatch succeeds (auth needs the App's bypass on the `main` ruleset).
- [ ] `cd-publish-rc` tag step succeeds and the RC GitHub Release shows the App as author.

Refs: [UN-20383](https://unique-ch.atlassian.net/browse/UN-20383)

Made with [Cursor](https://cursor.com)

[UN-20383]: https://unique-ch.atlassian.net/browse/UN-20383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ