### PR TITLE
fix(toolkit): prefer RFC 5987 UTF-8 filename in Content-Disposition header (UN-20243)

### DIFF
--- a/unique_toolkit/tests/content/test_content_functions_unit.py
+++ b/unique_toolkit/tests/content/test_content_functions_unit.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 
 from unique_toolkit.content.functions import (
+    _extract_filename,
     download_content,
     download_content_to_bytes,
     download_content_to_bytes_async,
@@ -762,3 +763,66 @@ async def test_trigger_upload_content_async_timeout_not_default_5s(
     assert not isinstance(timeout, httpx.Timeout) or timeout.read != 5.0, (
         "read timeout must not be the default 5 s"
     )
+
+
+class TestExtractFilename:
+    def test_prefers_utf8_filename_over_ascii(self):
+        header = (
+            'attachment; filename="??? ???????.pptx"; '
+            "filename*=UTF-8''%D0%98%D0%9A%D0%A2%20%D0%A3%D0%A0%D0%95%D0%82%D0%90%D0%88%D0%98.pptx"
+        )
+        assert _extract_filename(header) == "ИКТ УРЕЂАЈИ.pptx"
+
+    def test_utf8_filename_only(self):
+        header = "attachment; filename*=UTF-8''%C3%BCbersicht.pdf"
+        assert _extract_filename(header) == "übersicht.pdf"
+
+    def test_falls_back_to_ascii_filename(self):
+        header = 'attachment; filename="report.pdf"'
+        assert _extract_filename(header) == "report.pdf"
+
+    def test_returns_none_when_no_filename(self):
+        assert _extract_filename("") is None
+        assert _extract_filename("attachment") is None
+
+    def test_case_insensitive_charset(self):
+        header = "attachment; filename*=utf-8''%C3%A9t%C3%A9.docx"
+        assert _extract_filename(header) == "été.docx"
+
+    def test_latin_diacritics(self):
+        header = "attachment; filename=\"obican.txt\"; filename*=UTF-8''obi%C4%8Dan.txt"
+        assert _extract_filename(header) == "običan.txt"
+
+    def test_with_language_tag(self):
+        header = "attachment; filename*=UTF-8'sr'%D0%98%D0%9A%D0%A2%20%D0%A3%D0%A0%D0%95%D0%82%D0%90%D0%88%D0%98.pptx"
+        assert _extract_filename(header) == "ИКТ УРЕЂАЈИ.pptx"
+
+    def test_with_language_tag_and_ascii_fallback(self):
+        header = "attachment; filename=\"fallback.pptx\"; filename*=UTF-8'en'%C3%BCbersicht.pdf"
+        assert _extract_filename(header) == "übersicht.pdf"
+
+
+@patch("unique_toolkit.content.functions.requests.get")
+def test_download_content_to_file_by_id_utf8_filename(mock_get, tmp_path):
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.content = b"file bytes"
+    mock_response.headers = {
+        "Content-Disposition": (
+            'attachment; filename="??? ???????.pptx"; '
+            "filename*=UTF-8''%D0%98%D0%9A%D0%A2%20%D0%A3%D0%A0%D0%95%D0%82%D0%90%D0%88%D0%98.pptx"
+        )
+    }
+    mock_get.return_value = mock_response
+
+    result = download_content_to_file_by_id(
+        user_id="user123",
+        company_id="company123",
+        content_id="content123",
+        chat_id="chat123",
+        tmp_dir_path=tmp_path,
+    )
+
+    assert result.exists()
+    assert result.name == "ИКТ УРЕЂАЈИ.pptx"
+    assert result.read_bytes() == b"file bytes"

--- a/unique_toolkit/unique_toolkit/content/functions.py
+++ b/unique_toolkit/unique_toolkit/content/functions.py
@@ -2,6 +2,7 @@ import logging
 import os
 import re
 import tempfile
+import urllib.parse
 from pathlib import Path
 from typing import Any
 
@@ -725,6 +726,26 @@ async def request_content_by_id_async(
         return await client.get(url, headers=headers)
 
 
+def _extract_filename(content_disposition: str) -> str | None:
+    """Extract filename from a Content-Disposition header.
+
+    Prefers the RFC 5987 ``filename*=UTF-8''...`` parameter (which carries
+    properly percent-encoded UTF-8 filenames) and falls back to the legacy
+    ASCII ``filename="..."`` parameter.
+    """
+    utf8_match = re.search(
+        r"filename\*=UTF-8'[^']*'(.+?)(?:;|$)", content_disposition, re.IGNORECASE
+    )
+    if utf8_match:
+        return urllib.parse.unquote(utf8_match.group(1))
+
+    ascii_match = re.search(r'filename="([^"]+)"', content_disposition)
+    if ascii_match:
+        return ascii_match.group(1)
+
+    return None
+
+
 def download_content_to_file_by_id(
     user_id: str,
     company_id: str,
@@ -759,10 +780,11 @@ def download_content_to_file_by_id(
         if filename:
             content_path = Path(random_dir) / filename
         else:
-            pattern = r'filename="([^"]+)"'
-            match = re.search(pattern, response.headers.get("Content-Disposition", ""))
-            if match:
-                content_path = Path(random_dir) / match.group(1)
+            extracted = _extract_filename(
+                response.headers.get("Content-Disposition", "")
+            )
+            if extracted:
+                content_path = Path(random_dir) / extracted
             else:
                 error_msg = "Error downloading file: Filename could not be determined"
                 logger.error(error_msg)


### PR DESCRIPTION
## Summary

Fixes [UN-20243](https://unique-ch.atlassian.net/browse/UN-20243)

### Problem

`download_content_to_file_by_id` extracts the filename from the `Content-Disposition` response header using a regex that only matches the legacy ASCII `filename="..."` parameter:

```python
pattern = r'filename="([^"]+)"'
```

When the backend sends a file with non-ASCII characters (e.g. Serbian Cyrillic `ИКТ УРЕЂАЈИ.pptx` or Latin diacritics like `običan`, `ću`, `prevođenje`), the header looks like:

```
Content-Disposition: attachment; filename="??? ???????.pptx"; filename*=UTF-8''%D0%98%D0%9A%D0%A2...pptx
```

The regex captures the ASCII-degraded `filename` (with `?` for non-ASCII chars), saves the file locally with the corrupted name, and downstream consumers (e.g. the translator) propagate the corruption — resulting in filenames like `~___ _______~ (German).pptx`.

### Fix

- Extracted filename parsing into a new `_extract_filename` helper function that **prefers** the RFC 5987 `filename*=UTF-8''...` parameter (percent-encoded UTF-8) and **falls back** to the legacy ASCII `filename="..."` only when the UTF-8 variant is absent.
- Updated `download_content_to_file_by_id` to use this helper.

### Files changed

- `unique_toolkit/content/functions.py` — added `import urllib.parse`, new `_extract_filename` helper, updated `download_content_to_file_by_id`
- `tests/content/test_content_functions_unit.py` — added `TestExtractFilename` class (6 cases) and `test_download_content_to_file_by_id_utf8_filename` integration test

## Test plan

- [x] All 32 existing + new unit tests pass
- [ ] Verify with a real file that has non-ASCII characters in its name (e.g. Cyrillic, diacritics)
- [ ] Confirm translated file output carries the correct original filename


Made with [Cursor](https://cursor.com)

[UN-20243]: https://unique-ch.atlassian.net/browse/UN-20243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ