### PR TITLE
chore(ci): 2x2 matrix repro for App token (env x app_id)

### DIFF
--- a/.github/workflows/debug-app-token.yaml
+++ b/.github/workflows/debug-app-token.yaml
@@ -2,10 +2,22 @@ name: Debug App Token
 
 # Minimal repro for the "A JSON web token could not be decoded" 401 we hit on the
 # release-workflow App in this repo. This workflow has no checkout, no git push,
-# no release-please — only the App token generation step and a probe call. If
-# this fails, the cause is in vars.RELEASE_WORKFLOW_CLIENT_ID, the env-scoped
-# secret RELEASE_WORKFLOW_APP_PRIVATE_KEY_B64, or the App's server-side public
-# key set; nothing else can be at fault.
+# no release-please — only the App token generation step and a probe call.
+#
+# Four jobs in a 2x2 matrix that isolate the cause:
+#                                  | environment: release-workflow | no environment
+#   ----------------------------------------------------------------+---------------------------------
+#   vars.RELEASE_WORKFLOW_CLIENT_ID | via-wrapper-env-clientid      | via-wrapper-noenv-clientid
+#   vars.RELEASE_WORKFLOW_APP_ID    | via-wrapper-env-appid         | via-wrapper-noenv-appid
+#
+# Theory under test: the `release-workflow` GitHub Environment still holds stale
+# secret/var values from an earlier IaC iteration (its `environments:` block has
+# since been removed from `infrastructure/providers/github/unique-ag/repos/ai.yaml`,
+# but the env on GitHub itself wasn't deleted). Repo-level IaC currently defines
+# `RELEASE_WORKFLOW_APP_ID = "2324764"` and a working
+# `RELEASE_WORKFLOW_APP_PRIVATE_KEY_B64` (same blob the monorepo uses every day).
+# If our hypothesis holds, the `noenv-appid` job succeeds while the env-scoped
+# jobs fail, and the cleanup is to delete the GitHub Environment.
 
 on:
   workflow_dispatch:
@@ -13,8 +25,8 @@ on:
 permissions: {}
 
 jobs:
-  via-wrapper:
-    name: Generate token via unique-ag/actions wrapper
+  via-wrapper-env-clientid:
+    name: env=release-workflow + vars.RELEASE_WORKFLOW_CLIENT_ID (current prod config)
     runs-on: ubuntu-latest
     environment: release-workflow
     timeout-minutes: 5
@@ -30,40 +42,59 @@ jobs:
       - name: Probe App identity
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          gh api /installation/repositories --jq '.repositories[].full_name'
+        run: gh api /installation/repositories --jq '.repositories[].full_name'
 
-  via-upstream:
-    name: Generate token via actions/create-github-app-token directly
+  via-wrapper-env-appid:
+    name: env=release-workflow + vars.RELEASE_WORKFLOW_APP_ID (numeric, like monorepo)
     runs-on: ubuntu-latest
     environment: release-workflow
     timeout-minutes: 5
     steps:
-      - name: Decode base64 private key
-        id: decode
-        env:
-          BASE64_ENCODED_PRIVATE_KEY: ${{ secrets.RELEASE_WORKFLOW_APP_PRIVATE_KEY_B64 }}
-        run: |
-          set -euo pipefail
-          set +x
-          DECODED=$(echo -n "$BASE64_ENCODED_PRIVATE_KEY" | base64 -d)
-          echo "::add-mask::$DECODED"
-          {
-            echo "private_key<<__EOF__"
-            echo "$DECODED"
-            echo "__EOF__"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Generate GitHub App token (no wrapper)
+      - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        uses: unique-ag/actions/github/app-token-create@08cc24e926dda3254b05aa898c362790ec506a3d
         with:
-          app-id: ${{ vars.RELEASE_WORKFLOW_CLIENT_ID }}
-          private-key: ${{ steps.decode.outputs.private_key }}
+          app_id: ${{ vars.RELEASE_WORKFLOW_APP_ID }}
+          base64_encoded_private_key: ${{ secrets.RELEASE_WORKFLOW_APP_PRIVATE_KEY_B64 }}
           repositories: ai
 
       - name: Probe App identity
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          gh api /installation/repositories --jq '.repositories[].full_name'
+        run: gh api /installation/repositories --jq '.repositories[].full_name'
+
+  via-wrapper-noenv-clientid:
+    name: no environment + vars.RELEASE_WORKFLOW_CLIENT_ID
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: unique-ag/actions/github/app-token-create@08cc24e926dda3254b05aa898c362790ec506a3d
+        with:
+          app_id: ${{ vars.RELEASE_WORKFLOW_CLIENT_ID }}
+          base64_encoded_private_key: ${{ secrets.RELEASE_WORKFLOW_APP_PRIVATE_KEY_B64 }}
+          repositories: ai
+
+      - name: Probe App identity
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: gh api /installation/repositories --jq '.repositories[].full_name'
+
+  via-wrapper-noenv-appid:
+    name: no environment + vars.RELEASE_WORKFLOW_APP_ID (matches monorepo, expected ✅)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: unique-ag/actions/github/app-token-create@08cc24e926dda3254b05aa898c362790ec506a3d
+        with:
+          app_id: ${{ vars.RELEASE_WORKFLOW_APP_ID }}
+          base64_encoded_private_key: ${{ secrets.RELEASE_WORKFLOW_APP_PRIVATE_KEY_B64 }}
+          repositories: ai
+
+      - name: Probe App identity
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: gh api /installation/repositories --jq '.repositories[].full_name'


### PR DESCRIPTION
## Summary

Follow-up to #1598. Expands `debug-app-token.yaml` from two equivalent jobs into a 2×2 matrix that varies the two dimensions where the AI repo's call sites differ from the monorepo's working call sites:

|                                  | `environment: release-workflow` | no `environment:`                 |
|----------------------------------|---------------------------------|-----------------------------------|
| `vars.RELEASE_WORKFLOW_CLIENT_ID` | `via-wrapper-env-clientid` (current prod)     | `via-wrapper-noenv-clientid`      |
| `vars.RELEASE_WORKFLOW_APP_ID`    | `via-wrapper-env-appid`         | `via-wrapper-noenv-appid` (matches monorepo, expected ✅) |

## Hypothesis under test

The \`release-workflow\` GitHub Environment still holds stale secret/var values from an earlier IaC iteration. The \`environments:\` block has since been removed from \`infrastructure/providers/github/unique-ag/repos/ai.yaml\`, but the IaC reconciler doesn't delete environments or their content — only the desired state from source is enforced.

Repo-level IaC for \`ai\` currently defines:

\`\`\`yaml
actions_variables:
  RELEASE_WORKFLOW_APP_ID: \"2324764\"
encrypted_actions_secrets:
  RELEASE_WORKFLOW_APP_PRIVATE_KEY_B64: 5riWnJc1q2b579/dMUGKOD7j92399pUV5TJXE/wZyEshBXNIn…   # same blob as monorepo's
\`\`\`

If the hypothesis is right:

- `via-wrapper-noenv-appid` ✅ — uses the working repo-level secret + numeric App ID, just like monorepo.
- `via-wrapper-noenv-clientid` likely ❌ — \`RELEASE_WORKFLOW_CLIENT_ID\` isn't defined at repo level, so \`app_id\` is empty.
- `via-wrapper-env-*` ❌ — env-scoped \`RELEASE_WORKFLOW_APP_PRIVATE_KEY_B64\` shadows the working repo-level secret with the broken stale value, regardless of which \`app_id\` is used.

## Cleanup path implied

If the matrix confirms the hypothesis:

1. Delete the \`release-workflow\` GitHub Environment from this repo (Settings → Environments).
2. Switch all 7 production call sites in \`cd-arm-version.yaml\`, \`cd-publish-dev.yaml\`, \`cd-publish-rc.yaml\`, \`cd-release.yaml\` to \`vars.RELEASE_WORKFLOW_APP_ID\` and drop \`environment: release-workflow\`. This brings AI repo into parity with the monorepo's working pattern.

## Test plan

- [ ] Trigger via Actions tab → \"Debug App Token\" → Run workflow on \`chore/debug-app-token-no-env\`
- [ ] Read the four job statuses and update this PR with results
- [ ] Land the cleanup PR(s) implied by the matrix outcome

Refs: UN-20383

Made with [Cursor](https://cursor.com)