### PR TITLE
ci(scripts): align coverage pytest invocation with test job

### DIFF
--- a/.github/actions/run-coverage-check/action.yml
+++ b/.github/actions/run-coverage-check/action.yml
@@ -21,6 +21,10 @@ inputs:
     description: 'Minimum coverage percentage'
     required: false
     default: '60'
+  test_args:
+    description: 'Additional arguments passed to pytest (same as CI test job, e.g. -m "not integration")'
+    required: false
+    default: ''
 
 runs:
   using: 'composite'
@@ -53,6 +57,8 @@ runs:
 
     - name: Check coverage on new/changed code
       shell: bash
+      env:
+        CHECK_COVERAGE_PYTEST_ARGS: ${{ inputs.test_args }}
       run: |
         ARGS=(
           "${{ inputs.package_dir }}"

--- a/.github/scripts/check-coverage.sh
+++ b/.github/scripts/check-coverage.sh
@@ -3,6 +3,10 @@
 # Script to check test coverage on new/changed code
 # Can be used both in CI workflows and locally (e.g., with pre-commit)
 #
+# Pytest is invoked from the package directory with no path arguments, matching
+# the CI test job (default collection). Optional extra arguments may be passed
+# via the CHECK_COVERAGE_PYTEST_ARGS environment variable (e.g. -m "not integration").
+#
 # Usage:
 #   CI: check-coverage.sh <package_name> <base_ref> <min_coverage>
 #   Local: check-coverage.sh <package_name> [base_ref] [min_coverage]
@@ -54,9 +58,12 @@ USAGE:
 
 DESCRIPTION:
     This script checks test coverage on newly added or modified code by:
-    1. Running tests with coverage collection
+    1. Running tests with coverage collection (same pytest discovery as CI test)
     2. Comparing coverage against a base branch
     3. Ensuring new/changed code meets minimum coverage threshold
+
+ENVIRONMENT:
+    CHECK_COVERAGE_PYTEST_ARGS   Optional extra arguments for pytest (word-split like CI test_args)
 
 ARGUMENTS:
     package_name          Name of the package directory (e.g., unique_toolkit)
@@ -331,24 +338,15 @@ if [ "$SKIP_TESTS" = false ]; then
     print_info "Running tests with coverage..."
     # Extract package name from PACKAGE directory (e.g., unique_toolkit from unique_toolkit/)
     PACKAGE_NAME=$(basename "$PACKAGE")
-    
-    # Find tests directory - try multiple locations
-    if [ -d "tests" ]; then
-        TESTS_DIR="tests/"
-    elif [ -d "$PACKAGE_NAME/tests" ]; then
-        TESTS_DIR="$PACKAGE_NAME/tests/"
-    else
-        # Search for test files in the package
-        TESTS_DIR="$PACKAGE_NAME/"
-        print_info "No dedicated tests/ directory found, searching in $TESTS_DIR"
-    fi
-    
-    print_info "Running tests from: $TESTS_DIR"
+
+    # Match CI test job: pytest from package root with default discovery (no path args).
+    print_info "Running pytest with default collection (parity with CI test job)"
+    # shellcheck disable=SC2086
     $RUNNER pytest \
         --cov="$PACKAGE_NAME" \
         --cov-report=xml \
         --cov-report=term \
-        "$TESTS_DIR" || {
+        ${CHECK_COVERAGE_PYTEST_ARGS:-} || {
         print_warning "Some tests failed, but continuing with coverage check..."
     }
 fi

--- a/.github/scripts/dev.sh
+++ b/.github/scripts/dev.sh
@@ -204,7 +204,7 @@ cmd_coverage() {
         # Check if the CI script exists
         SCRIPT_PATH="$(git rev-parse --show-toplevel)/.github/scripts/check-coverage.sh"
         if [[ -f "$SCRIPT_PATH" ]]; then
-            bash "$SCRIPT_PATH" "$PACKAGE_DIR" --base-ref "$BASE_REF" --runner "$RUN" "${EXTRA_ARGS[@]}"
+            CHECK_COVERAGE_PYTEST_ARGS="${EXTRA_ARGS[*]}" bash "$SCRIPT_PATH" "$PACKAGE_DIR" --base-ref "$BASE_REF" --runner "$RUN"
         else
             print_warn "CI script not found, falling back to simple coverage"
             $RUN pytest --cov="$PACKAGE_NAME" --cov-report=term-missing "${EXTRA_ARGS[@]}"

--- a/.github/workflows/ci-coverage.yaml
+++ b/.github/workflows/ci-coverage.yaml
@@ -86,5 +86,6 @@ jobs:
           package_dir: ${{ matrix.dir }}
           python_version: ${{ matrix.python }}
           install_args: ${{ matrix.install_args }}
+          test_args: ${{ matrix.test_args }}
           base_ref: origin/${{ github.base_ref || 'main' }}
           min_coverage: ${{ matrix.min_coverage }}

--- a/unique_orchestrator/tests/test_config_gpt55_responses_api.py
+++ b/unique_orchestrator/tests/test_config_gpt55_responses_api.py
@@ -8,9 +8,8 @@ which tools are configured.
 
 Tracked in Jira: UN-20123.
 
-These tests live in the top-level ``tests/`` directory so the CI coverage
-script (``check-coverage.sh``) picks them up — pytest's collection in CI
-starts at ``tests/`` and does not descend into ``unique_orchestrator/tests/``.
+These tests live in the top-level ``tests/`` directory; CI test and coverage use
+the same pytest discovery from the package root.
 """
 
 from __future__ import annotations

--- a/unique_orchestrator/tests/test_settings.py
+++ b/unique_orchestrator/tests/test_settings.py
@@ -13,9 +13,9 @@ These tests exercise:
 * The module-level ``env_settings`` singleton, which is the entry point
   every other module in the package uses.
 
-Lives under the top-level ``tests/`` directory so the CI coverage runner
-(``check-coverage.sh``) picks it up — collection in CI starts at
-``tests/`` and does not descend into ``unique_orchestrator/tests/``.
+Lives under the top-level ``tests/`` directory; CI test and coverage both run
+pytest from the package root with default discovery, so inner-package tests are
+collected too.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- **`check-coverage.sh`** runs `pytest` from the package directory with **no explicit test paths**, matching `.github/actions/run-tests` default discovery (fixes orchestrator split between `tests/` and `unique_orchestrator/tests/`).
- **`run-coverage-check`** accepts **`test_args`** and passes them via **`CHECK_COVERAGE_PYTEST_ARGS`** (parity with SDK `-m "not integration"`).
- **`dev.sh coverage`** forwards extra pytest args through that env var instead of trailing argv (which `check-coverage.sh` rejected).
- Updated orchestrator test module docstrings that described the old coverage-only collection behavior.

## AI assist
Medium — CI script and workflow wiring.

Refs: —

Made with [Cursor](https://cursor.com)