### PR TITLE
docs(toolkit): add trailing periods to knowledge_base delete docstrings

### DIFF
--- a/unique_toolkit/unique_toolkit/services/knowledge_base.py
+++ b/unique_toolkit/unique_toolkit/services/knowledge_base.py
@@ -1128,8 +1128,7 @@ class KnowledgeBaseService:
         content_id: str | None = None,
         file_path: str | None = None,
     ) -> DeleteContentResponse:
-        """Delete content by id, file path or metadata filter"""
-
+        """Delete content by id, file path or metadata filter."""
         return delete_content(
             user_id=self._user_id,
             company_id=self._company_id,
@@ -1142,7 +1141,7 @@ class KnowledgeBaseService:
         *,
         metadata_filter: dict[str, Any],
     ) -> list[DeleteContentResponse]:
-        """Delete all content matching the metadata filter"""
+        """Delete all content matching the metadata filter."""
         resp: list[DeleteContentResponse] = []
 
         if metadata_filter:
@@ -1193,7 +1192,7 @@ class KnowledgeBaseService:
         *,
         metadata_filter: dict[str, Any],
     ) -> list[DeleteContentResponse]:
-        """Delete all content matching the metadata filter"""
+        """Delete all content matching the metadata filter."""
         if not metadata_filter:
             return []
 


### PR DESCRIPTION
## Summary

Three single-line docstrings on `KnowledgeBaseService.delete_content`, `KnowledgeBaseService.delete_contents`, and `KnowledgeBaseService.delete_contents_async` were missing terminal periods (PEP 257 / pydocstyle D415). Adds them and removes one stray blank line between docstring and body.

Cosmetic only; no behaviour change. Used as a smoke test for the now-fixed release-workflow App token plumbing — first toolkit-source change since #1599 went green.

Made with [Cursor](https://cursor.com)