### PR TITLE
feat(mcp-search): rewrite tutorial using InternalSearchService + search_mode switcher

### DIFF
--- a/tutorials/mcp/mcp_search/src/mcp_search/config.py
+++ b/tutorials/mcp/mcp_search/src/mcp_search/config.py
@@ -1,0 +1,51 @@
+"""Tool-level configuration for the Knowledge Base Search MCP tool.
+
+``SearchToolConfig`` is the single RJSF config model for the search tool.
+It holds one ``service_config`` key — either ``KBSearchConfig`` or ``ChatSearchConfig``
+— which is passed directly to the corresponding internal-search service via
+``from_config()``, with no field mapping required.
+
+Admin sets ``service_config.type`` once at deployment time to choose the search backend.
+``post_processing`` controls post-retrieval behaviour (token budget, reranking).
+
+Notes on the discriminated union and RJSF
+------------------------------------------
+- ``KBSearchConfig`` and ``ChatSearchConfig`` add a ``type`` literal field to
+  their respective toolkit base classes so Pydantic can emit a ``oneOf`` +
+  ``discriminator`` JSON schema that RJSF renders as a variant selector.
+- The ``type`` field is never stored by the LLM or passed by the caller — it
+  lives only in admin-managed config.
+- Stored configs must always include ``"type"`` explicitly; ``model_dump()``
+  emits it automatically so anything saved from the admin UI is always valid.
+"""
+
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, Field
+
+from unique_toolkit._common.pydantic_helpers import get_configuration_dict
+from unique_toolkit.experimental.components.internal_search import (
+    ChatInternalSearchConfig,
+    KnowledgeBaseInternalSearchConfig,
+    PostProcessorConfig,
+)
+
+
+class KBSearchConfig(KnowledgeBaseInternalSearchConfig):
+    model_config = get_configuration_dict(title="Knowledge Base")
+    type: Literal["kb"] = "kb"
+
+
+class ChatSearchConfig(ChatInternalSearchConfig):
+    model_config = get_configuration_dict(title="Chat")
+    type: Literal["chat"] = "chat"
+
+
+class SearchToolConfig(BaseModel):
+    model_config = get_configuration_dict()
+
+    service_config: Annotated[
+        KBSearchConfig | ChatSearchConfig,
+        Field(discriminator="type"),
+    ] = Field(default_factory=KBSearchConfig)
+    post_processing: PostProcessorConfig = Field(default_factory=PostProcessorConfig)

--- a/tutorials/mcp/mcp_search/src/mcp_search/config.py
+++ b/tutorials/mcp/mcp_search/src/mcp_search/config.py
@@ -23,6 +23,12 @@ class SearchToolConfig(BaseModel):
     model_config = get_configuration_dict()
 
     service_config: KnowledgeBaseInternalSearchConfig = Field(
-        default_factory=KnowledgeBaseInternalSearchConfig
+        default_factory=lambda: KnowledgeBaseInternalSearchConfig(
+            metadata_filter={
+                "path": ["folderId"],
+                "operator": "isNotNull",
+                "value": None,
+            }
+        )
     )
     post_processing: PostProcessorConfig = Field(default_factory=PostProcessorConfig)

--- a/tutorials/mcp/mcp_search/src/mcp_search/config.py
+++ b/tutorials/mcp/mcp_search/src/mcp_search/config.py
@@ -1,51 +1,28 @@
 """Tool-level configuration for the Knowledge Base Search MCP tool.
 
 ``SearchToolConfig`` is the single RJSF config model for the search tool.
-It holds one ``service_config`` key — either ``KBSearchConfig`` or ``ChatSearchConfig``
-— which is passed directly to the corresponding internal-search service via
+It holds one ``service_config`` key (``KnowledgeBaseInternalSearchConfig``)
+which is passed directly to :class:`KnowledgeBaseInternalSearchService` via
 ``from_config()``, with no field mapping required.
 
-Admin sets ``service_config.type`` once at deployment time to choose the search backend.
+Admin sets ``service_config`` fields at deployment time to control the search
+backend (metadata filter, limit, reranker, etc.).
 ``post_processing`` controls post-retrieval behaviour (token budget, reranking).
-
-Notes on the discriminated union and RJSF
-------------------------------------------
-- ``KBSearchConfig`` and ``ChatSearchConfig`` add a ``type`` literal field to
-  their respective toolkit base classes so Pydantic can emit a ``oneOf`` +
-  ``discriminator`` JSON schema that RJSF renders as a variant selector.
-- The ``type`` field is never stored by the LLM or passed by the caller — it
-  lives only in admin-managed config.
-- Stored configs must always include ``"type"`` explicitly; ``model_dump()``
-  emits it automatically so anything saved from the admin UI is always valid.
 """
-
-from typing import Annotated, Literal
 
 from pydantic import BaseModel, Field
 
 from unique_toolkit._common.pydantic_helpers import get_configuration_dict
 from unique_toolkit.experimental.components.internal_search import (
-    ChatInternalSearchConfig,
     KnowledgeBaseInternalSearchConfig,
     PostProcessorConfig,
 )
 
 
-class KBSearchConfig(KnowledgeBaseInternalSearchConfig):
-    model_config = get_configuration_dict(title="Knowledge Base")
-    type: Literal["kb"] = "kb"
-
-
-class ChatSearchConfig(ChatInternalSearchConfig):
-    model_config = get_configuration_dict(title="Chat")
-    type: Literal["chat"] = "chat"
-
-
 class SearchToolConfig(BaseModel):
     model_config = get_configuration_dict()
 
-    service_config: Annotated[
-        KBSearchConfig | ChatSearchConfig,
-        Field(discriminator="type"),
-    ] = Field(default_factory=KBSearchConfig)
+    service_config: KnowledgeBaseInternalSearchConfig = Field(
+        default_factory=KnowledgeBaseInternalSearchConfig
+    )
     post_processing: PostProcessorConfig = Field(default_factory=PostProcessorConfig)

--- a/tutorials/mcp/mcp_search/src/mcp_search/mcp_client.py
+++ b/tutorials/mcp/mcp_search/src/mcp_search/mcp_client.py
@@ -3,7 +3,7 @@ import os
 
 from fastmcp import Client
 
-from mcp_search.config import KBSearchConfig, SearchToolConfig
+from mcp_search.config import SearchToolConfig
 from unique_mcp.meta.keys import CONFIG_META_KEY, MetaKeys
 
 MCP_URL = os.environ.get("MCP_SEARCH_URL", "http://localhost:8003/mcp")
@@ -12,9 +12,7 @@ MCP_URL = os.environ.get("MCP_SEARCH_URL", "http://localhost:8003/mcp")
 SEARCH_ARGS = {"search_string": "what is unique?"}
 
 # Optional: override config injected by the host (useful for local testing).
-_CONFIG_OVERRIDE = SearchToolConfig(
-    service_config=KBSearchConfig(),
-).model_dump(mode="json", by_alias=True)
+_CONFIG_OVERRIDE = SearchToolConfig().model_dump(mode="json", by_alias=True)
 
 
 def _print_result(result: object) -> None:

--- a/tutorials/mcp/mcp_search/src/mcp_search/mcp_client.py
+++ b/tutorials/mcp/mcp_search/src/mcp_search/mcp_client.py
@@ -3,15 +3,18 @@ import os
 
 from fastmcp import Client
 
-from unique_mcp.meta.keys import MetaKeys
+from mcp_search.config import KBSearchConfig, SearchToolConfig
+from unique_mcp.meta.keys import CONFIG_META_KEY, MetaKeys
 
 MCP_URL = os.environ.get("MCP_SEARCH_URL", "http://localhost:8003/mcp")
 
-SEARCH_ARGS = {
-    "search_string": "what is unique?",
-    "search_type": "VECTOR",
-    "limit": 3,
-}
+# Only search_string is a tool argument; everything else lives in config.
+SEARCH_ARGS = {"search_string": "what is unique?"}
+
+# Optional: override config injected by the host (useful for local testing).
+_CONFIG_OVERRIDE = SearchToolConfig(
+    service_config=KBSearchConfig(),
+).model_dump(mode="json", by_alias=True)
 
 
 def _print_result(result: object) -> None:
@@ -28,13 +31,17 @@ async def main() -> None:
         tools = await client.list_tools()
         print(f"\nAvailable tools: {[t.name for t in tools]}")
 
-        # --- Call 1: normal auth (JWT claims / userinfo) ---
+        # --- Call 1: normal auth (JWT claims / userinfo), default server config ---
         print("\n--- Call 1: auth from JWT / userinfo ---")
-        result = await client.call_tool("search", SEARCH_ARGS)
+        result = await client.call_tool(
+            "search",
+            SEARCH_ARGS,
+            meta={"debug.probe": "mcp_client_call1"},
+        )
         print(f"Got {len(result.content)} result(s):")
         _print_result(result)
 
-        # --- Call 2: override auth via _meta ---
+        # --- Call 2: override auth + config via _meta ---
         meta_override = {
             MetaKeys.USER_ID.value: os.environ.get(
                 "UNIQUE_AUTH_USER_ID", "meta-test-user"
@@ -42,8 +49,9 @@ async def main() -> None:
             MetaKeys.COMPANY_ID.value: os.environ.get(
                 "UNIQUE_AUTH_COMPANY_ID", "meta-test-company"
             ),
+            CONFIG_META_KEY: _CONFIG_OVERRIDE,
         }
-        print(f"\n--- Call 2: auth from _meta {meta_override} ---")
+        print("\n--- Call 2: auth + config from _meta ---")
         result = await client.call_tool("search", SEARCH_ARGS, meta=meta_override)
         print(f"Got {len(result.content)} result(s):")
         _print_result(result)

--- a/tutorials/mcp/mcp_search/src/mcp_search/mcp_search_server.py
+++ b/tutorials/mcp/mcp_search/src/mcp_search/mcp_search_server.py
@@ -28,9 +28,7 @@ def main() -> None:
 
     tools_provider = FileSystemProvider(Path(__file__).parent / "tools")
 
-    mcp = FastMCP(
-        "Knowledge Base Search 🚀", auth=oidc_proxy, providers=[tools_provider]
-    )
+    mcp = FastMCP("Knowledge Base Search", auth=oidc_proxy, providers=[tools_provider])
 
     mcp.mount(get_custom_routes_provider())
 

--- a/tutorials/mcp/mcp_search/src/mcp_search/mcp_search_server.py
+++ b/tutorials/mcp/mcp_search/src/mcp_search/mcp_search_server.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 
 from fastmcp import FastMCP
@@ -15,6 +16,8 @@ from unique_mcp.settings import ServerSettings
 
 def main() -> None:
     """Main entry point for the MCP Search server."""
+
+    logging.getLogger("mcp_search").setLevel(logging.DEBUG)
 
     server_settings = ServerSettings()
 

--- a/tutorials/mcp/mcp_search/src/mcp_search/tools/search.py
+++ b/tutorials/mcp/mcp_search/src/mcp_search/tools/search.py
@@ -1,58 +1,102 @@
+"""Knowledge Base Search tool.
+
+Separation of concerns:
+- CONFIG  (admin-set, injected via the config meta key at call time)
+  → service_config: KBSearchConfig | ChatSearchConfig — all retrieval params
+  → post_processing: PostProcessorConfig — token budget, client-side reranking
+  → no LLM involvement
+- STATE   (LLM fills at call time, tool arguments)
+  → search_string   required — what to search for
+"""
+
+import logging
 from typing import Annotated
 
 from fastmcp.dependencies import Depends
 from fastmcp.tools import tool
 from mcp.types import CallToolResult, TextContent
+from mcp_search.config import KBSearchConfig, SearchToolConfig
 from pydantic import Field
 
-from unique_mcp import get_unique_service_factory
-from unique_toolkit.content.schemas import ContentSearchType
-from unique_toolkit.services.factory import UniqueServiceFactory
+from unique_mcp import (
+    ConfigSchemaMeta,
+    ContextRequirements,
+    MetaKeys,
+    get_tool_config,
+    merge_tool_meta,
+)
+from unique_mcp.unique_injectors import get_unique_settings
+from unique_toolkit.app.unique_settings import UniqueSettings
+from unique_toolkit.experimental.components.internal_search import (
+    ChatInternalSearchService,
+    InternalSearchPostProcessor,
+    KnowledgeBaseInternalSearchService,
+)
+
+_logger = logging.getLogger(__name__)
+
+_META = merge_tool_meta(
+    {
+        "unique.app/icon": "search",
+        "unique.app/system-prompt": (
+            "Choose this tool if you need to search in the knowledge base"
+        ),
+    },
+    ContextRequirements(
+        required=[MetaKeys.USER_ID, MetaKeys.COMPANY_ID],
+        optional=[MetaKeys.CHAT_ID],
+    ),
+    ConfigSchemaMeta(SearchToolConfig),
+)
 
 
 @tool(
     name="search",
-    description="This tool does search in the knowledge base for the given search string and search type and returns the search results",
-    meta={
-        "unique.app/icon": "search",
-        "unique.app/system-prompt": "Choose this tool if you need to search in the knowledge base",
-    },
+    description="Search the knowledge base for the given query and return relevant chunks.",
+    meta=_META,
 )
 async def search(
+    # ── STATE: LLM fills this at call time ───────────────────────────────────
     search_string: Annotated[
         str,
-        Field(
-            description="The search string that will be used to do the search in the knowledge base"
-        ),
+        Field(description="The query to search for in the knowledge base."),
     ],
-    search_type: Annotated[
-        ContentSearchType,
-        Field(
-            default=ContentSearchType.VECTOR,
-            description="The search type that will be used to do the search in the knowledge base",
-        ),
-    ] = ContentSearchType.VECTOR,
-    limit: Annotated[
-        int,
-        Field(
-            description="The limit for the number of search results",
-            default=10,
-        ),
-    ] = 10,
-    service_factory: UniqueServiceFactory = Depends(get_unique_service_factory),
+    # ── INJECTED: framework provides these, not part of the tool schema ───────
+    config: SearchToolConfig = get_tool_config(SearchToolConfig),
+    settings: UniqueSettings = Depends(get_unique_settings),
 ) -> CallToolResult:
-    """Search in the knowledge base"""
+    """Search the knowledge base.
 
-    content_chunks = service_factory.knowledge_base_service().search_content_chunks(
-        search_string=search_string,
-        search_type=search_type,
-        limit=limit,
-        scope_ids=None,  # type: ignore
-    )
+    All search behaviour is driven by ``SearchToolConfig`` read from the config
+    meta key. Pydantic fills any missing fields with model defaults.
+    """
+
+    try:
+        if isinstance(config.service_config, KBSearchConfig):
+            service = KnowledgeBaseInternalSearchService.from_config(
+                config.service_config
+            )
+        else:
+            service = ChatInternalSearchService.from_config(config.service_config)
+
+        service.bind_settings(settings)
+        service.state.search_queries = [search_string]
+
+        result = await service.run()
+
+        post_processor = InternalSearchPostProcessor.from_settings(
+            settings, config=config.post_processing
+        )
+        chunks = await post_processor.process(result)
+    except Exception as exc:
+        _logger.exception("search tool error: %s", exc)
+        return CallToolResult(
+            isError=True, content=[TextContent(type="text", text=str(exc))]
+        )
 
     return CallToolResult(
         content=[
             TextContent(type="text", text=chunk.text, _meta=chunk.model_dump())
-            for chunk in content_chunks
+            for chunk in chunks
         ],
     )

--- a/tutorials/mcp/mcp_search/src/mcp_search/tools/search.py
+++ b/tutorials/mcp/mcp_search/src/mcp_search/tools/search.py
@@ -17,7 +17,6 @@ from fastmcp.tools import tool
 from mcp.types import CallToolResult, TextContent
 from mcp_search.config import SearchToolConfig
 from pydantic import Field
-from pydantic.alias_generators import to_camel
 
 from unique_mcp import (
     ConfigSchemaMeta,
@@ -45,7 +44,7 @@ _META = merge_tool_meta(
     ContextRequirements(
         required=[MetaKeys.USER_ID, MetaKeys.COMPANY_ID],
     ),
-    ConfigSchemaMeta(SearchToolConfig, key_transform=to_camel),
+    ConfigSchemaMeta(SearchToolConfig),
 )
 
 

--- a/tutorials/mcp/mcp_search/src/mcp_search/tools/search.py
+++ b/tutorials/mcp/mcp_search/src/mcp_search/tools/search.py
@@ -2,7 +2,7 @@
 
 Separation of concerns:
 - CONFIG  (admin-set, injected via the config meta key at call time)
-  → service_config: KBSearchConfig | ChatSearchConfig — all retrieval params
+  → service_config: KnowledgeBaseInternalSearchConfig — all retrieval params
   → post_processing: PostProcessorConfig — token budget, client-side reranking
   → no LLM involvement
 - STATE   (LLM fills at call time, tool arguments)
@@ -15,8 +15,9 @@ from typing import Annotated
 from fastmcp.dependencies import Depends
 from fastmcp.tools import tool
 from mcp.types import CallToolResult, TextContent
-from mcp_search.config import KBSearchConfig, SearchToolConfig
+from mcp_search.config import SearchToolConfig
 from pydantic import Field
+from pydantic.alias_generators import to_camel
 
 from unique_mcp import (
     ConfigSchemaMeta,
@@ -28,12 +29,11 @@ from unique_mcp import (
 from unique_mcp.unique_injectors import get_unique_settings
 from unique_toolkit.app.unique_settings import UniqueSettings
 from unique_toolkit.experimental.components.internal_search import (
-    ChatInternalSearchService,
     InternalSearchPostProcessor,
     KnowledgeBaseInternalSearchService,
 )
 
-_logger = logging.getLogger(__name__)
+_LOGGER = logging.getLogger(__name__)
 
 _META = merge_tool_meta(
     {
@@ -44,9 +44,8 @@ _META = merge_tool_meta(
     },
     ContextRequirements(
         required=[MetaKeys.USER_ID, MetaKeys.COMPANY_ID],
-        optional=[MetaKeys.CHAT_ID],
     ),
-    ConfigSchemaMeta(SearchToolConfig),
+    ConfigSchemaMeta(SearchToolConfig, key_transform=to_camel),
 )
 
 
@@ -72,13 +71,7 @@ async def search(
     """
 
     try:
-        if isinstance(config.service_config, KBSearchConfig):
-            service = KnowledgeBaseInternalSearchService.from_config(
-                config.service_config
-            )
-        else:
-            service = ChatInternalSearchService.from_config(config.service_config)
-
+        service = KnowledgeBaseInternalSearchService.from_config(config.service_config)
         service.bind_settings(settings)
         service.state.search_queries = [search_string]
 
@@ -89,7 +82,7 @@ async def search(
         )
         chunks = await post_processor.process(result)
     except Exception as exc:
-        _logger.exception("search tool error: %s", exc)
+        _LOGGER.exception("search error")
         return CallToolResult(
             isError=True, content=[TextContent(type="text", text=str(exc))]
         )

--- a/tutorials/mcp/mcp_search/src/mcp_search/tools/search.py
+++ b/tutorials/mcp/mcp_search/src/mcp_search/tools/search.py
@@ -70,8 +70,9 @@ async def search(
     """
 
     try:
-        service = KnowledgeBaseInternalSearchService.from_config(config.service_config)
-        service.bind_settings(settings)
+        service = KnowledgeBaseInternalSearchService.from_config(
+            config.service_config
+        ).bind_settings(settings)
         service.state.search_queries = [search_string]
 
         result = await service.run()

--- a/tutorials/mcp/mcp_search/tests/test_search_tool.py
+++ b/tutorials/mcp/mcp_search/tests/test_search_tool.py
@@ -1,0 +1,209 @@
+"""Tests for the search tool — config schema and routing logic."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from mcp.types import CallToolResult
+from mcp_search.config import ChatSearchConfig, KBSearchConfig, SearchToolConfig
+from mcp_search.tools.search import search
+
+from unique_toolkit._common.pydantic.rjsf_tags import ui_schema_for_model
+from unique_toolkit.content.schemas import ContentChunk
+
+# ── Schema tests ──────────────────────────────────────────────────────────────
+
+
+def test_json_schema_has_oneof_discriminator():
+    schema = SearchToolConfig.model_json_schema()
+    sc = schema["properties"]["serviceConfig"]
+    assert "oneOf" in sc
+    assert sc["discriminator"]["propertyName"] == "type"
+    assert sc["discriminator"]["mapping"] == {
+        "kb": "#/$defs/KBSearchConfig",
+        "chat": "#/$defs/ChatSearchConfig",
+    }
+
+
+def test_json_schema_kb_variant_has_metadata_filter():
+    schema = SearchToolConfig.model_json_schema()
+    kb = schema["$defs"]["KBSearchConfig"]["properties"]
+    assert "metadataFilter" in kb
+    assert "type" in kb
+    assert kb["type"]["const"] == "kb"
+
+
+def test_json_schema_chat_variant_has_no_metadata_filter():
+    schema = SearchToolConfig.model_json_schema()
+    chat = schema["$defs"]["ChatSearchConfig"]["properties"]
+    assert "metadataFilter" not in chat
+    assert chat["type"]["const"] == "chat"
+
+
+def test_ui_schema_hides_max_tokens_for_sources():
+    ui = ui_schema_for_model(SearchToolConfig)
+    assert ui["post_processing"]["max_tokens_for_sources"] == {"ui:widget": "hidden"}
+
+
+def test_default_config_is_kb_and_round_trips():
+    default = SearchToolConfig().model_dump(mode="json")
+    assert default["service_config"]["type"] == "kb"
+    # Round-trip: stored config must validate back without error
+    restored = SearchToolConfig.model_validate(default)
+    assert isinstance(restored.service_config, KBSearchConfig)
+
+
+def test_validate_chat_config():
+    config = SearchToolConfig.model_validate({"service_config": {"type": "chat"}})
+    assert isinstance(config.service_config, ChatSearchConfig)
+
+
+# ── Routing tests ─────────────────────────────────────────────────────────────
+
+
+def _make_chunk(text: str) -> ContentChunk:
+    return MagicMock(
+        spec=ContentChunk, text=text, model_dump=MagicMock(return_value={})
+    )
+
+
+def _make_settings():
+    return MagicMock()
+
+
+def _patch_post_processor(chunks: list):
+    """Patch InternalSearchPostProcessor so process() returns the given chunks."""
+    mock_pp = MagicMock()
+    mock_pp.process = AsyncMock(return_value=chunks)
+    return patch(
+        "mcp_search.tools.search.InternalSearchPostProcessor.from_settings",
+        return_value=mock_pp,
+    )
+
+
+@pytest.mark.asyncio
+async def test_search_routes_to_kb_service():
+    chunks = [_make_chunk("result A")]
+    mock_service = MagicMock()
+    mock_service.bind_settings.return_value = mock_service
+    mock_service.state = MagicMock()
+    mock_service.run = AsyncMock(return_value=MagicMock())
+
+    with (
+        patch(
+            "mcp_search.tools.search.KnowledgeBaseInternalSearchService.from_config",
+            return_value=mock_service,
+        ) as mock_from_config,
+        _patch_post_processor(chunks),
+    ):
+        result = await search(
+            search_string="test query",
+            config=SearchToolConfig(),  # type=kb by default
+            settings=_make_settings(),
+        )
+
+    mock_from_config.assert_called_once()
+    assert isinstance(mock_from_config.call_args[0][0], KBSearchConfig)
+    mock_service.bind_settings.assert_called_once()
+    assert mock_service.state.search_queries == ["test query"]
+    assert isinstance(result, CallToolResult)
+    assert len(result.content) == 1
+
+
+@pytest.mark.asyncio
+async def test_search_routes_to_chat_service():
+    chunks = [_make_chunk("chat result")]
+    mock_service = MagicMock()
+    mock_service.bind_settings.return_value = mock_service
+    mock_service.state = MagicMock()
+    mock_service.run = AsyncMock(return_value=MagicMock())
+
+    config = SearchToolConfig.model_validate({"service_config": {"type": "chat"}})
+
+    with (
+        patch(
+            "mcp_search.tools.search.ChatInternalSearchService.from_config",
+            return_value=mock_service,
+        ) as mock_from_config,
+        _patch_post_processor(chunks),
+    ):
+        result = await search(
+            search_string="chat query",
+            config=config,
+            settings=_make_settings(),
+        )
+
+    mock_from_config.assert_called_once()
+    assert isinstance(mock_from_config.call_args[0][0], ChatSearchConfig)
+    assert mock_service.state.search_queries == ["chat query"]
+    assert isinstance(result, CallToolResult)
+
+
+@pytest.mark.asyncio
+async def test_search_uses_defaults_when_no_config_provided():
+    chunks = [_make_chunk("default")]
+    mock_service = MagicMock()
+    mock_service.bind_settings.return_value = mock_service
+    mock_service.state = MagicMock()
+    mock_service.run = AsyncMock(return_value=MagicMock())
+
+    with (
+        patch(
+            "mcp_search.tools.search.KnowledgeBaseInternalSearchService.from_config",
+            return_value=mock_service,
+        ),
+        _patch_post_processor(chunks),
+    ):
+        result = await search(
+            search_string="fallback query",
+            config=SearchToolConfig(),  # explicit defaults
+            settings=_make_settings(),
+        )
+
+    assert isinstance(result, CallToolResult)
+    assert mock_service.state.search_queries == ["fallback query"]
+
+
+@pytest.mark.asyncio
+async def test_search_returns_error_result_on_service_failure():
+    with patch(
+        "mcp_search.tools.search.KnowledgeBaseInternalSearchService.from_config",
+        side_effect=RuntimeError("KB unavailable"),
+    ):
+        result = await search(
+            search_string="query",
+            config=SearchToolConfig(),
+            settings=_make_settings(),
+        )
+
+    assert result.isError is True
+    assert "KB unavailable" in result.content[0].text  # type: ignore[union-attr]
+
+
+@pytest.mark.asyncio
+async def test_search_returns_error_result_on_post_processor_failure():
+    mock_service = MagicMock()
+    mock_service.bind_settings.return_value = mock_service
+    mock_service.state = MagicMock()
+    mock_service.run = AsyncMock(return_value=MagicMock())
+
+    mock_pp = MagicMock()
+    mock_pp.process = AsyncMock(side_effect=RuntimeError("post-processor failed"))
+
+    with (
+        patch(
+            "mcp_search.tools.search.KnowledgeBaseInternalSearchService.from_config",
+            return_value=mock_service,
+        ),
+        patch(
+            "mcp_search.tools.search.InternalSearchPostProcessor.from_settings",
+            return_value=mock_pp,
+        ),
+    ):
+        result = await search(
+            search_string="query",
+            config=SearchToolConfig(),
+            settings=_make_settings(),
+        )
+
+    assert result.isError is True
+    assert "post-processor failed" in result.content[0].text  # type: ignore[union-attr]

--- a/tutorials/mcp/mcp_search/tests/test_search_tool.py
+++ b/tutorials/mcp/mcp_search/tests/test_search_tool.py
@@ -7,7 +7,7 @@ from mcp.types import CallToolResult
 from mcp_search.config import SearchToolConfig
 from mcp_search.tools.search import search
 
-from unique_toolkit._common.pydantic.rjsf_tags import ui_schema_for_model
+from unique_mcp.meta.rjsf import ConfigSchemaMeta
 from unique_toolkit.content.schemas import ContentChunk
 from unique_toolkit.experimental.components.internal_search import (
     KnowledgeBaseInternalSearchConfig,
@@ -30,8 +30,10 @@ def test_json_schema_service_config_has_metadata_filter():
 
 
 def test_ui_schema_hides_max_tokens_for_sources():
-    ui = ui_schema_for_model(SearchToolConfig)
-    assert ui["post_processing"]["max_tokens_for_sources"] == {"ui:widget": "hidden"}
+    meta: dict = {}
+    ConfigSchemaMeta(SearchToolConfig).merge_into_meta(meta)
+    ui = meta["unique.app/config-schema"]["ui_schema"]
+    assert ui["postProcessing"]["maxTokensForSources"] == {"ui:widget": "hidden"}
 
 
 def test_default_config_round_trips():
@@ -84,10 +86,7 @@ async def test_search_calls_kb_service():
             settings=_make_settings(),
         )
 
-    mock_from_config.assert_called_once()
-    assert isinstance(
-        mock_from_config.call_args[0][0], KnowledgeBaseInternalSearchConfig
-    )
+    mock_from_config.assert_called_once_with(SearchToolConfig().service_config)
     mock_service.bind_settings.assert_called_once()
     assert mock_service.state.search_queries == ["test query"]
     assert isinstance(result, CallToolResult)

--- a/tutorials/mcp/mcp_search/tests/test_search_tool.py
+++ b/tutorials/mcp/mcp_search/tests/test_search_tool.py
@@ -4,39 +4,29 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from mcp.types import CallToolResult
-from mcp_search.config import ChatSearchConfig, KBSearchConfig, SearchToolConfig
+from mcp_search.config import SearchToolConfig
 from mcp_search.tools.search import search
 
 from unique_toolkit._common.pydantic.rjsf_tags import ui_schema_for_model
 from unique_toolkit.content.schemas import ContentChunk
+from unique_toolkit.experimental.components.internal_search import (
+    KnowledgeBaseInternalSearchConfig,
+)
 
 # ── Schema tests ──────────────────────────────────────────────────────────────
 
 
-def test_json_schema_has_oneof_discriminator():
+def test_json_schema_has_service_config():
     schema = SearchToolConfig.model_json_schema()
-    sc = schema["properties"]["serviceConfig"]
-    assert "oneOf" in sc
-    assert sc["discriminator"]["propertyName"] == "type"
-    assert sc["discriminator"]["mapping"] == {
-        "kb": "#/$defs/KBSearchConfig",
-        "chat": "#/$defs/ChatSearchConfig",
-    }
+    assert "serviceConfig" in schema["properties"]
 
 
-def test_json_schema_kb_variant_has_metadata_filter():
+def test_json_schema_service_config_has_metadata_filter():
     schema = SearchToolConfig.model_json_schema()
-    kb = schema["$defs"]["KBSearchConfig"]["properties"]
-    assert "metadataFilter" in kb
-    assert "type" in kb
-    assert kb["type"]["const"] == "kb"
-
-
-def test_json_schema_chat_variant_has_no_metadata_filter():
-    schema = SearchToolConfig.model_json_schema()
-    chat = schema["$defs"]["ChatSearchConfig"]["properties"]
-    assert "metadataFilter" not in chat
-    assert chat["type"]["const"] == "chat"
+    sc_ref = schema["properties"]["serviceConfig"].get("$ref", "")
+    def_name = sc_ref.split("/")[-1]
+    kb_props = schema["$defs"][def_name]["properties"]
+    assert "metadataFilter" in kb_props
 
 
 def test_ui_schema_hides_max_tokens_for_sources():
@@ -44,17 +34,10 @@ def test_ui_schema_hides_max_tokens_for_sources():
     assert ui["post_processing"]["max_tokens_for_sources"] == {"ui:widget": "hidden"}
 
 
-def test_default_config_is_kb_and_round_trips():
+def test_default_config_round_trips():
     default = SearchToolConfig().model_dump(mode="json")
-    assert default["service_config"]["type"] == "kb"
-    # Round-trip: stored config must validate back without error
     restored = SearchToolConfig.model_validate(default)
-    assert isinstance(restored.service_config, KBSearchConfig)
-
-
-def test_validate_chat_config():
-    config = SearchToolConfig.model_validate({"service_config": {"type": "chat"}})
-    assert isinstance(config.service_config, ChatSearchConfig)
+    assert isinstance(restored.service_config, KnowledgeBaseInternalSearchConfig)
 
 
 # ── Routing tests ─────────────────────────────────────────────────────────────
@@ -81,7 +64,7 @@ def _patch_post_processor(chunks: list):
 
 
 @pytest.mark.asyncio
-async def test_search_routes_to_kb_service():
+async def test_search_calls_kb_service():
     chunks = [_make_chunk("result A")]
     mock_service = MagicMock()
     mock_service.bind_settings.return_value = mock_service
@@ -97,45 +80,18 @@ async def test_search_routes_to_kb_service():
     ):
         result = await search(
             search_string="test query",
-            config=SearchToolConfig(),  # type=kb by default
+            config=SearchToolConfig(),
             settings=_make_settings(),
         )
 
     mock_from_config.assert_called_once()
-    assert isinstance(mock_from_config.call_args[0][0], KBSearchConfig)
+    assert isinstance(
+        mock_from_config.call_args[0][0], KnowledgeBaseInternalSearchConfig
+    )
     mock_service.bind_settings.assert_called_once()
     assert mock_service.state.search_queries == ["test query"]
     assert isinstance(result, CallToolResult)
     assert len(result.content) == 1
-
-
-@pytest.mark.asyncio
-async def test_search_routes_to_chat_service():
-    chunks = [_make_chunk("chat result")]
-    mock_service = MagicMock()
-    mock_service.bind_settings.return_value = mock_service
-    mock_service.state = MagicMock()
-    mock_service.run = AsyncMock(return_value=MagicMock())
-
-    config = SearchToolConfig.model_validate({"service_config": {"type": "chat"}})
-
-    with (
-        patch(
-            "mcp_search.tools.search.ChatInternalSearchService.from_config",
-            return_value=mock_service,
-        ) as mock_from_config,
-        _patch_post_processor(chunks),
-    ):
-        result = await search(
-            search_string="chat query",
-            config=config,
-            settings=_make_settings(),
-        )
-
-    mock_from_config.assert_called_once()
-    assert isinstance(mock_from_config.call_args[0][0], ChatSearchConfig)
-    assert mock_service.state.search_queries == ["chat query"]
-    assert isinstance(result, CallToolResult)
 
 
 @pytest.mark.asyncio
@@ -155,7 +111,7 @@ async def test_search_uses_defaults_when_no_config_provided():
     ):
         result = await search(
             search_string="fallback query",
-            config=SearchToolConfig(),  # explicit defaults
+            config=SearchToolConfig(),
             settings=_make_settings(),
         )
 

--- a/unique_mcp/pyproject.toml
+++ b/unique_mcp/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "platformdirs>=4.0.0",
     "pydantic>=2.12.5",
     "pydantic-settings>=2.0.0",
+    "python-dotenv>=1.0.0",
     "unique-toolkit>=2026.20.0",
 ]
 

--- a/unique_mcp/src/unique_mcp/meta/tool.py
+++ b/unique_mcp/src/unique_mcp/meta/tool.py
@@ -6,9 +6,9 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any, TypeVar
 
+from dotenv import dotenv_values
 from fastmcp.dependencies import CurrentFastMCP, Depends
-from pydantic import BaseModel, Field
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic import BaseModel
 
 from unique_mcp.meta.keys import CONFIG_META_KEY
 from unique_mcp.util.find_env_file import find_env_file
@@ -41,28 +41,16 @@ def _resolve_tool_env_file(
     return str(env_file) if env_file else None
 
 
-@lru_cache(maxsize=256)
-def _tool_config_env_settings_cls(
-    env_key: str, env_file: str | None
-) -> type[BaseSettings]:
-    class _ToolConfigEnvSettings(BaseSettings):
-        model_config = SettingsConfigDict(
-            env_file=env_file,
-            extra="ignore",
-        )
-
-        value: str | None = Field(default=None, validation_alias=env_key)
-
-    return _ToolConfigEnvSettings
-
-
 def _load_tool_config_override(env_key: str) -> str | None:
-    """Load a tool config override from env vars or env files."""
+    """Load a tool config override from process env or env file."""
+    if val := os.environ.get(env_key):
+        return val
     env_file = _resolve_tool_env_file(
         os.environ.get("ENVIRONMENT_FILE_PATH"), _cache_key_cwd=os.getcwd()
     )
-    settings_cls = _tool_config_env_settings_cls(env_key, env_file)
-    return settings_cls().value
+    if not env_file:
+        return None
+    return dotenv_values(env_file).get(env_key)
 
 
 def get_tool_config(config_model: type[_T]) -> _T:

--- a/unique_mcp/src/unique_mcp/meta/tool.py
+++ b/unique_mcp/src/unique_mcp/meta/tool.py
@@ -2,12 +2,16 @@ from __future__ import annotations
 
 import os
 import re
+from functools import lru_cache
+from pathlib import Path
 from typing import Any, TypeVar
 
 from fastmcp.dependencies import CurrentFastMCP, Depends
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from unique_mcp.meta.keys import CONFIG_META_KEY
+from unique_mcp.util.find_env_file import find_env_file
 
 _T = TypeVar("_T", bound=BaseModel)
 
@@ -26,12 +30,48 @@ def _config_env_key(server_name: str, config_model: type) -> str:
     return f"UNIQUE_MCP_TOOL_{server_part}_{config_snake}_CONFIG"
 
 
+@lru_cache(maxsize=32)
+def _resolve_tool_env_file(
+    environment_file_path: str | None,
+    _cache_key_cwd: str,  # cache-busting key only; invalidates on dir change
+) -> str | None:
+    if environment_file_path and Path(environment_file_path).is_file():
+        return environment_file_path
+    env_file = find_env_file(filenames=["unique_mcp.env", ".env"], required=False)
+    return str(env_file) if env_file else None
+
+
+@lru_cache(maxsize=256)
+def _tool_config_env_settings_cls(
+    env_key: str, env_file: str | None
+) -> type[BaseSettings]:
+    class _ToolConfigEnvSettings(BaseSettings):
+        model_config = SettingsConfigDict(
+            env_file=env_file,
+            extra="ignore",
+        )
+
+        value: str | None = Field(default=None, validation_alias=env_key)
+
+    return _ToolConfigEnvSettings
+
+
+def _load_tool_config_override(env_key: str) -> str | None:
+    """Load a tool config override from env vars or env files."""
+    env_file = _resolve_tool_env_file(
+        os.environ.get("ENVIRONMENT_FILE_PATH"), _cache_key_cwd=os.getcwd()
+    )
+    settings_cls = _tool_config_env_settings_cls(env_key, env_file)
+    return settings_cls().value
+
+
 def get_tool_config(config_model: type[_T]) -> _T:
     """Dependency factory — resolves and validates tool config.
 
     Lookup order:
       1. ``_meta[CONFIG_META_KEY]`` — injected by host at callTool time
-      2. ``UNIQUE_MCP_TOOL_{SERVER}_{CONFIG}_CONFIG`` env var — dev/CI override
+      2. ``UNIQUE_MCP_TOOL_{SERVER}_{CONFIG}_CONFIG`` override from process env
+         (and env files resolved by ``find_env_file(["unique_mcp.env", ".env"])``)
       3. ``config_model`` defaults
 
     Use as a default value in tool signatures::
@@ -48,7 +88,7 @@ def get_tool_config(config_model: type[_T]) -> _T:
             return config_model.model_validate(raw)
 
         env_key = _config_env_key(server.name, config_model)
-        env_val = os.environ.get(env_key)
+        env_val = _load_tool_config_override(env_key)
         if env_val:
             return config_model.model_validate_json(env_val)
 

--- a/unique_mcp/tests/test_tool_meta.py
+++ b/unique_mcp/tests/test_tool_meta.py
@@ -231,6 +231,44 @@ def test_get_tool_config_env_var_fallback(monkeypatch: pytest.MonkeyPatch) -> No
 
 
 @pytest.mark.ai
+def test_get_tool_config_env_file_fallback(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    class MyConfig(BaseModel):
+        value: int = 7
+
+    env_key = _config_env_key("test-server", MyConfig)
+    monkeypatch.delenv(env_key, raising=False)
+    env_file = tmp_path / "unique_mcp.env"
+    env_file.write_text(f'{env_key}={{"value": 88}}')
+    monkeypatch.setenv("ENVIRONMENT_FILE_PATH", str(env_file))
+    dep = get_tool_config(MyConfig)
+    config = dep.factory(server=_MockServer("test-server"))  # type: ignore[union-attr]
+
+    assert isinstance(config, MyConfig)
+    assert config.value == 88
+
+
+@pytest.mark.ai
+def test_get_tool_config_env_file_nonexistent_path_falls_back_to_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ENVIRONMENT_FILE_PATH pointing to a missing file should fall back to defaults."""
+
+    class MyConfig(BaseModel):
+        value: int = 7
+
+    env_key = _config_env_key("test-server", MyConfig)
+    monkeypatch.delenv(env_key, raising=False)
+    monkeypatch.setenv("ENVIRONMENT_FILE_PATH", "/nonexistent/path/unique_mcp.env")
+    dep = get_tool_config(MyConfig)
+    config = dep.factory(server=_MockServer("test-server"))  # type: ignore[union-attr]
+
+    assert isinstance(config, MyConfig)
+    assert config.value == 7  # default, env file was silently skipped
+
+
+@pytest.mark.ai
 def test_get_tool_config_meta_injection(monkeypatch: pytest.MonkeyPatch) -> None:
     """Primary production path: config injected by host via _meta[CONFIG_META_KEY]."""
 

--- a/uv.lock
+++ b/uv.lock
@@ -12,21 +12,21 @@ conflicts = [[
 ]]
 
 [options]
-exclude-newer = "2026-04-24T12:23:39.540107674Z"
+exclude-newer = "2026-04-27T09:07:26.291801Z"
 exclude-newer-span = "P2W"
 
 [options.exclude-newer-package]
 unique-toolkit = false
 unique-internal-search = false
-langchain-core = "2026-04-18T00:00:00Z"
+langchain-core = "2026-04-17T22:00:00Z"
 unique-swot = false
 unique-sdk = false
 unique-mcp = false
-authlib = "2026-04-18T00:00:00Z"
-litellm = "2026-04-28T00:00:00Z"
+authlib = "2026-04-17T22:00:00Z"
+litellm = "2026-04-27T22:00:00Z"
 unique-orchestrator = false
 unique-follow-up-questions = false
-langsmith = "2026-04-16T00:00:00Z"
+langsmith = "2026-04-15T22:00:00Z"
 unique-six = false
 unique-quartr = false
 unique-web-search = false
@@ -716,11 +716,11 @@ wheels = [
 
 [[package]]
 name = "certifi"
-version = "2026.4.22"
+version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077, upload-time = "2026-04-22T11:26:11.191Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707, upload-time = "2026-04-22T11:26:09.372Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
 ]
 
 [[package]]
@@ -5912,6 +5912,7 @@ dependencies = [
     { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'group-11-ai-monorepo-dev'" },
     { name = "pydantic", version = "2.13.3", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'group-11-ai-monorepo-docs' or extra != 'group-11-ai-monorepo-dev'" },
     { name = "pydantic-settings" },
+    { name = "python-dotenv" },
     { name = "unique-toolkit" },
 ]
 
@@ -5922,6 +5923,7 @@ requires-dist = [
     { name = "platformdirs", specifier = ">=4.0.0" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
+    { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "unique-toolkit", editable = "unique_toolkit" },
 ]
 


### PR DESCRIPTION
## Summary
- Rewrites `mcp_search` tutorial to use `KnowledgeBaseInternalSearchConfig` and `PostProcessorConfig` from the experimental internal search component instead of a hand-rolled flat config
- `SearchToolConfig` is KB-only — wraps `KnowledgeBaseInternalSearchConfig` (retrieval) and `PostProcessorConfig` (token budget, reranking)
- Stacked on top of `feat/UN-20104-rjsf` (RJSF infra)

## Changes
- `tutorials/mcp/mcp_search/src/mcp_search/config.py` — new: `SearchToolConfig` with `service_config` and `post_processing`
- `tutorials/mcp/mcp_search/src/mcp_search/tools/search.py` — rewired to use `KnowledgeBaseInternalSearchService`, config injected via `get_tool_config`
- `tutorials/mcp/mcp_search/src/mcp_search/mcp_client.py` — updated example calls with config override via `_meta`
- `tutorials/mcp/mcp_search/src/mcp_search/mcp_search_server.py` — minor cleanup
- `tutorials/mcp/mcp_search/tests/test_search_tool.py` — new tests

## Test plan
- [x] `rtk pytest tutorials/mcp/mcp_search/tests/test_search_tool.py` — 8 passed
- [x] Schema round-trip: `json_schema`, `ui_schema`, `default_config` all camelCase-aligned

## Risk / rollout
- Tutorial only — no production code affected

Refs: UN-20104