### PR TITLE
feat(unique-skill): including skill choices to payload

### DIFF
--- a/tool_packages/unique_skill_tool/tests/test_skill_tool.py
+++ b/tool_packages/unique_skill_tool/tests/test_skill_tool.py
@@ -453,81 +453,69 @@ class TestExtractInvokedSkills:
     swallowed.
     """
 
-    def test_no_tokens_returns_empty_and_original(self) -> None:
+    def test_no_tokens_returns_empty(self) -> None:
         reg = _make_skill_registry(_make_skill("foo"))
-        skills, remaining = extract_invoked_skills("just a question", reg)
+        skills = extract_invoked_skills("just a question", reg)
         assert skills == []
-        assert remaining == "just a question"
 
     def test_single_prefix_token(self) -> None:
         reg = _make_skill_registry(_make_skill("foo"))
-        skills, remaining = extract_invoked_skills("/foo how are things?", reg)
+        skills = extract_invoked_skills("/foo how are things?", reg)
         assert [s.name for s in skills] == ["foo"]
-        assert remaining == "how are things?"
 
     def test_multiple_prefix_tokens(self) -> None:
         reg = _make_skill_registry(_make_skill("foo"), _make_skill("bar"))
-        skills, remaining = extract_invoked_skills("/foo /bar the rest", reg)
+        skills = extract_invoked_skills("/foo /bar the rest", reg)
         assert [s.name for s in skills] == ["foo", "bar"]
-        assert remaining == "the rest"
 
     def test_duplicate_tokens_deduped_preserving_order(self) -> None:
         reg = _make_skill_registry(_make_skill("foo"), _make_skill("bar"))
-        skills, remaining = extract_invoked_skills("/foo /bar /foo ask away", reg)
+        skills = extract_invoked_skills("/foo /bar /foo ask away", reg)
         assert [s.name for s in skills] == ["foo", "bar"]
-        assert remaining == "ask away"
 
     def test_unknown_token_does_not_stop_matching(self) -> None:
         """Unknown ``/...`` tokens are left as text; known ones still activate."""
         reg = _make_skill_registry(_make_skill("foo"))
-        skills, remaining = extract_invoked_skills("/nope /foo rest", reg)
+        skills = extract_invoked_skills("/nope /foo rest", reg)
         assert [s.name for s in skills] == ["foo"]
-        assert remaining == "/nope rest"
 
     def test_known_then_unknown_keeps_known(self) -> None:
         reg = _make_skill_registry(_make_skill("foo"))
-        skills, remaining = extract_invoked_skills("/foo /nope rest", reg)
+        skills = extract_invoked_skills("/foo /nope rest", reg)
         assert [s.name for s in skills] == ["foo"]
-        assert remaining == "/nope rest"
 
     def test_token_in_middle_is_extracted(self) -> None:
         reg = _make_skill_registry(_make_skill("foo"))
-        skills, remaining = extract_invoked_skills("please run /foo for me", reg)
+        skills = extract_invoked_skills("please run /foo for me", reg)
         assert [s.name for s in skills] == ["foo"]
-        assert remaining == "please run for me"
 
     def test_token_at_end_is_extracted(self) -> None:
         reg = _make_skill_registry(_make_skill("foo"))
-        skills, remaining = extract_invoked_skills("please run /foo", reg)
+        skills = extract_invoked_skills("please run /foo", reg)
         assert [s.name for s in skills] == ["foo"]
-        assert remaining == "please run"
 
     def test_mixed_prefix_and_inline_tokens(self) -> None:
         reg = _make_skill_registry(_make_skill("foo"), _make_skill("bar"))
-        skills, remaining = extract_invoked_skills("/foo please also run /bar now", reg)
+        skills = extract_invoked_skills("/foo please also run /bar now", reg)
         assert [s.name for s in skills] == ["foo", "bar"]
-        assert remaining == "please also run now"
 
     def test_url_path_segments_are_not_matched(self) -> None:
         """Slashes inside URLs/paths must not be confused for skill tokens."""
         reg = _make_skill_registry(_make_skill("api"), _make_skill("foo"))
-        skills, remaining = extract_invoked_skills(
+        skills = extract_invoked_skills(
             "see https://example.com/api/v1 and src/foo.py", reg
         )
         assert skills == []
-        assert remaining == "see https://example.com/api/v1 and src/foo.py"
 
     def test_leading_whitespace_tolerated(self) -> None:
         reg = _make_skill_registry(_make_skill("foo"))
-        skills, remaining = extract_invoked_skills("   /foo  rest", reg)
+        skills = extract_invoked_skills("   /foo  rest", reg)
         assert [s.name for s in skills] == ["foo"]
-        assert remaining == "rest"
 
-    def test_token_alone_returns_empty_remainder(self) -> None:
+    def test_token_alone_returns_skill(self) -> None:
         reg = _make_skill_registry(_make_skill("foo"))
-        skills, remaining = extract_invoked_skills("/foo", reg)
+        skills = extract_invoked_skills("/foo", reg)
         assert [s.name for s in skills] == ["foo"]
-        assert remaining == ""
 
     def test_hyphenated_name_not_partially_matched(self) -> None:
         """``/foo-bar`` must not match a skill called ``foo``.
@@ -537,36 +525,30 @@ class TestExtractInvokedSkills:
         token is left in place as ordinary text.
         """
         reg = _make_skill_registry(_make_skill("foo"))
-        skills, remaining = extract_invoked_skills("/foo-bar rest", reg)
+        skills = extract_invoked_skills("/foo-bar rest", reg)
         assert skills == []
-        assert remaining == "/foo-bar rest"
 
     def test_hyphenated_name_matches_registered_skill(self) -> None:
         reg = _make_skill_registry(_make_skill("foo-bar"))
-        skills, remaining = extract_invoked_skills("/foo-bar rest", reg)
+        skills = extract_invoked_skills("/foo-bar rest", reg)
         assert [s.name for s in skills] == ["foo-bar"]
-        assert remaining == "rest"
 
     def test_empty_input(self) -> None:
         reg = _make_skill_registry(_make_skill("foo"))
-        skills, remaining = extract_invoked_skills("", reg)
+        skills = extract_invoked_skills("", reg)
         assert skills == []
-        assert remaining == ""
 
     def test_empty_registry(self) -> None:
-        skills, remaining = extract_invoked_skills("/foo hi", {})
+        skills = extract_invoked_skills("/foo hi", {})
         assert skills == []
-        assert remaining == "/foo hi"
 
     def test_name_starting_with_digit_is_matched(self) -> None:
         """Schema allows names starting with digits (e.g. ``5-forces``)."""
         reg = _make_skill_registry(_make_skill("5-forces"))
-        skills, remaining = extract_invoked_skills("/5-forces rest", reg)
+        skills = extract_invoked_skills("/5-forces rest", reg)
         assert [s.name for s in skills] == ["5-forces"]
-        assert remaining == "rest"
 
     def test_all_digits_name_is_matched(self) -> None:
         reg = _make_skill_registry(_make_skill("123"))
-        skills, remaining = extract_invoked_skills("/123 rest", reg)
+        skills = extract_invoked_skills("/123 rest", reg)
         assert [s.name for s in skills] == ["123"]
-        assert remaining == "rest"

--- a/tool_packages/unique_skill_tool/unique_skill_tool/utils.py
+++ b/tool_packages/unique_skill_tool/unique_skill_tool/utils.py
@@ -105,7 +105,7 @@ def normalize_skill_name(skill: str) -> str:
 def extract_invoked_skills(
     user_text: str,
     skill_registry: dict[str, SkillDefinition],
-) -> tuple[list[SkillDefinition], str]:
+) -> list[SkillDefinition]:
     """Pull every ``/skill-name`` invocation out of *user_text*.
 
     Tokens are recognised wherever they appear in the message — at the
@@ -121,23 +121,18 @@ def extract_invoked_skills(
     swallowed. Duplicates are dropped while preserving first-occurrence
     order.
 
-    Returns ``(ordered_skills, remaining_text)`` where *remaining_text*
-    is the original message with the matched tokens removed and any
-    surrounding whitespace tidied up so the final string reads naturally
-    to a downstream LLM.
+    Returns the invoked registered skills, deduplicated in first-occurrence
+    order.
     """
     ordered: list[SkillDefinition] = []
     seen: set[str] = set()
 
-    def _replace(match: re.Match[str]) -> str:
+    for match in _SKILL_TOKEN_RE.finditer(user_text):
         name = match.group(2)
         skill = skill_registry.get(name)
         if skill is None:
-            return match.group(0)
+            continue
         if name not in seen:
             seen.add(name)
             ordered.append(skill)
-        return ""
-
-    remaining = _SKILL_TOKEN_RE.sub(_replace, user_text)
-    return ordered, remaining.strip()
+    return ordered

--- a/unique_orchestrator/tests/test_skill_setup.py
+++ b/unique_orchestrator/tests/test_skill_setup.py
@@ -69,6 +69,7 @@ class TestPreloadInvokedSkills:
             tool_manager=tool_manager,  # type: ignore[arg-type]
             history_manager=history_manager,
             logger=logger,
+            skill_choices=[],
         )
 
         history_manager.add_tool_call.assert_not_called()
@@ -87,6 +88,7 @@ class TestPreloadInvokedSkills:
             tool_manager=tool_manager,  # type: ignore[arg-type]
             history_manager=history_manager,
             logger=logger,
+            skill_choices=[],
         )
 
         history_manager.add_tool_call.assert_called_once()
@@ -123,6 +125,27 @@ class TestPreloadInvokedSkills:
         synthetic_call = history_manager.add_tool_call.call_args.args[0]
         assert isinstance(synthetic_call, LanguageModelFunction)
         assert synthetic_call.arguments == {"skill_name": "foo"}
+
+    @pytest.mark.asyncio
+    async def test_duplicate_skill_choices_preload_once(self, logger: Logger) -> None:
+        event = _make_event("what are the revenue trends?")
+        history_manager = MagicMock()
+        skill_tool = _make_skill_tool([_make_skill("foo", content="FOO BODY")])
+        tool_manager = _FakeToolManager(skill_tool=skill_tool)
+
+        await preload_invoked_skills(
+            text=event.payload.user_message.text,
+            tool_manager=tool_manager,  # type: ignore[arg-type]
+            history_manager=history_manager,
+            logger=logger,
+            skill_choices=[
+                SelectableSkill(name="foo", content_id="cid-1"),
+                SelectableSkill(name="/foo", content_id="cid-2"),
+                SelectableSkill(name="foo", content_id="cid-3"),
+            ],
+        )
+
+        history_manager.add_tool_call.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_forced_skills_skip_slash_scan(self, logger: Logger) -> None:

--- a/unique_orchestrator/tests/test_skill_setup.py
+++ b/unique_orchestrator/tests/test_skill_setup.py
@@ -65,7 +65,7 @@ class TestPreloadInvokedSkills:
         tool_manager = _FakeToolManager(skill_tool=None)
 
         await preload_invoked_skills(
-            event=event,
+            text=event.payload.user_message.text,
             tool_manager=tool_manager,  # type: ignore[arg-type]
             history_manager=history_manager,
             logger=logger,
@@ -83,7 +83,7 @@ class TestPreloadInvokedSkills:
         tool_manager = _FakeToolManager(skill_tool=skill_tool)
 
         await preload_invoked_skills(
-            event=event,
+            text=event.payload.user_message.text,
             tool_manager=tool_manager,  # type: ignore[arg-type]
             history_manager=history_manager,
             logger=logger,
@@ -112,7 +112,7 @@ class TestPreloadInvokedSkills:
         tool_manager = _FakeToolManager(skill_tool=skill_tool)
 
         await preload_invoked_skills(
-            event=event,
+            text=event.payload.user_message.text,
             tool_manager=tool_manager,  # type: ignore[arg-type]
             history_manager=history_manager,
             logger=logger,
@@ -132,7 +132,7 @@ class TestPreloadInvokedSkills:
         tool_manager = _FakeToolManager(skill_tool=skill_tool)
 
         await preload_invoked_skills(
-            event=event,
+            text=event.payload.user_message.text,
             tool_manager=tool_manager,  # type: ignore[arg-type]
             history_manager=history_manager,
             logger=logger,

--- a/unique_orchestrator/tests/test_skill_setup.py
+++ b/unique_orchestrator/tests/test_skill_setup.py
@@ -64,14 +64,13 @@ class TestPreloadInvokedSkills:
         history_manager = MagicMock()
         tool_manager = _FakeToolManager(skill_tool=None)
 
-        stripped_text = await preload_invoked_skills(
+        await preload_invoked_skills(
             event=event,
             tool_manager=tool_manager,  # type: ignore[arg-type]
             history_manager=history_manager,
             logger=logger,
         )
 
-        assert stripped_text is None
         history_manager.add_tool_call.assert_not_called()
         history_manager._append_tool_calls_to_history.assert_not_called()
         history_manager.add_tool_call_results.assert_not_called()
@@ -83,14 +82,13 @@ class TestPreloadInvokedSkills:
         skill_tool = _make_skill_tool([_make_skill("foo", content="FOO BODY")])
         tool_manager = _FakeToolManager(skill_tool=skill_tool)
 
-        stripped_text = await preload_invoked_skills(
+        await preload_invoked_skills(
             event=event,
             tool_manager=tool_manager,  # type: ignore[arg-type]
             history_manager=history_manager,
             logger=logger,
         )
 
-        assert stripped_text == "what are the revenue trends?"
         history_manager.add_tool_call.assert_called_once()
         synthetic_call = history_manager.add_tool_call.call_args.args[0]
         assert isinstance(synthetic_call, LanguageModelFunction)
@@ -103,6 +101,45 @@ class TestPreloadInvokedSkills:
         response = responses[0]
         assert isinstance(response, ToolCallResponse)
         assert "FOO BODY" in response.content
+
+    @pytest.mark.asyncio
+    async def test_forced_skill_choice_preloaded_without_slash_token(
+        self, logger: Logger
+    ) -> None:
+        event = _make_event("what are the revenue trends?")
+        history_manager = MagicMock()
+        skill_tool = _make_skill_tool([_make_skill("foo", content="FOO BODY")])
+        tool_manager = _FakeToolManager(skill_tool=skill_tool)
+
+        await preload_invoked_skills(
+            event=event,
+            tool_manager=tool_manager,  # type: ignore[arg-type]
+            history_manager=history_manager,
+            logger=logger,
+            skill_choices=[SelectableSkill(name="foo", content_id="cid-1")],
+        )
+
+        history_manager.add_tool_call.assert_called_once()
+        synthetic_call = history_manager.add_tool_call.call_args.args[0]
+        assert isinstance(synthetic_call, LanguageModelFunction)
+        assert synthetic_call.arguments == {"skill_name": "foo"}
+
+    @pytest.mark.asyncio
+    async def test_forced_skills_skip_slash_scan(self, logger: Logger) -> None:
+        event = _make_event("/foo what are the revenue trends?")
+        history_manager = MagicMock()
+        skill_tool = _make_skill_tool([_make_skill("foo", content="FOO BODY")])
+        tool_manager = _FakeToolManager(skill_tool=skill_tool)
+
+        await preload_invoked_skills(
+            event=event,
+            tool_manager=tool_manager,  # type: ignore[arg-type]
+            history_manager=history_manager,
+            logger=logger,
+            skill_choices=[SelectableSkill(name="foo", content_id="cid-1")],
+        )
+
+        history_manager.add_tool_call.assert_called_once()
 
 
 class TestBuildSkill:
@@ -237,6 +274,78 @@ class TestConfigureSkillTool:
 
     @pytest.mark.asyncio
     async def test_enabled_with_selectables_populates_tool_registry(
+        self, logger: Logger
+    ) -> None:
+        selectable_skills = [SelectableSkill(content_id="cid-1", name="Skill 1")]
+        config = self._build_config(
+            is_enabled=True, selectable_skills=selectable_skills
+        )
+        content_service = MagicMock()
+        tool_manager = MagicMock()
+        skill_tool = self._make_skill_tool()
+        tool_manager.get_tool_by_name.return_value = skill_tool
+        expected_registry = {"foo": _make_skill("foo", content="skill content")}
+
+        with patch(
+            "unique_orchestrator._builders.skill_setup.load_selectable_skills",
+            new=AsyncMock(return_value=expected_registry),
+        ) as mock_load_selectable_skills:
+            await configure_skill_tool(
+                config=config,
+                logger=logger,
+                content_service=content_service,
+                tool_manager=tool_manager,
+            )
+
+        mock_load_selectable_skills.assert_awaited_once_with(
+            content_service=content_service,
+            selectable_skills=selectable_skills,
+            logger=logger,
+        )
+        assert skill_tool.skill_registry == expected_registry
+        tool_manager.exclude_tool.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_enabled_with_multiple_selectables_loads_full_registry(
+        self, logger: Logger
+    ) -> None:
+        selectable_skills = [
+            SelectableSkill(content_id="cid-1", name="Skill 1"),
+            SelectableSkill(content_id="cid-2", name="Skill 2"),
+        ]
+        config = self._build_config(
+            is_enabled=True, selectable_skills=selectable_skills
+        )
+        content_service = MagicMock()
+        tool_manager = MagicMock()
+        skill_tool = self._make_skill_tool()
+        tool_manager.get_tool_by_name.return_value = skill_tool
+        expected_registry = {
+            "foo": _make_skill("foo", content="skill content"),
+            "bar": _make_skill("bar", content="other skill content"),
+        }
+
+        with patch(
+            "unique_orchestrator._builders.skill_setup.load_selectable_skills",
+            new=AsyncMock(return_value=expected_registry),
+        ) as mock_load_selectable_skills:
+            await configure_skill_tool(
+                config=config,
+                logger=logger,
+                content_service=content_service,
+                tool_manager=tool_manager,
+            )
+
+        mock_load_selectable_skills.assert_awaited_once_with(
+            content_service=content_service,
+            selectable_skills=selectable_skills,
+            logger=logger,
+        )
+        assert skill_tool.skill_registry == expected_registry
+        tool_manager.exclude_tool.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_enabled_with_single_selectable_loads_registry(
         self, logger: Logger
     ) -> None:
         selectable_skills = [SelectableSkill(content_id="cid-1", name="Skill 1")]

--- a/unique_orchestrator/tests/test_unique_ai_skill_and_reminders.py
+++ b/unique_orchestrator/tests/test_unique_ai_skill_and_reminders.py
@@ -89,7 +89,6 @@ class TestPreloadSkillsInRun:
     async def _run_until_preload(
         self,
         ua: "UniqueAI",
-        preload_return: str | None,
     ) -> None:
         ua._chat_service.modify_assistant_message_async = AsyncMock()
         ua._chat_service.cancellation.on_cancellation.subscribe = MagicMock(
@@ -99,7 +98,7 @@ class TestPreloadSkillsInRun:
         with (
             patch(
                 "unique_orchestrator.unique_ai.preload_invoked_skills",
-                new=AsyncMock(return_value=preload_return),
+                new=AsyncMock(),
             ),
             patch("unique_orchestrator.unique_ai.feature_flags") as mock_feature_flags,
         ):
@@ -108,14 +107,14 @@ class TestPreloadSkillsInRun:
                 await ua.run()
 
     @pytest.mark.asyncio
-    async def test_stripped_text_replaces_user_message(
+    async def test_preload_does_not_mutate_user_message(
         self, mock_unique_ai: "UniqueAI"
     ) -> None:
         mock_unique_ai._event.payload.user_message.text = "/foo the real query"
 
-        await self._run_until_preload(mock_unique_ai, "the real query")
+        await self._run_until_preload(mock_unique_ai)
 
-        assert mock_unique_ai._event.payload.user_message.text == "the real query"
+        assert mock_unique_ai._event.payload.user_message.text == "/foo the real query"
 
     @pytest.mark.asyncio
     async def test_no_skills_leaves_user_message_untouched(
@@ -123,7 +122,7 @@ class TestPreloadSkillsInRun:
     ) -> None:
         mock_unique_ai._event.payload.user_message.text = "plain question"
 
-        await self._run_until_preload(mock_unique_ai, None)
+        await self._run_until_preload(mock_unique_ai)
 
         assert mock_unique_ai._event.payload.user_message.text == "plain question"
 

--- a/unique_orchestrator/unique_orchestrator/_builders/skill_setup.py
+++ b/unique_orchestrator/unique_orchestrator/_builders/skill_setup.py
@@ -59,7 +59,6 @@ if TYPE_CHECKING:
         ResponsesApiToolManager,
         ToolManager,
     )
-    from unique_toolkit.app.schemas import ChatEvent
     from unique_toolkit.content.service import ContentService
 
     from unique_orchestrator.config import UniqueAIConfig
@@ -309,7 +308,7 @@ async def preload_invoked_skills(
         return
 
     forced_skills = []
-    
+
     if skill_choices:
         for choice in skill_choices:
             if not choice.name:

--- a/unique_orchestrator/unique_orchestrator/_builders/skill_setup.py
+++ b/unique_orchestrator/unique_orchestrator/_builders/skill_setup.py
@@ -41,7 +41,7 @@ from __future__ import annotations
 
 import asyncio
 from logging import Logger
-from typing import TYPE_CHECKING, Any, Sequence, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import frontmatter
 from pydantic import ValidationError
@@ -280,7 +280,7 @@ async def preload_invoked_skills(
     tool_manager: ToolManager | ResponsesApiToolManager,
     history_manager: HistoryManager,
     logger: Logger,
-    skill_choices: Sequence[SelectableSkill] = (),
+    skill_choices: list[SelectableSkill],
 ) -> None:
     """Preload forced and slash-invoked skills before the first model turn.
 

--- a/unique_orchestrator/unique_orchestrator/_builders/skill_setup.py
+++ b/unique_orchestrator/unique_orchestrator/_builders/skill_setup.py
@@ -41,14 +41,14 @@ from __future__ import annotations
 
 import asyncio
 from logging import Logger
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Sequence, cast
 
 import frontmatter
 from pydantic import ValidationError
 from unique_skill_tool.config import SkillToolConfig
 from unique_skill_tool.schemas import SelectableSkill, SkillDefinition
 from unique_skill_tool.service import SkillTool
-from unique_skill_tool.utils import extract_invoked_skills
+from unique_skill_tool.utils import extract_invoked_skills, normalize_skill_name
 from unique_toolkit.agentic.tools.config import ToolBuildConfig
 from unique_toolkit.agentic.tools.schemas import ToolCallResponse
 from unique_toolkit.language_model.schemas import LanguageModelFunction
@@ -277,47 +277,59 @@ async def configure_skill_tool(
 
 async def preload_invoked_skills(
     *,
-    event: ChatEvent,
+    text: str,
     tool_manager: ToolManager | ResponsesApiToolManager,
     history_manager: HistoryManager,
     logger: Logger,
-) -> str | None:
-    """Preload skills invoked as ``/skill-name`` tokens in the user message.
+    skill_choices: Sequence[SelectableSkill] = (),
+) -> None:
+    """Preload forced and slash-invoked skills before the first model turn.
 
     Mirrors the normal mid-loop activation path so preloaded skills are
     indistinguishable from skills the model activates itself:
 
-    1. Pulls every ``/skill-name`` token out of the user message —
-       whether at the start, between words, or at the end — as long as
-       it is properly word-boundaried so URLs and file paths are not
-       mistaken for invocations. Unknown tokens are left as ordinary
-       text.
+    1. Resolves forced ``skill_choices`` first.
+    2. If no forced skills are found, pulls every ``/skill-name`` token
+       out of the user message — whether at the start, between words, or
+       at the end — as long as it is properly word-boundaried so URLs and
+       file paths are not mistaken for invocations. Unknown tokens are
+       left as ordinary text.
     2. For each matched skill, synthesizes a ``LanguageModelFunction``
        and runs it through the already-registered ``SkillTool`` — the
        exact same code path ``UniqueAI._handle_tool_calls`` uses.
     3. Appends the synthetic assistant tool-call message plus the
        resulting tool-result messages to history, so the first model
        turn sees the skills as already-activated tool calls.
-    4. Strips the matched ``/skill-name`` tokens from the user message
-       so the rendered turn shows only the user's actual query.
-
-    No-ops when the SkillTool is not registered or no tokens match.
+    ``skill_choices`` are treated as forced skills and loaded even when
+    the user message does not contain ``/skill-name`` tokens. User
+    message text is never modified in this preload step.
     """
     skill_tool = tool_manager.get_tool_by_name(SkillTool.name)
     if not isinstance(skill_tool, SkillTool):
-        return None
+        return
 
-    original_text = event.payload.user_message.text or ""
+    forced_skills = []
+    
+    if skill_choices:
+        for choice in skill_choices:
+            if not choice.name:
+                continue
+            normalized_name = normalize_skill_name(choice.name)
+            forced_skill = skill_tool.skill_registry.get(normalized_name)
+            if forced_skill is None:
+                continue
+            forced_skills.append(forced_skill)
 
-    skills, stripped_text = extract_invoked_skills(
-        original_text, skill_tool.skill_registry
-    )
-    if not skills:
-        return None
+    else:
+        if text:
+            forced_skills = extract_invoked_skills(text, skill_tool.skill_registry)
+
+    if not forced_skills:
+        return
 
     tool_calls: list[LanguageModelFunction] = []
     responses: list[ToolCallResponse] = []
-    for skill in skills:
+    for skill in forced_skills:
         tool_call = LanguageModelFunction(
             name=SkillTool.name,
             arguments={"skill_name": skill.name},
@@ -331,9 +343,7 @@ async def preload_invoked_skills(
     history_manager.add_tool_call_results(responses)
 
     logger.info(
-        "Preloaded %d skill(s) from slash invocation: %s",
-        len(skills),
-        [s.name for s in skills],
+        "Preloaded %d skill(s) before first model turn: %s",
+        len(forced_skills),
+        [s.name for s in forced_skills],
     )
-
-    return stripped_text

--- a/unique_orchestrator/unique_orchestrator/_builders/skill_setup.py
+++ b/unique_orchestrator/unique_orchestrator/_builders/skill_setup.py
@@ -300,8 +300,10 @@ async def preload_invoked_skills(
        resulting tool-result messages to history, so the first model
        turn sees the skills as already-activated tool calls.
     ``skill_choices`` are treated as forced skills and loaded even when
-    the user message does not contain ``/skill-name`` tokens. User
-    message text is never modified in this preload step.
+    the user message does not contain ``/skill-name`` tokens. Duplicate
+    choices that resolve to the same registered skill are ignored after
+    the first (same deduplication idea as ``extract_invoked_skills``).
+    User message text is never modified in this preload step.
     """
     skill_tool = tool_manager.get_tool_by_name(SkillTool.name)
     if not isinstance(skill_tool, SkillTool):
@@ -310,6 +312,7 @@ async def preload_invoked_skills(
     forced_skills = []
 
     if skill_choices:
+        seen_forced: set[str] = set()
         for choice in skill_choices:
             if not choice.name:
                 continue
@@ -317,6 +320,9 @@ async def preload_invoked_skills(
             forced_skill = skill_tool.skill_registry.get(normalized_name)
             if forced_skill is None:
                 continue
+            if forced_skill.name in seen_forced:
+                continue
+            seen_forced.add(forced_skill.name)
             forced_skills.append(forced_skill)
 
     else:

--- a/unique_orchestrator/unique_orchestrator/tests/test_unique_ai_async_modify.py
+++ b/unique_orchestrator/unique_orchestrator/tests/test_unique_ai_async_modify.py
@@ -86,6 +86,7 @@ def _make_ua(monkeypatch, *, feature_flag_enabled: bool = False):
     ua._execution_times = []
     ua._current_loop_timing = {}
     ua.current_iteration_index = 0
+    ua._skill_choices = []
 
     return ua
 

--- a/unique_orchestrator/unique_orchestrator/tests/test_unique_ai_reference_order.py
+++ b/unique_orchestrator/unique_orchestrator/tests/test_unique_ai_reference_order.py
@@ -27,6 +27,7 @@ async def test_history_updated_before_reference_extraction(monkeypatch):
             assistant_message = AssistantMessage()
             user_message = MagicMock()
             user_message.text = "query"
+            skill_choices = []
 
         payload = Payload()
 

--- a/unique_orchestrator/unique_orchestrator/unique_ai.py
+++ b/unique_orchestrator/unique_orchestrator/unique_ai.py
@@ -212,14 +212,13 @@ class UniqueAI:
         self._execution_times = []
         run_start = time.perf_counter()
 
-        stripped_text = await preload_invoked_skills(
-            event=self._event,
+        await preload_invoked_skills(
+            text=self._event.payload.user_message.text,
             tool_manager=self._tool_manager,
             history_manager=self._history_manager,
             logger=self._logger,
+            skill_choices=self._event.payload.skill_choices,
         )
-        if stripped_text is not None:
-            self._event.payload.user_message.text = stripped_text
 
         sub = self._chat_service.cancellation.on_cancellation.subscribe(
             self._on_cancellation

--- a/unique_orchestrator/unique_orchestrator/unique_ai.py
+++ b/unique_orchestrator/unique_orchestrator/unique_ai.py
@@ -138,6 +138,7 @@ class UniqueAI:
         self._chat_service = chat_service
         self._content_service = content_service
         self._uploaded_documents = uploaded_documents or []
+        self._skill_choices = event.payload.skill_choices
 
         self._debug_info_manager = debug_info_manager
         self._reference_manager = reference_manager
@@ -217,7 +218,7 @@ class UniqueAI:
             tool_manager=self._tool_manager,
             history_manager=self._history_manager,
             logger=self._logger,
-            skill_choices=self._event.payload.skill_choices,
+            skill_choices=self._skill_choices,
         )
 
         sub = self._chat_service.cancellation.on_cancellation.subscribe(

--- a/unique_orchestrator/unique_orchestrator/unique_ai.py
+++ b/unique_orchestrator/unique_orchestrator/unique_ai.py
@@ -138,7 +138,7 @@ class UniqueAI:
         self._chat_service = chat_service
         self._content_service = content_service
         self._uploaded_documents = uploaded_documents or []
-        self._skill_choices = event.payload.skill_choices
+        self._skill_choices = getattr(event.payload, "skill_choices", [])
 
         self._debug_info_manager = debug_info_manager
         self._reference_manager = reference_manager

--- a/unique_sdk/tests/test_async_fixes.py
+++ b/unique_sdk/tests/test_async_fixes.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from unique_sdk.api_resources._agentic_table import AgenticTable
+from unique_sdk.api_resources._space import Space
 
 
 @pytest.mark.asyncio
@@ -107,3 +108,38 @@ async def test_wait_for_ingestion_completion_uses_async_search():
 
         mock_search.assert_awaited()
         assert state == "FINISHED"
+
+
+def test_space_create_message_defaults_skill_choices_to_empty_list():
+    with patch.object(Space, "_static_request") as mock_req:
+        mock_req.return_value = {"id": "m1", "chatId": "c1"}
+
+        Space.create_message(
+            user_id="u1",
+            company_id="c1",
+            assistantId="a1",
+            text="hello",
+        )
+
+        mock_req.assert_called_once()
+        params = mock_req.call_args.kwargs["params"]
+        assert params["toolChoices"] == []
+        assert params["skillChoices"] == []
+
+
+@pytest.mark.asyncio
+async def test_space_create_message_async_defaults_skill_choices_to_empty_list():
+    with patch.object(Space, "_static_request_async", new_callable=AsyncMock) as mock_req:
+        mock_req.return_value = {"id": "m1", "chatId": "c1"}
+
+        await Space.create_message_async(
+            user_id="u1",
+            company_id="c1",
+            assistantId="a1",
+            text="hello",
+        )
+
+        mock_req.assert_awaited_once()
+        params = mock_req.await_args.kwargs["params"]
+        assert params["toolChoices"] == []
+        assert params["skillChoices"] == []

--- a/unique_sdk/tests/test_async_fixes.py
+++ b/unique_sdk/tests/test_async_fixes.py
@@ -129,7 +129,9 @@ def test_space_create_message_defaults_skill_choices_to_empty_list():
 
 @pytest.mark.asyncio
 async def test_space_create_message_async_defaults_skill_choices_to_empty_list():
-    with patch.object(Space, "_static_request_async", new_callable=AsyncMock) as mock_req:
+    with patch.object(
+        Space, "_static_request_async", new_callable=AsyncMock
+    ) as mock_req:
         mock_req.return_value = {"id": "m1", "chatId": "c1"}
 
         await Space.create_message_async(

--- a/unique_sdk/unique_sdk/api_resources/_space.py
+++ b/unique_sdk/unique_sdk/api_resources/_space.py
@@ -89,6 +89,7 @@ class Space(APIResource["Space"]):
         assistantId: str
         text: NotRequired[str | None]
         toolChoices: NotRequired[list[str] | None]
+        skillChoices: NotRequired[list[dict[str, Any]]]
         scopeRules: NotRequired[dict[str, Any] | None]
         correlation: NotRequired["Space.Correlation | None"]
 
@@ -297,6 +298,7 @@ class Space(APIResource["Space"]):
         Send a message in a space.
         """
         params["toolChoices"] = params.get("toolChoices") or []
+        params["skillChoices"] = params.get("skillChoices") or []
         return cast(
             "Space.Message",
             cls._static_request(
@@ -319,6 +321,7 @@ class Space(APIResource["Space"]):
         Async send a message in a space.
         """
         params["toolChoices"] = params.get("toolChoices") or []
+        params["skillChoices"] = params.get("skillChoices") or []
         return cast(
             "Space.Message",
             await cls._static_request_async(

--- a/unique_sdk/unique_sdk/utils/chat_in_space.py
+++ b/unique_sdk/unique_sdk/utils/chat_in_space.py
@@ -1,6 +1,7 @@
 import asyncio
 import warnings
-from typing import Any, Literal, Sequence
+from collections.abc import Sequence
+from typing import Any, Literal
 
 from unique_sdk.api_resources._message import Message
 from unique_sdk.api_resources._space import Space

--- a/unique_sdk/unique_sdk/utils/chat_in_space.py
+++ b/unique_sdk/unique_sdk/utils/chat_in_space.py
@@ -1,6 +1,6 @@
 import asyncio
 import warnings
-from typing import Any, Literal
+from typing import Any, Literal, Sequence
 
 from unique_sdk.api_resources._message import Message
 from unique_sdk.api_resources._space import Space
@@ -16,6 +16,7 @@ async def send_message_and_wait_for_completion(
     assistant_id: str,
     text: str,
     tool_choices: list[str] | None = None,
+    skill_choices: Sequence[dict[str, Any]] = (),
     scope_rules: dict[str, Any] | None = None,
     chat_id: str | None = None,
     poll_interval: float = 1.0,
@@ -32,6 +33,7 @@ async def send_message_and_wait_for_completion(
         assistant_id: The assistant ID.
         text: The prompt text.
         tool_choices: List of tool names to use.
+        skill_choices: Sequence of selected skill objects to use.
         scope_rules: Scope rules for filtering content.
         chat_id: Optional chat ID to continue an existing chat.
         poll_interval: Seconds between polls.
@@ -50,6 +52,7 @@ async def send_message_and_wait_for_completion(
         chatId=chat_id,
         text=text,
         toolChoices=tool_choices,
+        skillChoices=list(skill_choices),
         scopeRules=scope_rules,
         correlation=correlation,
     )

--- a/unique_toolkit/unique_toolkit/app/schemas.py
+++ b/unique_toolkit/unique_toolkit/app/schemas.py
@@ -10,6 +10,7 @@ from humps import camelize
 from pydantic import BaseModel, ConfigDict, Field, JsonValue, field_validator
 from pydantic_settings import BaseSettings
 from typing_extensions import deprecated
+from unique_skill_tool.schemas import SelectableSkill
 
 from unique_toolkit._common.exception import ConfigurationException
 from unique_toolkit.app.chat_event_filter_options_settings import (
@@ -242,7 +243,7 @@ class ChatEventPayload(BaseModel):
         default_factory=list,
         description="A list containing the tool names the user has chosen to be activated.",
     )
-    skill_choices: list[ChatEventSkillChoice] = Field(
+    skill_choices: list[SelectableSkill] = Field(
         default_factory=list,
         description=(
             "A list containing selected skills with ``scope_id``, "

--- a/unique_toolkit/unique_toolkit/app/schemas.py
+++ b/unique_toolkit/unique_toolkit/app/schemas.py
@@ -10,7 +10,6 @@ from humps import camelize
 from pydantic import BaseModel, ConfigDict, Field, JsonValue, field_validator
 from pydantic_settings import BaseSettings
 from typing_extensions import deprecated
-from unique_skill_tool.schemas import SelectableSkill
 
 from unique_toolkit._common.exception import ConfigurationException
 from unique_toolkit.app.chat_event_filter_options_settings import (
@@ -243,7 +242,7 @@ class ChatEventPayload(BaseModel):
         default_factory=list,
         description="A list containing the tool names the user has chosen to be activated.",
     )
-    skill_choices: list[SelectableSkill] = Field(
+    skill_choices: list[ChatEventSkillChoice] = Field(
         default_factory=list,
         description=(
             "A list containing selected skills with ``scope_id``, "

--- a/unique_toolkit/unique_toolkit/app/schemas.py
+++ b/unique_toolkit/unique_toolkit/app/schemas.py
@@ -215,6 +215,14 @@ class Correlation(BaseModel):
     parent_assistant_id: str
 
 
+class ChatEventSkillChoice(BaseModel):
+    model_config = model_config
+
+    scope_id: str = ""
+    content_id: str = ""
+    name: str = ""
+
+
 class ChatEventPayload(BaseModel):
     model_config = model_config
 
@@ -233,6 +241,13 @@ class ChatEventPayload(BaseModel):
     tool_choices: list[str] = Field(
         default_factory=list,
         description="A list containing the tool names the user has chosen to be activated.",
+    )
+    skill_choices: list[ChatEventSkillChoice] = Field(
+        default_factory=list,
+        description=(
+            "A list containing selected skills with ``scope_id``, "
+            "``content_id``, and ``name``."
+        ),
     )
     disabled_tools: list[str] = Field(
         default_factory=list,

--- a/unique_toolkit/unique_toolkit/app/schemas.py
+++ b/unique_toolkit/unique_toolkit/app/schemas.py
@@ -218,9 +218,15 @@ class Correlation(BaseModel):
 class ChatEventSkillChoice(BaseModel):
     model_config = model_config
 
-    scope_id: str = ""
-    content_id: str = ""
-    name: str = ""
+    name: str = Field(default="", description="Skill name.")
+    scope_id: str = Field(
+        default="",
+        description="Knowledge base scope ID that contains the skill file.",
+    )
+    content_id: str = Field(
+        default="",
+        description="Knowledge base content ID of the ``SKILL.md`` file.",
+    )
 
 
 class ChatEventPayload(BaseModel):


### PR DESCRIPTION
## 🚀 Summary
Refs: https://unique-ch.atlassian.net/browse/UN-18944

- include option to load forced skills from skillChoices in payload (backward compatible)
- triggered tools are not removed from user message

## ✅ Changes

- [ ] Added feature / fixed bug / updated docs
- [ ] Refactored code / cleaned up
- [ ] Other (describe below)

## 🧪 Testing

- Triggered tool remains in message
<img width="434" height="268" alt="image" src="https://github.com/user-attachments/assets/9af204eb-a7d9-46ad-902f-f666b9d7d1c2" />

- Backward compatible. Still works when skillChoices not in payload
<img width="432" height="166" alt="image" src="https://github.com/user-attachments/assets/3d305572-3f23-47be-afcd-dacbd0f4aa95" />

