### PR TITLE
fix(ci): drop ${version} from release-please group-pull-request-title-pattern

### DIFF
--- a/.github/scripts/cut-release-branch.sh
+++ b/.github/scripts/cut-release-branch.sh
@@ -67,8 +67,19 @@ fi
 
 SHA=$(git rev-list -n 1 "refs/tags/${TAG}")
 
-if git ls-remote --heads "$REMOTE" "$BRANCH" | grep -qF "$BRANCH"; then
-  echo "::error::branch ${BRANCH} already exists on ${REMOTE}" >&2
+# Idempotent: if the branch already exists on the remote, treat as success
+# when it's already at the target SHA. This lets cd-release re-runs and
+# manual recovery flows converge without operator intervention. We only
+# error if the existing branch points at a different SHA, since that would
+# silently mask a divergence between the manual cut and what the sentinel
+# tag pins.
+EXISTING_SHA=$(git ls-remote --heads "$REMOTE" "$BRANCH" | awk '{print $1}')
+if [[ -n "$EXISTING_SHA" ]]; then
+  if [[ "$EXISTING_SHA" == "$SHA" ]]; then
+    echo "Branch ${BRANCH} already at ${SHA} — nothing to do."
+    exit 0
+  fi
+  echo "::error::branch ${BRANCH} exists on ${REMOTE} at ${EXISTING_SHA}, but tag ${TAG} pins ${SHA}" >&2
   exit 1
 fi
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "python",
   "separate-pull-requests": false,
-  "group-pull-request-title-pattern": "chore: stable release ${version}",
+  "group-pull-request-title-pattern": "chore: stable release ${branch}",
   "include-component-in-tag": true,
   "include-v-in-tag": true,
   "tag-separator": "-",

--- a/release-please-config.release.json
+++ b/release-please-config.release.json
@@ -3,7 +3,7 @@
   "release-type": "python",
   "versioning": "always-bump-patch",
   "separate-pull-requests": false,
-  "group-pull-request-title-pattern": "chore: hotfix ${branch} to ${version}",
+  "group-pull-request-title-pattern": "chore: hotfix ${branch}",
   "include-component-in-tag": true,
   "include-v-in-tag": true,
   "tag-separator": "-",


### PR DESCRIPTION
## Why

release-please-action@v4.4.1 cannot render `${version}` for grouped PRs (even with the `linked-versions` plugin) and substitutes it with an empty string. The resulting title — e.g. `chore: stable release` instead of `chore: stable release 2026.20.0` — fails the title parser when `createReleases()` reverse-parses it after merge with `✖ Bad pull request title`. The release PR is then accepted into main but no tags or GitHub releases are ever created, leaving the `autorelease: pending` label stuck and skipping the `cut-and-arm` job that depends on `releases_created=true`.

**Symptom on this repo (cycle 2026.20):**
- PR #1509 merged 2026-05-08 with title `chore: stable release` (no version)
- No `<component>-v2026.20.0` tags or GitHub releases were produced
- No `release/2026.20` branch was cut by automation (created manually as a hotfix)
- No `Release-As: 2026.22.0` arm commit was pushed
- Wheels were published manually via `cd-publish.yaml` `workflow_dispatch`

The same bug recurred on the release branch (PR #1659: `chore: hotfix release/2026.20 to`).

## What

- Switch the grouped title patterns to use `${branch}` instead of `${version}`, which release-please always substitutes correctly:
  - main: `chore: stable release main`
  - release: `chore: hotfix release/YYYY.WW`
- Make `cut-release-branch.sh` idempotent so cd-release re-runs and manual recoveries converge: if the release branch already exists at the SHA the sentinel tag pins, treat as success; only error when the existing branch points elsewhere (silent divergence between a manual cut and the tagged SHA would otherwise be masked).

## Recovery sequence after merge

1. Rename PR #1509 to `chore: stable release main` (manual one-off — title pattern only fixes future PRs).
2. Re-run `cd-release` on the merge SHA `8e11d463a`. release-please will then create the 13 missing v2026.20.0 tags + GitHub releases, flip #1509's label to `autorelease: tagged`, and `cut-and-arm` will run (idempotent cut → no-op; arm-next pushes `Release-As: 2026.22.0`).
3. Rename PR #1659 to `chore: hotfix release/2026.20`. Next push to `release/2026.20` will then process it correctly.

## Notes

- The 13 v2026.20.0 GitHub releases that release-please creates in step 2 will trigger `cd-publish.yaml`. Those publish runs will harmlessly fail with PyPI's "version already exists" because the wheels were already published manually. This is expected and idempotent.


Made with [Cursor](https://cursor.com)