### PR TITLE
fix(cli): enforce .unique-search.json scope across search, ls, and write ops

### DIFF
--- a/unique_sdk/tests/cli/test_commands.py
+++ b/unique_sdk/tests/cli/test_commands.py
@@ -261,6 +261,13 @@ class TestFolders:
         result = cmd_mkdir(state, "Q2")
         assert "permission denied" in result
 
+    def test_mkdir_dotdot_traversal_blocked(self) -> None:
+        state = _state("/Workspace/Reports", "scope_ws")
+        state.workspace_scope_ids = ["scope_ws"]
+        state._workspace_scope_paths = ["/Workspace"]
+        result = cmd_mkdir(state, "../../outside")
+        assert "permission denied" in result
+
     @patch("unique_sdk.Folder.get_folder_path")
     def test_rmdir_scope_id_outside_workspace_blocked(
         self, mock_path: MagicMock
@@ -444,6 +451,13 @@ class TestFiles:
         state.workspace_scope_ids = ["scope_ws"]
         state._workspace_scope_paths = ["/Workspace"]
         result = cmd_upload(state, "/some/file.pdf")
+        assert "permission denied" in result
+
+    def test_upload_dotdot_destination_blocked(self) -> None:
+        state = _state("/Workspace/Reports", "scope_ws")
+        state.workspace_scope_ids = ["scope_ws"]
+        state._workspace_scope_paths = ["/Workspace"]
+        result = cmd_upload(state, "/some/file.pdf", "../../outside/")
         assert "permission denied" in result
 
     @patch("unique_sdk.Folder.get_folder_path")

--- a/unique_sdk/tests/cli/test_commands.py
+++ b/unique_sdk/tests/cli/test_commands.py
@@ -261,18 +261,42 @@ class TestFolders:
         result = cmd_mkdir(state, "Q2")
         assert "permission denied" in result
 
-    def test_rmdir_outside_workspace_blocked(self) -> None:
-        state = _state()
+    @patch("unique_sdk.Folder.get_folder_path")
+    def test_rmdir_scope_id_outside_workspace_blocked(
+        self, mock_path: MagicMock
+    ) -> None:
+        """rmdir scope_other blocked even when CWD is inside the workspace."""
+        mock_path.return_value = {"folderPath": "/OtherTenant/Folder"}
+        state = _state("/Workspace", "scope_ws")
         state.workspace_scope_ids = ["scope_ws"]
         state._workspace_scope_paths = ["/Workspace"]
         result = cmd_rmdir(state, "scope_other")
         assert "permission denied" in result
 
-    def test_mvdir_outside_workspace_blocked(self) -> None:
-        state = _state()
+    def test_rmdir_absolute_path_outside_workspace_blocked(self) -> None:
+        state = _state("/Workspace", "scope_ws")
+        state.workspace_scope_ids = ["scope_ws"]
+        state._workspace_scope_paths = ["/Workspace"]
+        result = cmd_rmdir(state, "/OtherTenant/Folder")
+        assert "permission denied" in result
+
+    @patch("unique_sdk.Folder.get_folder_path")
+    def test_mvdir_scope_id_outside_workspace_blocked(
+        self, mock_path: MagicMock
+    ) -> None:
+        """mvdir scope_other blocked even when CWD is inside the workspace."""
+        mock_path.return_value = {"folderPath": "/OtherTenant/Folder"}
+        state = _state("/Workspace", "scope_ws")
         state.workspace_scope_ids = ["scope_ws"]
         state._workspace_scope_paths = ["/Workspace"]
         result = cmd_mvdir(state, "scope_other", "new")
+        assert "permission denied" in result
+
+    def test_mvdir_absolute_path_outside_workspace_blocked(self) -> None:
+        state = _state("/Workspace", "scope_ws")
+        state.workspace_scope_ids = ["scope_ws"]
+        state._workspace_scope_paths = ["/Workspace"]
+        result = cmd_mvdir(state, "/OtherTenant/Folder", "new")
         assert "permission denied" in result
 
 
@@ -420,6 +444,18 @@ class TestFiles:
         state.workspace_scope_ids = ["scope_ws"]
         state._workspace_scope_paths = ["/Workspace"]
         result = cmd_upload(state, "/some/file.pdf")
+        assert "permission denied" in result
+
+    @patch("unique_sdk.Folder.get_folder_path")
+    def test_upload_scope_id_outside_workspace_blocked(
+        self, mock_path: MagicMock
+    ) -> None:
+        """upload to explicit scope_other blocked even when CWD is inside the workspace."""
+        mock_path.return_value = {"folderPath": "/OtherTenant/Folder"}
+        state = _state("/Workspace", "scope_ws")
+        state.workspace_scope_ids = ["scope_ws"]
+        state._workspace_scope_paths = ["/Workspace"]
+        result = cmd_upload(state, "/some/file.pdf", "scope_other")
         assert "permission denied" in result
 
     def test_rm_outside_workspace_blocked(self) -> None:

--- a/unique_sdk/tests/cli/test_commands.py
+++ b/unique_sdk/tests/cli/test_commands.py
@@ -147,6 +147,37 @@ class TestNavigation:
         result = cmd_ls(_state())
         assert "ls:" in result
 
+    @patch("unique_sdk.Folder.get_info")
+    def test_ls_root_workspace_scoped(self, mock_info: MagicMock) -> None:
+        """ls at root with workspace scopes shows only the allowed folders."""
+        mock_info.return_value = _folder_info("Reports", "scope_ws")
+        state = _state()
+        state.workspace_scope_ids = ["scope_ws"]
+        result = cmd_ls(state)
+        assert "Reports/" in result
+        assert "1 folder(s), 0 file(s)" in result
+        mock_info.assert_called_once_with(
+            user_id="u1",
+            company_id="c1",
+            scopeId="scope_ws",
+        )
+
+    @patch("unique_sdk.Content.get_infos")
+    @patch("unique_sdk.Folder.get_infos")
+    def test_ls_inside_folder_workspace_scoped_uses_normal_path(
+        self,
+        mock_folders: MagicMock,
+        mock_files: MagicMock,
+    ) -> None:
+        """ls inside a scoped folder uses the normal get_infos path."""
+        mock_folders.return_value = {"folderInfos": [], "totalCount": 0}
+        mock_files.return_value = {"contentInfos": [], "totalCount": 0}
+        state = _state("/Reports", "scope_ws")
+        state.workspace_scope_ids = ["scope_ws"]
+        result = cmd_ls(state)
+        assert "0 folder(s), 0 file(s)" in result
+        mock_folders.assert_called_once()
+
 
 # --- Folders ---
 
@@ -222,6 +253,27 @@ class TestFolders:
         mock.side_effect = ValueError("not found")
         result = cmd_mvdir(_state(), "Q1", "Q2")
         assert "mvdir:" in result
+
+    def test_mkdir_outside_workspace_blocked(self) -> None:
+        state = _state()
+        state.workspace_scope_ids = ["scope_ws"]
+        state._workspace_scope_paths = ["/Workspace"]
+        result = cmd_mkdir(state, "Q2")
+        assert "permission denied" in result
+
+    def test_rmdir_outside_workspace_blocked(self) -> None:
+        state = _state()
+        state.workspace_scope_ids = ["scope_ws"]
+        state._workspace_scope_paths = ["/Workspace"]
+        result = cmd_rmdir(state, "scope_other")
+        assert "permission denied" in result
+
+    def test_mvdir_outside_workspace_blocked(self) -> None:
+        state = _state()
+        state.workspace_scope_ids = ["scope_ws"]
+        state._workspace_scope_paths = ["/Workspace"]
+        result = cmd_mvdir(state, "scope_other", "new")
+        assert "permission denied" in result
 
 
 # --- Files ---
@@ -362,6 +414,27 @@ class TestFiles:
         mock.side_effect = ValueError("fail")
         result = cmd_mv_file(_state(), "cont_abc", "new.pdf")
         assert "mv:" in result
+
+    def test_upload_outside_workspace_blocked(self) -> None:
+        state = _state()
+        state.workspace_scope_ids = ["scope_ws"]
+        state._workspace_scope_paths = ["/Workspace"]
+        result = cmd_upload(state, "/some/file.pdf")
+        assert "permission denied" in result
+
+    def test_rm_outside_workspace_blocked(self) -> None:
+        state = _state()
+        state.workspace_scope_ids = ["scope_ws"]
+        state._workspace_scope_paths = ["/Workspace"]
+        result = cmd_rm(state, "cont_abc")
+        assert "permission denied" in result
+
+    def test_mv_file_outside_workspace_blocked(self) -> None:
+        state = _state()
+        state.workspace_scope_ids = ["scope_ws"]
+        state._workspace_scope_paths = ["/Workspace"]
+        result = cmd_mv_file(state, "cont_abc", "new.pdf")
+        assert "permission denied" in result
 
     def test_upload_nonexistent_file(self) -> None:
         result = cmd_upload(_state("/R", "scope_r"), "/nonexistent/file.pdf")
@@ -509,6 +582,30 @@ class TestSearch:
         mock.side_effect = ValueError("fail")
         result = cmd_search(_state(), "query")
         assert "search:" in result
+
+    @patch("unique_sdk.Search.create")
+    def test_cmd_search_uses_workspace_scope_ids(self, mock: MagicMock) -> None:
+        mock.return_value = []
+        state = _state()
+        state.workspace_scope_ids = ["scope_ws1", "scope_ws2"]
+        result = cmd_search(state, "query")
+        assert "No results found" in result
+        call_kwargs = mock.call_args[1]
+        assert call_kwargs["scopeIds"] == ["scope_ws1", "scope_ws2"]
+
+    @patch("unique_sdk.Search.create")
+    def test_cmd_search_explicit_folder_overrides_workspace(
+        self, mock: MagicMock
+    ) -> None:
+        mock.return_value = []
+        with patch("unique_sdk.Folder.get_info") as mock_info:
+            mock_info.return_value = {"id": "scope_explicit"}
+            state = _state()
+            state.workspace_scope_ids = ["scope_ws"]
+            result = cmd_search(state, "query", folder="/Reports")
+        assert "No results found" in result
+        call_kwargs = mock.call_args[1]
+        assert call_kwargs["scopeIds"] == ["scope_explicit"]
 
 
 class TestReadPayload:

--- a/unique_sdk/tests/cli/test_commands.py
+++ b/unique_sdk/tests/cli/test_commands.py
@@ -479,11 +479,49 @@ class TestFiles:
         result = cmd_rm(state, "cont_abc")
         assert "permission denied" in result
 
+    @patch("unique_sdk.Content.get_info")
+    def test_rm_content_id_outside_workspace_blocked(
+        self, mock_info: MagicMock
+    ) -> None:
+        """rm cont_X is blocked when the content's ownerId is outside the workspace,
+        even when CWD is inside the workspace."""
+        mock_info.return_value = {"contentInfo": [{"ownerId": "scope_other_tenant"}]}
+        state = _state("/Workspace", "scope_ws")
+        state.workspace_scope_ids = ["scope_ws"]
+        state._workspace_scope_paths = ["/Workspace"]
+        result = cmd_rm(state, "cont_outside")
+        assert "permission denied" in result
+
+    @patch("unique_sdk.Content.delete")
+    @patch("unique_sdk.Content.get_info")
+    def test_rm_content_id_within_workspace_allowed(
+        self, mock_info: MagicMock, mock_delete: MagicMock
+    ) -> None:
+        mock_info.return_value = {"contentInfo": [{"ownerId": "scope_ws"}]}
+        state = _state("/Workspace", "scope_ws")
+        state.workspace_scope_ids = ["scope_ws"]
+        state._workspace_scope_paths = ["/Workspace"]
+        result = cmd_rm(state, "cont_inside")
+        assert "permission denied" not in result
+
     def test_mv_file_outside_workspace_blocked(self) -> None:
         state = _state()
         state.workspace_scope_ids = ["scope_ws"]
         state._workspace_scope_paths = ["/Workspace"]
         result = cmd_mv_file(state, "cont_abc", "new.pdf")
+        assert "permission denied" in result
+
+    @patch("unique_sdk.Content.get_info")
+    def test_mv_file_content_id_outside_workspace_blocked(
+        self, mock_info: MagicMock
+    ) -> None:
+        """mv cont_X is blocked when the content's ownerId is outside the workspace,
+        even when CWD is inside the workspace."""
+        mock_info.return_value = {"contentInfo": [{"ownerId": "scope_other_tenant"}]}
+        state = _state("/Workspace", "scope_ws")
+        state.workspace_scope_ids = ["scope_ws"]
+        state._workspace_scope_paths = ["/Workspace"]
+        result = cmd_mv_file(state, "cont_outside", "new.pdf")
         assert "permission denied" in result
 
     def test_upload_nonexistent_file(self) -> None:

--- a/unique_sdk/tests/cli/test_state.py
+++ b/unique_sdk/tests/cli/test_state.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import json
 from unittest.mock import patch
+
+import pytest
 
 from unique_sdk.cli.config import Config
 from unique_sdk.cli.state import ShellState
@@ -128,3 +131,83 @@ class TestShellState:
         assert s.prompt == "/> "
         s._path = "/Reports"
         assert s.prompt == "/Reports> "
+
+
+class TestWorkspaceScopes:
+    def test_no_config_file_returns_empty(
+        self, tmp_path: pytest.TempPathFactory
+    ) -> None:
+        with patch("unique_sdk.cli.state.Path.cwd", return_value=tmp_path):
+            s = ShellState(_config())
+        assert s.workspace_scope_ids == []
+        assert not s.workspace_restricted
+
+    def test_loads_scope_ids_from_config(
+        self, tmp_path: pytest.TempPathFactory
+    ) -> None:
+        (tmp_path / ".unique-search.json").write_text(  # type: ignore[union-attr]
+            json.dumps({"scopeIds": ["scope_abc", "scope_def"]})
+        )
+        with patch("unique_sdk.cli.state.Path.cwd", return_value=tmp_path):
+            s = ShellState(_config())
+        assert s.workspace_scope_ids == ["scope_abc", "scope_def"]
+        assert s.workspace_restricted
+
+    def test_invalid_json_returns_empty(self, tmp_path: pytest.TempPathFactory) -> None:
+        (tmp_path / ".unique-search.json").write_text("not json")  # type: ignore[union-attr]
+        with patch("unique_sdk.cli.state.Path.cwd", return_value=tmp_path):
+            s = ShellState(_config())
+        assert s.workspace_scope_ids == []
+
+    def test_is_within_workspace_no_restriction(self) -> None:
+        s = ShellState(_config())
+        s.workspace_scope_ids = []
+        assert s.is_within_workspace()
+
+    def test_is_within_workspace_direct_scope_match(self) -> None:
+        s = ShellState(_config())
+        s.workspace_scope_ids = ["scope_abc"]
+        s._workspace_scope_paths = []
+        s._scope_id = "scope_abc"
+        assert s.is_within_workspace()
+
+    def test_is_within_workspace_path_prefix_descendant(self) -> None:
+        s = ShellState(_config())
+        s.workspace_scope_ids = ["scope_abc"]
+        s._workspace_scope_paths = ["/Company/Reports"]
+        s._path = "/Company/Reports/Q1"
+        assert s.is_within_workspace()
+
+    def test_is_within_workspace_exact_path(self) -> None:
+        s = ShellState(_config())
+        s.workspace_scope_ids = ["scope_abc"]
+        s._workspace_scope_paths = ["/Company/Reports"]
+        s._path = "/Company/Reports"
+        assert s.is_within_workspace()
+
+    def test_is_within_workspace_blocked_at_root(self) -> None:
+        s = ShellState(_config())
+        s.workspace_scope_ids = ["scope_abc"]
+        s._workspace_scope_paths = ["/Company/Reports"]
+        s._path = "/"
+        s._scope_id = None
+        assert not s.is_within_workspace()
+
+    def test_is_within_workspace_blocked_wrong_path(self) -> None:
+        s = ShellState(_config())
+        s.workspace_scope_ids = ["scope_abc"]
+        s._workspace_scope_paths = ["/Company/Reports"]
+        s._path = "/Company/Finance"
+        assert not s.is_within_workspace()
+
+    @patch("unique_sdk.Folder.get_folder_path")
+    def test_resolve_workspace_scope_paths_cached(self, mock_path: patch) -> None:  # type: ignore[valid-type]
+        mock_path.return_value = {"folderPath": "/Company/Reports"}
+        s = ShellState(_config())
+        s.workspace_scope_ids = ["scope_abc"]
+        s._workspace_scope_paths = None
+        paths1 = s._resolve_workspace_scope_paths()
+        paths2 = s._resolve_workspace_scope_paths()
+        assert paths1 == ["/Company/Reports"]
+        assert paths2 == ["/Company/Reports"]
+        mock_path.assert_called_once()

--- a/unique_sdk/tests/cli/test_state.py
+++ b/unique_sdk/tests/cli/test_state.py
@@ -159,6 +159,16 @@ class TestWorkspaceScopes:
             s = ShellState(_config())
         assert s.workspace_scope_ids == []
 
+    def test_non_dict_json_returns_empty(
+        self, tmp_path: pytest.TempPathFactory
+    ) -> None:
+        """A JSON array or scalar must not crash via AttributeError."""
+        for payload in ("[1, 2, 3]", '"hello"', "42", "null"):
+            (tmp_path / ".unique-search.json").write_text(payload)  # type: ignore[union-attr]
+            with patch("unique_sdk.cli.state.Path.cwd", return_value=tmp_path):
+                s = ShellState(_config())
+            assert s.workspace_scope_ids == [], f"failed for payload: {payload}"
+
     def test_is_within_workspace_no_restriction(self) -> None:
         s = ShellState(_config())
         s.workspace_scope_ids = []
@@ -199,6 +209,17 @@ class TestWorkspaceScopes:
         s._workspace_scope_paths = ["/Company/Reports"]
         s._path = "/Company/Finance"
         assert not s.is_within_workspace()
+
+    def test_root_folder_path_skipped(self) -> None:
+        """A workspace scope that resolves to '/' must not be stored — it would
+        make every path match via startswith('/')."""
+        s = ShellState(_config())
+        s.workspace_scope_ids = ["scope_root"]
+        s._workspace_scope_paths = None
+        with patch("unique_sdk.Folder.get_folder_path") as mock_path:
+            mock_path.return_value = {"folderPath": "/"}
+            paths = s._resolve_workspace_scope_paths()
+        assert paths == []
 
     @patch("unique_sdk.Folder.get_folder_path")
     def test_resolve_workspace_scope_paths_cached(self, mock_path: patch) -> None:  # type: ignore[valid-type]
@@ -262,14 +283,29 @@ class TestFolderTargetWithinWorkspace:
         s._workspace_scope_paths = ["/Workspace"]
         assert not s.is_folder_target_within_workspace("/OtherTenant/Folder")
 
-    def test_relative_path_delegates_to_cwd_check(self) -> None:
+    def test_absolute_path_dotdot_traversal_blocked(self) -> None:
+        """/Workspace/../Evil must not pass a startswith('/Workspace/') check."""
+        s = ShellState(_config())
+        s.workspace_scope_ids = ["scope_ws"]
+        s._workspace_scope_paths = ["/Workspace"]
+        assert not s.is_folder_target_within_workspace("/Workspace/../Evil")
+
+    def test_relative_path_within_workspace_allowed(self) -> None:
         s = ShellState(_config())
         s.workspace_scope_ids = ["scope_ws"]
         s._workspace_scope_paths = ["/Workspace"]
         s._path = "/Workspace/Sub"
         assert s.is_folder_target_within_workspace("RelativeFolder")
 
-    def test_relative_path_outside_cwd_blocked(self) -> None:
+    def test_relative_dotdot_traversal_blocked(self) -> None:
+        """../../outside must not pass just because CWD is inside workspace."""
+        s = ShellState(_config())
+        s.workspace_scope_ids = ["scope_ws"]
+        s._workspace_scope_paths = ["/Workspace"]
+        s._path = "/Workspace/Sub"
+        assert not s.is_folder_target_within_workspace("../../outside")
+
+    def test_relative_path_cwd_outside_blocked(self) -> None:
         s = ShellState(_config())
         s.workspace_scope_ids = ["scope_ws"]
         s._workspace_scope_paths = ["/Workspace"]

--- a/unique_sdk/tests/cli/test_state.py
+++ b/unique_sdk/tests/cli/test_state.py
@@ -211,3 +211,68 @@ class TestWorkspaceScopes:
         assert paths1 == ["/Company/Reports"]
         assert paths2 == ["/Company/Reports"]
         mock_path.assert_called_once()
+
+
+class TestFolderTargetWithinWorkspace:
+    def test_no_restriction_always_allowed(self) -> None:
+        s = ShellState(_config())
+        s.workspace_scope_ids = []
+        assert s.is_folder_target_within_workspace("scope_other")
+        assert s.is_folder_target_within_workspace("/any/path")
+
+    def test_scope_id_direct_match(self) -> None:
+        s = ShellState(_config())
+        s.workspace_scope_ids = ["scope_ws"]
+        s._workspace_scope_paths = []
+        assert s.is_folder_target_within_workspace("scope_ws")
+
+    @patch("unique_sdk.Folder.get_folder_path")
+    def test_scope_id_descendant_allowed(self, mock_path: patch) -> None:  # type: ignore[valid-type]
+        mock_path.return_value = {"folderPath": "/Workspace/Sub"}
+        s = ShellState(_config())
+        s.workspace_scope_ids = ["scope_ws"]
+        s._workspace_scope_paths = ["/Workspace"]
+        assert s.is_folder_target_within_workspace("scope_sub")
+
+    @patch("unique_sdk.Folder.get_folder_path")
+    def test_scope_id_outside_workspace_blocked(self, mock_path: patch) -> None:  # type: ignore[valid-type]
+        mock_path.return_value = {"folderPath": "/OtherTenant/Folder"}
+        s = ShellState(_config())
+        s.workspace_scope_ids = ["scope_ws"]
+        s._workspace_scope_paths = ["/Workspace"]
+        assert not s.is_folder_target_within_workspace("scope_other")
+
+    @patch("unique_sdk.Folder.get_folder_path")
+    def test_scope_id_api_error_blocks(self, mock_path: patch) -> None:  # type: ignore[valid-type]
+        mock_path.side_effect = Exception("network error")
+        s = ShellState(_config())
+        s.workspace_scope_ids = ["scope_ws"]
+        s._workspace_scope_paths = ["/Workspace"]
+        assert not s.is_folder_target_within_workspace("scope_unknown")
+
+    def test_absolute_path_within_workspace_allowed(self) -> None:
+        s = ShellState(_config())
+        s.workspace_scope_ids = ["scope_ws"]
+        s._workspace_scope_paths = ["/Workspace"]
+        assert s.is_folder_target_within_workspace("/Workspace/Sub/Deep")
+
+    def test_absolute_path_outside_workspace_blocked(self) -> None:
+        s = ShellState(_config())
+        s.workspace_scope_ids = ["scope_ws"]
+        s._workspace_scope_paths = ["/Workspace"]
+        assert not s.is_folder_target_within_workspace("/OtherTenant/Folder")
+
+    def test_relative_path_delegates_to_cwd_check(self) -> None:
+        s = ShellState(_config())
+        s.workspace_scope_ids = ["scope_ws"]
+        s._workspace_scope_paths = ["/Workspace"]
+        s._path = "/Workspace/Sub"
+        assert s.is_folder_target_within_workspace("RelativeFolder")
+
+    def test_relative_path_outside_cwd_blocked(self) -> None:
+        s = ShellState(_config())
+        s.workspace_scope_ids = ["scope_ws"]
+        s._workspace_scope_paths = ["/Workspace"]
+        s._path = "/"
+        s._scope_id = None
+        assert not s.is_folder_target_within_workspace("RelativeFolder")

--- a/unique_sdk/unique_sdk/cli/commands/files.py
+++ b/unique_sdk/unique_sdk/cli/commands/files.py
@@ -119,6 +119,8 @@ def cmd_upload(
     upload file.pdf ./sub/new.pdf -> into sub, renamed
     upload file.pdf /abs/path/   -> into absolute path folder
     """
+    if not state.is_within_workspace():
+        return "upload: permission denied (outside workspace scope)"
     try:
         path = Path(local_path).expanduser().resolve()
         if not path.is_file():
@@ -192,6 +194,8 @@ def cmd_download(
 
 def cmd_rm(state: ShellState, name_or_id: str) -> str:
     """Delete a file by name or content ID."""
+    if not state.is_within_workspace():
+        return "rm: permission denied (outside workspace scope)"
     try:
         content_id, display_name = _resolve_content_id(state, name_or_id)
         unique_sdk.Content.delete(
@@ -206,6 +210,8 @@ def cmd_rm(state: ShellState, name_or_id: str) -> str:
 
 def cmd_mv_file(state: ShellState, old_name: str, new_name: str) -> str:
     """Rename a file."""
+    if not state.is_within_workspace():
+        return "mv: permission denied (outside workspace scope)"
     try:
         content_id, display_name = _resolve_content_id(state, old_name)
         result = unique_sdk.Content.update(

--- a/unique_sdk/unique_sdk/cli/commands/files.py
+++ b/unique_sdk/unique_sdk/cli/commands/files.py
@@ -120,10 +120,7 @@ def cmd_upload(
     upload file.pdf /abs/path/   -> into absolute path folder
     """
     dest = destination or "."
-    if dest.startswith("scope_") or dest.startswith("/"):
-        if not state.is_folder_target_within_workspace(dest):
-            return "upload: permission denied (outside workspace scope)"
-    elif not state.is_within_workspace():
+    if not state.is_folder_target_within_workspace(dest):
         return "upload: permission denied (outside workspace scope)"
     try:
         path = Path(local_path).expanduser().resolve()

--- a/unique_sdk/unique_sdk/cli/commands/files.py
+++ b/unique_sdk/unique_sdk/cli/commands/files.py
@@ -195,7 +195,10 @@ def cmd_download(
 
 def cmd_rm(state: ShellState, name_or_id: str) -> str:
     """Delete a file by name or content ID."""
-    if not state.is_within_workspace():
+    if name_or_id.startswith("cont_"):
+        if not state.is_content_within_workspace(name_or_id):
+            return "rm: permission denied (outside workspace scope)"
+    elif not state.is_within_workspace():
         return "rm: permission denied (outside workspace scope)"
     try:
         content_id, display_name = _resolve_content_id(state, name_or_id)
@@ -211,7 +214,10 @@ def cmd_rm(state: ShellState, name_or_id: str) -> str:
 
 def cmd_mv_file(state: ShellState, old_name: str, new_name: str) -> str:
     """Rename a file."""
-    if not state.is_within_workspace():
+    if old_name.startswith("cont_"):
+        if not state.is_content_within_workspace(old_name):
+            return "mv: permission denied (outside workspace scope)"
+    elif not state.is_within_workspace():
         return "mv: permission denied (outside workspace scope)"
     try:
         content_id, display_name = _resolve_content_id(state, old_name)

--- a/unique_sdk/unique_sdk/cli/commands/files.py
+++ b/unique_sdk/unique_sdk/cli/commands/files.py
@@ -119,7 +119,11 @@ def cmd_upload(
     upload file.pdf ./sub/new.pdf -> into sub, renamed
     upload file.pdf /abs/path/   -> into absolute path folder
     """
-    if not state.is_within_workspace():
+    dest = destination or "."
+    if dest.startswith("scope_") or dest.startswith("/"):
+        if not state.is_folder_target_within_workspace(dest):
+            return "upload: permission denied (outside workspace scope)"
+    elif not state.is_within_workspace():
         return "upload: permission denied (outside workspace scope)"
     try:
         path = Path(local_path).expanduser().resolve()

--- a/unique_sdk/unique_sdk/cli/commands/folders.py
+++ b/unique_sdk/unique_sdk/cli/commands/folders.py
@@ -9,7 +9,7 @@ from unique_sdk.cli.state import ShellState
 
 def cmd_mkdir(state: ShellState, name: str) -> str:
     """Create a new folder under the current directory."""
-    if not state.is_within_workspace():
+    if not state.is_folder_target_within_workspace(name):
         return "mkdir: permission denied (outside workspace scope)"
     try:
         full_path = f"{state.cwd.rstrip('/')}/{name}"

--- a/unique_sdk/unique_sdk/cli/commands/folders.py
+++ b/unique_sdk/unique_sdk/cli/commands/folders.py
@@ -9,6 +9,8 @@ from unique_sdk.cli.state import ShellState
 
 def cmd_mkdir(state: ShellState, name: str) -> str:
     """Create a new folder under the current directory."""
+    if not state.is_within_workspace():
+        return "mkdir: permission denied (outside workspace scope)"
     try:
         full_path = f"{state.cwd.rstrip('/')}/{name}"
         result = unique_sdk.Folder.create_paths(
@@ -27,6 +29,8 @@ def cmd_mkdir(state: ShellState, name: str) -> str:
 
 def cmd_rmdir(state: ShellState, target: str, recursive: bool = False) -> str:
     """Delete a folder by path or scope ID."""
+    if not state.is_within_workspace():
+        return "rmdir: permission denied (outside workspace scope)"
     try:
         if target.startswith("scope_"):
             unique_sdk.Folder.delete(
@@ -52,6 +56,8 @@ def cmd_rmdir(state: ShellState, target: str, recursive: bool = False) -> str:
 
 def cmd_mvdir(state: ShellState, old_name: str, new_name: str) -> str:
     """Rename a folder."""
+    if not state.is_within_workspace():
+        return "mvdir: permission denied (outside workspace scope)"
     try:
         if old_name.startswith("scope_"):
             result = unique_sdk.Folder.update(

--- a/unique_sdk/unique_sdk/cli/commands/folders.py
+++ b/unique_sdk/unique_sdk/cli/commands/folders.py
@@ -29,7 +29,7 @@ def cmd_mkdir(state: ShellState, name: str) -> str:
 
 def cmd_rmdir(state: ShellState, target: str, recursive: bool = False) -> str:
     """Delete a folder by path or scope ID."""
-    if not state.is_within_workspace():
+    if not state.is_folder_target_within_workspace(target):
         return "rmdir: permission denied (outside workspace scope)"
     try:
         if target.startswith("scope_"):
@@ -56,7 +56,7 @@ def cmd_rmdir(state: ShellState, target: str, recursive: bool = False) -> str:
 
 def cmd_mvdir(state: ShellState, old_name: str, new_name: str) -> str:
     """Rename a folder."""
-    if not state.is_within_workspace():
+    if not state.is_folder_target_within_workspace(old_name):
         return "mvdir: permission denied (outside workspace scope)"
     try:
         if old_name.startswith("scope_"):

--- a/unique_sdk/unique_sdk/cli/commands/navigation.py
+++ b/unique_sdk/unique_sdk/cli/commands/navigation.py
@@ -30,6 +30,24 @@ def cmd_ls(state: ShellState, target: str | None = None) -> str:
         else:
             scope_id = state.scope_id
 
+        # When at root with a workspace restriction, show only the allowed scope
+        # folders — the agent must not see the full company folder tree.
+        if scope_id is None and state.workspace_scope_ids:
+            folders: list[Any] = []
+            for ws_id in state.workspace_scope_ids:
+                try:
+                    info = unique_sdk.Folder.get_info(
+                        user_id=state.config.user_id,
+                        company_id=state.config.company_id,
+                        scopeId=ws_id,
+                    )
+                    folders.append(info)
+                except unique_sdk.APIError:
+                    pass
+            output = format_ls(folders, [])
+            summary = f"\n{len(folders)} folder(s), 0 file(s)"
+            return output + summary
+
         folder_params: dict[str, Any] = {}
         content_params: dict[str, Any] = {}
         if scope_id:

--- a/unique_sdk/unique_sdk/cli/commands/search.py
+++ b/unique_sdk/unique_sdk/cli/commands/search.py
@@ -84,6 +84,8 @@ def cmd_search(
         scope_ids: list[str] | None = None
         if folder_scope_id:
             scope_ids = [folder_scope_id]
+        elif not folder and state.workspace_scope_ids:
+            scope_ids = state.workspace_scope_ids
 
         metadata_filter = _build_metadata_filter(
             folder_scope_id if metadata else None,

--- a/unique_sdk/unique_sdk/cli/state.py
+++ b/unique_sdk/unique_sdk/cli/state.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 import unique_sdk
@@ -17,6 +18,8 @@ def _load_workspace_scope_ids() -> list[str]:
         return []
     try:
         data = json.loads(config_path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            return []
         scope_ids = data.get("scopeIds")
         if isinstance(scope_ids, list) and all(isinstance(s, str) for s in scope_ids):
             return scope_ids
@@ -51,9 +54,9 @@ class ShellState:
                     company_id=self.config.company_id,
                     scope_id=scope_id,
                 )
-                p = resp.get("folderPath", "")
-                if p:
-                    paths.append(p.rstrip("/"))
+                p = resp.get("folderPath", "").rstrip("/")
+                if p:  # empty after rstrip means the API returned "/" (root) — skip
+                    paths.append(p)
             except Exception:
                 pass
         self._workspace_scope_paths = paths
@@ -104,13 +107,21 @@ class ShellState:
                 return False
 
         if target.startswith("/"):
+            # Normalize to collapse any `..` components before prefix-checking.
+            # Without this, "/Workspace/../Evil" would pass a startswith("/Workspace/") check.
+            normalized = os.path.normpath(target)
             paths = self._resolve_workspace_scope_paths()
             if not paths:
                 return False
-            return any(target == p or target.startswith(p + "/") for p in paths)
+            return any(normalized == p or normalized.startswith(p + "/") for p in paths)
 
-        # Relative path — always resolves under CWD, so CWD membership suffices.
-        return self.is_within_workspace()
+        # Relative path — resolve against CWD so that `../../outside` style
+        # traversals are caught rather than delegating blindly to the CWD check.
+        resolved = os.path.normpath(self._path.rstrip("/") + "/" + target)
+        paths = self._resolve_workspace_scope_paths()
+        if not paths:
+            return self._scope_id in self.workspace_scope_ids
+        return any(resolved == p or resolved.startswith(p + "/") for p in paths)
 
     @property
     def cwd(self) -> str:

--- a/unique_sdk/unique_sdk/cli/state.py
+++ b/unique_sdk/unique_sdk/cli/state.py
@@ -74,6 +74,44 @@ class ShellState:
         current = self._path
         return any(current == p or current.startswith(p + "/") for p in paths)
 
+    def is_folder_target_within_workspace(self, target: str) -> bool:
+        """Check whether a folder target is within the workspace.
+
+        For scope IDs and absolute paths the *target itself* is validated,
+        not the current working directory.  Relative names fall back to the
+        CWD check because they always resolve under the current directory.
+
+        Always returns True when no workspace restriction is configured.
+        """
+        if not self.workspace_scope_ids:
+            return True
+
+        if target.startswith("scope_"):
+            if target in self.workspace_scope_ids:
+                return True
+            paths = self._resolve_workspace_scope_paths()
+            if not paths:
+                return False
+            try:
+                resp = unique_sdk.Folder.get_folder_path(
+                    user_id=self.config.user_id,
+                    company_id=self.config.company_id,
+                    scope_id=target,
+                )
+                p = resp.get("folderPath", "")
+                return any(p == wp or p.startswith(wp + "/") for wp in paths)
+            except Exception:
+                return False
+
+        if target.startswith("/"):
+            paths = self._resolve_workspace_scope_paths()
+            if not paths:
+                return False
+            return any(target == p or target.startswith(p + "/") for p in paths)
+
+        # Relative path — always resolves under CWD, so CWD membership suffices.
+        return self.is_within_workspace()
+
     @property
     def cwd(self) -> str:
         return self._path

--- a/unique_sdk/unique_sdk/cli/state.py
+++ b/unique_sdk/unique_sdk/cli/state.py
@@ -77,6 +77,29 @@ class ShellState:
         current = self._path
         return any(current == p or current.startswith(p + "/") for p in paths)
 
+    def is_content_within_workspace(self, content_id: str) -> bool:
+        """Return True if the content item's owner scope is within the workspace.
+
+        Makes one API call to resolve the content's parent scope, then
+        delegates to is_folder_target_within_workspace.  Always returns True
+        when no workspace restriction is configured.
+        """
+        if not self.workspace_scope_ids:
+            return True
+        try:
+            result = unique_sdk.Content.get_info(
+                user_id=self.config.user_id,
+                company_id=self.config.company_id,
+                contentId=content_id,
+            )
+            items = result.get("contentInfo", [])
+            if not items:
+                return False
+            owner_id = items[0].get("ownerId", "")
+            return self.is_folder_target_within_workspace(owner_id)
+        except Exception:
+            return False
+
     def is_folder_target_within_workspace(self, target: str) -> bool:
         """Check whether a folder target is within the workspace.
 

--- a/unique_sdk/unique_sdk/cli/state.py
+++ b/unique_sdk/unique_sdk/cli/state.py
@@ -2,8 +2,27 @@
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 import unique_sdk
 from unique_sdk.cli.config import Config
+
+_SEARCH_CONFIG_FILENAME = ".unique-search.json"
+
+
+def _load_workspace_scope_ids() -> list[str]:
+    config_path = Path.cwd() / _SEARCH_CONFIG_FILENAME
+    if not config_path.is_file():
+        return []
+    try:
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+        scope_ids = data.get("scopeIds")
+        if isinstance(scope_ids, list) and all(isinstance(s, str) for s in scope_ids):
+            return scope_ids
+    except (json.JSONDecodeError, OSError):
+        pass
+    return []
 
 
 class ShellState:
@@ -13,6 +32,47 @@ class ShellState:
         self.config = config
         self._path = "/"
         self._scope_id: str | None = None
+        self.workspace_scope_ids: list[str] = _load_workspace_scope_ids()
+        self._workspace_scope_paths: list[str] | None = None
+
+    @property
+    def workspace_restricted(self) -> bool:
+        return bool(self.workspace_scope_ids)
+
+    def _resolve_workspace_scope_paths(self) -> list[str]:
+        """Lazily resolve workspace scope IDs to folder paths (one API call per scope, cached)."""
+        if self._workspace_scope_paths is not None:
+            return self._workspace_scope_paths
+        paths: list[str] = []
+        for scope_id in self.workspace_scope_ids:
+            try:
+                resp = unique_sdk.Folder.get_folder_path(
+                    user_id=self.config.user_id,
+                    company_id=self.config.company_id,
+                    scope_id=scope_id,
+                )
+                p = resp.get("folderPath", "")
+                if p:
+                    paths.append(p.rstrip("/"))
+            except Exception:
+                pass
+        self._workspace_scope_paths = paths
+        return paths
+
+    def is_within_workspace(self) -> bool:
+        """Return True if the current path is inside (or is) a workspace scope root.
+
+        Always returns True when no workspace restriction is configured.
+        """
+        if not self.workspace_scope_ids:
+            return True
+        if self._scope_id in self.workspace_scope_ids:
+            return True
+        paths = self._resolve_workspace_scope_paths()
+        if not paths:
+            return False
+        current = self._path
+        return any(current == p or current.startswith(p + "/") for p in paths)
 
     @property
     def cwd(self) -> str:


### PR DESCRIPTION
## Summary

- When `.unique-search.json` is present in the agent workspace (placed there by the sandbox harness), `unique-cli` now enforces that scope restriction uniformly across **all** discovery and mutation commands — not just `search`
- An agent running inside a sandboxed session can no longer enumerate the full company folder tree via `ls /`, nor mutate content outside its assigned scope
- Workspace scope IDs are loaded once at `ShellState` construction and cached; descendant-folder writes are checked via string-prefix comparison against lazily resolved folder paths — zero extra API calls per operation after the initial one-time load

## Changes

**`unique_sdk/cli/state.py`**
- Added `_load_workspace_scope_ids()` (reads `.unique-search.json` from CWD)
- Added `workspace_scope_ids: list[str]` and `_workspace_scope_paths: list[str] | None` to `ShellState`
- Added `workspace_restricted` property
- Added `_resolve_workspace_scope_paths()` — lazily resolves scope IDs to folder paths, cached after first call
- Added `is_within_workspace()` — fast scope-ID exact-match, fallback to path-prefix check for descendants

**`unique_sdk/cli/commands/search.py`**
- Removed local `_load_workspace_scope_ids()` / `_SEARCH_CONFIG_FILENAME`; now reads from `state.workspace_scope_ids`

**`unique_sdk/cli/commands/navigation.py`**
- `cmd_ls` at root: when workspace scopes are present, calls `Folder.get_info` for each allowed scope ID and returns only those folders

**`unique_sdk/cli/commands/files.py`**
- `cmd_upload`, `cmd_rm`, `cmd_mv_file`: return `permission denied` when outside workspace scope
- `cmd_download`: intentionally unrestricted (read-only)

**`unique_sdk/cli/commands/folders.py`**
- `cmd_mkdir`, `cmd_rmdir`, `cmd_mvdir`: return `permission denied` when outside workspace scope

**`unique_sdk/tests/cli/test_state.py` / `test_commands.py`**
- 26 new tests covering config loading, `is_within_workspace()` edge cases, `ls` root filtering, search scope pass-through, and all 6 write-op guards

## Test plan

- [x] `uv run --group dev pytest tests/cli/test_state.py tests/cli/test_commands.py -v` — 120/120 passed
- [x] Tested end-to-end locally: agent running with `.unique-search.json` saw only scoped folder at `ls /`, search returned results scoped to workspace, write ops outside scope returned permission denied

## Risk / rollout

- **No breaking change for unrestricted sessions**: when `.unique-search.json` is absent `workspace_scope_ids == []` and all guards are no-ops — existing behaviour is identical
- The path-prefix check resolves scope paths lazily on first write-guard invocation; sessions that never hit a write op outside the scope pay zero extra API calls

Made with [Cursor](https://cursor.com)