### PR TITLE
fix(ci): drop ${version} from release-please group-pull-request-title-pattern

### DIFF
--- a/.github/scripts/cut-release-branch.sh
+++ b/.github/scripts/cut-release-branch.sh
@@ -67,8 +67,19 @@ fi
 
 SHA=$(git rev-list -n 1 "refs/tags/${TAG}")
 
-if git ls-remote --heads "$REMOTE" "$BRANCH" | grep -qF "$BRANCH"; then
-  echo "::error::branch ${BRANCH} already exists on ${REMOTE}" >&2
+# Idempotent: if the branch already exists on the remote, treat as success
+# when it's already at the target SHA. This lets cd-release re-runs and
+# manual recovery flows converge without operator intervention. We only
+# error if the existing branch points at a different SHA, since that would
+# silently mask a divergence between the manual cut and what the sentinel
+# tag pins.
+EXISTING_SHA=$(git ls-remote --heads "$REMOTE" "$BRANCH" | awk '{print $1}')
+if [[ -n "$EXISTING_SHA" ]]; then
+  if [[ "$EXISTING_SHA" == "$SHA" ]]; then
+    echo "Branch ${BRANCH} already at ${SHA} — nothing to do."
+    exit 0
+  fi
+  echo "::error::branch ${BRANCH} exists on ${REMOTE} at ${EXISTING_SHA}, but tag ${TAG} pins ${SHA}" >&2
   exit 1
 fi
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "python",
   "separate-pull-requests": false,
-  "group-pull-request-title-pattern": "chore: stable release ${version}",
+  "group-pull-request-title-pattern": "chore: stable release ${branch}",
   "include-component-in-tag": true,
   "include-v-in-tag": true,
   "tag-separator": "-",

--- a/release-please-config.release.json
+++ b/release-please-config.release.json
@@ -3,7 +3,7 @@
   "release-type": "python",
   "versioning": "always-bump-patch",
   "separate-pull-requests": false,
-  "group-pull-request-title-pattern": "chore: hotfix ${branch} to ${version}",
+  "group-pull-request-title-pattern": "chore: hotfix ${branch}",
   "include-component-in-tag": true,
   "include-v-in-tag": true,
   "tag-separator": "-",


### PR DESCRIPTION
Backport of #1660 to `release/2026.20`.

## Why

`release/2026.20` was cut from `8e11d463a` *before* the title-pattern fix landed on main, so its `release-please-config.release.json` still uses the broken `chore: hotfix ${branch} to ${version}`. release-please-action@v4.4.1 renders `${version}` as empty for grouped PRs (even with `linked-versions`), so the title becomes `chore: hotfix release/2026.20 to ` — the same parse-failure that broke the main-branch v2026.20.0 release on #1509.

Symptom on this branch: open PR #1659 had title `chore: hotfix release/2026.20 to` (renamed manually to `chore: hotfix release/2026.20` so it'll match the new pattern after this lands).

## What

Identical fix to #1660:

- `release-please-config.release.json`: `chore: hotfix ${branch} to ${version}` → `chore: hotfix ${branch}`
- `release-please-config.json`: same `${branch}` change so the file stays in sync if a follow-up cycle ever re-cuts from this branch.
- `cut-release-branch.sh`: idempotent (no-op if branch already exists at the target SHA).

## After merge

`cd-release` will run on `release/2026.20`, find #1659 with the new (parseable) title and the new config, and process it normally if/when a hotfix is merged. No state is currently broken on this branch — this is preventative for the next hotfix.

Made with [Cursor](https://cursor.com)