### PR TITLE
feat(unique_toolkit): multiprocess-aware metrics + python_ prefix rename (UN-19849)

### DIFF
--- a/unique_toolkit/tests/monitoring/test_gunicorn.py
+++ b/unique_toolkit/tests/monitoring/test_gunicorn.py
@@ -1,0 +1,33 @@
+"""Tests for unique_toolkit.monitoring.gunicorn module."""
+
+import pytest
+
+pytest.importorskip("prometheus_client")
+
+from unique_toolkit.monitoring.gunicorn import child_exit  # noqa: E402
+
+
+class _FakeWorker:
+    def __init__(self, pid: int) -> None:
+        self.pid = pid
+
+
+@pytest.mark.ai
+def test_child_exit__calls_mark_process_dead__with_worker_pid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Purpose: Verify child_exit calls multiprocess.mark_process_dead with the worker's PID.
+    Why this matters: Without this call, dead workers' .db files accumulate in
+    PROMETHEUS_MULTIPROC_DIR and inflate aggregated metric values on every future scrape.
+    Setup summary: Monkeypatch mark_process_dead, call child_exit with a FakeWorker(pid=12345),
+    assert mark_process_dead was called exactly once with 12345.
+    """
+    import prometheus_client.multiprocess as mp_module
+
+    calls: list[int] = []
+    monkeypatch.setattr(mp_module, "mark_process_dead", lambda pid: calls.append(pid))
+
+    child_exit(server=None, worker=_FakeWorker(pid=12345))
+
+    assert calls == [12345]

--- a/unique_toolkit/tests/monitoring/test_gunicorn.py
+++ b/unique_toolkit/tests/monitoring/test_gunicorn.py
@@ -14,17 +14,18 @@ class _FakeWorker:
 
 @pytest.mark.ai
 def test_child_exit__calls_mark_process_dead__with_worker_pid(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, tmp_path
 ) -> None:
     """
     Purpose: Verify child_exit calls multiprocess.mark_process_dead with the worker's PID.
     Why this matters: Without this call, dead workers' .db files accumulate in
     PROMETHEUS_MULTIPROC_DIR and inflate aggregated metric values on every future scrape.
-    Setup summary: Monkeypatch mark_process_dead, call child_exit with a FakeWorker(pid=12345),
-    assert mark_process_dead was called exactly once with 12345.
+    Setup summary: Set PROMETHEUS_MULTIPROC_DIR, monkeypatch mark_process_dead, call
+    child_exit with a FakeWorker(pid=12345), assert mark_process_dead was called once with 12345.
     """
     import prometheus_client.multiprocess as mp_module
 
+    monkeypatch.setenv("PROMETHEUS_MULTIPROC_DIR", str(tmp_path))
     calls: list[int] = []
     monkeypatch.setattr(mp_module, "mark_process_dead", lambda pid: calls.append(pid))
 

--- a/unique_toolkit/tests/monitoring/test_middleware.py
+++ b/unique_toolkit/tests/monitoring/test_middleware.py
@@ -256,3 +256,28 @@ def test_middleware__uses_custom_excluded_paths__when_provided() -> None:
     middleware = MetricsMiddleware(_simple_app, excluded_paths={"/custom"})
 
     assert middleware._excluded_paths == {"/custom"}
+
+
+# ---------------------------------------------------------------------------
+# Metric naming
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.ai
+def test_middleware__emits_python_prefixed_metric_names() -> None:
+    """
+    Purpose: Verify MetricsMiddleware emits metrics with the python_ prefix.
+    Why this matters: Grafana dashboards are built on python_http_* names; the old
+    unprefixed names must not appear so cross-service naming is consistent.
+    Setup summary: Inspect the module-level metric objects for their fully-qualified name.
+    """
+    assert (
+        middleware_module._http_request_duration_seconds._name
+        == "python_http_request_duration_seconds"
+    )
+    # prometheus_client strips the _total suffix from Counter._name (it appends it at render time)
+    assert middleware_module._http_requests_total._name == "python_http_requests"
+    assert (
+        middleware_module._http_requests_in_progress._name
+        == "python_http_requests_in_progress"
+    )

--- a/unique_toolkit/tests/monitoring/test_multiprocess.py
+++ b/unique_toolkit/tests/monitoring/test_multiprocess.py
@@ -1,0 +1,139 @@
+"""Tests for multiprocess mode in unique_toolkit.monitoring.registry."""
+
+import multiprocessing
+import os
+
+import pytest
+
+pytest.importorskip("prometheus_client")
+
+from unique_toolkit.monitoring.registry import get_metrics  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Worker helper — must be module-level so multiprocessing.spawn can pickle it
+# ---------------------------------------------------------------------------
+
+
+def _worker_write_http_histogram(tmp_dir: str, pid: int) -> None:
+    """Simulate a worker writing HTTP histogram metrics under a fake PID."""
+    os.environ["PROMETHEUS_MULTIPROC_DIR"] = tmp_dir
+
+    from prometheus_client import CollectorRegistry, Histogram, values
+
+    values.ValueClass = values.MultiProcessValue(lambda: pid)
+    registry = CollectorRegistry()
+    h = Histogram(
+        "python_http_request_duration_seconds",
+        "HTTP request duration",
+        ["method", "path"],
+        registry=registry,
+    )
+    h.labels(method="GET", path="/api/test").observe(0.05)
+
+
+def _worker_write_counter(tmp_dir: str, pid: int, count: int) -> None:
+    """Simulate a Gunicorn worker: write `count` increments under a fake PID."""
+    os.environ["PROMETHEUS_MULTIPROC_DIR"] = tmp_dir
+
+    from prometheus_client import CollectorRegistry, Counter, values
+
+    values.ValueClass = values.MultiProcessValue(lambda: pid)
+
+    registry = CollectorRegistry()
+    c = Counter(
+        "test_multiprocess_requests_total",
+        "Test counter for multiprocess aggregation",
+        ["method"],
+        registry=registry,
+    )
+    for _ in range(count):
+        c.labels(method="GET").inc()
+
+
+# ---------------------------------------------------------------------------
+# Two-PID aggregation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.ai
+def test_get_metrics__multiprocess__sums_two_worker_pids(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    Purpose: Verify get_metrics() aggregates per-PID .db files from two simulated workers.
+    Why this matters: Without MultiProcessCollector, scrapes return only one worker's view —
+    the root cause of the sawtooth counter pattern described in UN-19849.
+    Setup summary: Spawn two worker processes each writing to the same PROMETHEUS_MULTIPROC_DIR
+    under distinct fake PIDs, then call get_metrics() and assert the total equals the sum.
+    """
+    monkeypatch.setenv("PROMETHEUS_MULTIPROC_DIR", str(tmp_path))
+
+    ctx = multiprocessing.get_context("spawn")
+
+    # Worker A writes 3 requests; worker B writes 5 requests.
+    p1 = ctx.Process(target=_worker_write_counter, args=(str(tmp_path), 1001, 3))
+    p2 = ctx.Process(target=_worker_write_counter, args=(str(tmp_path), 1002, 5))
+    p1.start()
+    p2.start()
+    p1.join()
+    p2.join()
+
+    assert p1.exitcode == 0, f"Worker 1 failed with exit code {p1.exitcode}"
+    assert p2.exitcode == 0, f"Worker 2 failed with exit code {p2.exitcode}"
+
+    output = get_metrics().decode()
+
+    assert "test_multiprocess_requests_total" in output
+    # Prometheus text format: name{labels} value — the total line is the _total suffix
+    assert 'test_multiprocess_requests_total{method="GET"} 8.0' in output
+
+
+@pytest.mark.ai
+def test_get_metrics__multiprocess__contains_python_http_metric_name(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    Purpose: Verify get_metrics() output contains the renamed python_http_* family.
+    Why this matters: Dashboards and alerts query python_http_request_duration_seconds_*;
+    the old unprefixed name must not appear in the output.
+    Setup summary: Use monkeypatched PROMETHEUS_MULTIPROC_DIR to activate multiprocess path,
+    then check that get_metrics() mentions the new metric family name (from files on disk).
+    """
+    monkeypatch.setenv("PROMETHEUS_MULTIPROC_DIR", str(tmp_path))
+
+    ctx = multiprocessing.get_context("spawn")
+
+    p = ctx.Process(target=_worker_write_http_histogram, args=(str(tmp_path), 2001))
+    p.start()
+    p.join()
+    assert p.exitcode == 0
+
+    output = get_metrics().decode()
+
+    assert "python_http_request_duration_seconds" in output
+    assert "http_request_duration_seconds" not in output.replace(
+        "python_http_request_duration_seconds", ""
+    )
+
+
+# ---------------------------------------------------------------------------
+# Import-order warning
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.ai
+def test_get_metrics__warns__when_env_var_set_after_import(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    Purpose: Verify get_metrics() emits a RuntimeWarning when PROMETHEUS_MULTIPROC_DIR is set
+    after prometheus_client was already imported (import-order violation).
+    Why this matters: Silent misconfiguration causes the sawtooth bug to persist even with
+    the multiprocess flag set. The warning surfaces the problem during development.
+    Setup summary: Set env var after import (the test process already imported prometheus_client),
+    call get_metrics(), assert a RuntimeWarning containing the key phrase is raised.
+    """
+    monkeypatch.setenv("PROMETHEUS_MULTIPROC_DIR", str(tmp_path))
+
+    with pytest.warns(RuntimeWarning, match="imported before the env var"):
+        get_metrics()

--- a/unique_toolkit/tests/monitoring/test_multiprocess.py
+++ b/unique_toolkit/tests/monitoring/test_multiprocess.py
@@ -81,7 +81,11 @@ def test_get_metrics__multiprocess__sums_two_worker_pids(
     assert p1.exitcode == 0, f"Worker 1 failed with exit code {p1.exitcode}"
     assert p2.exitcode == 0, f"Worker 2 failed with exit code {p2.exitcode}"
 
-    output = get_metrics().decode()
+    # The test process imported prometheus_client before PROMETHEUS_MULTIPROC_DIR was set,
+    # so get_metrics() correctly warns about the import-order violation. We acknowledge it
+    # explicitly here so it doesn't leak as an uncaught warning in CI output.
+    with pytest.warns(RuntimeWarning, match="imported before the env var"):
+        output = get_metrics().decode()
 
     assert "test_multiprocess_requests_total" in output
     # Prometheus text format: name{labels} value — the total line is the _total suffix
@@ -108,7 +112,9 @@ def test_get_metrics__multiprocess__contains_python_http_metric_name(
     p.join()
     assert p.exitcode == 0
 
-    output = get_metrics().decode()
+    # Same import-order caveat as the aggregation test above — acknowledge the warning.
+    with pytest.warns(RuntimeWarning, match="imported before the env var"):
+        output = get_metrics().decode()
 
     assert "python_http_request_duration_seconds" in output
     assert "http_request_duration_seconds" not in output.replace(

--- a/unique_toolkit/tests/monitoring/test_registry.py
+++ b/unique_toolkit/tests/monitoring/test_registry.py
@@ -104,6 +104,27 @@ def test_metric_namespace__gauge__registers_with_prefix(
     assert "svc_in_flight" in output
 
 
+@pytest.mark.ai
+def test_metric_namespace__gauge__forwards_multiprocess_mode(
+    fresh_registry: CollectorRegistry,
+) -> None:
+    """
+    Purpose: Verify MetricNamespace.gauge() forwards the multiprocess_mode parameter to prometheus_client.
+    Why this matters: Callers tracking in-flight requests under Gunicorn need livesum semantics;
+    if multiprocess_mode is silently ignored they get incorrect aggregation across workers.
+    Setup summary: Create a gauge with multiprocess_mode="livesum", assert the internal
+    _multiprocess_mode attribute reflects the chosen mode.
+    """
+    from prometheus_client import Gauge
+
+    m = MetricNamespace("svc")
+
+    g = m.gauge("active", "Active", ["label"], multiprocess_mode="livesum")
+
+    assert isinstance(g, Gauge)
+    assert g._multiprocess_mode == "livesum"
+
+
 # ---------------------------------------------------------------------------
 # get_metrics()
 # ---------------------------------------------------------------------------

--- a/unique_toolkit/unique_toolkit/monitoring/gunicorn.py
+++ b/unique_toolkit/unique_toolkit/monitoring/gunicorn.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+
 
 def child_exit(server, worker) -> None:
     """Gunicorn child_exit hook: clean up dead worker's per-PID metric files.
@@ -12,7 +14,11 @@ def child_exit(server, worker) -> None:
     config file whenever a worker process exits. Without this, dead workers'
     .db files accumulate in PROMETHEUS_MULTIPROC_DIR and inflate aggregated
     metric values on every future scrape.
+
+    No-ops when PROMETHEUS_MULTIPROC_DIR is not set (single-process mode).
     """
+    if not os.environ.get("PROMETHEUS_MULTIPROC_DIR"):
+        return
     from prometheus_client import multiprocess  # pyright: ignore[reportMissingImports]
 
     multiprocess.mark_process_dead(worker.pid)

--- a/unique_toolkit/unique_toolkit/monitoring/gunicorn.py
+++ b/unique_toolkit/unique_toolkit/monitoring/gunicorn.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+
+def child_exit(server, worker) -> None:
+    """Gunicorn child_exit hook: clean up dead worker's per-PID metric files.
+
+    Wire this up in gunicorn.conf.py:
+
+        from unique_toolkit.monitoring.gunicorn import child_exit  # noqa: F401
+
+    Gunicorn calls any function named child_exit(server, worker) in the
+    config file whenever a worker process exits. Without this, dead workers'
+    .db files accumulate in PROMETHEUS_MULTIPROC_DIR and inflate aggregated
+    metric values on every future scrape.
+    """
+    from prometheus_client import multiprocess  # pyright: ignore[reportMissingImports]
+
+    multiprocess.mark_process_dead(worker.pid)

--- a/unique_toolkit/unique_toolkit/monitoring/middleware.py
+++ b/unique_toolkit/unique_toolkit/monitoring/middleware.py
@@ -11,22 +11,23 @@ from prometheus_client import (  # pyright: ignore[reportMissingImports]
 from .registry import REGISTRY
 
 _http_requests_total = Counter(
-    "http_requests_total",
+    "python_http_requests_total",
     "Total HTTP requests",
     ["method", "path", "status_code"],
     registry=REGISTRY,
 )
 _http_request_duration_seconds = Histogram(
-    "http_request_duration_seconds",
+    "python_http_request_duration_seconds",
     "HTTP request duration",
     ["method", "path"],
     registry=REGISTRY,
 )
 _http_requests_in_progress = Gauge(
-    "http_requests_in_progress",
+    "python_http_requests_in_progress",
     "In-flight HTTP requests",
     ["method"],
     registry=REGISTRY,
+    multiprocess_mode="livesum",
 )
 
 _DEFAULT_EXCLUDED_PATHS = frozenset({"/health", "/metrics", "/"})

--- a/unique_toolkit/unique_toolkit/monitoring/registry.py
+++ b/unique_toolkit/unique_toolkit/monitoring/registry.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import asyncio
 import functools
+import os
 import time
+import warnings
 from contextlib import contextmanager
-from typing import Any, Callable
+from typing import Any, Callable, Literal
 
 from prometheus_client import (  # pyright: ignore[reportMissingImports]
     CollectorRegistry,
@@ -18,7 +20,36 @@ REGISTRY = CollectorRegistry()
 
 
 def get_metrics() -> bytes:
-    """Returns all registered metrics in Prometheus text format."""
+    """Returns all registered metrics in Prometheus text format.
+
+    In multiprocess mode (PROMETHEUS_MULTIPROC_DIR is set), aggregates
+    per-PID .db files from all Gunicorn workers via MultiProcessCollector.
+    In single-process mode, returns metrics from the in-process REGISTRY.
+
+    NOTE: PROMETHEUS_MULTIPROC_DIR must be set in the shell/entrypoint
+    *before* Python starts. Setting it from Python after prometheus_client
+    has been imported has no effect — metrics will silently bypass per-PID
+    files and this function will emit a warning.
+    """
+    if os.environ.get("PROMETHEUS_MULTIPROC_DIR"):
+        from prometheus_client import (  # pyright: ignore[reportMissingImports]
+            multiprocess,
+            values,
+        )
+
+        if not getattr(values.ValueClass, "_multiprocess", False):
+            warnings.warn(
+                "PROMETHEUS_MULTIPROC_DIR is set but prometheus_client was imported "
+                "before the env var — metrics will silently bypass per-PID files. "
+                "Set PROMETHEUS_MULTIPROC_DIR in the shell/entrypoint before launching Python.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+
+        registry = CollectorRegistry()
+        multiprocess.MultiProcessCollector(registry)
+        return generate_latest(registry)
+
     return generate_latest(REGISTRY)
 
 
@@ -43,8 +74,20 @@ class MetricNamespace:
     def counter(self, name: str, description: str, labels: list[str]) -> Counter:
         return Counter(f"{self._prefix}_{name}", description, labels, registry=REGISTRY)
 
-    def gauge(self, name: str, description: str, labels: list[str]) -> Gauge:
-        return Gauge(f"{self._prefix}_{name}", description, labels, registry=REGISTRY)
+    def gauge(
+        self,
+        name: str,
+        description: str,
+        labels: list[str],
+        multiprocess_mode: Literal["all", "livesum", "liveall", "min", "max"] = "all",
+    ) -> Gauge:
+        return Gauge(
+            f"{self._prefix}_{name}",
+            description,
+            labels,
+            registry=REGISTRY,
+            multiprocess_mode=multiprocess_mode,
+        )
 
 
 @contextmanager

--- a/unique_toolkit/unique_toolkit/monitoring/registry.py
+++ b/unique_toolkit/unique_toolkit/monitoring/registry.py
@@ -79,7 +79,18 @@ class MetricNamespace:
         name: str,
         description: str,
         labels: list[str],
-        multiprocess_mode: Literal["all", "livesum", "liveall", "min", "max"] = "all",
+        multiprocess_mode: Literal[
+            "all",
+            "liveall",
+            "min",
+            "livemin",
+            "max",
+            "livemax",
+            "sum",
+            "livesum",
+            "mostrecent",
+            "livemostrecent",
+        ] = "all",
     ) -> Gauge:
         return Gauge(
             f"{self._prefix}_{name}",


### PR DESCRIPTION
Fix sawtooth counter pattern in Gunicorn deployments and align metric naming with Node services.

- `get_metrics()` uses `MultiProcessCollector` when `PROMETHEUS_MULTIPROC_DIR` is set, aggregating per-PID `.db` files across workers instead of returning one worker's in-process registry
- HTTP metrics renamed: `http_*` → `python_http_*` (parity with `nestjs_http_server_*`)
- `Gauge` gets `multiprocess_mode="livesum"` for correct in-flight request aggregation across workers
- New `unique_toolkit.monitoring.gunicorn.child_exit` hook cleans up dead workers' `.db` files
- `MetricNamespace.gauge()` gains a `Literal`-typed `multiprocess_mode` parameter

Monorepo wiring (`entrypoint.sh`, `gunicorn.conf.py`, helm values) is a separate PR.