### PR TITLE
chore(ci): add minimal repro workflow for App token JWT decode 401

### DIFF
--- a/.github/workflows/debug-app-token.yaml
+++ b/.github/workflows/debug-app-token.yaml
@@ -1,0 +1,69 @@
+name: Debug App Token
+
+# Minimal repro for the "A JSON web token could not be decoded" 401 we hit on the
+# release-workflow App in this repo. This workflow has no checkout, no git push,
+# no release-please — only the App token generation step and a probe call. If
+# this fails, the cause is in vars.RELEASE_WORKFLOW_CLIENT_ID, the env-scoped
+# secret RELEASE_WORKFLOW_APP_PRIVATE_KEY_B64, or the App's server-side public
+# key set; nothing else can be at fault.
+
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  via-wrapper:
+    name: Generate token via unique-ag/actions wrapper
+    runs-on: ubuntu-latest
+    environment: release-workflow
+    timeout-minutes: 5
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: unique-ag/actions/github/app-token-create@08cc24e926dda3254b05aa898c362790ec506a3d
+        with:
+          app_id: ${{ vars.RELEASE_WORKFLOW_CLIENT_ID }}
+          base64_encoded_private_key: ${{ secrets.RELEASE_WORKFLOW_APP_PRIVATE_KEY_B64 }}
+          repositories: ai
+
+      - name: Probe App identity
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh api /installation/repositories --jq '.repositories[].full_name'
+
+  via-upstream:
+    name: Generate token via actions/create-github-app-token directly
+    runs-on: ubuntu-latest
+    environment: release-workflow
+    timeout-minutes: 5
+    steps:
+      - name: Decode base64 private key
+        id: decode
+        env:
+          BASE64_ENCODED_PRIVATE_KEY: ${{ secrets.RELEASE_WORKFLOW_APP_PRIVATE_KEY_B64 }}
+        run: |
+          set -euo pipefail
+          set +x
+          DECODED=$(echo -n "$BASE64_ENCODED_PRIVATE_KEY" | base64 -d)
+          echo "::add-mask::$DECODED"
+          {
+            echo "private_key<<__EOF__"
+            echo "$DECODED"
+            echo "__EOF__"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Generate GitHub App token (no wrapper)
+        id: app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        with:
+          app-id: ${{ vars.RELEASE_WORKFLOW_CLIENT_ID }}
+          private-key: ${{ steps.decode.outputs.private_key }}
+          repositories: ai
+
+      - name: Probe App identity
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh api /installation/repositories --jq '.repositories[].full_name'


### PR DESCRIPTION
## Summary

Adds a minimal `workflow_dispatch` workflow that reproduces the `A JSON web token could not be decoded` 401 we keep hitting on the `release-workflow` App in this repo. Two jobs, both with `environment: release-workflow`, no checkout, no side effects:

1. `via-wrapper` — uses `unique-ag/actions/github/app-token-create` exactly as the production workflows do.
2. `via-upstream` — calls `actions/create-github-app-token@v3.0.0` directly with a hand-rolled base64 decode, bypassing our wrapper.

Each job ends with a single `gh api /installation/repositories` call so a successful run prints `Unique-AG/ai`.

## Why

If both jobs fail at the token step, the cause is in `vars.RELEASE_WORKFLOW_CLIENT_ID`, the env-scoped secret `RELEASE_WORKFLOW_APP_PRIVATE_KEY_B64`, or the App's server-side public key set — nothing else in the workflow can be at fault.

If only `via-wrapper` fails, the wrapper is the culprit.
If only `via-upstream` fails, our base64 step is fine.

## Test plan

- [ ] Trigger via Actions tab → \"Debug App Token\" → Run workflow on \`chore/debug-app-token-repro\`
- [ ] Compare outputs of the two jobs
- [ ] Once root-caused and the App token works again, delete this workflow

Refs: UN-20383

Made with [Cursor](https://cursor.com)