### PR TITLE
docs(skills): add ci-local-parity local CI workflow skill

### DIFF
--- a/.claude/skills/ci-local-parity/SKILL.md
+++ b/.claude/skills/ci-local-parity/SKILL.md
@@ -1,0 +1,245 @@
+---
+name: ci-local-parity
+description: Reproduce ai-repo PR checks locally with Poe and CI scripts, including per-package typecheck and coverage behavior. Use when validating changes before push or when user asks which local commands match CI.
+license: MIT
+compatibility: claude cursor opencode
+metadata:
+  version: "1.0.0"
+  languages: python
+  audience: developers
+  workflow: automation
+  since: "2026-05-07"
+---
+
+## What I do
+
+I run the `ai` repository checks locally with the closest possible parity to PR CI:
+
+- Map changed files to affected packages
+- Run package checks in CI order (`format --check`, lint, test, types, coverage, depcheck)
+- Apply package-specific behavior from `.github/actions/get-packages-matrix/package_configuration.json`
+- Use baseline/diff mode for packages that use it, strict mode for packages that require zero errors
+- Call out CI checks that are not fully reproducible through Poe alone
+
+## When to use me
+
+- User asks how to run CI checks locally in `ai`
+- User wants the exact local commands before opening/updating a PR
+- User asks about Poe tasks vs CI scripts and where they differ
+- You need to validate one package or all changed packages with CI-like behavior
+
+## Use Instead [if available]
+
+- Use `ci-fix` when the primary task is diagnosing an already-failed CI run.
+- Use `ruff` for lint/format-only cleanup without CI parity requirements.
+- Use `uv` for dependency/lockfile maintenance not tied to CI parity.
+
+## Example usage
+
+```
+/ci-local-parity
+/ci-local-parity unique_toolkit
+/ci-local-parity changed-packages
+```
+
+---
+
+## Workflow
+
+### Step 0: Preconditions
+
+Run from repository root:
+
+```bash
+cd /Users/aurelgruber/Unique/code/ai
+```
+
+Ensure tooling is available:
+
+```bash
+uv --version
+uv run poe --help
+```
+
+If `uv` is missing, stop and ask the user to install/repair it before proceeding.
+
+---
+
+### Step 1: Determine target packages
+
+For changed packages in current branch:
+
+```bash
+BASE_REF=origin/main
+git fetch origin main
+git diff --name-only "$BASE_REF"...HEAD
+```
+
+Map changed files to package directories using:
+
+- `.github/actions/get-packages-matrix/package_configuration.json`
+
+Treat the `dir` field as canonical package path.
+
+If the user asked for one package, skip auto-detection and use that package directly.
+
+---
+
+### Step 2: Run baseline package checks (CI-like order)
+
+Inside each package directory (`cd <package_dir>`), run:
+
+```bash
+uv run ruff format --check .
+uv run poe lint
+uv run poe test
+uv run poe depcheck
+```
+
+Then run typecheck + coverage per Step 3 and Step 4 (mode differs by package).
+
+Notes:
+
+- CI lint uses both format check and lint check.
+- `poe format` is not equivalent to CI lint because it writes files.
+
+---
+
+### Step 3: Typecheck mode (strict vs baseline)
+
+Read package behavior from matrix flags:
+
+- `typecheck_use_baseline`
+- `typecheck_require_zero_errors`
+
+#### Strict/full mode
+
+Use for packages with `typecheck_use_baseline: false` and for any package requiring zero errors:
+
+- `toolkit`
+- `sdk`
+- `skill_tool`
+
+Command:
+
+```bash
+uv run poe typecheck
+```
+
+#### Baseline mode (new errors vs base)
+
+Use for packages with `typecheck_use_baseline: true`:
+
+```bash
+uv run poe ci-typecheck
+```
+
+This routes to `.github/scripts/dev.sh typecheck` and mirrors CI’s baseline behavior closely.
+
+Fallback if `ci-typecheck` task does not exist in a package:
+
+```bash
+bash "$(git rev-parse --show-toplevel)/.github/scripts/dev.sh" typecheck --dir .
+```
+
+---
+
+### Step 4: Coverage mode (diff-based parity)
+
+Preferred CI-like command:
+
+```bash
+uv run poe ci-coverage
+```
+
+Fallback if task missing:
+
+```bash
+bash "$(git rev-parse --show-toplevel)/.github/scripts/dev.sh" coverage --dir .
+```
+
+Full-package (non-diff) coverage when requested:
+
+```bash
+uv run poe coverage
+```
+
+---
+
+### Step 5: Apply package-specific CI arguments
+
+From matrix config:
+
+- `sdk` test args: `-m "not integration"`
+- `toolkit` install extras: `--extra fastapi --extra monitoring` (CI setup behavior)
+
+For SDK parity:
+
+```bash
+uv run poe test -- -m "not integration"
+```
+
+For toolkit parity, if needed before tests/coverage:
+
+```bash
+uv sync --locked --inexact --extra fastapi --extra monitoring
+```
+
+---
+
+### Step 6: CI checks that are not pure Poe parity
+
+Call these out explicitly in summary; do not claim full parity:
+
+- Dependency job (`ci-dependency-checks.yaml`) uses min-deps installation strategy via `.github/actions/run-min-tests-and-deptry` (not the same as `poe depcheck`).
+- Config compatibility job (`ci-config-check.yaml`) uses `unique_toolkit._common.config_checker` export/check flow.
+- PR policy checks:
+  - PR title validation
+  - no-manual-release script
+  - gatekeeper status aggregation
+
+Run these manually only when needed with their underlying scripts/workflows.
+
+---
+
+## Package quick recipes
+
+### One package, closest PR-CI parity
+
+```bash
+cd <package_dir>
+uv run ruff format --check .
+uv run poe lint
+uv run poe test
+uv run poe depcheck
+uv run poe ci-typecheck || bash "$(git rev-parse --show-toplevel)/.github/scripts/dev.sh" typecheck --dir .
+uv run poe ci-coverage || bash "$(git rev-parse --show-toplevel)/.github/scripts/dev.sh" coverage --dir .
+```
+
+### Strict packages (`toolkit`, `sdk`, `skill_tool`)
+
+```bash
+cd <package_dir>
+uv run ruff format --check .
+uv run poe lint
+uv run poe test
+uv run poe depcheck
+uv run poe typecheck
+uv run poe ci-coverage || bash "$(git rev-parse --show-toplevel)/.github/scripts/dev.sh" coverage --dir .
+```
+
+For `sdk` test parity:
+
+```bash
+uv run poe test -- -m "not integration"
+```
+
+---
+
+## Tips for success
+
+1. **Always include `ruff format --check`** for CI lint parity.
+2. **Use matrix flags, not assumptions** for strict vs baseline typecheck mode.
+3. **Prefer `ci-*` Poe tasks** for diff/baseline parity, then fall back to `dev.sh`.
+4. **Do not over-claim parity**: deps/config/policy jobs are only partially reproducible via Poe.
+5. **Run from repo root first** so relative script paths and git base refs work reliably.

--- a/.claude/skills/ci-local-parity/SKILL.md
+++ b/.claude/skills/ci-local-parity/SKILL.md
@@ -4,7 +4,7 @@ description: Reproduce ai-repo PR checks locally with Poe and CI scripts, includ
 license: MIT
 compatibility: claude cursor opencode
 metadata:
-  version: "1.1.0"
+  version: "1.0.0"
   languages: python
   audience: developers
   workflow: automation

--- a/.claude/skills/ci-local-parity/SKILL.md
+++ b/.claude/skills/ci-local-parity/SKILL.md
@@ -4,7 +4,7 @@ description: Reproduce ai-repo PR checks locally with Poe and CI scripts, includ
 license: MIT
 compatibility: claude cursor opencode
 metadata:
-  version: "1.0.0"
+  version: "1.1.0"
   languages: python
   audience: developers
   workflow: automation
@@ -13,34 +13,24 @@ metadata:
 
 ## What I do
 
-I run the `ai` repository checks locally with the closest possible parity to PR CI:
+Run `ai` repository checks locally with the closest possible parity to PR CI:
 
 - Map changed files to affected packages
-- Run package checks in CI order (`format --check`, lint, test, types, coverage, depcheck)
-- Apply package-specific behavior from `.github/actions/get-packages-matrix/package_configuration.json`
-- Use baseline/diff mode for packages that use it, strict mode for packages that require zero errors
-- Call out CI checks that are not fully reproducible through Poe alone
+- Run checks in CI order: format-check → lint → test → typecheck → coverage → depcheck
+- Apply per-package behavior (strict vs baseline typecheck, test args, extras)
+- Highlight checks that cannot be fully reproduced via Poe
 
 ## When to use me
 
 - User asks how to run CI checks locally in `ai`
 - User wants the exact local commands before opening/updating a PR
 - User asks about Poe tasks vs CI scripts and where they differ
-- You need to validate one package or all changed packages with CI-like behavior
 
-## Use Instead [if available]
+## Use instead
 
-- Use `ci-fix` when the primary task is diagnosing an already-failed CI run.
-- Use `ruff` for lint/format-only cleanup without CI parity requirements.
-- Use `uv` for dependency/lockfile maintenance not tied to CI parity.
-
-## Example usage
-
-```
-/ci-local-parity
-/ci-local-parity unique_toolkit
-/ci-local-parity changed-packages
-```
+- `ci-fix` — diagnosing an already-failed CI run
+- `ruff` — lint/format-only cleanup without CI parity
+- `uv` — dependency/lockfile maintenance
 
 ---
 
@@ -48,163 +38,91 @@ I run the `ai` repository checks locally with the closest possible parity to PR 
 
 ### Step 0: Preconditions
 
-Run from repository root:
-
-```bash
-cd /Users/aurelgruber/Unique/code/ai
-```
-
-Ensure tooling is available:
+Run from the repo root. Verify tooling:
 
 ```bash
 uv --version
 uv run poe --help
 ```
 
-If `uv` is missing, stop and ask the user to install/repair it before proceeding.
+If `uv` is missing, stop and ask the user to install it.
 
 ---
 
 ### Step 1: Determine target packages
 
-For changed packages in current branch:
-
 ```bash
-BASE_REF=origin/main
 git fetch origin main
-git diff --name-only "$BASE_REF"...HEAD
+git diff --name-only origin/main...HEAD
 ```
 
-Map changed files to package directories using:
+Map changed files to packages using the `dir` field in:
+`.github/actions/get-packages-matrix/package_configuration.json`
 
-- `.github/actions/get-packages-matrix/package_configuration.json`
-
-Treat the `dir` field as canonical package path.
-
-If the user asked for one package, skip auto-detection and use that package directly.
+→ See [references/package-matrix.md](references/package-matrix.md) for the full package list.
 
 ---
 
-### Step 2: Run baseline package checks (CI-like order)
+### Step 2: Run baseline checks (CI order)
 
-Inside each package directory (`cd <package_dir>`), run:
+From inside each package directory:
 
 ```bash
-uv run ruff format --check .
+uv run ruff format --check .   # CI lint = format check + lint check
 uv run poe lint
 uv run poe test
 uv run poe depcheck
 ```
 
-Then run typecheck + coverage per Step 3 and Step 4 (mode differs by package).
-
-Notes:
-
-- CI lint uses both format check and lint check.
-- `poe format` is not equivalent to CI lint because it writes files.
+> `poe format` writes files — it is **not** equivalent to the CI lint step.
 
 ---
 
-### Step 3: Typecheck mode (strict vs baseline)
+### Step 3: Typecheck (strict vs baseline)
 
-Read package behavior from matrix flags:
+Determine mode from `package_configuration.json` flags:
 
-- `typecheck_use_baseline`
-- `typecheck_require_zero_errors`
+- **Strict** (`typecheck_use_baseline: false`, `typecheck_require_zero_errors: true`):
+  ```bash
+  uv run poe typecheck
+  ```
+- **Baseline** (new errors vs `origin/main` only):
+  ```bash
+  uv run poe ci-typecheck
+  # fallback if task missing:
+  bash "$(git rev-parse --show-toplevel)/.github/scripts/dev.sh" typecheck --dir .
+  ```
 
-#### Strict/full mode
-
-Use for packages with `typecheck_use_baseline: false` and for any package requiring zero errors:
-
-- `toolkit`
-- `sdk`
-- `skill_tool`
-
-Command:
-
-```bash
-uv run poe typecheck
-```
-
-#### Baseline mode (new errors vs base)
-
-Use for packages with `typecheck_use_baseline: true`:
-
-```bash
-uv run poe ci-typecheck
-```
-
-This routes to `.github/scripts/dev.sh typecheck` and mirrors CI’s baseline behavior closely.
-
-Fallback if `ci-typecheck` task does not exist in a package:
-
-```bash
-bash "$(git rev-parse --show-toplevel)/.github/scripts/dev.sh" typecheck --dir .
-```
+→ See [references/package-matrix.md](references/package-matrix.md) for per-package mode.
 
 ---
 
-### Step 4: Coverage mode (diff-based parity)
-
-Preferred CI-like command:
+### Step 4: Coverage (diff-based)
 
 ```bash
 uv run poe ci-coverage
-```
-
-Fallback if task missing:
-
-```bash
+# fallback if task missing:
 bash "$(git rev-parse --show-toplevel)/.github/scripts/dev.sh" coverage --dir .
 ```
 
-Full-package (non-diff) coverage when requested:
-
+Full-package (non-diff) coverage:
 ```bash
 uv run poe coverage
 ```
 
 ---
 
-### Step 5: Apply package-specific CI arguments
+### Step 5: Call out CI gaps
 
-From matrix config:
+Some jobs are not reproducible via Poe. Note them explicitly; do not claim full parity.
 
-- `sdk` test args: `-m "not integration"`
-- `toolkit` install extras: `--extra fastapi --extra monitoring` (CI setup behavior)
-
-For SDK parity:
-
-```bash
-uv run poe test -- -m "not integration"
-```
-
-For toolkit parity, if needed before tests/coverage:
-
-```bash
-uv sync --locked --inexact --extra fastapi --extra monitoring
-```
+→ See [references/ci-gaps.md](references/ci-gaps.md) for the full list (min-deps, config-check, PR policy).
 
 ---
 
-### Step 6: CI checks that are not pure Poe parity
+## Quick recipes
 
-Call these out explicitly in summary; do not claim full parity:
-
-- Dependency job (`ci-dependency-checks.yaml`) uses min-deps installation strategy via `.github/actions/run-min-tests-and-deptry` (not the same as `poe depcheck`).
-- Config compatibility job (`ci-config-check.yaml`) uses `unique_toolkit._common.config_checker` export/check flow.
-- PR policy checks:
-  - PR title validation
-  - no-manual-release script
-  - gatekeeper status aggregation
-
-Run these manually only when needed with their underlying scripts/workflows.
-
----
-
-## Package quick recipes
-
-### One package, closest PR-CI parity
+### Any package — closest PR-CI parity
 
 ```bash
 cd <package_dir>
@@ -213,33 +131,27 @@ uv run poe lint
 uv run poe test
 uv run poe depcheck
 uv run poe ci-typecheck || bash "$(git rev-parse --show-toplevel)/.github/scripts/dev.sh" typecheck --dir .
-uv run poe ci-coverage || bash "$(git rev-parse --show-toplevel)/.github/scripts/dev.sh" coverage --dir .
+uv run poe ci-coverage  || bash "$(git rev-parse --show-toplevel)/.github/scripts/dev.sh" coverage  --dir .
 ```
 
-### Strict packages (`toolkit`, `sdk`, `skill_tool`)
+### Strict packages: `unique_toolkit`, `unique_sdk`, `unique_skill_tool`
 
 ```bash
 cd <package_dir>
 uv run ruff format --check .
 uv run poe lint
-uv run poe test
+uv run poe test        # sdk: add -- -m "not integration"
 uv run poe depcheck
 uv run poe typecheck
 uv run poe ci-coverage || bash "$(git rev-parse --show-toplevel)/.github/scripts/dev.sh" coverage --dir .
 ```
 
-For `sdk` test parity:
-
-```bash
-uv run poe test -- -m "not integration"
-```
-
 ---
 
-## Tips for success
+## Tips
 
-1. **Always include `ruff format --check`** for CI lint parity.
-2. **Use matrix flags, not assumptions** for strict vs baseline typecheck mode.
-3. **Prefer `ci-*` Poe tasks** for diff/baseline parity, then fall back to `dev.sh`.
-4. **Do not over-claim parity**: deps/config/policy jobs are only partially reproducible via Poe.
-5. **Run from repo root first** so relative script paths and git base refs work reliably.
+1. Always include `ruff format --check` — CI lint is two commands, not one.
+2. Check the matrix flags; don't assume strict or baseline mode.
+3. Prefer `ci-*` Poe tasks for diff parity; fall back to `dev.sh` when absent.
+4. Never claim full parity — deps/config/policy jobs require manual steps.
+5. Run from the repo root so script paths and git base refs resolve correctly.

--- a/.claude/skills/ci-local-parity/references/ci-gaps.md
+++ b/.claude/skills/ci-local-parity/references/ci-gaps.md
@@ -1,0 +1,49 @@
+# CI checks not fully reproducible via Poe
+
+These jobs run in PR CI but cannot be replicated locally using `poe` tasks.
+Call them out in any summary; never claim full parity.
+
+## Dependency min-deps job (`ci-dependency-checks.yaml`)
+
+CI installs with `--resolution lowest-direct`, reinstalls workspace packages
+from source, then runs deptry and pytest in that environment.
+
+`poe depcheck` only runs `deptry .` in the normal dev environment — it does not
+test against minimum dependency versions.
+
+To reproduce manually from the package dir:
+```bash
+uv venv --python 3.12
+uv pip install -e . --resolution lowest-direct
+# reinstall workspace packages from source (toolkit etc.)
+uv pip install --no-deps -e "$REPO_ROOT/unique_toolkit"
+# install dev tools from root
+uv export --directory "$REPO_ROOT" --frozen --only-group dev --no-hashes | \
+  uv pip install -r -
+.venv/bin/deptry .
+.venv/bin/pytest
+```
+
+## Config compatibility check (`ci-config-check.yaml`)
+
+Exports `unique_toolkit._common.config_checker` defaults from the merge-base,
+then validates the PR tip doesn't introduce breaking config changes.
+
+Runs only on packages that have config checker support:
+`toolkit`, `web_search`, `deep_research`, `swot`, `internal_search`,
+`skill_tool`, `stock_ticker`, `follow_up_questions`, `six`.
+
+No Poe equivalent; run manually from package dir if needed:
+```bash
+uv run python -m unique_toolkit._common.config_checker export --package . --output /tmp/base/
+uv run python -m unique_toolkit._common.config_checker check \
+  --artifacts /tmp/base/ --package . --report-defaults --fail-on-missing
+```
+
+## PR policy checks (CI-only governance)
+
+- **PR title**: semantic PR title format validation (GitHub Action).
+- **No-manual-release**: `bash .github/scripts/check-no-manual-release.sh <base_sha> <head_sha>`
+- **Gatekeeper**: aggregates all job statuses; posts commit status via `gh api`.
+
+These are governance checks; they have no local Poe equivalent.

--- a/.claude/skills/ci-local-parity/references/package-matrix.md
+++ b/.claude/skills/ci-local-parity/references/package-matrix.md
@@ -1,0 +1,65 @@
+# Package matrix reference
+
+Source of truth: `.github/actions/get-packages-matrix/package_configuration.json`
+
+## Typecheck mode per package
+
+| Package dir | `typecheck_use_baseline` | `typecheck_require_zero_errors` | Local command |
+|---|---|---|---|
+| `unique_toolkit` | false | true | `uv run poe typecheck` |
+| `unique_sdk` | false | true | `uv run poe typecheck` |
+| `tool_packages/unique_skill_tool` | false | true | `uv run poe typecheck` |
+| all others | true | false | `uv run poe ci-typecheck` |
+
+**Strict** = no baseline, zero errors required → `poe typecheck`  
+**Baseline** = only new errors vs `origin/main` → `poe ci-typecheck`
+
+## Package-specific test and install args
+
+| Package | test_args | install_args (extras) |
+|---|---|---|
+| `unique_sdk` | `-m "not integration"` | — |
+| `unique_toolkit` | — | `fastapi,monitoring` |
+| all others | — | — |
+
+For SDK test parity:
+```bash
+uv run poe test -- -m "not integration"
+```
+
+For toolkit, if extras are needed before tests or coverage:
+```bash
+uv sync --locked --inexact --extra fastapi --extra monitoring
+```
+
+## Python versions
+
+- `unique_sdk`: Python 3.11
+- all others: Python 3.12
+
+## Coverage threshold
+
+All packages: `min_coverage: 60` (diff-based, new/changed lines only in CI)
+
+## Full package list and dirs
+
+| id | dir |
+|---|---|
+| toolkit | `unique_toolkit` |
+| sdk | `unique_sdk` |
+| mcp | `unique_mcp` |
+| orchestrator | `unique_orchestrator` |
+| web_search | `tool_packages/unique_web_search` |
+| swot | `tool_packages/unique_swot` |
+| follow_up_questions | `postprocessors/unique_follow_up_questions` |
+| stock_ticker | `postprocessors/unique_stock_ticker` |
+| deep_research | `tool_packages/unique_deep_research` |
+| internal_search | `tool_packages/unique_internal_search` |
+| skill_tool | `tool_packages/unique_skill_tool` |
+| quartr | `connectors/unique_quartr` |
+| six | `connectors/unique_six` |
+| search_proxy | `connectors/unique_search_proxy` |
+
+**Notes:**
+- `unique_six` has no `[tool.poe.tasks]` block — call `uv run ruff check .`, `uv run pytest`, `uv run deptry .` directly.
+- `unique_search_proxy` has basic Poe tasks but no `ci-typecheck` / `ci-coverage`.


### PR DESCRIPTION
## Summary
- add a new `ci-local-parity` skill under `.claude/skills` in the `ai` repo
- document the closest local command flow to mirror PR CI checks, including strict vs baseline typecheck behavior per package
- call out known CI gaps that are not fully reproducible via Poe alone

## Test plan
- [x] verify skill file exists at `.claude/skills/ci-local-parity/SKILL.md`
- [x] verify branch diff vs `main` only contains the new skill file
- [ ] optionally invoke the skill in a follow-up chat and validate command suggestions against current workflows

Made with [Cursor](https://cursor.com)