### PR TITLE
feat(unique_orchestrator): Allow configuration of UploadedSearch Tool

### DIFF
--- a/tool_packages/unique_internal_search/tests/test_uploaded_search_service.py
+++ b/tool_packages/unique_internal_search/tests/test_uploaded_search_service.py
@@ -77,7 +77,7 @@ class TestUploadedSearchTool:
     """Tests for UploadedSearchTool class."""
 
     @pytest.mark.ai
-    def test_tool_description_for_system_prompt__returns_formatted_prompt__with_valid_documents_only(
+    def test_tool_description_for_system_prompt__returns_formatted_prompt__with_searchable_documents_only(
         self,
         uploaded_search_config: UploadedSearchConfig,
         mock_chat_event: ChatEvent,
@@ -85,9 +85,9 @@ class TestUploadedSearchTool:
         mock_tool_progress_reporter: ToolProgressReporter,
     ) -> None:
         """
-        Purpose: Verify tool_description_for_system_prompt returns formatted prompt with valid documents listed.
+        Purpose: Verify tool_description_for_system_prompt returns formatted prompt with searchable documents listed.
         Why this matters: Ensures the system prompt includes information about available uploaded documents.
-        Setup summary: Mock ContentService to return valid documents only, verify formatted output.
+        Setup summary: Mock ContentService to return searchable documents only, verify formatted output.
         """
         # Arrange
         with (
@@ -177,9 +177,9 @@ class TestUploadedSearchTool:
         mock_tool_progress_reporter: ToolProgressReporter,
     ) -> None:
         """
-        Purpose: Verify tool_description_for_system_prompt lists only valid documents when uploads are mixed.
+        Purpose: Verify tool_description_for_system_prompt lists only searchable documents when uploads are mixed.
         Why this matters: Expired uploads must not appear alongside searchable documents.
-        Setup summary: Mock ContentService to return mixed documents, verify only valid documents appear.
+        Setup summary: Mock ContentService to return mixed documents, verify only searchable documents appear.
         """
         # Arrange
         with (
@@ -395,12 +395,12 @@ class TestUploadedSearchTool:
             # Assert
             assert "Still Valid" in result
             assert "Just Expired" not in result
-            valid_section_start = result.find(
+            searchable_section_start = result.find(
                 "**The currently uploaded and searchable documents are the following**"
             )
             still_valid_pos = result.find("Still Valid")
 
-            assert valid_section_start < still_valid_pos
+            assert searchable_section_start < still_valid_pos
 
     @pytest.mark.ai
     def test_tool_description_for_system_prompt__formats_multiple_documents_with_newlines(
@@ -442,12 +442,12 @@ class TestUploadedSearchTool:
             assert "- Q2 Financial Report (content_id: doc_1)" in result
             assert "- policy_document.pdf (content_id: doc_2)" in result
             # Verify documents are on separate lines by checking the searchable documents section
-            valid_section = result.split(
+            searchable_section = result.split(
                 "**The currently uploaded and searchable documents are the following**"
             )[1]
             # Make sure both documents appear in the searchable section
-            assert "Q2 Financial Report" in valid_section
-            assert "policy_document.pdf" in valid_section
+            assert "Q2 Financial Report" in searchable_section
+            assert "policy_document.pdf" in searchable_section
 
     @pytest.mark.ai
     def test_display_name__returns_uploaded_search(
@@ -643,7 +643,7 @@ class TestToolDescriptionForSystemPromptIngestionFilter:
         return tool
 
     @pytest.mark.ai
-    def test_skip_ingestion_doc_excluded_from_valid_section(
+    def test_skip_ingestion_doc_excluded_from_searchable_section(
         self,
         uploaded_search_config: UploadedSearchConfig,
         mock_chat_event,
@@ -653,10 +653,10 @@ class TestToolDescriptionForSystemPromptIngestionFilter:
         Purpose: Verify that a doc with SKIP_INGESTION mode does not appear in
                  the searchable documents section of the system prompt.
         Why this matters: Non-ingested docs cannot be searched, so surfacing them
-                          as "valid" would mislead the model into attempting searches
+                          as searchable would mislead the model into attempting searches
                           that would return no results.
         Setup summary: Create a Content with SKIP_INGESTION applied_ingestion_config
-                       and expired_at=None; assert neither the doc name nor the valid
+                       and expired_at=None; assert neither the doc name nor the searchable
                        section header appears in the rendered prompt.
         """
         skip_doc = Content(
@@ -692,7 +692,7 @@ class TestToolDescriptionForSystemPromptIngestionFilter:
         Purpose: Verify that ingested docs still appear in the prompt when mixed
                  with non-ingested (SKIP_INGESTION) docs.
         Why this matters: The ingestion filter must only suppress non-ingested docs —
-                          valid ingested docs must remain visible.
+                          searchable ingested docs must remain visible.
         Setup summary: Mix one SKIP_INGESTION doc with one normally-ingested doc
                        (applied_ingestion_config=None); assert only the ingested doc
                        appears in the searchable section.

--- a/tool_packages/unique_internal_search/tests/test_uploaded_search_service.py
+++ b/tool_packages/unique_internal_search/tests/test_uploaded_search_service.py
@@ -1,7 +1,8 @@
 from datetime import datetime, timedelta, timezone
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from unique_toolkit.agentic.tools.schemas import ToolCallResponse
 from unique_toolkit.agentic.tools.tool_progress_reporter import ToolProgressReporter
 from unique_toolkit.app.schemas import ChatEvent
 from unique_toolkit.content.schemas import Content
@@ -125,7 +126,7 @@ class TestUploadedSearchTool:
             assert "You can use the UploadedSearch tool" in result
 
     @pytest.mark.ai
-    def test_tool_description_for_system_prompt__returns_formatted_prompt__with_expired_documents_only(
+    def test_tool_description_for_system_prompt__omits_expired_documents(
         self,
         uploaded_search_config: UploadedSearchConfig,
         mock_chat_event: ChatEvent,
@@ -133,9 +134,9 @@ class TestUploadedSearchTool:
         mock_tool_progress_reporter: ToolProgressReporter,
     ) -> None:
         """
-        Purpose: Verify tool_description_for_system_prompt returns formatted prompt with expired documents listed.
-        Why this matters: Ensures the system knows which documents are expired and unavailable.
-        Setup summary: Mock ContentService to return expired documents only, verify formatted output.
+        Purpose: Verify tool_description_for_system_prompt omits expired documents from the prompt.
+        Why this matters: Expired uploads should not be surfaced as searchable context.
+        Setup summary: Mock ContentService to return expired documents only, verify they are absent.
         """
         # Arrange
         with (
@@ -160,15 +161,12 @@ class TestUploadedSearchTool:
             result = tool.tool_description_for_system_prompt()
 
             # Assert
-            assert (
-                "**The currently uploaded and expired documents are the following**"
-                in result
-            )
-            assert "Old Report (content_id: doc_expired_1)" in result
+            assert "Old Report (content_id: doc_expired_1)" not in result
             assert (
                 "**The currently uploaded and valid documents are the following**"
                 not in result
             )
+            assert "You can use the UploadedSearch tool" in result
 
     @pytest.mark.ai
     def test_tool_description_for_system_prompt__returns_formatted_prompt__with_mixed_documents(
@@ -179,9 +177,9 @@ class TestUploadedSearchTool:
         mock_tool_progress_reporter: ToolProgressReporter,
     ) -> None:
         """
-        Purpose: Verify tool_description_for_system_prompt correctly separates valid and expired documents.
-        Why this matters: Ensures proper categorization when both valid and expired documents exist.
-        Setup summary: Mock ContentService to return mixed documents, verify both sections present.
+        Purpose: Verify tool_description_for_system_prompt lists only valid documents when uploads are mixed.
+        Why this matters: Expired uploads must not appear alongside searchable documents.
+        Setup summary: Mock ContentService to return mixed documents, verify only valid documents appear.
         """
         # Arrange
         with (
@@ -212,11 +210,7 @@ class TestUploadedSearchTool:
             )
             assert "Valid Document (content_id: doc_valid_1)" in result
             assert "another_valid.pdf (content_id: doc_valid_2)" in result
-            assert (
-                "**The currently uploaded and expired documents are the following**"
-                in result
-            )
-            assert "Expired Document (content_id: doc_expired_1)" in result
+            assert "Expired Document (content_id: doc_expired_1)" not in result
 
     @pytest.mark.ai
     def test_tool_description_for_system_prompt__returns_base_prompt__with_no_documents(
@@ -254,10 +248,6 @@ class TestUploadedSearchTool:
             assert "You can use the UploadedSearch tool" in result
             assert (
                 "**The currently uploaded and valid documents are the following**"
-                not in result
-            )
-            assert (
-                "**The currently uploaded and expired documents are the following**"
                 not in result
             )
 
@@ -404,21 +394,13 @@ class TestUploadedSearchTool:
 
             # Assert
             assert "Still Valid" in result
-            assert "Just Expired" in result
-            # Verify they are in the correct sections
+            assert "Just Expired" not in result
             valid_section_start = result.find(
                 "**The currently uploaded and valid documents are the following**"
             )
-            expired_section_start = result.find(
-                "**The currently uploaded and expired documents are the following**"
-            )
             still_valid_pos = result.find("Still Valid")
-            just_expired_pos = result.find("Just Expired")
 
-            # "Still Valid" should appear after valid section header and before expired section
-            assert valid_section_start < still_valid_pos < expired_section_start
-            # "Just Expired" should appear after expired section header
-            assert expired_section_start < just_expired_pos
+            assert valid_section_start < still_valid_pos
 
     @pytest.mark.ai
     def test_tool_description_for_system_prompt__formats_multiple_documents_with_newlines(
@@ -543,13 +525,99 @@ class TestUploadedSearchTool:
         assert UploadedSearchTool._display_name == "Uploaded Search"
         assert hasattr(UploadedSearchTool, "_display_name")
 
+    @pytest.mark.ai
+    @pytest.mark.asyncio
+    async def test_run__overrides_internal_search_system_reminder__when_enabled(
+        self,
+        uploaded_search_config: UploadedSearchConfig,
+        mock_chat_event: ChatEvent,
+    ) -> None:
+        """
+        Purpose: Verify run replaces the internal-search reminder with the uploaded-search reminder by default.
+        Why this matters: Preserves current uploaded-search behavior unless the new toggle is disabled.
+        Setup summary: Mock internal search to return a reminder, run the tool, and assert uploaded-search text is used.
+        """
+        # Arrange
+        with patch(
+            "unique_internal_search.uploaded_search.service.ContentService"
+        ) as mock_content_service_class:
+            mock_content_service = Mock(spec=ContentService)
+            mock_content_service.get_documents_uploaded_to_chat = Mock(return_value=[])
+            mock_content_service_class.from_event.return_value = mock_content_service
+
+            tool = UploadedSearchTool(
+                config=uploaded_search_config,
+                event=mock_chat_event,
+                tool_progress_reporter=None,
+            )
+            tool._internal_search_tool.run = AsyncMock(
+                return_value=ToolCallResponse(
+                    id="tool_call_123",
+                    name="InternalSearch",
+                    system_reminder="Internal reminder",
+                )
+            )
+            tool_call = Mock()
+            tool_call.arguments = {"search_string": "test query"}
+
+            # Act
+            result = await tool.run(tool_call)
+
+            # Assert
+            assert result.name == "UploadedSearch"
+            assert "automatically executed to retrieve" in result.system_reminder
+            assert "Internal reminder" not in result.system_reminder
+
+    @pytest.mark.ai
+    @pytest.mark.asyncio
+    async def test_run__preserves_internal_search_system_reminder__when_disabled(
+        self,
+        uploaded_search_config: UploadedSearchConfig,
+        mock_chat_event: ChatEvent,
+    ) -> None:
+        """
+        Purpose: Verify run keeps the internal-search reminder when the uploaded-search reminder is disabled.
+        Why this matters: Disabling the uploaded-search reminder should not discard configured InternalSearch reminders.
+        Setup summary: Disable the toggle, mock internal search to return a reminder, and assert it remains unchanged.
+        """
+        # Arrange
+        uploaded_search_config.enable_tool_call_system_reminder = False
+        with patch(
+            "unique_internal_search.uploaded_search.service.ContentService"
+        ) as mock_content_service_class:
+            mock_content_service = Mock(spec=ContentService)
+            mock_content_service.get_documents_uploaded_to_chat = Mock(return_value=[])
+            mock_content_service_class.from_event.return_value = mock_content_service
+
+            tool = UploadedSearchTool(
+                config=uploaded_search_config,
+                event=mock_chat_event,
+                tool_progress_reporter=None,
+            )
+            tool._internal_search_tool.run = AsyncMock(
+                return_value=ToolCallResponse(
+                    id="tool_call_123",
+                    name="InternalSearch",
+                    system_reminder="Internal reminder",
+                )
+            )
+            tool_call = Mock()
+            tool_call.arguments = {"search_string": "test query"}
+
+            # Act
+            result = await tool.run(tool_call)
+
+            # Assert
+            assert result.name == "UploadedSearch"
+            assert result.system_reminder == "Internal reminder"
+
 
 @pytest.mark.ai
 class TestToolDescriptionForSystemPromptIngestionFilter:
     """Tests for ingestion filtering in tool_description_for_system_prompt.
 
     Docs whose is_ingested() returns False (e.g. SKIP_INGESTION mode) must be
-    excluded from both the valid and expired document lists in the system prompt.
+    excluded from the valid document list in the system prompt.
     """
 
     def _make_tool(
@@ -610,46 +678,6 @@ class TestToolDescriptionForSystemPromptIngestionFilter:
         assert "Skipped Document" not in result
         assert (
             "**The currently uploaded and valid documents are the following**"
-            not in result
-        )
-
-    @pytest.mark.ai
-    def test_skip_ingestion_doc_excluded_from_expired_section(
-        self,
-        uploaded_search_config: UploadedSearchConfig,
-        mock_chat_event,
-        mock_tool_progress_reporter,
-    ) -> None:
-        """
-        Purpose: Verify that a doc with SKIP_INGESTION mode does not appear in
-                 the expired documents section even when its expired_at is in the past.
-        Why this matters: Docs skipped from ingestion should be invisible in all
-                          sections of the system prompt regardless of their expiry state.
-        Setup summary: Create a Content with SKIP_INGESTION and a past expired_at;
-                       assert the doc name and the expired section header are absent.
-        """
-        now = datetime.now(timezone.utc)
-        past_expiry = now - timedelta(days=1)
-
-        skip_expired_doc = Content(
-            id="skip_expired_1",
-            key="skip_expired.pdf",
-            title="Skipped Expired Document",
-            expired_at=past_expiry,
-            applied_ingestion_config={"uniqueIngestionMode": "SKIP_INGESTION"},
-        )
-
-        tool = self._make_tool(
-            [skip_expired_doc],
-            uploaded_search_config,
-            mock_chat_event,
-            mock_tool_progress_reporter,
-        )
-        result = tool.tool_description_for_system_prompt()
-
-        assert "Skipped Expired Document" not in result
-        assert (
-            "**The currently uploaded and expired documents are the following**"
             not in result
         )
 

--- a/tool_packages/unique_internal_search/tests/test_uploaded_search_service.py
+++ b/tool_packages/unique_internal_search/tests/test_uploaded_search_service.py
@@ -113,7 +113,7 @@ class TestUploadedSearchTool:
 
             # Assert
             assert (
-                "**The currently uploaded and valid documents are the following**"
+                "**The currently uploaded and searchable documents are the following**"
                 in result
             )
             assert "Q2 Financial Report (content_id: doc_1)" in result
@@ -163,7 +163,7 @@ class TestUploadedSearchTool:
             # Assert
             assert "Old Report (content_id: doc_expired_1)" not in result
             assert (
-                "**The currently uploaded and valid documents are the following**"
+                "**The currently uploaded and searchable documents are the following**"
                 not in result
             )
             assert "You can use the UploadedSearch tool" in result
@@ -205,7 +205,7 @@ class TestUploadedSearchTool:
 
             # Assert
             assert (
-                "**The currently uploaded and valid documents are the following**"
+                "**The currently uploaded and searchable documents are the following**"
                 in result
             )
             assert "Valid Document (content_id: doc_valid_1)" in result
@@ -247,7 +247,7 @@ class TestUploadedSearchTool:
             # Assert
             assert "You can use the UploadedSearch tool" in result
             assert (
-                "**The currently uploaded and valid documents are the following**"
+                "**The currently uploaded and searchable documents are the following**"
                 not in result
             )
 
@@ -396,7 +396,7 @@ class TestUploadedSearchTool:
             assert "Still Valid" in result
             assert "Just Expired" not in result
             valid_section_start = result.find(
-                "**The currently uploaded and valid documents are the following**"
+                "**The currently uploaded and searchable documents are the following**"
             )
             still_valid_pos = result.find("Still Valid")
 
@@ -441,11 +441,11 @@ class TestUploadedSearchTool:
             # Verify bullet points are present
             assert "- Q2 Financial Report (content_id: doc_1)" in result
             assert "- policy_document.pdf (content_id: doc_2)" in result
-            # Verify documents are on separate lines by checking the valid documents section
+            # Verify documents are on separate lines by checking the searchable documents section
             valid_section = result.split(
-                "**The currently uploaded and valid documents are the following**"
+                "**The currently uploaded and searchable documents are the following**"
             )[1]
-            # Make sure both documents appear in the valid section
+            # Make sure both documents appear in the searchable section
             assert "Q2 Financial Report" in valid_section
             assert "policy_document.pdf" in valid_section
 
@@ -617,7 +617,7 @@ class TestToolDescriptionForSystemPromptIngestionFilter:
     """Tests for ingestion filtering in tool_description_for_system_prompt.
 
     Docs whose is_ingested() returns False (e.g. SKIP_INGESTION mode) must be
-    excluded from the valid document list in the system prompt.
+    excluded from the searchable document list in the system prompt.
     """
 
     def _make_tool(
@@ -651,7 +651,7 @@ class TestToolDescriptionForSystemPromptIngestionFilter:
     ) -> None:
         """
         Purpose: Verify that a doc with SKIP_INGESTION mode does not appear in
-                 the valid documents section of the system prompt.
+                 the searchable documents section of the system prompt.
         Why this matters: Non-ingested docs cannot be searched, so surfacing them
                           as "valid" would mislead the model into attempting searches
                           that would return no results.
@@ -677,7 +677,7 @@ class TestToolDescriptionForSystemPromptIngestionFilter:
 
         assert "Skipped Document" not in result
         assert (
-            "**The currently uploaded and valid documents are the following**"
+            "**The currently uploaded and searchable documents are the following**"
             not in result
         )
 
@@ -695,7 +695,7 @@ class TestToolDescriptionForSystemPromptIngestionFilter:
                           valid ingested docs must remain visible.
         Setup summary: Mix one SKIP_INGESTION doc with one normally-ingested doc
                        (applied_ingestion_config=None); assert only the ingested doc
-                       appears in the valid section.
+                       appears in the searchable section.
         """
         skip_doc = Content(
             id="skip_2",
@@ -723,5 +723,6 @@ class TestToolDescriptionForSystemPromptIngestionFilter:
         assert "Ingested File (content_id: ingested_1)" in result
         assert "Skipped File" not in result
         assert (
-            "**The currently uploaded and valid documents are the following**" in result
+            "**The currently uploaded and searchable documents are the following**"
+            in result
         )

--- a/tool_packages/unique_internal_search/unique_internal_search/uploaded_search/config.py
+++ b/tool_packages/unique_internal_search/unique_internal_search/uploaded_search/config.py
@@ -1,5 +1,7 @@
 from typing import Annotated
 
+from pydantic import Field
+from pydantic.json_schema import SkipJsonSchema
 from unique_toolkit._common.pydantic.rjsf_tags import RJSFMetaTag
 
 from unique_internal_search.config import InternalSearchConfig
@@ -50,4 +52,10 @@ class UploadedSearchConfig(InternalSearchConfig):
     ] = get_string_field_with_pattern_validation(
         DEFAULT_TOOL_FORMAT_INFORMATION_FOR_SYSTEM_PROMPT,
         description="Tool format information for the system prompt.",
+    )
+    # This is a hack to ensure that the system reminder is enabled when the tool is forced,
+    # as we cannot at the moment easily pass extra values to the tool constructor
+    enable_tool_call_system_reminder: SkipJsonSchema[bool] = Field(
+        default=True,
+        description="Whether to attach the uploaded-search system reminder to tool responses.",
     )

--- a/tool_packages/unique_internal_search/unique_internal_search/uploaded_search/prompts/__init__.py
+++ b/tool_packages/unique_internal_search/unique_internal_search/uploaded_search/prompts/__init__.py
@@ -1,18 +1,11 @@
-DEFAULT_TOOL_DESCRIPTION_FOR_SYSTEM_PROMPT = (
-    "You can use the UploadedSearch tool to access and analyze documents uploaded by users during a chat. This tool is designed to handle a variety of document-related tasks, including summarization, explanation, and detailed information retrieval. "
-    "Use cases for the UploadedSearch tool include:\n"
-    "- Document Analysis: When a user uploads a document and asks for a summary, explanation, or specific details, this tool can extract and provide the requested information.\n"
-    "- Named Document Queries: If a user refers to a previously uploaded document by name (e.g., 'What does the Q2_Report.pdf say about revenue?'), this tool can locate and analyze the document to answer the query.\n"
-    "- Policy and Procedure Verification: Use the tool to find the most current company policies, procedures, or guidelines within uploaded documents.\n"
-    "- Project-Specific Information: Access project documents, reports, or meeting notes uploaded by users to provide precise details.\n"
-    "- Confidential and Proprietary Information: Ensure that sensitive topics requiring proprietary knowledge or confidential data are sourced securely from uploaded documents.\n\n"
-    "**Instruction Query Splitting**\n"
-    "You should split the user question into multiple search strings when the user's question needs to be decomposed / rewritten to find different facts. Perform an individual tool call for each search string. Avoid overly broad queries that may return unrelated results. Ensure the search string is specific and relevant to the uploaded document(s).\n\n"
-    "Examples:\n"
-    'User: "What does the Q2_Report.pdf say about revenue and expenses?" => search strings: ["Q2_Report.pdf revenue", "Q2_Report.pdf expenses"]\n'
-    'User: "Summarize the uploaded document." => search string: ["Summarize the uploaded document"]\n\n'
-    "{system_prompt_valid_documents}"
-    "{system_prompt_expired_documents}"
+from pathlib import Path
+
+from unique_toolkit._common.utils.jinja.helpers import load_template
+
+_PROMPTS_DIR = Path(__file__).parent
+
+DEFAULT_TOOL_DESCRIPTION_FOR_SYSTEM_PROMPT = load_template(
+    _PROMPTS_DIR, "tool_description_for_system_prompt.j2"
 )
 
 DEFAULT_TOOL_FORMAT_INFORMATION_FOR_SYSTEM_PROMPT = (

--- a/tool_packages/unique_internal_search/unique_internal_search/uploaded_search/prompts/tool_description_for_system_prompt.j2
+++ b/tool_packages/unique_internal_search/unique_internal_search/uploaded_search/prompts/tool_description_for_system_prompt.j2
@@ -1,0 +1,21 @@
+You can use the UploadedSearch tool to access and analyze documents uploaded by users during a chat. This tool is designed to handle a variety of document-related tasks, including summarization, explanation, and detailed information retrieval. Use cases for the UploadedSearch tool include:
+- Document Analysis: When a user uploads a document and asks for a summary, explanation, or specific details, this tool can extract and provide the requested information.
+- Named Document Queries: If a user refers to a previously uploaded document by name (e.g., 'What does the Q2_Report.pdf say about revenue?'), this tool can locate and analyze the document to answer the query.
+- Policy and Procedure Verification: Use the tool to find the most current company policies, procedures, or guidelines within uploaded documents.
+- Project-Specific Information: Access project documents, reports, or meeting notes uploaded by users to provide precise details.
+- Confidential and Proprietary Information: Ensure that sensitive topics requiring proprietary knowledge or confidential data are sourced securely from uploaded documents.
+
+**Instruction Query Splitting**
+You should split the user question into multiple search strings when the user's question needs to be decomposed / rewritten to find different facts. Perform an individual tool call for each search string. Avoid overly broad queries that may return unrelated results. Ensure the search string is specific and relevant to the uploaded document(s).
+
+Examples:
+User: "What does the Q2_Report.pdf say about revenue and expenses?" => search strings: ["Q2_Report.pdf revenue", "Q2_Report.pdf expenses"]
+User: "Summarize the uploaded document." => search string: ["Summarize the uploaded document"]
+
+{% if valid_documents %}
+**The currently uploaded and searchable documents are the following**
+{% for document in valid_documents %}
+- {{ document.name }} (content_id: {{ document.id }})
+{% endfor %}
+
+{% endif %}

--- a/tool_packages/unique_internal_search/unique_internal_search/uploaded_search/service.py
+++ b/tool_packages/unique_internal_search/unique_internal_search/uploaded_search/service.py
@@ -1,6 +1,7 @@
 from pydantic import Field, create_model
 from typing_extensions import override
 from unique_toolkit import ContentService
+from unique_toolkit._common.utils.jinja.render import render_template
 from unique_toolkit.agentic.evaluation.schemas import EvaluationMetricName
 from unique_toolkit.agentic.feature_flags import feature_flags
 from unique_toolkit.agentic.tools.factory import ToolFactory
@@ -82,45 +83,19 @@ class UploadedSearchTool(Tool[UploadedSearchConfig]):
             ]
 
         valid_documents = []
-        expired_documents = []
         for doc in documents:
-            if not doc.is_ingested(default_if_unknown=True):
+            if not doc.is_ingested(default_if_unknown=True) or doc.is_expired():
                 continue
-            if doc.is_expired():
-                expired_documents.append(doc)
-            else:
-                valid_documents.append(doc)
-
-        system_prompt_valid_documents = ""
-        system_prompt_expired_documents = ""
-        if valid_documents:
-            system_prompt_valid_documents = (
-                "**The currently uploaded and valid documents are the following**\n"
-            )
-            system_prompt_valid_documents = (
-                system_prompt_valid_documents
-                + "\n".join(
-                    f"- {doc.title or doc.key} (content_id: {doc.id})"
-                    for doc in valid_documents
-                )
-                + "\n"
+            valid_documents.append(
+                {
+                    "name": doc.title or doc.key,
+                    "id": doc.id,
+                }
             )
 
-        if expired_documents:
-            system_prompt_expired_documents = (
-                "**The currently uploaded and expired documents are the following**\n"
-            )
-            system_prompt_expired_documents = (
-                system_prompt_expired_documents
-                + "\n".join(
-                    f"- {doc.title or doc.key} (content_id: {doc.id})"
-                    for doc in expired_documents
-                )
-            )
-
-        return self._config.tool_description_for_system_prompt.format(
-            system_prompt_valid_documents=system_prompt_valid_documents,
-            system_prompt_expired_documents=system_prompt_expired_documents,
+        return render_template(
+            self._config.tool_description_for_system_prompt,
+            valid_documents=valid_documents,
         )
 
     def tool_format_information_for_system_prompt(self) -> str:
@@ -153,7 +128,10 @@ class UploadedSearchTool(Tool[UploadedSearchConfig]):
                 state=ProgressState.FINISHED,
             )
         tool_response.name = self.name
-        tool_response.system_reminder = self._get_tool_call_response_system_reminder()
+        if self._config.enable_tool_call_system_reminder:
+            tool_response.system_reminder = (
+                self._get_tool_call_response_system_reminder()
+            )
         return tool_response
 
     def _get_tool_call_response_system_reminder(self) -> str:

--- a/unique_orchestrator/tests/test_unique_ai_builder_uploaded_search.py
+++ b/unique_orchestrator/tests/test_unique_ai_builder_uploaded_search.py
@@ -14,7 +14,7 @@ from unique_toolkit.agentic.tools.tool_manager import ToolManagerConfig
 from unique_toolkit.content.schemas import Content
 
 from unique_orchestrator._builders.open_file_setup import configure_file_payload
-from unique_orchestrator.config import UniqueAIConfig
+from unique_orchestrator.config import UniqueAIConfig, UploadedSearchToolConfig
 from unique_orchestrator.unique_ai_builder import (
     _build_responses,
     _CommonComponents,
@@ -320,13 +320,14 @@ class TestConfigureUploadedSearchToolIngestionFilter:
             mime_type=mime_type,
         )
 
-    def _run(self, docs, tool_choices=None):
+    def _run(self, docs, tool_choices=None, config=None):
         common_components = _make_common_components(docs)
         event = self._make_event(tool_choices)
         _configure_uploaded_search_tool(
             event=event,
             logger=MagicMock(),
             common_components=common_components,
+            config=config or UploadedSearchToolConfig(),
         )
         return common_components
 
@@ -387,3 +388,46 @@ class TestConfigureUploadedSearchToolIngestionFilter:
         common = self._run(docs)
         tool_names = [t.name for t in common.tool_manager_config.tools]
         assert UploadedSearchTool.name not in tool_names
+
+
+class TestConfigureUploadedSearchToolForcing:
+    def _make_doc(self):
+        doc = MagicMock()
+        doc.is_expired.return_value = False
+        return doc
+
+    def _run(self, docs, tool_choices=None, is_forced=True):
+        common_components = _make_common_components(docs)
+        event = _make_event(tool_choices or [])
+        config = UploadedSearchToolConfig(is_forced=is_forced)
+        should_force = _configure_uploaded_search_tool(
+            event=event,
+            logger=MagicMock(),
+            common_components=common_components,
+            config=config,
+        )
+        return should_force, common_components, event
+
+    def test_forces_when_valid_docs_and_is_forced_true(self):
+        should_force, _, _ = self._run([self._make_doc()], is_forced=True)
+        assert should_force is True
+
+    def test_does_not_force_when_is_forced_false(self):
+        should_force, _, _ = self._run([self._make_doc()], is_forced=False)
+        assert should_force is False
+
+    def test_does_not_force_when_no_docs(self):
+        should_force, _, _ = self._run([], is_forced=True)
+        assert should_force is False
+
+    def test_does_not_force_when_tool_choices_already_exist(self):
+        # Tool is added to tool_choices for availability instead of being force-called
+        should_force, _, event = self._run(
+            [self._make_doc()], tool_choices=["InternalSearch"], is_forced=True
+        )
+        assert should_force is False
+        assert UploadedSearchTool.name in event.payload.tool_choices
+
+    def test_tool_not_appended_to_empty_tool_choices(self):
+        _, _, event = self._run([self._make_doc()], tool_choices=[], is_forced=True)
+        assert event.payload.tool_choices == []

--- a/unique_orchestrator/tests/test_unique_ai_builder_uploaded_search.py
+++ b/unique_orchestrator/tests/test_unique_ai_builder_uploaded_search.py
@@ -396,10 +396,10 @@ class TestConfigureUploadedSearchToolForcing:
         doc.is_expired.return_value = False
         return doc
 
-    def _run(self, docs, tool_choices=None, is_forced=True):
+    def _run(self, docs, tool_choices=None, force=True):
         common_components = _make_common_components(docs)
         event = _make_event(tool_choices or [])
-        config = UploadedSearchToolConfig(is_forced=is_forced)
+        config = UploadedSearchToolConfig(force=force)
         should_force = _configure_uploaded_search_tool(
             event=event,
             logger=MagicMock(),
@@ -408,26 +408,26 @@ class TestConfigureUploadedSearchToolForcing:
         )
         return should_force, common_components, event
 
-    def test_forces_when_valid_docs_and_is_forced_true(self):
-        should_force, _, _ = self._run([self._make_doc()], is_forced=True)
+    def test_forces_when_valid_docs_and_force_true(self):
+        should_force, _, _ = self._run([self._make_doc()], force=True)
         assert should_force is True
 
-    def test_does_not_force_when_is_forced_false(self):
-        should_force, _, _ = self._run([self._make_doc()], is_forced=False)
+    def test_does_not_force_when_force_false(self):
+        should_force, _, _ = self._run([self._make_doc()], force=False)
         assert should_force is False
 
     def test_does_not_force_when_no_docs(self):
-        should_force, _, _ = self._run([], is_forced=True)
+        should_force, _, _ = self._run([], force=True)
         assert should_force is False
 
     def test_does_not_force_when_tool_choices_already_exist(self):
         # Tool is added to tool_choices for availability instead of being force-called
         should_force, _, event = self._run(
-            [self._make_doc()], tool_choices=["InternalSearch"], is_forced=True
+            [self._make_doc()], tool_choices=["InternalSearch"], force=True
         )
         assert should_force is False
         assert UploadedSearchTool.name in event.payload.tool_choices
 
     def test_tool_not_appended_to_empty_tool_choices(self):
-        _, _, event = self._run([self._make_doc()], tool_choices=[], is_forced=True)
+        _, _, event = self._run([self._make_doc()], tool_choices=[], force=True)
         assert event.payload.tool_choices == []

--- a/unique_orchestrator/unique_orchestrator/config.py
+++ b/unique_orchestrator/unique_orchestrator/config.py
@@ -333,16 +333,16 @@ class ResponsesApiConfig(BaseToolConfig):
 
 
 class UploadedSearchToolConfig(BaseToolConfig):
-    is_forced: bool = Field(
+    force: bool = Field(
         default=True,
         title="Force tool",
-        description="Whether the search is forced when the user uploads files",
+        description="If set, the tool will be forced when the user uploads a file",
     )
     tool_config: UploadedSearchConfig = UploadedSearchConfig()
 
     @model_validator(mode="after")
     def validate_tool_config(self) -> "UploadedSearchToolConfig":
-        self.tool_config.enable_tool_call_system_reminder = self.is_forced
+        self.tool_config.enable_tool_call_system_reminder = self.force
         return self
 
 

--- a/unique_orchestrator/unique_orchestrator/config.py
+++ b/unique_orchestrator/unique_orchestrator/config.py
@@ -340,6 +340,11 @@ class UploadedSearchToolConfig(BaseToolConfig):
     )
     tool_config: UploadedSearchConfig = UploadedSearchConfig()
 
+    @model_validator(mode="after")
+    def validate_tool_config(self) -> "UploadedSearchToolConfig":
+        self.tool_config.enable_tool_call_system_reminder = self.is_forced
+        return self
+
 
 class ExperimentalConfig(BaseToolConfig):
     """Experimental features this part of the configuration might evolve in the future continuously"""

--- a/unique_orchestrator/unique_orchestrator/config.py
+++ b/unique_orchestrator/unique_orchestrator/config.py
@@ -9,6 +9,9 @@ from unique_deep_research.service import DeepResearchTool
 from unique_follow_up_questions.config import FollowUpQuestionsConfig
 from unique_internal_search.config import InternalSearchConfig
 from unique_internal_search.service import InternalSearchTool
+from unique_internal_search.uploaded_search.config import (
+    UploadedSearchConfig,
+)
 from unique_stock_ticker.config import StockTickerConfig
 from unique_swot import SwotAnalysisTool, SwotAnalysisToolConfig
 from unique_toolkit._common.validators import (
@@ -329,6 +332,15 @@ class ResponsesApiConfig(BaseToolConfig):
     )
 
 
+class UploadedSearchToolConfig(BaseToolConfig):
+    is_forced: bool = Field(
+        default=True,
+        title="Force tool",
+        description="Whether the search is forced when the user uploads files",
+    )
+    tool_config: UploadedSearchConfig = UploadedSearchConfig()
+
+
 class ExperimentalConfig(BaseToolConfig):
     """Experimental features this part of the configuration might evolve in the future continuously"""
 
@@ -366,6 +378,8 @@ class ExperimentalConfig(BaseToolConfig):
         description="Configuration for the todo tool",
         default_factory=TodoConfig,
     )
+
+    uploaded_search_tool_config: UploadedSearchToolConfig = UploadedSearchToolConfig()
 
     use_responses_api: bool = Field(
         default=False,

--- a/unique_orchestrator/unique_orchestrator/unique_ai_builder.py
+++ b/unique_orchestrator/unique_orchestrator/unique_ai_builder.py
@@ -6,9 +6,6 @@ from typing_extensions import override
 from unique_follow_up_questions.follow_up_postprocessor import (
     FollowUpPostprocessor,
 )
-from unique_internal_search.uploaded_search.config import (
-    UploadedSearchConfig,
-)
 from unique_internal_search.uploaded_search.service import (
     UploadedSearchTool,
 )
@@ -86,7 +83,7 @@ from unique_orchestrator._builders.skill_setup import (
     configure_skill_tool,
     normalize_available_skills_for_tool,
 )
-from unique_orchestrator.config import UniqueAIConfig
+from unique_orchestrator.config import UniqueAIConfig, UploadedSearchToolConfig
 from unique_orchestrator.unique_ai import UniqueAI
 from unique_orchestrator.utils import filter_uploaded_documents_by_selection
 
@@ -390,8 +387,7 @@ async def _build_responses(
         in config.space.language_model.capabilities
     )
 
-    has_valid_uploaded_documents = False
-    has_tool_choices = False
+    force_uploaded_search = False
     if config.agent.experimental.open_file_tool_config.enabled:
         handle_uploaded_file_tool_choices(
             config,
@@ -400,12 +396,11 @@ async def _build_responses(
             logger,
         )
     else:
-        has_valid_uploaded_documents, has_tool_choices = (
-            _configure_uploaded_search_tool(
-                event=event,
-                logger=logger,
-                common_components=common_components,
-            )
+        force_uploaded_search = _configure_uploaded_search_tool(
+            event=event,
+            logger=logger,
+            common_components=common_components,
+            config=config.agent.experimental.uploaded_search_tool_config,
         )
 
     builtin_tool_manager = await OpenAIBuiltInToolManager.build_manager(
@@ -430,7 +425,7 @@ async def _build_responses(
         builtin_tool_manager=builtin_tool_manager,
     )
     if not config.agent.experimental.open_file_tool_config.enabled:
-        if not has_tool_choices and has_valid_uploaded_documents:
+        if force_uploaded_search:
             tool_manager.add_forced_tool(UploadedSearchTool.name)
 
     agent_file_registry: list[str] = []
@@ -512,10 +507,11 @@ async def _build_completions(
     common_components: _CommonComponents,
     debug_info_manager: DebugInfoManager,
 ) -> UniqueAI:
-    has_valid_uploaded_documents, has_tool_choices = _configure_uploaded_search_tool(
+    force_uploaded_search = _configure_uploaded_search_tool(
         event=event,
         logger=logger,
         common_components=common_components,
+        config=config.agent.experimental.uploaded_search_tool_config,
     )
 
     tool_manager = ToolManager(
@@ -526,7 +522,7 @@ async def _build_completions(
         mcp_manager=common_components.mcp_manager,
         a2a_manager=common_components.a2a_manager,
     )
-    if not has_tool_choices and has_valid_uploaded_documents:
+    if force_uploaded_search:
         tool_manager.add_forced_tool(UploadedSearchTool.name)
 
     await configure_skill_tool(
@@ -587,8 +583,9 @@ def _configure_uploaded_search_tool(
     event: ChatEvent,
     logger: Logger,
     common_components: _CommonComponents,
-) -> tuple[bool, bool]:
-    """Mirror uploaded-file bootstrapping across completions and Responses API."""
+    config: UploadedSearchToolConfig,
+) -> bool:
+    """Add the uploaded search tool when documents are present and return whether it should be forced."""
     valid_uploaded_documents: list[Content] = []
     expired_uploaded_documents: list[Content] = []
     for doc in common_components.uploaded_documents:
@@ -598,29 +595,30 @@ def _configure_uploaded_search_tool(
             expired_uploaded_documents.append(doc)
         else:
             valid_uploaded_documents.append(doc)
-    has_tool_choices = len(event.payload.tool_choices) > 0
 
     if expired_uploaded_documents:
         logger.info(
             f"Number of expired uploaded documents: {len(expired_uploaded_documents)}"
         )
 
-    if valid_uploaded_documents:
-        logger.info(
-            f"Number of valid uploaded documents: {len(valid_uploaded_documents)}"
-        )
-        common_components.tool_manager_config.tools.append(
-            ToolBuildConfig(
-                name=UploadedSearchTool.name,
-                display_name=UploadedSearchTool.name,
-                configuration=UploadedSearchConfig(),
-            )
-        )
+    if not valid_uploaded_documents:
+        return False
 
-    if has_tool_choices and valid_uploaded_documents:
+    logger.info(f"Number of valid uploaded documents: {len(valid_uploaded_documents)}")
+
+    common_components.tool_manager_config.tools.append(
+        ToolBuildConfig(
+            name=UploadedSearchTool.name,
+            display_name=UploadedSearchTool.name,
+            configuration=config.tool_config,
+        )
+    )
+
+    if len(event.payload.tool_choices) > 0 and config.is_forced:
         event.payload.tool_choices.append(str(UploadedSearchTool.name))
+        return False
 
-    return bool(valid_uploaded_documents), has_tool_choices
+    return config.is_forced
 
 
 def _add_sub_agents_postprocessor(

--- a/unique_orchestrator/unique_orchestrator/unique_ai_builder.py
+++ b/unique_orchestrator/unique_orchestrator/unique_ai_builder.py
@@ -616,11 +616,11 @@ def _configure_uploaded_search_tool(
         )
     )
 
-    if len(event.payload.tool_choices) > 0 and config.is_forced:
+    if len(event.payload.tool_choices) > 0 and config.force:
         event.payload.tool_choices.append(str(UploadedSearchTool.name))
         return False
 
-    return config.is_forced
+    return config.force
 
 
 def _add_sub_agents_postprocessor(

--- a/unique_orchestrator/unique_orchestrator/unique_ai_builder.py
+++ b/unique_orchestrator/unique_orchestrator/unique_ai_builder.py
@@ -424,9 +424,11 @@ async def _build_responses(
         a2a_manager=common_components.a2a_manager,
         builtin_tool_manager=builtin_tool_manager,
     )
-    if not config.agent.experimental.open_file_tool_config.enabled:
-        if force_uploaded_search:
-            tool_manager.add_forced_tool(UploadedSearchTool.name)
+    if (
+        not config.agent.experimental.open_file_tool_config.enabled
+        and force_uploaded_search
+    ):
+        tool_manager.add_forced_tool(UploadedSearchTool.name)
 
     agent_file_registry: list[str] = []
     if config.agent.experimental.open_file_tool_config.enabled:


### PR DESCRIPTION
## 🚀 Summary
Refs: [UN-20704](https://unique-ch.atlassian.net/browse/UN-20704), [UN-20684](https://unique-ch.atlassian.net/browse/UN-20684)

- Allow the `UploadedSearchTool` to not be forced in every iteration if there are uploaded files
- Allow `UploadedSearch` to be configured through the experimental config
- Remove the duplicated `expired documents` section
- Make UploadedSearch system reminder depend on whether tool is forced or not

## ✅ Changes

- [x] Added feature / fixed bug / updated docs
- [ ] Refactored code / cleaned up
- [ ] Other (describe below)

## 🧪 Testing

Local and ai-generated tests.

[UN-20704]: https://unique-ch.atlassian.net/browse/UN-20704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[UN-20684]: https://unique-ch.atlassian.net/browse/UN-20684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ