### PR TITLE
fix(tutorials): remove uv.lock from mcp_sql_demo Dockerfile

### DIFF
--- a/tutorials/mcp/mcp_sql_demo/Dockerfile
+++ b/tutorials/mcp/mcp_sql_demo/Dockerfile
@@ -1,10 +1,10 @@
 FROM python:3.12-slim
 WORKDIR /app
 
-COPY pyproject.toml uv.lock README.md ./
+COPY pyproject.toml README.md ./
 COPY src/ ./src/
 
-RUN pip install --no-cache-dir uv && uv sync --no-dev --frozen
+RUN pip install --no-cache-dir uv && uv sync --no-dev
 
 EXPOSE 8002
 CMD ["uv", "run", "python", "src/mcp_sql_demo/mcp_sql_demo.py"]


### PR DESCRIPTION
## Summary

- Removes `uv.lock` from the `COPY` instruction — the file is no longer tracked in git (workspace `.gitignore` policy ignores all per-package lockfiles except the root)
- Drops `--frozen` from `uv sync --no-dev` so dependency resolution happens from `pyproject.toml` at build time

## Why

The previous PR (#security-fix) deleted `tutorials/mcp/mcp_sql_demo/uv.lock` from git tracking. A fresh `docker build` would fail immediately at the `COPY pyproject.toml uv.lock …` step because the file no longer exists in the build context.

Since this is a tutorial/demo image (not a production service), resolving deps at build time from the constrained `pyproject.toml` is the right trade-off — reproducibility is enforced via the `constraint-dependencies` and `exclude-newer-package` settings already in place.

## Test plan
- [ ] `docker build tutorials/mcp/mcp_sql_demo/` completes without error

Made with [Cursor](https://cursor.com)