### PR TITLE
feat(sdk): add WebSearch / WebCrawl resources and unique-cli web-search

### DIFF
--- a/.github/scripts/check-coverage.sh
+++ b/.github/scripts/check-coverage.sh
@@ -63,7 +63,8 @@ DESCRIPTION:
     3. Ensuring new/changed code meets minimum coverage threshold
 
 ENVIRONMENT:
-    CHECK_COVERAGE_PYTEST_ARGS   Optional extra arguments for pytest (word-split like CI test_args)
+    CHECK_COVERAGE_PYTEST_ARGS   Optional extra arguments for pytest. Parsed with shell quoting
+                                 rules (so e.g. -m "not integration" stays as two tokens).
 
 ARGUMENTS:
     package_name          Name of the package directory (e.g., unique_toolkit)
@@ -341,12 +342,22 @@ if [ "$SKIP_TESTS" = false ]; then
 
     # Match CI test job: pytest from package root with default discovery (no path args).
     print_info "Running pytest with default collection (parity with CI test job)"
-    # shellcheck disable=SC2086
+
+    # Parse CHECK_COVERAGE_PYTEST_ARGS with shell quoting rules so values like
+    # `-m "not integration"` survive as two tokens. Naive ${VAR} expansion
+    # word-splits on whitespace and would emit `-m`, `"not`, `integration"`,
+    # leaving pytest to treat `integration"` as a missing test path.
+    EXTRA_PYTEST_ARGS=()
+    if [ -n "${CHECK_COVERAGE_PYTEST_ARGS:-}" ]; then
+        # shellcheck disable=SC2294
+        eval "EXTRA_PYTEST_ARGS=( ${CHECK_COVERAGE_PYTEST_ARGS} )"
+    fi
+
     $RUNNER pytest \
         --cov="$PACKAGE_NAME" \
         --cov-report=xml \
         --cov-report=term \
-        ${CHECK_COVERAGE_PYTEST_ARGS:-} || {
+        "${EXTRA_PYTEST_ARGS[@]}" || {
         print_warning "Some tests failed, but continuing with coverage check..."
     }
 fi

--- a/unique_sdk/tests/cli/test_web_search.py
+++ b/unique_sdk/tests/cli/test_web_search.py
@@ -1,0 +1,893 @@
+"""Tests for the unique-cli web-search subcommands."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+import unique_sdk
+from unique_sdk.cli.cli import main as cli_main
+from unique_sdk.cli.commands.web_search import (
+    WEB_CRAWL_ERROR_PREFIX,
+    WEB_SEARCH_ERROR_PREFIX,
+    _format_crawl_results,
+    _format_crawl_results_json,
+    _format_search_results,
+    _format_search_results_json,
+    _parse_crawler_config,
+    _parse_engine_config,
+    _payload_from_resource,
+    cmd_web_crawl,
+    cmd_web_search,
+    is_error_output,
+)
+from unique_sdk.cli.commands.web_search_config import (
+    ENV_CONFIG_PATH,
+    ConfigOverrides,
+    WebSearchCLIConfigError,
+    is_full_platform_config,
+    load_overrides,
+    parse_config_data,
+    resolve_config_path,
+)
+from unique_sdk.cli.config import Config
+from unique_sdk.cli.state import ShellState
+
+
+def _config() -> Config:
+    return Config(
+        user_id="u1",
+        company_id="c1",
+        api_key="key",
+        app_id="app",
+        api_base="https://example.com",
+    )
+
+
+def _state() -> ShellState:
+    return ShellState(_config())
+
+
+def _make_search_payload(
+    *,
+    engine: str = "Google",
+    query: str = "q",
+    results: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    return {
+        "engine": engine,
+        "query": query,
+        "results": results or [],
+        "object": "web-search.search",
+    }
+
+
+def _make_crawl_payload(
+    *,
+    crawler: str = "BasicCrawler",
+    results: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    return {
+        "crawler": crawler,
+        "results": results or [],
+        "object": "web-search.crawl",
+    }
+
+
+class _FakeResource:
+    """Stand-in for a UniqueObject — exposes ``to_dict_recursive``."""
+
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._payload = payload
+
+    def to_dict_recursive(self) -> dict[str, Any]:
+        return self._payload
+
+
+class TestParseConfigOverrides:
+    def test_parse_engine_config_none(self) -> None:
+        assert _parse_engine_config(None) is None
+
+    def test_parse_engine_config_object(self) -> None:
+        result = _parse_engine_config('{"searchEngineName": "Google"}')
+        assert result == {"searchEngineName": "Google"}
+
+    def test_parse_engine_config_invalid_json(self) -> None:
+        with pytest.raises(ValueError, match="not valid JSON"):
+            _parse_engine_config("{bad}")
+
+    def test_parse_engine_config_not_object(self) -> None:
+        with pytest.raises(ValueError, match="must be a JSON object"):
+            _parse_engine_config('["a"]')
+
+    def test_parse_crawler_config_none(self) -> None:
+        assert _parse_crawler_config(None) is None
+
+    def test_parse_crawler_config_object(self) -> None:
+        result = _parse_crawler_config('{"crawlerType": "BasicCrawler"}')
+        assert result == {"crawlerType": "BasicCrawler"}
+
+    def test_parse_crawler_config_not_object(self) -> None:
+        with pytest.raises(ValueError, match="must be a JSON object"):
+            _parse_crawler_config("123")
+
+
+class TestPayloadExtraction:
+    def test_to_dict_recursive_takes_precedence(self) -> None:
+        payload = {"engine": "Google", "query": "x", "results": []}
+        assert _payload_from_resource(_FakeResource(payload)) == payload
+
+    def test_dict_passthrough(self) -> None:
+        payload = {"engine": "Brave", "query": "y", "results": []}
+        assert _payload_from_resource(payload) == payload
+
+    def test_attribute_fallback(self) -> None:
+        class Plain:
+            engine = "Tavily"
+            query = "z"
+            results: list[dict[str, Any]] = []
+
+        result = _payload_from_resource(Plain())
+        assert result == {"engine": "Tavily", "query": "z", "results": []}
+
+
+class TestSearchFormatting:
+    def test_search_human_no_results(self) -> None:
+        out = _format_search_results(_make_search_payload(results=[]))
+        assert "No results found" in out
+        assert "engine=Google" in out
+
+    def test_search_human_with_results(self) -> None:
+        out = _format_search_results(
+            _make_search_payload(
+                results=[
+                    {
+                        "url": "https://a.com",
+                        "title": "A",
+                        "snippet": "snippet a",
+                        "content": "",
+                    },
+                    {
+                        "url": "https://b.com",
+                        "title": "B",
+                        "snippet": "snippet b",
+                        "content": "page text",
+                    },
+                ]
+            )
+        )
+        assert "engine: Google" in out
+        assert "1. A" in out
+        assert "https://a.com" in out
+        assert "snippet a" in out
+        assert "[9 chars of content]" in out
+
+    def test_search_long_snippet_is_truncated(self) -> None:
+        long = "x" * 300
+        out = _format_search_results(
+            _make_search_payload(
+                results=[
+                    {
+                        "url": "https://a.com",
+                        "title": "A",
+                        "snippet": long,
+                        "content": "",
+                    }
+                ]
+            )
+        )
+        assert "..." in out
+        assert long not in out
+
+    def test_search_json_envelope(self) -> None:
+        payload = _make_search_payload(
+            results=[{"url": "u", "title": "t", "snippet": "s", "content": ""}]
+        )
+        parsed = json.loads(_format_search_results_json(payload))
+        assert parsed == {
+            "engine": "Google",
+            "query": "q",
+            "results": [{"url": "u", "title": "t", "snippet": "s", "content": ""}],
+        }
+
+
+class TestCrawlFormatting:
+    def test_crawl_human_no_results(self) -> None:
+        out = _format_crawl_results(_make_crawl_payload(results=[]))
+        assert "No crawl results" in out
+        assert "BasicCrawler" in out
+
+    def test_crawl_human_with_results(self) -> None:
+        out = _format_crawl_results(
+            _make_crawl_payload(
+                results=[
+                    {"url": "https://a.com", "content": "page text", "error": None},
+                    {"url": "https://b.com", "content": "", "error": "boom"},
+                    {"url": "https://c.com", "content": "", "error": None},
+                ]
+            )
+        )
+        assert "crawler: BasicCrawler" in out
+        assert "1. https://a.com" in out
+        assert "[9 chars]" in out
+        assert "ERROR: boom" in out
+        assert "(empty)" in out
+
+    def test_crawl_json_envelope(self) -> None:
+        payload = _make_crawl_payload(
+            results=[{"url": "u", "content": "c", "error": None}]
+        )
+        parsed = json.loads(_format_crawl_results_json(payload))
+        assert parsed == {
+            "crawler": "BasicCrawler",
+            "results": [{"url": "u", "content": "c", "error": None}],
+        }
+
+
+class TestCmdWebSearch:
+    @patch("unique_sdk.WebSearch.search")
+    def test_cmd_web_search_happy_path(self, mock_search: MagicMock) -> None:
+        mock_search.return_value = _FakeResource(
+            _make_search_payload(
+                results=[
+                    {"url": "https://a", "title": "A", "snippet": "s", "content": ""}
+                ]
+            )
+        )
+        out = cmd_web_search(_state(), "tax reform")
+        assert "Found 1 result" in out
+        mock_search.assert_called_once()
+        call_kwargs = mock_search.call_args[1]
+        assert call_kwargs["query"] == "tax reform"
+        assert call_kwargs["user_id"] == "u1"
+        assert call_kwargs["company_id"] == "c1"
+
+    @patch("unique_sdk.WebSearch.search")
+    def test_cmd_web_search_passes_overrides(self, mock_search: MagicMock) -> None:
+        mock_search.return_value = _FakeResource(_make_search_payload(results=[]))
+        cmd_web_search(
+            _state(),
+            "x",
+            fetch_size=5,
+            include_content=True,
+            engine_config_raw='{"searchEngineName":"Google"}',
+            crawler_config_raw='{"crawlerType":"BasicCrawler"}',
+        )
+        call_kwargs = mock_search.call_args[1]
+        assert call_kwargs["fetchSize"] == 5
+        assert call_kwargs["includeContent"] is True
+        assert call_kwargs["searchEngineConfig"] == {"searchEngineName": "Google"}
+        assert call_kwargs["crawlerConfig"] == {"crawlerType": "BasicCrawler"}
+
+    @patch("unique_sdk.WebSearch.search")
+    def test_cmd_web_search_json_output(self, mock_search: MagicMock) -> None:
+        mock_search.return_value = _FakeResource(_make_search_payload(results=[]))
+        out = cmd_web_search(_state(), "x", output_json=True)
+        parsed = json.loads(out)
+        assert parsed["engine"] == "Google"
+        assert parsed["results"] == []
+
+    @patch("unique_sdk.WebSearch.search")
+    def test_cmd_web_search_invalid_engine_config(self, mock_search: MagicMock) -> None:
+        out = cmd_web_search(_state(), "x", engine_config_raw="not-json")
+        assert "web-search:" in out
+        mock_search.assert_not_called()
+
+    @patch("unique_sdk.WebSearch.search")
+    def test_cmd_web_search_api_error(self, mock_search: MagicMock) -> None:
+        mock_search.side_effect = unique_sdk.APIError("upstream boom")
+        out = cmd_web_search(_state(), "x")
+        assert "web-search:" in out
+        assert "upstream boom" in out
+
+
+class TestCmdWebCrawl:
+    @patch("unique_sdk.WebCrawl.crawl")
+    def test_cmd_web_crawl_happy_path(self, mock_crawl: MagicMock) -> None:
+        mock_crawl.return_value = _FakeResource(
+            _make_crawl_payload(
+                results=[{"url": "https://a", "content": "page", "error": None}]
+            )
+        )
+        out = cmd_web_crawl(_state(), ["https://a"], parallel=2)
+        assert "Crawled 1 URL" in out
+        call_kwargs = mock_crawl.call_args[1]
+        assert call_kwargs["urls"] == ["https://a"]
+        assert call_kwargs["parallel"] == 2
+
+    def test_cmd_web_crawl_no_urls(self) -> None:
+        out = cmd_web_crawl(_state(), [])
+        assert "no URLs provided" in out
+
+    def test_cmd_web_crawl_invalid_parallel(self) -> None:
+        out = cmd_web_crawl(_state(), ["https://a"], parallel=0)
+        assert "--parallel must be >= 1" in out
+
+    @patch("unique_sdk.WebCrawl.crawl")
+    def test_cmd_web_crawl_passes_crawler_override(self, mock_crawl: MagicMock) -> None:
+        mock_crawl.return_value = _FakeResource(_make_crawl_payload(results=[]))
+        cmd_web_crawl(
+            _state(),
+            ["https://a"],
+            crawler_config_raw='{"crawlerType":"Crawl4AI"}',
+        )
+        assert mock_crawl.call_args[1]["crawlerConfig"] == {"crawlerType": "Crawl4AI"}
+
+    @patch("unique_sdk.WebCrawl.crawl")
+    def test_cmd_web_crawl_invalid_crawler_config(self, mock_crawl: MagicMock) -> None:
+        out = cmd_web_crawl(_state(), ["https://a"], crawler_config_raw="garbage")
+        assert "web-crawl:" in out
+        mock_crawl.assert_not_called()
+
+    @patch("unique_sdk.WebCrawl.crawl")
+    def test_cmd_web_crawl_json_output(self, mock_crawl: MagicMock) -> None:
+        mock_crawl.return_value = _FakeResource(
+            _make_crawl_payload(results=[{"url": "u", "content": "c", "error": None}])
+        )
+        out = cmd_web_crawl(_state(), ["u"], output_json=True)
+        parsed = json.loads(out)
+        assert parsed["crawler"] == "BasicCrawler"
+        assert parsed["results"] == [{"url": "u", "content": "c", "error": None}]
+
+    @patch("unique_sdk.WebCrawl.crawl")
+    def test_cmd_web_crawl_api_error(self, mock_crawl: MagicMock) -> None:
+        mock_crawl.side_effect = unique_sdk.APIError("nope")
+        out = cmd_web_crawl(_state(), ["u"])
+        assert "web-crawl:" in out
+        assert "nope" in out
+
+
+class TestApiResourceContract:
+    """Verify the SDK resource posts to the right URL with the right shape."""
+
+    @patch("unique_sdk.api_resources._web_search.WebSearch._static_request")
+    def test_web_search_search_url(self, mock_request: MagicMock) -> None:
+        mock_request.return_value = _make_search_payload(results=[])
+        unique_sdk.WebSearch.search(user_id="u", company_id="c", query="q")
+        method, url, *_ = mock_request.call_args[0]
+        assert method == "post"
+        assert url == "/web-search-api/search"
+
+    @patch("unique_sdk.api_resources._web_search.WebCrawl._static_request")
+    def test_web_crawl_crawl_url(self, mock_request: MagicMock) -> None:
+        mock_request.return_value = _make_crawl_payload(results=[])
+        unique_sdk.WebCrawl.crawl(
+            user_id="u",
+            company_id="c",
+            urls=["https://a"],
+        )
+        method, url, *_ = mock_request.call_args[0]
+        assert method == "post"
+        assert url == "/web-search-api/crawl"
+
+    def test_object_names(self) -> None:
+        assert unique_sdk.WebSearch.OBJECT_NAME == "web-search.search"
+        assert unique_sdk.WebCrawl.OBJECT_NAME == "web-search.crawl"
+
+    def test_object_classes_registered(self) -> None:
+        from unique_sdk._object_classes import OBJECT_CLASSES
+
+        assert OBJECT_CLASSES["web-search.search"] is unique_sdk.WebSearch
+        assert OBJECT_CLASSES["web-search.crawl"] is unique_sdk.WebCrawl
+
+
+class TestErrorOutputDetection:
+    def test_search_error_prefix_recognised(self) -> None:
+        assert is_error_output(f"{WEB_SEARCH_ERROR_PREFIX} boom") is True
+
+    def test_crawl_error_prefix_recognised(self) -> None:
+        assert is_error_output(f"{WEB_CRAWL_ERROR_PREFIX} boom") is True
+
+    def test_normal_output_not_flagged(self) -> None:
+        assert is_error_output("Found 1 result(s):") is False
+        assert is_error_output("crawler: BasicCrawler") is False
+
+
+class TestIsFullPlatformConfig:
+    """Mirrors the upstream unique-websearch heuristics."""
+
+    def test_simple_overrides_not_detected(self) -> None:
+        data = {
+            "search_engine_config": {"fetch_size": 50},
+            "crawler_config": {"timeout": 15},
+        }
+        assert is_full_platform_config(data) is False
+
+    def test_mode_key_camel(self) -> None:
+        assert is_full_platform_config({"webSearchActiveMode": "v2"}) is True
+
+    def test_mode_key_snake(self) -> None:
+        assert is_full_platform_config({"web_search_active_mode": "v1"}) is True
+
+    def test_engine_discriminator_snake(self) -> None:
+        data = {
+            "search_engine_config": {
+                "search_engine_name": "google",
+                "fetch_size": 50,
+            }
+        }
+        assert is_full_platform_config(data) is True
+
+    def test_engine_discriminator_camel(self) -> None:
+        data = {"searchEngineConfig": {"searchEngineName": "Google"}}
+        assert is_full_platform_config(data) is True
+
+    def test_crawler_discriminator_camel(self) -> None:
+        data = {"crawlerConfig": {"crawlerType": "BasicCrawler"}}
+        assert is_full_platform_config(data) is True
+
+    def test_empty_dict(self) -> None:
+        assert is_full_platform_config({}) is False
+
+    def test_unrelated_keys(self) -> None:
+        assert is_full_platform_config({"foo": "bar"}) is False
+
+
+class TestParseConfigData:
+    def test_full_platform_camel_passes_through(self) -> None:
+        data = {
+            "webSearchActiveMode": "v2",
+            "searchEngineConfig": {"searchEngineName": "Google", "fetchSize": 7},
+            "crawlerConfig": {"crawlerType": "BasicCrawler"},
+        }
+        overrides = parse_config_data(data)
+        assert overrides.engine_config == {
+            "searchEngineName": "Google",
+            "fetchSize": 7,
+        }
+        assert overrides.crawler_config == {"crawlerType": "BasicCrawler"}
+        assert overrides.fetch_size is None
+
+    def test_full_platform_snake_passes_through(self) -> None:
+        data = {
+            "search_engine_config": {
+                "search_engine_name": "google",
+                "fetch_size": 7,
+            },
+            "crawler_config": {"crawler_type": "BasicCrawler"},
+        }
+        overrides = parse_config_data(data)
+        assert overrides.engine_config == {
+            "search_engine_name": "google",
+            "fetch_size": 7,
+        }
+        assert overrides.crawler_config == {"crawler_type": "BasicCrawler"}
+
+    def test_simple_overrides_extracts_fetch_size_snake(self) -> None:
+        overrides = parse_config_data({"search_engine_config": {"fetch_size": 25}})
+        assert overrides.engine_config is None
+        assert overrides.crawler_config is None
+        assert overrides.fetch_size == 25
+
+    def test_simple_overrides_extracts_fetch_size_camel(self) -> None:
+        overrides = parse_config_data({"searchEngineConfig": {"fetchSize": 13}})
+        assert overrides.fetch_size == 13
+
+    def test_simple_overrides_no_fetch_size(self) -> None:
+        overrides = parse_config_data({"search_engine_config": {"timeout": 30}})
+        assert overrides.is_empty
+
+    def test_simple_overrides_invalid_fetch_size_type(self) -> None:
+        with pytest.raises(WebSearchCLIConfigError, match="must be an integer"):
+            parse_config_data({"search_engine_config": {"fetch_size": "ten"}})
+
+    def test_simple_overrides_invalid_fetch_size_bool_rejected(self) -> None:
+        with pytest.raises(WebSearchCLIConfigError, match="must be an integer"):
+            parse_config_data({"search_engine_config": {"fetch_size": True}})
+
+    def test_simple_overrides_invalid_fetch_size_value(self) -> None:
+        with pytest.raises(WebSearchCLIConfigError, match="must be >= 1"):
+            parse_config_data({"search_engine_config": {"fetch_size": 0}})
+
+    def test_empty_dict_yields_empty(self) -> None:
+        overrides = parse_config_data({})
+        assert overrides.is_empty
+
+
+class TestResolveConfigPath:
+    def test_explicit_path_used_when_exists(self, tmp_path: Path) -> None:
+        cfg = tmp_path / "ws.json"
+        cfg.write_text("{}", encoding="utf-8")
+        assert resolve_config_path(str(cfg)) == cfg
+
+    def test_explicit_missing_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(WebSearchCLIConfigError, match="not found"):
+            resolve_config_path(str(tmp_path / "nope.json"))
+
+    def test_env_var_used_when_set(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cfg = tmp_path / "via-env.json"
+        cfg.write_text("{}", encoding="utf-8")
+        monkeypatch.setenv(ENV_CONFIG_PATH, str(cfg))
+        assert resolve_config_path(None) == cfg
+
+    def test_env_var_missing_path_raises(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(ENV_CONFIG_PATH, str(tmp_path / "missing.json"))
+        with pytest.raises(WebSearchCLIConfigError, match=ENV_CONFIG_PATH):
+            resolve_config_path(None)
+
+    def test_default_path_returned_when_present(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv(ENV_CONFIG_PATH, raising=False)
+        default = tmp_path / ".unique-websearch.json"
+        default.write_text("{}", encoding="utf-8")
+        with patch(
+            "unique_sdk.cli.commands.web_search_config.DEFAULT_CONFIG_PATH",
+            default,
+        ):
+            assert resolve_config_path(None) == default
+
+    def test_no_default_returns_none(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv(ENV_CONFIG_PATH, raising=False)
+        with patch(
+            "unique_sdk.cli.commands.web_search_config.DEFAULT_CONFIG_PATH",
+            tmp_path / ".unique-websearch.json",
+        ):
+            assert resolve_config_path(None) is None
+
+    def test_explicit_path_expands_tilde(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        cfg = tmp_path / "ws.json"
+        cfg.write_text("{}", encoding="utf-8")
+        assert resolve_config_path("~/ws.json") == cfg
+
+
+class TestLoadOverrides:
+    def test_returns_empty_when_no_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv(ENV_CONFIG_PATH, raising=False)
+        with patch(
+            "unique_sdk.cli.commands.web_search_config.DEFAULT_CONFIG_PATH",
+            tmp_path / ".unique-websearch.json",
+        ):
+            assert load_overrides(None) == ConfigOverrides()
+
+    def test_loads_full_platform_config(self, tmp_path: Path) -> None:
+        cfg = tmp_path / "ws.json"
+        cfg.write_text(
+            json.dumps(
+                {
+                    "searchEngineConfig": {"searchEngineName": "Google"},
+                    "crawlerConfig": {"crawlerType": "BasicCrawler"},
+                }
+            ),
+            encoding="utf-8",
+        )
+        overrides = load_overrides(str(cfg))
+        assert overrides.engine_config == {"searchEngineName": "Google"}
+        assert overrides.crawler_config == {"crawlerType": "BasicCrawler"}
+
+    def test_loads_simple_overrides(self, tmp_path: Path) -> None:
+        cfg = tmp_path / "ws.json"
+        cfg.write_text(
+            json.dumps({"search_engine_config": {"fetch_size": 42}}),
+            encoding="utf-8",
+        )
+        overrides = load_overrides(str(cfg))
+        assert overrides.fetch_size == 42
+        assert overrides.engine_config is None
+
+    def test_invalid_json_raises(self, tmp_path: Path) -> None:
+        cfg = tmp_path / "bad.json"
+        cfg.write_text("{not json", encoding="utf-8")
+        with pytest.raises(WebSearchCLIConfigError, match="Invalid JSON"):
+            load_overrides(str(cfg))
+
+    def test_non_object_top_level_raises(self, tmp_path: Path) -> None:
+        cfg = tmp_path / "list.json"
+        cfg.write_text("[1, 2]", encoding="utf-8")
+        with pytest.raises(WebSearchCLIConfigError, match="JSON object"):
+            load_overrides(str(cfg))
+
+
+class TestCmdWebSearchConfigMerging:
+    """File overrides apply when no inline override is given; inline always wins."""
+
+    @patch("unique_sdk.WebSearch.search")
+    def test_file_engine_config_used_when_no_inline_override(
+        self, mock_search: MagicMock, tmp_path: Path
+    ) -> None:
+        cfg = tmp_path / "ws.json"
+        cfg.write_text(
+            json.dumps(
+                {"searchEngineConfig": {"searchEngineName": "Google", "fetchSize": 5}}
+            ),
+            encoding="utf-8",
+        )
+        mock_search.return_value = _FakeResource(_make_search_payload(results=[]))
+
+        cmd_web_search(_state(), "q", config_path=str(cfg))
+
+        params = mock_search.call_args[1]
+        assert params["searchEngineConfig"] == {
+            "searchEngineName": "Google",
+            "fetchSize": 5,
+        }
+
+    @patch("unique_sdk.WebSearch.search")
+    def test_inline_engine_config_overrides_file(
+        self, mock_search: MagicMock, tmp_path: Path
+    ) -> None:
+        cfg = tmp_path / "ws.json"
+        cfg.write_text(
+            json.dumps({"searchEngineConfig": {"searchEngineName": "Google"}}),
+            encoding="utf-8",
+        )
+        mock_search.return_value = _FakeResource(_make_search_payload(results=[]))
+
+        cmd_web_search(
+            _state(),
+            "q",
+            engine_config_raw='{"searchEngineName":"Brave"}',
+            config_path=str(cfg),
+        )
+
+        assert mock_search.call_args[1]["searchEngineConfig"] == {
+            "searchEngineName": "Brave"
+        }
+
+    @patch("unique_sdk.WebSearch.search")
+    def test_file_crawler_config_used_when_no_inline_override(
+        self, mock_search: MagicMock, tmp_path: Path
+    ) -> None:
+        cfg = tmp_path / "ws.json"
+        cfg.write_text(
+            json.dumps(
+                {
+                    "searchEngineConfig": {"searchEngineName": "Google"},
+                    "crawlerConfig": {"crawlerType": "BasicCrawler"},
+                }
+            ),
+            encoding="utf-8",
+        )
+        mock_search.return_value = _FakeResource(_make_search_payload(results=[]))
+
+        cmd_web_search(_state(), "q", config_path=str(cfg))
+
+        assert mock_search.call_args[1]["crawlerConfig"] == {
+            "crawlerType": "BasicCrawler"
+        }
+
+    @patch("unique_sdk.WebSearch.search")
+    def test_simple_override_fetch_size_used_when_no_inline(
+        self, mock_search: MagicMock, tmp_path: Path
+    ) -> None:
+        cfg = tmp_path / "ws.json"
+        cfg.write_text(
+            json.dumps({"search_engine_config": {"fetch_size": 42}}),
+            encoding="utf-8",
+        )
+        mock_search.return_value = _FakeResource(_make_search_payload(results=[]))
+
+        cmd_web_search(_state(), "q", config_path=str(cfg))
+
+        params = mock_search.call_args[1]
+        assert params["fetchSize"] == 42
+        assert "searchEngineConfig" not in params
+
+    @patch("unique_sdk.WebSearch.search")
+    def test_inline_fetch_size_wins_over_file(
+        self, mock_search: MagicMock, tmp_path: Path
+    ) -> None:
+        cfg = tmp_path / "ws.json"
+        cfg.write_text(
+            json.dumps({"search_engine_config": {"fetch_size": 42}}),
+            encoding="utf-8",
+        )
+        mock_search.return_value = _FakeResource(_make_search_payload(results=[]))
+
+        cmd_web_search(_state(), "q", fetch_size=3, config_path=str(cfg))
+
+        assert mock_search.call_args[1]["fetchSize"] == 3
+
+    @patch("unique_sdk.WebSearch.search")
+    def test_invalid_config_file_returns_error(
+        self, mock_search: MagicMock, tmp_path: Path
+    ) -> None:
+        cfg = tmp_path / "broken.json"
+        cfg.write_text("{not json", encoding="utf-8")
+
+        out = cmd_web_search(_state(), "q", config_path=str(cfg))
+
+        assert out.startswith(WEB_SEARCH_ERROR_PREFIX)
+        assert "Invalid JSON" in out
+        mock_search.assert_not_called()
+
+    @patch("unique_sdk.WebSearch.search")
+    def test_missing_config_file_returns_error(
+        self, mock_search: MagicMock, tmp_path: Path
+    ) -> None:
+        out = cmd_web_search(_state(), "q", config_path=str(tmp_path / "missing.json"))
+        assert out.startswith(WEB_SEARCH_ERROR_PREFIX)
+        assert "not found" in out
+        mock_search.assert_not_called()
+
+
+class TestCmdWebCrawlConfigMerging:
+    @patch("unique_sdk.WebCrawl.crawl")
+    def test_file_crawler_config_used_when_no_inline_override(
+        self, mock_crawl: MagicMock, tmp_path: Path
+    ) -> None:
+        cfg = tmp_path / "ws.json"
+        cfg.write_text(
+            json.dumps({"crawlerConfig": {"crawlerType": "BasicCrawler"}}),
+            encoding="utf-8",
+        )
+        mock_crawl.return_value = _FakeResource(_make_crawl_payload(results=[]))
+
+        cmd_web_crawl(_state(), ["https://a"], config_path=str(cfg))
+
+        assert mock_crawl.call_args[1]["crawlerConfig"] == {
+            "crawlerType": "BasicCrawler"
+        }
+
+    @patch("unique_sdk.WebCrawl.crawl")
+    def test_inline_crawler_config_overrides_file(
+        self, mock_crawl: MagicMock, tmp_path: Path
+    ) -> None:
+        cfg = tmp_path / "ws.json"
+        cfg.write_text(
+            json.dumps({"crawlerConfig": {"crawlerType": "BasicCrawler"}}),
+            encoding="utf-8",
+        )
+        mock_crawl.return_value = _FakeResource(_make_crawl_payload(results=[]))
+
+        cmd_web_crawl(
+            _state(),
+            ["https://a"],
+            crawler_config_raw='{"crawlerType":"Crawl4AI"}',
+            config_path=str(cfg),
+        )
+
+        assert mock_crawl.call_args[1]["crawlerConfig"] == {"crawlerType": "Crawl4AI"}
+
+    @patch("unique_sdk.WebCrawl.crawl")
+    def test_invalid_config_file_returns_error(
+        self, mock_crawl: MagicMock, tmp_path: Path
+    ) -> None:
+        cfg = tmp_path / "broken.json"
+        cfg.write_text("{not json", encoding="utf-8")
+
+        out = cmd_web_crawl(_state(), ["https://a"], config_path=str(cfg))
+
+        assert out.startswith(WEB_CRAWL_ERROR_PREFIX)
+        assert "Invalid JSON" in out
+        mock_crawl.assert_not_called()
+
+
+class TestClickIntegration:
+    """End-to-end Click checks: --config plumbing, --version, exit codes."""
+
+    def _bootstrap_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # LazyState.load_config requires user/company env vars.
+        monkeypatch.setenv("UNIQUE_USER_ID", "u1")
+        monkeypatch.setenv("UNIQUE_COMPANY_ID", "c1")
+        monkeypatch.setenv("UNIQUE_API_KEY", "ukey_test")
+        monkeypatch.setenv("UNIQUE_APP_ID", "app_test")
+        monkeypatch.delenv(ENV_CONFIG_PATH, raising=False)
+
+    def test_group_version_flag(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._bootstrap_env(monkeypatch)
+        runner = CliRunner()
+        result = runner.invoke(cli_main, ["web-search", "--version"])
+        assert result.exit_code == 0
+        assert "unique-cli web-search" in result.output
+
+    @patch("unique_sdk.cli.cli.cmd_web_search")
+    def test_search_success_exit_zero(
+        self, mock_cmd: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._bootstrap_env(monkeypatch)
+        mock_cmd.return_value = "Found 1 result(s):\n..."
+        runner = CliRunner()
+        result = runner.invoke(cli_main, ["web-search", "search", "x"])
+        assert result.exit_code == 0
+        assert "Found 1 result(s)" in result.output
+
+    @patch("unique_sdk.cli.cli.cmd_web_search")
+    def test_search_error_exit_one(
+        self, mock_cmd: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._bootstrap_env(monkeypatch)
+        mock_cmd.return_value = f"{WEB_SEARCH_ERROR_PREFIX} something failed"
+        runner = CliRunner()
+        result = runner.invoke(cli_main, ["web-search", "search", "x"])
+        assert result.exit_code == 1
+        assert "something failed" in result.output
+
+    @patch("unique_sdk.cli.cli.cmd_web_crawl")
+    def test_crawl_error_exit_one(
+        self, mock_cmd: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._bootstrap_env(monkeypatch)
+        mock_cmd.return_value = f"{WEB_CRAWL_ERROR_PREFIX} no URLs"
+        runner = CliRunner()
+        result = runner.invoke(cli_main, ["web-search", "crawl"])
+        assert result.exit_code == 1
+        assert "no URLs" in result.output
+
+    @patch("unique_sdk.cli.cli.cmd_web_search")
+    def test_group_config_flag_propagates_to_search(
+        self,
+        mock_cmd: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        self._bootstrap_env(monkeypatch)
+        cfg = tmp_path / "ws.json"
+        cfg.write_text("{}", encoding="utf-8")
+        mock_cmd.return_value = "ok"
+        runner = CliRunner()
+        result = runner.invoke(
+            cli_main, ["web-search", "--config", str(cfg), "search", "x"]
+        )
+        assert result.exit_code == 0
+        assert mock_cmd.call_args[1]["config_path"] == str(cfg)
+
+    @patch("unique_sdk.cli.cli.cmd_web_search")
+    def test_subcommand_config_overrides_group(
+        self,
+        mock_cmd: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        self._bootstrap_env(monkeypatch)
+        group_cfg = tmp_path / "group.json"
+        group_cfg.write_text("{}", encoding="utf-8")
+        sub_cfg = tmp_path / "sub.json"
+        sub_cfg.write_text("{}", encoding="utf-8")
+        mock_cmd.return_value = "ok"
+        runner = CliRunner()
+        result = runner.invoke(
+            cli_main,
+            [
+                "web-search",
+                "--config",
+                str(group_cfg),
+                "search",
+                "--config",
+                str(sub_cfg),
+                "x",
+            ],
+        )
+        assert result.exit_code == 0
+        assert mock_cmd.call_args[1]["config_path"] == str(sub_cfg)
+
+    @patch("unique_sdk.cli.cli.cmd_web_crawl")
+    def test_crawl_subcommand_config_passed_through(
+        self,
+        mock_cmd: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        self._bootstrap_env(monkeypatch)
+        cfg = tmp_path / "ws.json"
+        cfg.write_text("{}", encoding="utf-8")
+        mock_cmd.return_value = "ok"
+        runner = CliRunner()
+        result = runner.invoke(
+            cli_main,
+            [
+                "web-search",
+                "crawl",
+                "--config",
+                str(cfg),
+                "https://a",
+            ],
+        )
+        assert result.exit_code == 0
+        assert mock_cmd.call_args[1]["config_path"] == str(cfg)

--- a/unique_sdk/unique_sdk/__init__.py
+++ b/unique_sdk/unique_sdk/__init__.py
@@ -107,6 +107,12 @@ from unique_sdk.api_resources._analytics_order import (
 )
 from unique_sdk.api_resources._module import Module as Module
 from unique_sdk.api_resources._briefing import Briefing as Briefing
+from unique_sdk.api_resources._web_search import (
+    WebSearch as WebSearch,
+    WebCrawl as WebCrawl,
+    WebSearchResultItem as WebSearchResultItem,
+    WebCrawlResultItem as WebCrawlResultItem,
+)
 
 # Unique QL
 from unique_sdk._unique_ql import UQLOperator as UQLOperator

--- a/unique_sdk/unique_sdk/_object_classes.py
+++ b/unique_sdk/unique_sdk/_object_classes.py
@@ -8,4 +8,6 @@ OBJECT_CLASSES = {
     unique_sdk.ChatCompletion.OBJECT_NAME: unique_sdk.ChatCompletion,
     unique_sdk.ScheduledTask.OBJECT_NAME: unique_sdk.ScheduledTask,
     unique_sdk.Briefing.OBJECT_NAME: unique_sdk.Briefing,
+    unique_sdk.WebSearch.OBJECT_NAME: unique_sdk.WebSearch,
+    unique_sdk.WebCrawl.OBJECT_NAME: unique_sdk.WebCrawl,
 }

--- a/unique_sdk/unique_sdk/api_resources/_web_search.py
+++ b/unique_sdk/unique_sdk/api_resources/_web_search.py
@@ -1,0 +1,172 @@
+"""HTTP-API bindings for the public ``web-search-api`` endpoints.
+
+These mirror the assistants-core ``unique-websearch`` CLI (search + crawl)
+through the chat ``/public/web-search-api/{search,crawl}`` REST surface, so
+SDK consumers get a typed, server-resolved engine/crawler without touching
+``unique_web_search`` directly.
+
+Two distinct resources are exposed because the two endpoints carry
+different response envelopes (search returns ``{engine, query, results}``
+with per-result ``url/title/snippet/content``; crawl returns ``{crawler,
+results}`` with per-URL ``url/content/error``). Modelling them as separate
+classes keeps the typed shape obvious at the call site and lets each one
+register its own ``OBJECT_NAME`` for response routing.
+"""
+
+from typing import Any, Literal, TypedDict, cast
+
+from typing_extensions import NotRequired, Unpack
+
+from unique_sdk._api_resource import APIResource
+from unique_sdk._request_options import RequestOptions
+from unique_sdk._util import classproperty
+
+
+class WebSearchResultItem(TypedDict):
+    """A single search hit returned by the configured search engine."""
+
+    url: str
+    title: str
+    snippet: str
+    # Empty string unless ``includeContent=True`` and the engine requires
+    # scraping (or the engine itself returned page content).
+    content: str
+
+
+class WebSearch(APIResource["WebSearch"]):
+    """``POST /web-search-api/search`` — query the configured search engine.
+
+    Mirrors the assistants-core ``unique-websearch search`` CLI command.
+    Engine selection follows the server's
+    ``ACTIVE_SEARCH_ENGINES`` env config and may be overridden per request
+    via ``searchEngineConfig``. ``includeContent=True`` triggers the
+    server's crawler (configurable via ``crawlerConfig``) to populate
+    ``result.content`` for engines that require scraping.
+    """
+
+    @classproperty
+    def OBJECT_NAME(cls) -> Literal["web-search.search"]:
+        return "web-search.search"
+
+    class SearchParams(RequestOptions):
+        query: str
+        fetchSize: NotRequired[int | None]
+        includeContent: NotRequired[bool | None]
+        # Full discriminated-union payload passed straight through to the
+        # server's WebSearchConfig.searchEngineConfig (e.g.
+        # ``{"searchEngineName": "Google", ...}``).
+        searchEngineConfig: NotRequired[dict[str, Any] | None]
+        # Used only when includeContent=True and the engine needs scraping.
+        crawlerConfig: NotRequired[dict[str, Any] | None]
+
+    # Response envelope.
+    engine: str
+    query: str
+    results: list[WebSearchResultItem]
+
+    @classmethod
+    def search(
+        cls,
+        user_id: str,
+        company_id: str,
+        **params: Unpack["WebSearch.SearchParams"],
+    ) -> "WebSearch":
+        return cast(
+            "WebSearch",
+            cls._static_request(
+                "post",
+                "/web-search-api/search",
+                user_id,
+                company_id,
+                params=params,
+            ),
+        )
+
+    @classmethod
+    async def search_async(
+        cls,
+        user_id: str,
+        company_id: str,
+        **params: Unpack["WebSearch.SearchParams"],
+    ) -> "WebSearch":
+        return cast(
+            "WebSearch",
+            await cls._static_request_async(
+                "post",
+                "/web-search-api/search",
+                user_id,
+                company_id,
+                params=params,
+            ),
+        )
+
+
+class WebCrawlResultItem(TypedDict):
+    """A single crawl outcome — content on success, error message on failure."""
+
+    url: str
+    content: str
+    # Per-batch failure surfaces as a string here while ``content`` stays
+    # an empty string; consumers can check truthiness of ``error`` to
+    # distinguish a successful empty page from a failed crawl.
+    error: str | None
+
+
+class WebCrawl(APIResource["WebCrawl"]):
+    """``POST /web-search-api/crawl`` — crawl URLs in parallel batches.
+
+    Mirrors the assistants-core ``unique-websearch crawl`` CLI command.
+    Crawler selection follows the server's ``ACTIVE_INHOUSE_CRAWLERS`` env
+    config and may be overridden per request via ``crawlerConfig``.
+    Per-batch crawl failures appear inline as ``{"error": <message>}``
+    entries instead of aborting the whole call.
+    """
+
+    @classproperty
+    def OBJECT_NAME(cls) -> Literal["web-search.crawl"]:
+        return "web-search.crawl"
+
+    class CrawlParams(RequestOptions):
+        urls: list[str]
+        parallel: NotRequired[int | None]
+        crawlerConfig: NotRequired[dict[str, Any] | None]
+
+    # Response envelope.
+    crawler: str
+    results: list[WebCrawlResultItem]
+
+    @classmethod
+    def crawl(
+        cls,
+        user_id: str,
+        company_id: str,
+        **params: Unpack["WebCrawl.CrawlParams"],
+    ) -> "WebCrawl":
+        return cast(
+            "WebCrawl",
+            cls._static_request(
+                "post",
+                "/web-search-api/crawl",
+                user_id,
+                company_id,
+                params=params,
+            ),
+        )
+
+    @classmethod
+    async def crawl_async(
+        cls,
+        user_id: str,
+        company_id: str,
+        **params: Unpack["WebCrawl.CrawlParams"],
+    ) -> "WebCrawl":
+        return cast(
+            "WebCrawl",
+            await cls._static_request_async(
+                "post",
+                "/web-search-api/crawl",
+                user_id,
+                company_id,
+                params=params,
+            ),
+        )

--- a/unique_sdk/unique_sdk/cli/cli.py
+++ b/unique_sdk/unique_sdk/cli/cli.py
@@ -1087,6 +1087,13 @@ def elicit_respond(
 # -- Web Search ------------------------------------------------------------
 
 
+# Key under which the `web-search` group stashes its `--config` path on
+# `ctx.meta`, so subcommands can read it back via
+# ``_resolve_web_search_config_path``. Kept as a module-level constant so the
+# writer (group) and reader (subcommand helper) cannot drift.
+_WEB_SEARCH_GROUP_CONFIG_KEY = "web_search_config_path"
+
+
 @main.group("web-search")
 @click.version_option(version=__version__, prog_name="unique-cli web-search")
 @click.option(
@@ -1130,10 +1137,7 @@ def web_search_group(ctx: click.Context, config_path: str | None) -> None:
       crawl     Crawl a list of URLs and print their content
     """
     if config_path is not None:
-        ctx.meta["web_search_config_path"] = config_path
-
-
-_WEB_SEARCH_GROUP_CONFIG_KEY = "web_search_config_path"
+        ctx.meta[_WEB_SEARCH_GROUP_CONFIG_KEY] = config_path
 
 
 def _resolve_web_search_config_path(

--- a/unique_sdk/unique_sdk/cli/cli.py
+++ b/unique_sdk/unique_sdk/cli/cli.py
@@ -27,6 +27,14 @@ from unique_sdk.cli.commands.scheduled_tasks import (
     cmd_schedule_update,
 )
 from unique_sdk.cli.commands.search import cmd_search
+from unique_sdk.cli.commands.web_search import (
+    cmd_web_crawl,
+    cmd_web_search,
+)
+from unique_sdk.cli.commands.web_search import (
+    is_error_output as _is_web_search_error_output,
+)
+from unique_sdk.cli.commands.web_search_config import ENV_CONFIG_PATH
 from unique_sdk.cli.config import load_config
 from unique_sdk.cli.shell import UniqueShell
 from unique_sdk.cli.state import ShellState
@@ -74,6 +82,8 @@ Examples:
   unique-cli upload ./file.pdf      Upload to current folder
   unique-cli download cont_abc123   Download by content ID
   unique-cli elicit ask "Which?"    Ask the user a question synchronously
+  unique-cli web-search search "x"  Search the web via the public API
+  unique-cli web-search crawl URL   Crawl a URL via the public API
 """
 
 
@@ -1072,3 +1082,235 @@ def elicit_respond(
             content=content,
         )
     )
+
+
+# -- Web Search ------------------------------------------------------------
+
+
+@main.group("web-search")
+@click.version_option(version=__version__, prog_name="unique-cli web-search")
+@click.option(
+    "--config",
+    "-c",
+    "config_path",
+    default=None,
+    type=click.Path(),
+    help=(
+        "Path to a JSON config file (full WebSearchConfig payload or "
+        "simple {search_engine_config: {...}, crawler_config: {...}} "
+        f"overrides). Falls back to ${ENV_CONFIG_PATH} and then "
+        "~/.unique-websearch.json."
+    ),
+)
+@click.pass_context
+def web_search_group(ctx: click.Context, config_path: str | None) -> None:
+    """Two-phase web search through the Unique public API.
+
+    \b
+    Phase 1 -- search:  query a search engine, get back URLs and snippets.
+    Phase 2 -- crawl:   fetch full page content for selected URLs.
+
+    \b
+    Engine and crawler are resolved server-side from
+    ACTIVE_SEARCH_ENGINES / ACTIVE_INHOUSE_CRAWLERS, matching the
+    server's WebSearchConfig defaults. Per-call overrides use the
+    same JSON shapes the assistants-core service expects, and can be
+    supplied via --config (file), inline --engine-config /
+    --crawler-config (JSON), or the equivalent flags on each subcommand.
+
+    \b
+    Override precedence (highest first):
+      1. Inline --fetch-size / --engine-config / --crawler-config flags
+      2. Config file (--config / $UNIQUE_WEBSEARCH_CONFIG / ~/.unique-websearch.json)
+      3. Server-side defaults
+
+    \b
+    Subcommands:
+      search    Run a web search and print URLs + snippets
+      crawl     Crawl a list of URLs and print their content
+    """
+    if config_path is not None:
+        ctx.meta["web_search_config_path"] = config_path
+
+
+_WEB_SEARCH_GROUP_CONFIG_KEY = "web_search_config_path"
+
+
+def _resolve_web_search_config_path(
+    ctx: click.Context, subcommand_value: str | None
+) -> str | None:
+    """Subcommand value wins; otherwise fall back to the group's --config."""
+    if subcommand_value is not None:
+        return subcommand_value
+    return ctx.meta.get(_WEB_SEARCH_GROUP_CONFIG_KEY)
+
+
+def _emit_web_search(ctx: click.Context, output: str) -> None:
+    """Echo a cmd_web_* result and translate error strings to exit code 1."""
+    click.echo(output)
+    if _is_web_search_error_output(output):
+        ctx.exit(1)
+
+
+_SEARCH_HELP = """\
+Run a web search via /web-search-api/search.
+
+\b
+Examples:
+  unique-cli web-search search "quarterly earnings 2026"
+  unique-cli web-search search "AI regulation" -n 10
+  unique-cli web-search search "python tutorial" --json
+  unique-cli web-search search "sustainability" --include-content --json
+  unique-cli web-search search "tax reform" \\
+    --engine-config '{"searchEngineName":"Google","fetchSize":3}'
+  unique-cli web-search --config ./ws.json search "EU AI act"
+"""
+
+
+@web_search_group.command("search", help=_SEARCH_HELP)
+@click.argument("query")
+@click.option(
+    "--fetch-size",
+    "-n",
+    default=None,
+    type=int,
+    help="Override the engine's fetchSize (number of results to fetch).",
+)
+@click.option(
+    "--include-content",
+    "-i",
+    is_flag=True,
+    default=False,
+    help="Populate result.content via the configured crawler when the engine requires scraping.",
+)
+@click.option(
+    "--engine-config",
+    "engine_config_raw",
+    default=None,
+    help='Override the searchEngineConfig as a JSON object (e.g. \'{"searchEngineName":"Google"}\').',
+)
+@click.option(
+    "--crawler-config",
+    "crawler_config_raw",
+    default=None,
+    help="Override the crawlerConfig as a JSON object (only used with --include-content).",
+)
+@click.option(
+    "--config",
+    "-c",
+    "config_path",
+    default=None,
+    type=click.Path(),
+    help="Per-call override of the web-search group's --config path.",
+)
+@click.option(
+    "--json",
+    "output_json",
+    is_flag=True,
+    help="Output results as JSON (suitable for piping into web-search crawl --stdin).",
+)
+@click.pass_context
+def web_search_search_cmd(
+    ctx: click.Context,
+    query: str,
+    fetch_size: int | None,
+    include_content: bool,
+    engine_config_raw: str | None,
+    crawler_config_raw: str | None,
+    config_path: str | None,
+    output_json: bool,
+) -> None:
+    """Search the web via the Unique public API."""
+    resolved_config = _resolve_web_search_config_path(ctx, config_path)
+    output = cmd_web_search(
+        LazyState.get(ctx),
+        query,
+        fetch_size=fetch_size,
+        include_content=include_content,
+        engine_config_raw=engine_config_raw,
+        crawler_config_raw=crawler_config_raw,
+        output_json=output_json,
+        config_path=resolved_config,
+    )
+    _emit_web_search(ctx, output)
+
+
+_CRAWL_HELP = """\
+Crawl a list of URLs via /web-search-api/crawl.
+
+URLs can be passed as positional arguments or piped via stdin (one per line).
+
+\b
+Examples:
+  unique-cli web-search crawl https://example.com https://other.com
+  unique-cli web-search crawl --parallel 5 https://a.com https://b.com
+  echo "https://example.com" | unique-cli web-search crawl --stdin
+  unique-cli web-search search "query" --json | jq -r '.results[].url' \\
+    | unique-cli web-search crawl --stdin
+"""
+
+
+@web_search_group.command("crawl", help=_CRAWL_HELP)
+@click.argument("urls", nargs=-1)
+@click.option(
+    "--parallel",
+    "-p",
+    default=10,
+    type=click.IntRange(min=1),
+    show_default=True,
+    help="Number of URLs the server crawls concurrently per batch.",
+)
+@click.option(
+    "--stdin",
+    "from_stdin",
+    is_flag=True,
+    help="Read URLs from stdin (one per line).",
+)
+@click.option(
+    "--crawler-config",
+    "crawler_config_raw",
+    default=None,
+    help='Override the crawlerConfig as a JSON object (e.g. \'{"crawlerType":"BasicCrawler"}\').',
+)
+@click.option(
+    "--config",
+    "-c",
+    "config_path",
+    default=None,
+    type=click.Path(),
+    help="Per-call override of the web-search group's --config path.",
+)
+@click.option(
+    "--json",
+    "output_json",
+    is_flag=True,
+    help="Output results as JSON.",
+)
+@click.pass_context
+def web_search_crawl_cmd(
+    ctx: click.Context,
+    urls: tuple[str, ...],
+    parallel: int,
+    from_stdin: bool,
+    crawler_config_raw: str | None,
+    config_path: str | None,
+    output_json: bool,
+) -> None:
+    """Crawl URLs via the Unique public API."""
+    url_list: list[str] = list(urls)
+    if from_stdin:
+        stdin_urls = [
+            line.strip() for line in click.get_text_stream("stdin") if line.strip()
+        ]
+        url_list.extend(stdin_urls)
+
+    resolved_config = _resolve_web_search_config_path(ctx, config_path)
+    output = cmd_web_crawl(
+        LazyState.get(ctx),
+        url_list,
+        parallel=parallel,
+        crawler_config_raw=crawler_config_raw,
+        output_json=output_json,
+        config_path=resolved_config,
+    )
+    _emit_web_search(ctx, output)

--- a/unique_sdk/unique_sdk/cli/commands/web_search.py
+++ b/unique_sdk/unique_sdk/cli/commands/web_search.py
@@ -1,0 +1,333 @@
+"""Web-search command: query a search engine and crawl URLs through the API.
+
+Mirrors the assistants-core ``unique-websearch`` CLI (search + crawl) but
+talks to the Unique platform via :class:`unique_sdk.WebSearch` /
+:class:`unique_sdk.WebCrawl` instead of instantiating engines / crawlers
+locally. Engine and crawler are resolved server-side from
+``ACTIVE_SEARCH_ENGINES`` / ``ACTIVE_INHOUSE_CRAWLERS``; per-call
+overrides use the same discriminated-union shapes the server expects.
+
+Override precedence (highest first):
+    1. Inline ``--engine-config`` / ``--crawler-config`` / ``--fetch-size`` flags
+    2. Config file (``--config``, ``$UNIQUE_WEBSEARCH_CONFIG``, or
+       ``~/.unique-websearch.json``) — shape-compatible with the
+       reference ``unique-websearch`` CLI
+    3. Server-side defaults (``ACTIVE_SEARCH_ENGINES`` etc.)
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, cast
+
+import unique_sdk
+from unique_sdk.cli.commands.web_search_config import (
+    ConfigOverrides,
+    WebSearchCLIConfigError,
+    load_overrides,
+)
+from unique_sdk.cli.state import ShellState
+
+DEFAULT_PARALLEL = 10
+_SNIPPET_PREVIEW_LIMIT = 200
+_CONTENT_PREVIEW_LIMIT = 500
+
+WEB_SEARCH_ERROR_PREFIX = "web-search:"
+WEB_CRAWL_ERROR_PREFIX = "web-crawl:"
+
+
+def _format_search_results(payload: dict[str, Any]) -> str:
+    """Render a /web-search-api/search response for terminal display."""
+    results: list[dict[str, Any]] = payload.get("results", [])
+    engine = payload.get("engine", "unknown")
+    query = payload.get("query", "")
+
+    if not results:
+        return f"No results found (engine={engine}, query={query!r})."
+
+    lines: list[str] = [f"engine: {engine}    query: {query!r}"]
+    lines.append(f"Found {len(results)} result(s):\n")
+
+    for i, result in enumerate(results, start=1):
+        title = result.get("title", "")
+        url = result.get("url", "")
+        snippet = (result.get("snippet") or "").replace("\n", " ").strip()
+        content = result.get("content") or ""
+
+        lines.append(f"  {i}. {title}")
+        lines.append(f"     {url}")
+
+        if snippet:
+            if len(snippet) > _SNIPPET_PREVIEW_LIMIT:
+                snippet = snippet[: _SNIPPET_PREVIEW_LIMIT - 3] + "..."
+            lines.append(f"     {snippet}")
+
+        if content:
+            lines.append(f"     [{len(content)} chars of content]")
+
+        lines.append("")
+
+    return "\n".join(lines).rstrip()
+
+
+def _format_search_results_json(payload: dict[str, Any]) -> str:
+    """Stable JSON projection — drops the SDK envelope ``object`` discriminator."""
+    return json.dumps(
+        {
+            "engine": payload.get("engine"),
+            "query": payload.get("query"),
+            "results": payload.get("results", []),
+        },
+        indent=2,
+        ensure_ascii=False,
+    )
+
+
+def _format_crawl_results(payload: dict[str, Any]) -> str:
+    """Render a /web-search-api/crawl response for terminal display."""
+    results: list[dict[str, Any]] = payload.get("results", [])
+    crawler = payload.get("crawler", "unknown")
+
+    if not results:
+        return f"No crawl results (crawler={crawler})."
+
+    lines: list[str] = [f"crawler: {crawler}"]
+    lines.append(f"Crawled {len(results)} URL(s):\n")
+
+    for i, entry in enumerate(results, start=1):
+        url = entry.get("url", "")
+        content = entry.get("content") or ""
+        error = entry.get("error")
+
+        lines.append(f"  {i}. {url}")
+        if error:
+            lines.append(f"     ERROR: {error}")
+        elif content.strip():
+            lines.append(f"     [{len(content)} chars]")
+            preview = content[:_CONTENT_PREVIEW_LIMIT].replace("\n", " ").strip()
+            if len(content) > _CONTENT_PREVIEW_LIMIT:
+                preview += "..."
+            lines.append(f"     {preview}")
+        else:
+            lines.append("     (empty)")
+
+        lines.append("")
+
+    return "\n".join(lines).rstrip()
+
+
+def _format_crawl_results_json(payload: dict[str, Any]) -> str:
+    return json.dumps(
+        {
+            "crawler": payload.get("crawler"),
+            "results": payload.get("results", []),
+        },
+        indent=2,
+        ensure_ascii=False,
+    )
+
+
+def _payload_from_resource(resource: Any) -> dict[str, Any]:
+    """Extract a plain dict envelope from a UniqueObject-style SDK response.
+
+    The SDK base class exposes ``.to_dict_recursive()``; falling back to
+    raw attribute access keeps this resilient to lighter mock responses
+    in tests.
+    """
+    to_dict = getattr(resource, "to_dict_recursive", None)
+    if callable(to_dict):
+        return cast(dict[str, Any], to_dict())
+    if isinstance(resource, dict):
+        return cast(dict[str, Any], resource)
+    # Last-resort: rebuild from the few fields we care about.
+    return {
+        key: getattr(resource, key)
+        for key in ("engine", "query", "crawler", "results")
+        if hasattr(resource, key)
+    }
+
+
+def _parse_engine_config(raw: str | None) -> dict[str, Any] | None:
+    if raw is None:
+        return None
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"--engine-config is not valid JSON: {exc}") from exc
+    if not isinstance(parsed, dict):
+        raise ValueError("--engine-config must be a JSON object")
+    return parsed
+
+
+def _parse_crawler_config(raw: str | None) -> dict[str, Any] | None:
+    if raw is None:
+        return None
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"--crawler-config is not valid JSON: {exc}") from exc
+    if not isinstance(parsed, dict):
+        raise ValueError("--crawler-config must be a JSON object")
+    return parsed
+
+
+def _load_file_overrides(config_path: str | None) -> ConfigOverrides | str:
+    """Load config-file overrides, returning a string error on failure.
+
+    Returns either a populated :class:`ConfigOverrides` (possibly empty
+    when no file is discovered) or a ``"web-search: ..."`` error string
+    that callers can return verbatim.
+    """
+    try:
+        return load_overrides(config_path)
+    except WebSearchCLIConfigError as exc:
+        return f"{WEB_SEARCH_ERROR_PREFIX} {exc}"
+
+
+def cmd_web_search(
+    state: ShellState,
+    query: str,
+    fetch_size: int | None = None,
+    include_content: bool = False,
+    engine_config_raw: str | None = None,
+    crawler_config_raw: str | None = None,
+    output_json: bool = False,
+    config_path: str | None = None,
+) -> str:
+    """Run a web search via the public API.
+
+    Args:
+        state: Shell state carrying user/company credentials.
+        query: Search query string.
+        fetch_size: Override the engine's default ``fetchSize``. Wins
+            over any value loaded from a config file.
+        include_content: When ``True``, populate ``result.content`` via
+            the configured crawler when the engine requires scraping.
+        engine_config_raw: Optional JSON string overriding the
+            ``searchEngineConfig`` discriminated union (e.g.
+            ``{"searchEngineName": "Google", "fetchSize": 5}``). Wins
+            over the config file's full-platform engine block.
+        crawler_config_raw: Optional JSON string overriding the
+            ``crawlerConfig`` discriminated union. Wins over the config
+            file's full-platform crawler block.
+        config_path: Optional path to a JSON config file shape-compatible
+            with the reference ``unique-websearch`` CLI (full
+            ``WebSearchConfig`` payload or simple-overrides). When
+            ``None``, falls back to ``$UNIQUE_WEBSEARCH_CONFIG`` and
+            then ``~/.unique-websearch.json``.
+        output_json: When ``True``, return a JSON envelope instead of a
+            human-friendly table.
+    """
+    file_overrides = _load_file_overrides(config_path)
+    if isinstance(file_overrides, str):
+        return file_overrides
+
+    try:
+        engine_override = _parse_engine_config(engine_config_raw)
+        crawler_override = _parse_crawler_config(crawler_config_raw)
+    except ValueError as exc:
+        return f"{WEB_SEARCH_ERROR_PREFIX} {exc}"
+
+    if engine_override is None:
+        engine_override = file_overrides.engine_config
+    if crawler_override is None:
+        crawler_override = file_overrides.crawler_config
+    if fetch_size is None:
+        fetch_size = file_overrides.fetch_size
+
+    params: dict[str, Any] = {"query": query}
+    if fetch_size is not None:
+        params["fetchSize"] = fetch_size
+    if include_content:
+        params["includeContent"] = True
+    if engine_override is not None:
+        params["searchEngineConfig"] = engine_override
+    if crawler_override is not None:
+        params["crawlerConfig"] = crawler_override
+
+    try:
+        resource = unique_sdk.WebSearch.search(
+            user_id=state.config.user_id,
+            company_id=state.config.company_id,
+            **params,
+        )
+    except (ValueError, unique_sdk.APIError) as exc:
+        return f"{WEB_SEARCH_ERROR_PREFIX} {exc}"
+
+    payload = _payload_from_resource(resource)
+    if output_json:
+        return _format_search_results_json(payload)
+    return _format_search_results(payload)
+
+
+def cmd_web_crawl(
+    state: ShellState,
+    urls: list[str],
+    parallel: int = DEFAULT_PARALLEL,
+    crawler_config_raw: str | None = None,
+    output_json: bool = False,
+    config_path: str | None = None,
+) -> str:
+    """Crawl a list of URLs via the public API.
+
+    Args:
+        state: Shell state carrying user/company credentials.
+        urls: List of URLs to crawl.
+        parallel: Number of URLs the server should crawl concurrently per
+            batch (must be ``>= 1``).
+        crawler_config_raw: Optional JSON string overriding the
+            ``crawlerConfig`` discriminated union. Wins over the config
+            file's full-platform crawler block.
+        config_path: Optional path to a JSON config file shape-compatible
+            with the reference ``unique-websearch`` CLI. See
+            :func:`cmd_web_search` for resolution rules.
+        output_json: When ``True``, return a JSON envelope instead of a
+            human-friendly table.
+    """
+    if not urls:
+        return f"{WEB_CRAWL_ERROR_PREFIX} no URLs provided. Pass URLs as arguments or use --stdin."
+    if parallel < 1:
+        return f"{WEB_CRAWL_ERROR_PREFIX} --parallel must be >= 1 (got {parallel})."
+
+    try:
+        file_overrides = load_overrides(config_path)
+    except WebSearchCLIConfigError as exc:
+        return f"{WEB_CRAWL_ERROR_PREFIX} {exc}"
+
+    try:
+        crawler_override = _parse_crawler_config(crawler_config_raw)
+    except ValueError as exc:
+        return f"{WEB_CRAWL_ERROR_PREFIX} {exc}"
+
+    if crawler_override is None:
+        crawler_override = file_overrides.crawler_config
+
+    params: dict[str, Any] = {"urls": list(urls), "parallel": parallel}
+    if crawler_override is not None:
+        params["crawlerConfig"] = crawler_override
+
+    try:
+        resource = unique_sdk.WebCrawl.crawl(
+            user_id=state.config.user_id,
+            company_id=state.config.company_id,
+            **params,
+        )
+    except (ValueError, unique_sdk.APIError) as exc:
+        return f"{WEB_CRAWL_ERROR_PREFIX} {exc}"
+
+    payload = _payload_from_resource(resource)
+    if output_json:
+        return _format_crawl_results_json(payload)
+    return _format_crawl_results(payload)
+
+
+def is_error_output(output: str) -> bool:
+    """Return ``True`` when ``output`` is a CLI error message.
+
+    Used by the Click layer to translate a returned error string into a
+    non-zero exit code without changing the existing string-returning
+    contract of the ``cmd_*`` functions.
+    """
+    return output.startswith(WEB_SEARCH_ERROR_PREFIX) or output.startswith(
+        WEB_CRAWL_ERROR_PREFIX
+    )

--- a/unique_sdk/unique_sdk/cli/commands/web_search_config.py
+++ b/unique_sdk/unique_sdk/cli/commands/web_search_config.py
@@ -1,0 +1,203 @@
+"""Config-file loading for the unique-cli ``web-search`` subcommands.
+
+Mirrors the discovery and shape rules of the reference ``unique-websearch``
+CLI so the same config files work with both tools, but resolves the
+config to plain dicts that are forwarded as ``searchEngineConfig`` /
+``crawlerConfig`` payloads on the public API. Engine and crawler
+selection is still performed server-side from the active env config; the
+file just provides per-call overrides.
+
+Two file shapes are recognised:
+
+1. **Full platform config** — a complete ``WebSearchConfig`` payload as
+   emitted by the platform (camelCase or snake_case). Detected by the
+   presence of ``webSearchActiveMode`` / ``web_search_active_mode`` or a
+   discriminator field (``search_engine_name`` / ``searchEngineName``,
+   ``crawler_type`` / ``crawlerType``) inside the nested engine/crawler
+   dicts. The nested ``searchEngineConfig`` and ``crawlerConfig`` blocks
+   are forwarded verbatim to the API.
+
+2. **Simple overrides** — a flat overrides file such as
+   ``{"search_engine_config": {"fetch_size": 50}}`` (the legacy shape
+   used by the reference CLI). Without a discriminator we cannot pin an
+   engine server-side, so only well-known scalar overrides are
+   extracted: today that means a default ``fetch_size`` /
+   ``fetchSize`` for ``--fetch-size``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+DEFAULT_CONFIG_PATH = Path.home() / ".unique-websearch.json"
+ENV_CONFIG_PATH = "UNIQUE_WEBSEARCH_CONFIG"
+
+_MODE_KEYS = frozenset({"webSearchActiveMode", "web_search_active_mode"})
+_ENGINE_DISCRIMINATORS = frozenset({"search_engine_name", "searchEngineName"})
+_CRAWLER_DISCRIMINATORS = frozenset({"crawler_type", "crawlerType"})
+
+_ENGINE_KEYS = ("searchEngineConfig", "search_engine_config")
+_CRAWLER_KEYS = ("crawlerConfig", "crawler_config")
+
+
+class WebSearchCLIConfigError(Exception):
+    """Raised when the CLI cannot load or interpret the config file."""
+
+
+@dataclass(frozen=True)
+class ConfigOverrides:
+    """Resolved overrides from a CLI config file.
+
+    Attributes:
+        engine_config: Full ``searchEngineConfig`` dict to forward to the
+            API, or ``None`` when no override applies.
+        crawler_config: Full ``crawlerConfig`` dict to forward to the
+            API, or ``None`` when no override applies.
+        fetch_size: Default ``fetchSize`` extracted from a simple-override
+            file; only meaningful when ``engine_config`` is ``None``.
+    """
+
+    engine_config: dict[str, Any] | None = None
+    crawler_config: dict[str, Any] | None = None
+    fetch_size: int | None = None
+
+    @property
+    def is_empty(self) -> bool:
+        return (
+            self.engine_config is None
+            and self.crawler_config is None
+            and self.fetch_size is None
+        )
+
+
+def resolve_config_path(explicit_path: str | None = None) -> Path | None:
+    """Locate a config file, mirroring ``unique-websearch`` discovery.
+
+    Order of resolution:
+
+    1. ``explicit_path`` (from ``--config``) — must exist if set.
+    2. ``$UNIQUE_WEBSEARCH_CONFIG`` — must exist if set.
+    3. ``~/.unique-websearch.json`` — used only if it exists.
+
+    Returns ``None`` when no file is configured or the default is absent.
+    """
+    if explicit_path:
+        path = Path(explicit_path).expanduser()
+        if not path.exists():
+            raise WebSearchCLIConfigError(f"Config file not found: {path}")
+        return path
+
+    env_path = os.environ.get(ENV_CONFIG_PATH)
+    if env_path:
+        path = Path(env_path).expanduser()
+        if not path.exists():
+            raise WebSearchCLIConfigError(
+                f"Config file not found: {path} (set via {ENV_CONFIG_PATH})"
+            )
+        return path
+
+    default = DEFAULT_CONFIG_PATH
+    return default if default.exists() else None
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise WebSearchCLIConfigError(f"Invalid JSON in {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise WebSearchCLIConfigError(
+            f"Config file {path} must contain a JSON object at the top level."
+        )
+    return data
+
+
+def _nested_has_discriminator(
+    data: dict[str, Any],
+    nested_keys: tuple[str, ...],
+    discriminators: frozenset[str],
+) -> bool:
+    """Return ``True`` if any nested dict carries a discriminator key."""
+    for key in nested_keys:
+        value = data.get(key)
+        if isinstance(value, dict) and (set(value.keys()) & discriminators):
+            return True
+    return False
+
+
+def is_full_platform_config(data: dict[str, Any]) -> bool:
+    """Detect the "full ``WebSearchConfig``" shape vs. a simple-override file.
+
+    A full config is identified by the ``webSearchActiveMode`` /
+    ``web_search_active_mode`` top-level key, or by a discriminator
+    (``searchEngineName`` / ``crawlerType``) inside the nested
+    engine/crawler config dicts.
+    """
+    if set(data.keys()) & _MODE_KEYS:
+        return True
+    if _nested_has_discriminator(data, _ENGINE_KEYS, _ENGINE_DISCRIMINATORS):
+        return True
+    if _nested_has_discriminator(data, _CRAWLER_KEYS, _CRAWLER_DISCRIMINATORS):
+        return True
+    return False
+
+
+def _first_present(data: dict[str, Any], keys: tuple[str, ...]) -> Any:
+    """Return the first value among ``keys`` present in ``data``, else ``None``."""
+    for key in keys:
+        if key in data:
+            return data[key]
+    return None
+
+
+def _extract_simple_fetch_size(data: dict[str, Any]) -> int | None:
+    """Pull ``fetch_size`` / ``fetchSize`` out of a simple-overrides file."""
+    block = _first_present(data, _ENGINE_KEYS)
+    if not isinstance(block, dict):
+        return None
+    raw = _first_present(block, ("fetchSize", "fetch_size"))
+    if raw is None:
+        return None
+    if isinstance(raw, bool) or not isinstance(raw, int):
+        raise WebSearchCLIConfigError(
+            f"Config field fetch_size must be an integer (got {raw!r})."
+        )
+    if raw < 1:
+        raise WebSearchCLIConfigError(
+            f"Config field fetch_size must be >= 1 (got {raw})."
+        )
+    return raw
+
+
+def parse_config_data(data: dict[str, Any]) -> ConfigOverrides:
+    """Project a parsed config-file dict into ``ConfigOverrides``.
+
+    Full-platform configs forward the nested engine/crawler dicts
+    verbatim. Simple-override configs only contribute a ``fetch_size``
+    default today; other scalar overrides are intentionally ignored
+    because the server cannot apply them without a discriminator.
+    """
+    if is_full_platform_config(data):
+        engine_block = _first_present(data, _ENGINE_KEYS)
+        crawler_block = _first_present(data, _CRAWLER_KEYS)
+        return ConfigOverrides(
+            engine_config=engine_block if isinstance(engine_block, dict) else None,
+            crawler_config=crawler_block if isinstance(crawler_block, dict) else None,
+        )
+    return ConfigOverrides(fetch_size=_extract_simple_fetch_size(data))
+
+
+def load_overrides(config_path: str | None = None) -> ConfigOverrides:
+    """Resolve a config file (if any) and return the projected overrides.
+
+    Returns an empty :class:`ConfigOverrides` when no config file is
+    discovered, so callers can unconditionally apply the result.
+    """
+    path = resolve_config_path(config_path)
+    if path is None:
+        return ConfigOverrides()
+    return parse_config_data(_load_json(path))

--- a/unique_sdk/unique_sdk/cli/skills/unique-cli-web-search/SKILL.md
+++ b/unique_sdk/unique_sdk/cli/skills/unique-cli-web-search/SKILL.md
@@ -1,0 +1,366 @@
+---
+name: unique-cli-web-search
+description: >-
+  ALWAYS use this skill when the user asks to search the public web,
+  research a topic online, look up news/articles/regulations, fetch the
+  contents of one or more URLs, or perform any "two-phase" web research
+  (search → review snippets → crawl selected URLs for full content).
+  Routes through the Unique AI Platform's `/web-search-api` endpoints
+  via `unique-cli web-search`, so the engine (Google, Brave, Tavily,
+  Jina, Firecrawl, …) and crawler are resolved server-side from the
+  current environment — you never need to manage engine API keys
+  yourself. Use this instead of fabricating answers from training data
+  whenever fresh / source-cited information is needed. Do NOT use this
+  skill for the internal knowledge base (`unique-cli search`) or for
+  arbitrary tool execution (`unique-cli mcp`).
+---
+
+# Unique CLI -- Web Search & Crawl
+
+Two-phase web research from the terminal, backed by the Unique AI Platform's public `/web-search-api`. Phase 1 (`search`) queries a search engine and returns URLs + snippets. Phase 2 (`crawl`) fetches the full page content for the URLs you actually want to read. The two-phase split lets you (or an LLM) review titles and snippets cheaply before paying the latency cost of full-page crawling.
+
+> **Server-side engine/crawler.** Unlike `unique-websearch`, this CLI does not instantiate engines locally — it just posts to the Unique platform, which resolves the engine and crawler from `ACTIVE_SEARCH_ENGINES` / `ACTIVE_INHOUSE_CRAWLERS` server-side. **You do not need any engine API keys** (Google, Brave, Tavily, etc.) on the client.
+
+## Two-Phase Workflow (preferred for AI agents)
+
+1. `unique-cli web-search search "<query>" --json` → candidate URLs with snippets.
+2. Review titles + snippets, pick the URLs that look relevant.
+3. `unique-cli web-search crawl <selected-urls>` → full page content for those URLs.
+4. Reason over the crawled content and respond with proper citations.
+
+This sequencing is much cheaper than crawling everything up-front and is the recommended pattern when an LLM is the consumer.
+
+```bash
+unique-cli web-search search "EU AI Act enforcement timeline" --json \
+  | jq -r '.results[].url' \
+  | unique-cli web-search crawl --stdin
+```
+
+For convenience, search can also crawl in one shot via `--include-content` when the engine requires scraping (see below).
+
+## Phase 1 — Search
+
+```bash
+# Basic search (uses server-side engine + default fetchSize)
+unique-cli web-search search "quarterly earnings 2026"
+
+# Limit the number of hits
+unique-cli web-search search "AI regulation" -n 10
+
+# JSON output (for piping or programmatic use)
+unique-cli web-search search "python tutorial" --json
+
+# Search AND populate result.content in one call (engine + crawler)
+unique-cli web-search search "sustainability reports" --include-content --json
+```
+
+### Per-call engine override
+
+Force a specific engine (or any engine-specific knob) without changing server config:
+
+```bash
+unique-cli web-search search "tax reform" \
+  --engine-config '{"searchEngineName":"Google","fetchSize":3}'
+```
+
+The `--engine-config` value is a JSON object matching the server's
+`searchEngineConfig` discriminated union (same shape `assistants-core`
+expects). The discriminator key is `searchEngineName`.
+
+## Phase 2 — Crawl
+
+```bash
+# Crawl one or more URLs explicitly
+unique-cli web-search crawl https://example.com https://other.com
+
+# Tune server-side concurrency
+unique-cli web-search crawl --parallel 5 https://a.com https://b.com
+
+# Read URLs from stdin (one per line) — composes nicely with `search --json`
+echo "https://example.com" | unique-cli web-search crawl --stdin
+
+# JSON output (preserves per-URL error info)
+unique-cli web-search crawl https://example.com --json
+```
+
+### Per-call crawler override
+
+```bash
+unique-cli web-search crawl https://example.com \
+  --crawler-config '{"crawlerType":"BasicCrawler"}'
+```
+
+The `--crawler-config` value is a JSON object matching the server's
+`crawlerConfig` discriminated union (discriminator key: `crawlerType`).
+
+## Config files (`~/.unique-websearch.json`)
+
+For non-interactive workflows you can persist overrides in a JSON file
+shape-compatible with the reference `unique-websearch` CLI. Resolution
+order:
+
+1. `--config / -c PATH` (subcommand value beats group value)
+2. `$UNIQUE_WEBSEARCH_CONFIG`
+3. `~/.unique-websearch.json` (used only if it exists)
+
+Two file shapes are supported:
+
+### A. Full platform config (camelCase or snake_case)
+
+Includes a discriminator (`searchEngineName` / `crawlerType`) or the
+top-level `webSearchActiveMode` key. The nested `searchEngineConfig` /
+`crawlerConfig` blocks are forwarded verbatim to the API:
+
+```json
+{
+  "searchEngineConfig": { "searchEngineName": "Google", "fetchSize": 5 },
+  "crawlerConfig":      { "crawlerType": "BasicCrawler" }
+}
+```
+
+### B. Simple overrides
+
+No discriminator — the file just tunes well-known scalars. Only
+`fetch_size` / `fetchSize` is currently honoured client-side; the rest
+is ignored because the server can't apply scalar tweaks without a
+discriminator:
+
+```json
+{ "search_engine_config": { "fetch_size": 50 } }
+```
+
+### Override precedence (highest first)
+
+1. Inline `--fetch-size` / `--engine-config` / `--crawler-config` flags
+2. Config file (`--config` / `$UNIQUE_WEBSEARCH_CONFIG` / `~/.unique-websearch.json`)
+3. Server-side defaults (`ACTIVE_SEARCH_ENGINES`, etc.)
+
+## Command Reference
+
+### `unique-cli web-search search <query>`
+
+| Option | Short | Default | Description |
+|--------|-------|---------|-------------|
+| `--fetch-size` | `-n` | server default | Override the engine's `fetchSize` |
+| `--include-content` | `-i` | off | Populate `result.content` via the configured crawler |
+| `--engine-config` | | none | Override `searchEngineConfig` (JSON object, must include `searchEngineName`) |
+| `--crawler-config` | | none | Override `crawlerConfig` (JSON object) — only used with `--include-content` |
+| `--config` | `-c` | none | Per-call override of the group's `--config` path |
+| `--json` | | off | Emit `{engine, query, results: [...]}` JSON envelope |
+
+### `unique-cli web-search crawl <url>...`
+
+| Option | Short | Default | Description |
+|--------|-------|---------|-------------|
+| `--parallel` | `-p` | 10 | URLs the server crawls concurrently per batch (≥ 1) |
+| `--stdin` | | off | Read URLs from stdin (one per line) — combines with positional URLs |
+| `--crawler-config` | | none | Override `crawlerConfig` (JSON object, must include `crawlerType`) |
+| `--config` | `-c` | none | Per-call override of the group's `--config` path |
+| `--json` | | off | Emit `{crawler, results: [...]}` JSON envelope |
+
+### Group options
+
+| Option | Short | Description |
+|--------|-------|-------------|
+| `--config` | `-c` | Config file path; falls back to `$UNIQUE_WEBSEARCH_CONFIG` and `~/.unique-websearch.json` |
+| `--version` | | Show the CLI version |
+| `--help` | | Show help |
+
+## Output Format
+
+### `search` (text)
+
+```
+engine: Google    query: 'quarterly earnings 2026'
+Found 3 result(s):
+
+  1. Example Page Title
+     https://example.com/article
+     A short snippet describing the page content...
+
+  2. Another Relevant Result
+     https://another.com/page
+     [4523 chars of content]    # only when --include-content
+```
+
+### `search --json`
+
+```json
+{
+  "engine": "Google",
+  "query": "quarterly earnings 2026",
+  "results": [
+    {
+      "url": "https://example.com/article",
+      "title": "Example Page Title",
+      "snippet": "A short snippet describing the page content...",
+      "content": ""
+    }
+  ]
+}
+```
+
+> The `--json` envelope (`engine`, `query`, `results`, plus per-result
+> `content`) is richer than the reference `unique-websearch` CLI's flat
+> array. To pipe URLs into `crawl`, address `.results[].url` (not
+> `.[].url`):
+>
+> ```bash
+> unique-cli web-search search "q" --json \
+>   | jq -r '.results[].url' \
+>   | unique-cli web-search crawl --stdin
+> ```
+
+### `crawl` (text)
+
+```
+crawler: BasicCrawler
+Crawled 2 URL(s):
+
+  1. https://example.com/article
+     [4523 chars]
+     Full page content preview, truncated to ~500 characters...
+
+  2. https://other.com/page
+     ERROR: HTTP 503 from upstream
+```
+
+### `crawl --json`
+
+```json
+{
+  "crawler": "BasicCrawler",
+  "results": [
+    {
+      "url": "https://example.com/article",
+      "content": "Full page content as markdown...",
+      "error": null
+    },
+    {
+      "url": "https://other.com/page",
+      "content": "",
+      "error": "HTTP 503 from upstream"
+    }
+  ]
+}
+```
+
+## Exit Codes
+
+In one-shot mode, the CLI exits **`0`** on success and **`1`** on
+failures (config-file errors, invalid JSON overrides, API errors,
+missing URLs for `crawl`). Error messages are prefixed with
+`web-search:` or `web-crawl:` so they're easy to grep.
+
+```bash
+unique-cli web-search crawl  # no URLs → exits 1
+# web-crawl: no URLs provided. Pass URLs as arguments or use --stdin.
+```
+
+## Workflow Examples
+
+### Research a fast-moving topic and cite sources
+
+User: "What did the EU just decide about general-purpose AI models?"
+
+```bash
+# 1. Find candidate sources
+unique-cli web-search search "EU general-purpose AI model rules 2026" -n 10 --json \
+  > /tmp/hits.json
+
+# 2. Inspect the snippets, pick 3 promising URLs from /tmp/hits.json,
+#    then crawl them for full content
+jq -r '.results[0:3][].url' /tmp/hits.json \
+  | unique-cli web-search crawl --stdin --json \
+  > /tmp/pages.json
+
+# 3. Reason over /tmp/pages.json and respond with citations.
+```
+
+### One-shot search-with-content (no manual selection)
+
+When you trust the engine and just want full content for the top hits:
+
+```bash
+unique-cli web-search search "Swiss FINMA AI guidance" \
+  --include-content --json -n 5
+```
+
+This populates `results[].content` server-side via the configured
+crawler; no separate `crawl` call is needed.
+
+### Force a specific engine for one call
+
+```bash
+unique-cli web-search search "OECD principles on AI" \
+  --engine-config '{"searchEngineName":"Brave","fetchSize":5}'
+```
+
+### Persist defaults per environment
+
+```bash
+# Set once for the shell session
+export UNIQUE_WEBSEARCH_CONFIG=~/configs/ws-google-fast.json
+
+# Or pin per-invocation (sub-command --config wins over the group's)
+unique-cli web-search --config ~/configs/ws-default.json \
+  search --config ~/configs/ws-low-fetch.json "macro outlook 2026"
+```
+
+## SDK Usage (Python)
+
+The CLI is a thin wrapper around `unique_sdk.WebSearch` and
+`unique_sdk.WebCrawl`. Use these directly when scripting:
+
+```python
+import unique_sdk
+
+unique_sdk.api_key = "ukey_..."
+unique_sdk.app_id = "app_..."
+
+# Phase 1 — search
+hits = unique_sdk.WebSearch.search(
+    user_id="user_123",
+    company_id="company_456",
+    query="EU AI Act enforcement",
+    fetchSize=10,
+    # Optional per-call overrides forwarded to the server's
+    # WebSearchConfig.searchEngineConfig discriminated union:
+    searchEngineConfig={"searchEngineName": "Google"},
+)
+urls = [r["url"] for r in hits.results]
+
+# Phase 2 — crawl the URLs we want to read
+pages = unique_sdk.WebCrawl.crawl(
+    user_id="user_123",
+    company_id="company_456",
+    urls=urls[:5],
+    parallel=5,
+    crawlerConfig={"crawlerType": "BasicCrawler"},
+)
+for entry in pages.results:
+    if entry["error"]:
+        continue
+    process(entry["url"], entry["content"])
+```
+
+Both classes have `*_async` variants (`WebSearch.search_async`,
+`WebCrawl.crawl_async`) for async contexts.
+
+## Prerequisites
+
+```bash
+UNIQUE_USER_ID    # User ID (required)
+UNIQUE_COMPANY_ID # Company ID (required)
+UNIQUE_API_KEY    # API key — optional on localhost / secured cluster
+UNIQUE_APP_ID     # App ID — optional on localhost / secured cluster
+
+# Optional — config file location
+UNIQUE_WEBSEARCH_CONFIG   # Path to a JSON config (overrides default ~/.unique-websearch.json)
+```
+
+You **do not** need any engine-specific API keys (`GOOGLE_SEARCH_API_KEY`,
+`BRAVE_SEARCH_API_KEY`, `TAVILY_API_KEY`, etc.) on the client — they live
+on the server.
+
+Install: `pip install unique-sdk`


### PR DESCRIPTION
## Summary

Adds the SDK and CLI surface for the platform's two-phase web search (`/web-search-api/{search,crawl}`):

- **SDK**: `unique_sdk.WebSearch.search` and `unique_sdk.WebCrawl.crawl` (plus `*_async` variants), with TypedDicts for the per-result envelopes and `OBJECT_NAME` registration.
- **CLI**: `unique-cli web-search {search,crawl}` group, designed for feature parity with the reference `unique-websearch` CLI shipped from `tool_packages/unique_web_search` so users can swap one for the other:
  - `--config / -c PATH`, `$UNIQUE_WEBSEARCH_CONFIG`, default `~/.unique-websearch.json`
  - Both file shapes accepted: full `WebSearchConfig` (camelCase or snake_case) and simple-overrides
  - `--version`, exit code 1 on failures
- **SDK super-set retained**: inline `--engine-config` / `--crawler-config` JSON overrides, `--include-content` (one-shot search+crawl), richer `{engine, query, results}` / `{crawler, results}` JSON envelope.
- **Override precedence**: inline flags > config file > server defaults.
- **Skill**: new `unique-cli-web-search` agent skill describing the two-phase workflow, override surface, and Python usage.

## Test plan

- [x] Unit tests: 82 web-search tests (config detection, file loading, merge precedence, error exit codes, `--version`, group-vs-subcommand `--config` resolution).
- [x] Full SDK suite: 552 passed, 39 skipped.
- [x] `ruff check` + `ruff format --check` on all touched files.
- [x] Validated end-to-end against a localhost backend across 19 scenarios:
  - 13 varied search queries (OECD, ECB, Premier League, GPT-5, Bitcoin, Tesla earnings, k8s debugging, etc.) all returned 3 Google results.
  - Crawl of 3 random URLs (Wikipedia / OpenAI / Python) returned 402K, 256, 14K char content.
  - `--include-content` one-shot search+crawl populated content for all hits.
  - `search --json | jq -r '.results[].url' | crawl --stdin --parallel 2` end-to-end pipeline.
  - Inline `--engine-config '{"fetchSize":1}'` correctly overrides a file-supplied `fetchSize:2`.
  - Bad `--config` path exits 1 with `web-search: Config file not found: …`.
  - Empty `crawl` exits 1 with `web-crawl: no URLs provided. …`.
- [x] Verified the `/web-search-api/{search,crawl}` route is **not** yet deployed on QA (`gateway.qa.unique.app`); other endpoints (e.g. `unique-cli ls /`) work fine with the same credentials. The SDK is forward-compatible — once the backend route lands on QA the CLI will work there with no SDK changes.

## Follow-ups

- Once this lands, a follow-up PR will remove the now-redundant CLI from `tool_packages/unique_web_search` (`cli/`, `tests/test_cli.py`, the `unique-websearch` console script entry, and the `unique-websearch-cli` skill).

Made with [Cursor](https://cursor.com)