### PR TITLE
fix(unique_toolkit): Fix sub agent progress message italic display

### DIFF
--- a/unique_toolkit/unique_toolkit/agentic/tools/a2a/tool/service.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/a2a/tool/service.py
@@ -198,7 +198,9 @@ class SubAgentTool(Tool[SubAgentToolConfig]):
                 )
 
                 active_message_log = self._create_or_update_message_log(
-                    progress_message=f"_Executing sub agent with input: {tool_input}_",
+                    progress_message=_italicize_multiline(
+                        f"Executing sub agent with input: {tool_input}"
+                    ),
                     active_message_log=active_message_log,
                 )
 
@@ -268,7 +270,9 @@ class SubAgentTool(Tool[SubAgentToolConfig]):
 
                 # Update message log entry to completed
                 active_message_log = self._create_or_update_message_log(
-                    progress_message=f"_Completed sub agent with input: {tool_input}_",
+                    progress_message=_italicize_multiline(
+                        f"Completed sub agent with input: {tool_input}"
+                    ),
                     status=MessageLogStatus.COMPLETED,
                     active_message_log=active_message_log,
                 )
@@ -419,6 +423,10 @@ class SubAgentTool(Tool[SubAgentToolConfig]):
             raise TimeoutError(
                 "Timeout while waiting for response from sub agent. The user should consider increasing the max wait time.",
             ) from e
+
+
+def _italicize_multiline(text: str) -> str:
+    return "\n".join(f"_{line}_" if line else line for line in text.split("\n"))
 
 
 def _format_response(tool_name: str, text: str, system_reminders: list[str]) -> str:

--- a/unique_toolkit/unique_toolkit/agentic/tools/a2a/tool/service.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/a2a/tool/service.py
@@ -198,9 +198,7 @@ class SubAgentTool(Tool[SubAgentToolConfig]):
                 )
 
                 active_message_log = self._create_or_update_message_log(
-                    progress_message=_italicize_multiline(
-                        f"Executing sub agent with input: {tool_input}"
-                    ),
+                    progress_message=f"<em>Executing sub agent with input: {tool_input}</em>",
                     active_message_log=active_message_log,
                 )
 
@@ -270,9 +268,7 @@ class SubAgentTool(Tool[SubAgentToolConfig]):
 
                 # Update message log entry to completed
                 active_message_log = self._create_or_update_message_log(
-                    progress_message=_italicize_multiline(
-                        f"Completed sub agent with input: {tool_input}"
-                    ),
+                    progress_message=f"<em>Completed sub agent with input: {tool_input}</em>",
                     status=MessageLogStatus.COMPLETED,
                     active_message_log=active_message_log,
                 )
@@ -423,10 +419,6 @@ class SubAgentTool(Tool[SubAgentToolConfig]):
             raise TimeoutError(
                 "Timeout while waiting for response from sub agent. The user should consider increasing the max wait time.",
             ) from e
-
-
-def _italicize_multiline(text: str) -> str:
-    return "\n".join(f"_{line}_" if line else line for line in text.split("\n"))
 
 
 def _format_response(tool_name: str, text: str, system_reminders: list[str]) -> str:

--- a/unique_toolkit/unique_toolkit/agentic/tools/a2a/tool/test/test_service_utils.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/a2a/tool/test/test_service_utils.py
@@ -17,7 +17,6 @@ from unique_toolkit.agentic.tools.a2a.tool.config import (
 from unique_toolkit.agentic.tools.a2a.tool.service import (
     _format_response,
     _get_sub_agent_system_reminders,
-    _italicize_multiline,
     _prepare_sub_agent_response_refs,
     _remove_extra_refs,
     _response_has_refs,
@@ -828,25 +827,3 @@ def test_get_sub_agent_system_reminders__captures_all_regexp_matches__in_text_ma
     assert "CODE123" in result[0]
     assert "CODE456" in result[0]
     assert "CODE789" in result[0]
-
-
-class TestItalicizeMultiline:
-    def test_single_line(self):
-        assert _italicize_multiline("hello") == "_hello_"
-
-    def test_multiline_wraps_each_line(self):
-        # Each line must be wrapped individually because markdown italics
-        # do not span newlines.
-        result = _italicize_multiline("line one\nline two\nline three")
-        assert result == "_line one_\n_line two_\n_line three_"
-
-    def test_preserves_blank_lines_without_wrapping(self):
-        # Wrapping an empty line as "__" would render as bold start, not italic.
-        result = _italicize_multiline("first\n\nlast")
-        assert result == "_first_\n\n_last_"
-
-    def test_empty_string(self):
-        assert _italicize_multiline("") == ""
-
-    def test_trailing_newline(self):
-        assert _italicize_multiline("a\n") == "_a_\n"

--- a/unique_toolkit/unique_toolkit/agentic/tools/a2a/tool/test/test_service_utils.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/a2a/tool/test/test_service_utils.py
@@ -17,6 +17,7 @@ from unique_toolkit.agentic.tools.a2a.tool.config import (
 from unique_toolkit.agentic.tools.a2a.tool.service import (
     _format_response,
     _get_sub_agent_system_reminders,
+    _italicize_multiline,
     _prepare_sub_agent_response_refs,
     _remove_extra_refs,
     _response_has_refs,
@@ -827,3 +828,25 @@ def test_get_sub_agent_system_reminders__captures_all_regexp_matches__in_text_ma
     assert "CODE123" in result[0]
     assert "CODE456" in result[0]
     assert "CODE789" in result[0]
+
+
+class TestItalicizeMultiline:
+    def test_single_line(self):
+        assert _italicize_multiline("hello") == "_hello_"
+
+    def test_multiline_wraps_each_line(self):
+        # Each line must be wrapped individually because markdown italics
+        # do not span newlines.
+        result = _italicize_multiline("line one\nline two\nline three")
+        assert result == "_line one_\n_line two_\n_line three_"
+
+    def test_preserves_blank_lines_without_wrapping(self):
+        # Wrapping an empty line as "__" would render as bold start, not italic.
+        result = _italicize_multiline("first\n\nlast")
+        assert result == "_first_\n\n_last_"
+
+    def test_empty_string(self):
+        assert _italicize_multiline("") == ""
+
+    def test_trailing_newline(self):
+        assert _italicize_multiline("a\n") == "_a_\n"


### PR DESCRIPTION
## 🚀 Summary

Fix italic display of sub agent progress reporter when input is multiline

## ✅ Changes

- [x] Added feature / fixed bug / updated docs
- [ ] Refactored code / cleaned up
- [ ] Other (describe below)

## 🧪 Testing
<img width="813" height="702" alt="image" src="https://github.com/user-attachments/assets/baa87457-5b34-4edb-8fec-489774307328" />
