### PR TITLE
fix(unique-skills): available skill parameter included

### DIFF
--- a/tool_packages/unique_skill_tool/unique_skill_tool/__init__.py
+++ b/tool_packages/unique_skill_tool/unique_skill_tool/__init__.py
@@ -1,10 +1,9 @@
 from unique_skill_tool.config import SkillToolConfig
-from unique_skill_tool.schemas import SkillDefinition, SkillReference
+from unique_skill_tool.schemas import SkillDefinition
 from unique_skill_tool.service import SkillTool
 
 __all__ = [
     "SkillTool",
     "SkillToolConfig",
     "SkillDefinition",
-    "SkillReference",
 ]

--- a/tool_packages/unique_skill_tool/unique_skill_tool/__init__.py
+++ b/tool_packages/unique_skill_tool/unique_skill_tool/__init__.py
@@ -1,10 +1,10 @@
 from unique_skill_tool.config import SkillToolConfig
-from unique_skill_tool.schemas import SelectableSkill, SkillDefinition
+from unique_skill_tool.schemas import SkillDefinition, SkillReference
 from unique_skill_tool.service import SkillTool
 
 __all__ = [
     "SkillTool",
     "SkillToolConfig",
     "SkillDefinition",
-    "SelectableSkill",
+    "SkillReference",
 ]

--- a/tool_packages/unique_skill_tool/unique_skill_tool/config.py
+++ b/tool_packages/unique_skill_tool/unique_skill_tool/config.py
@@ -15,7 +15,7 @@ from unique_skill_tool.prompts import (
     DEFAULT_TOOL_PARAMETER_SKILL_NAME_DESCRIPTION,
     DEFAULT_TOOL_SYSTEM_REMINDER_FOR_USER_MESSAGE,
 )
-from unique_skill_tool.schemas import SelectableSkill
+from unique_skill_tool.schemas import SkillReference
 
 CHARS_PER_TOKEN = 4
 DEFAULT_CHAR_BUDGET = 8_000
@@ -37,7 +37,7 @@ class SkillSelection(BaseModel):
         default="",
         description="The root skills folder ID.",
     )
-    selected: list[SelectableSkill] = Field(
+    selected: list[SkillReference] = Field(
         default_factory=list,
         description="Individual skills selected from the knowledge base.",
     )

--- a/tool_packages/unique_skill_tool/unique_skill_tool/config.py
+++ b/tool_packages/unique_skill_tool/unique_skill_tool/config.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, Field
 from unique_toolkit._common.pydantic.rjsf_tags import CustomWidgetName, RJSFMetaTag
 from unique_toolkit._common.pydantic_helpers import get_configuration_dict
 from unique_toolkit.agentic.tools.schemas import BaseToolConfig
+from unique_toolkit.app.schemas import SkillReference
 
 from unique_skill_tool.prompts import (
     DEFAULT_TOOL_DESCRIPTION,
@@ -15,7 +16,6 @@ from unique_skill_tool.prompts import (
     DEFAULT_TOOL_PARAMETER_SKILL_NAME_DESCRIPTION,
     DEFAULT_TOOL_SYSTEM_REMINDER_FOR_USER_MESSAGE,
 )
-from unique_skill_tool.schemas import SkillReference
 
 CHARS_PER_TOKEN = 4
 DEFAULT_CHAR_BUDGET = 8_000

--- a/tool_packages/unique_skill_tool/unique_skill_tool/schemas.py
+++ b/tool_packages/unique_skill_tool/unique_skill_tool/schemas.py
@@ -25,10 +25,6 @@ class SelectableSkill(BaseModel):
         default="",
         description="Knowledge base scope ID that contains the skill file.",
     )
-    content_id: str = Field(
-        default="",
-        description="Knowledge base content ID of the ``SKILL.md`` file.",
-    )
 
 
 class SkillDefinition(BaseModel):

--- a/tool_packages/unique_skill_tool/unique_skill_tool/schemas.py
+++ b/tool_packages/unique_skill_tool/unique_skill_tool/schemas.py
@@ -7,30 +7,6 @@ SKILL_NAME_PATTERN = r"^[a-z0-9]+(?:-[a-z0-9]+)*$"
 SKILL_NAME_MAX_LENGTH = 64
 
 
-class SelectableSkill(BaseModel):
-    """A specific skill file selected by reference from the knowledge base.
-
-    Each entry resolves to exactly one knowledge base document via its
-    ``content_id``; ``scope_id`` scopes the lookup so access is explicit,
-    and ``name`` is the skill file's own frontmatter name.
-    """
-
-    model_config = get_configuration_dict()
-
-    name: str = Field(
-        default="",
-        description=("Skill name"),
-    )
-    scope_id: str = Field(
-        default="",
-        description="Knowledge base scope ID that contains the skill file.",
-    )
-    content_id: str = Field(
-        default="",
-        description="Knowledge base content ID of the ``SKILL.md`` file.",
-    )
-
-
 class SkillDefinition(BaseModel):
     """A skill that the agent can activate via the SkillTool.
 

--- a/tool_packages/unique_skill_tool/unique_skill_tool/schemas.py
+++ b/tool_packages/unique_skill_tool/unique_skill_tool/schemas.py
@@ -57,3 +57,10 @@ class SkillDefinition(BaseModel):
     content: str = Field(
         description="Full prompt / instructions injected when the skill is invoked.",
     )
+    source_content_id: str = Field(
+        default="",
+        description=(
+            "Knowledge base content id this definition was loaded from; "
+            "used to match per-message skill choices that omit ``name``."
+        ),
+    )

--- a/tool_packages/unique_skill_tool/unique_skill_tool/schemas.py
+++ b/tool_packages/unique_skill_tool/unique_skill_tool/schemas.py
@@ -25,6 +25,10 @@ class SelectableSkill(BaseModel):
         default="",
         description="Knowledge base scope ID that contains the skill file.",
     )
+    content_id: str = Field(
+        default="",
+        description="Knowledge base content ID of the ``SKILL.md`` file.",
+    )
 
 
 class SkillDefinition(BaseModel):
@@ -52,11 +56,4 @@ class SkillDefinition(BaseModel):
     )
     content: str = Field(
         description="Full prompt / instructions injected when the skill is invoked.",
-    )
-    source_content_id: str = Field(
-        default="",
-        description=(
-            "Knowledge base content id this definition was loaded from; "
-            "used to match per-message skill choices that omit ``name``."
-        ),
     )

--- a/unique_orchestrator/tests/test_skill_setup.py
+++ b/unique_orchestrator/tests/test_skill_setup.py
@@ -6,10 +6,9 @@ from logging import Logger
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from unique_skill_tool.schemas import SelectableSkill, SkillDefinition
+from unique_skill_tool.schemas import SkillReference, SkillDefinition
 from unique_skill_tool.service import SkillTool
 from unique_toolkit.agentic.tools.schemas import ToolCallResponse
-from unique_toolkit.app.schemas import ChatEventSkillChoice
 from unique_toolkit.language_model.schemas import LanguageModelFunction
 
 from unique_orchestrator._builders.skill_setup import (
@@ -17,12 +16,14 @@ from unique_orchestrator._builders.skill_setup import (
     _parse_frontmatter,
     configure_skill_tool,
     load_selectable_skills,
+    message_skills_as_selectable,
     preload_invoked_skills,
 )
 
 
 def _make_skill(name: str, content: str = "skill body") -> SkillDefinition:
     return SkillDefinition(name=name, description="desc", content=content)
+
 
 class _FakeToolManager:
     def __init__(self, skill_tool: SkillTool | None) -> None:
@@ -78,7 +79,7 @@ class TestPreloadInvokedSkills:
             tool_manager=tool_manager,  # type: ignore[arg-type]
             history_manager=history_manager,
             logger=logger,
-            skill_choices=[SelectableSkill(name="foo", content_id="cid-1")],
+            skill_choices=[SkillReference(name="foo", content_id="cid-1")],
         )
 
         history_manager.add_tool_call.assert_called_once()
@@ -106,7 +107,7 @@ class TestPreloadInvokedSkills:
             tool_manager=tool_manager,  # type: ignore[arg-type]
             history_manager=history_manager,
             logger=logger,
-            skill_choices=[SelectableSkill(name="foo", content_id="cid-1")],
+            skill_choices=[SkillReference(name="foo", content_id="cid-1")],
         )
 
         history_manager.add_tool_call.assert_called_once()
@@ -144,9 +145,9 @@ class TestPreloadInvokedSkills:
             history_manager=history_manager,
             logger=logger,
             skill_choices=[
-                SelectableSkill(name="foo", content_id="cid-1"),
-                SelectableSkill(name="/foo", content_id="cid-2"),
-                SelectableSkill(name="foo", content_id="cid-3"),
+                SkillReference(name="foo", content_id="cid-1"),
+                SkillReference(name="/foo", content_id="cid-2"),
+                SkillReference(name="foo", content_id="cid-3"),
             ],
         )
 
@@ -187,6 +188,29 @@ class TestParseFrontmatter:
         assert body == "hello"
 
 
+class TestMessageSkillsAsSelectable:
+    def test_empty_input(self) -> None:
+        assert message_skills_as_selectable([]) == []
+
+    def test_skips_empty_content_id(self) -> None:
+        rows = message_skills_as_selectable(
+            [
+                SkillReference(content_id="", scope_id="s", name="n"),
+                SkillReference(content_id="cid-1", scope_id="", name="ok"),
+            ]
+        )
+        assert rows == [SkillReference(name="ok", scope_id="", content_id="cid-1")]
+
+    def test_dedupes_by_content_id_keeps_first(self) -> None:
+        rows = message_skills_as_selectable(
+            [
+                SkillReference(content_id="x", scope_id="a", name="first"),
+                SkillReference(content_id="x", scope_id="b", name="second"),
+            ]
+        )
+        assert rows == [SkillReference(name="first", scope_id="a", content_id="x")]
+
+
 class TestLoadSelectableSkills:
     @pytest.mark.asyncio
     async def test_empty_list_returns_empty(self, logger: Logger) -> None:
@@ -208,7 +232,7 @@ class TestConfigureSkillTool:
         self,
         *,
         is_enabled: bool | None,
-        selectable_skills: list[SelectableSkill] | None = None,
+        selectable_skills: list[SkillReference] | None = None,
     ) -> MagicMock:
         from unique_skill_tool.config import SkillSelection, SkillToolConfig
         from unique_toolkit.agentic.tools.config import ToolBuildConfig
@@ -257,7 +281,7 @@ class TestConfigureSkillTool:
     async def test_space_selectables_ignored_without_available_skills(
         self, logger: Logger
     ) -> None:
-        selectable_skills = [SelectableSkill(content_id="cid-1", name="Skill 1")]
+        selectable_skills = [SkillReference(content_id="cid-1", name="Skill 1")]
         config = self._build_config(
             is_enabled=True, selectable_skills=selectable_skills
         )
@@ -286,7 +310,7 @@ class TestConfigureSkillTool:
         config = self._build_config(
             is_enabled=True,
             selectable_skills=[
-                SelectableSkill(content_id="space-only", name="Ignored in space"),
+                SkillReference(content_id="space-only", name="Ignored in space"),
             ],
         )
         content_service = MagicMock()
@@ -295,10 +319,10 @@ class TestConfigureSkillTool:
         tool_manager.get_tool_by_name.return_value = skill_tool
         expected_registry = {"foo": _make_skill("foo", content="skill content")}
         from_message = [
-            ChatEventSkillChoice(content_id="cid-1", scope_id="", name="Skill 1")
+            SkillReference(content_id="cid-1", scope_id="", name="Skill 1")
         ]
         expected_selectable = [
-            SelectableSkill(name="Skill 1", scope_id="", content_id="cid-1")
+            SkillReference(name="Skill 1", scope_id="", content_id="cid-1")
         ]
 
         with patch(
@@ -310,7 +334,7 @@ class TestConfigureSkillTool:
                 logger=logger,
                 content_service=content_service,
                 tool_manager=tool_manager,
-                available_skills=from_message,
+                selectable_skills=message_skills_as_selectable(from_message),
             )
 
         mock_load_selectable_skills.assert_awaited_once_with(
@@ -331,12 +355,12 @@ class TestConfigureSkillTool:
         skill_tool = self._make_skill_tool()
         tool_manager.get_tool_by_name.return_value = skill_tool
         from_message = [
-            ChatEventSkillChoice(content_id="cid-1", scope_id="", name="Skill 1"),
-            ChatEventSkillChoice(content_id="cid-2", scope_id="", name="Skill 2"),
+            SkillReference(content_id="cid-1", scope_id="", name="Skill 1"),
+            SkillReference(content_id="cid-2", scope_id="", name="Skill 2"),
         ]
         expected_selectable = [
-            SelectableSkill(name="Skill 1", scope_id="", content_id="cid-1"),
-            SelectableSkill(name="Skill 2", scope_id="", content_id="cid-2"),
+            SkillReference(name="Skill 1", scope_id="", content_id="cid-1"),
+            SkillReference(name="Skill 2", scope_id="", content_id="cid-2"),
         ]
         expected_registry = {
             "foo": _make_skill("foo", content="skill content"),
@@ -352,7 +376,7 @@ class TestConfigureSkillTool:
                 logger=logger,
                 content_service=content_service,
                 tool_manager=tool_manager,
-                available_skills=from_message,
+                selectable_skills=message_skills_as_selectable(from_message),
             )
 
         mock_load_selectable_skills.assert_awaited_once_with(
@@ -373,10 +397,10 @@ class TestConfigureSkillTool:
         skill_tool = self._make_skill_tool()
         tool_manager.get_tool_by_name.return_value = skill_tool
         from_message = [
-            ChatEventSkillChoice(content_id="cid-1", scope_id="", name="Skill 1")
+            SkillReference(content_id="cid-1", scope_id="", name="Skill 1")
         ]
         expected_selectable = [
-            SelectableSkill(name="Skill 1", scope_id="", content_id="cid-1")
+            SkillReference(name="Skill 1", scope_id="", content_id="cid-1")
         ]
         expected_registry = {"foo": _make_skill("foo", content="skill content")}
 
@@ -389,7 +413,7 @@ class TestConfigureSkillTool:
                 logger=logger,
                 content_service=content_service,
                 tool_manager=tool_manager,
-                available_skills=from_message,
+                selectable_skills=message_skills_as_selectable(from_message),
             )
 
         mock_load_selectable_skills.assert_awaited_once_with(
@@ -407,7 +431,7 @@ class TestConfigureSkillTool:
         config = self._build_config(
             is_enabled=True,
             selectable_skills=[
-                SelectableSkill(content_id="space-only", name="Space skill"),
+                SkillReference(content_id="space-only", name="Space skill"),
             ],
         )
         content_service = MagicMock()
@@ -415,14 +439,14 @@ class TestConfigureSkillTool:
         skill_tool = self._make_skill_tool()
         tool_manager.get_tool_by_name.return_value = skill_tool
         from_message = [
-            ChatEventSkillChoice(
+            SkillReference(
                 content_id="cid-msg",
                 scope_id="scope_1",
                 name="",
             )
         ]
         expected_merged = [
-            SelectableSkill(
+            SkillReference(
                 name="",
                 scope_id="scope_1",
                 content_id="cid-msg",
@@ -439,7 +463,7 @@ class TestConfigureSkillTool:
                 logger=logger,
                 content_service=content_service,
                 tool_manager=tool_manager,
-                available_skills=from_message,
+                selectable_skills=message_skills_as_selectable(from_message),
             )
 
         mock_load_selectable_skills.assert_awaited_once_with(
@@ -455,7 +479,7 @@ class TestConfigureSkillTool:
         self, logger: Logger
     ) -> None:
         from_message = [
-            ChatEventSkillChoice(content_id="cid-1", scope_id="", name="Skill 1")
+            SkillReference(content_id="cid-1", scope_id="", name="Skill 1")
         ]
         config = self._build_config(is_enabled=True, selectable_skills=[])
         tool_manager = MagicMock()
@@ -470,7 +494,7 @@ class TestConfigureSkillTool:
                 logger=logger,
                 content_service=content_service,
                 tool_manager=tool_manager,
-                available_skills=from_message,
+                selectable_skills=message_skills_as_selectable(from_message),
             )
 
         mock_load_selectable_skills.assert_awaited_once()

--- a/unique_orchestrator/tests/test_skill_setup.py
+++ b/unique_orchestrator/tests/test_skill_setup.py
@@ -9,6 +9,7 @@ import pytest
 from unique_skill_tool.schemas import SelectableSkill, SkillDefinition
 from unique_skill_tool.service import SkillTool
 from unique_toolkit.agentic.tools.schemas import ToolCallResponse
+from unique_toolkit.app.schemas import ChatEventSkillChoice
 from unique_toolkit.language_model.schemas import LanguageModelFunction
 
 from unique_orchestrator._builders.skill_setup import (
@@ -20,14 +21,18 @@ from unique_orchestrator._builders.skill_setup import (
 )
 
 
-def _make_skill(name: str, content: str = "skill body") -> SkillDefinition:
-    return SkillDefinition(name=name, description="desc", content=content)
-
-
-def _make_event(text: str) -> MagicMock:
-    event = MagicMock()
-    event.payload.user_message.text = text
-    return event
+def _make_skill(
+    name: str,
+    content: str = "skill body",
+    *,
+    source_content_id: str = "",
+) -> SkillDefinition:
+    return SkillDefinition(
+        name=name,
+        description="desc",
+        content=content,
+        source_content_id=source_content_id,
+    )
 
 
 class _FakeToolManager:
@@ -60,12 +65,10 @@ def logger() -> Logger:
 class TestPreloadInvokedSkills:
     @pytest.mark.asyncio
     async def test_noop_when_skill_tool_not_registered(self, logger: Logger) -> None:
-        event = _make_event("/foo question")
         history_manager = MagicMock()
         tool_manager = _FakeToolManager(skill_tool=None)
 
         await preload_invoked_skills(
-            text=event.payload.user_message.text,
             tool_manager=tool_manager,  # type: ignore[arg-type]
             history_manager=history_manager,
             logger=logger,
@@ -78,17 +81,15 @@ class TestPreloadInvokedSkills:
 
     @pytest.mark.asyncio
     async def test_single_skill_preloaded(self, logger: Logger) -> None:
-        event = _make_event("/foo what are the revenue trends?")
         history_manager = MagicMock()
         skill_tool = _make_skill_tool([_make_skill("foo", content="FOO BODY")])
         tool_manager = _FakeToolManager(skill_tool=skill_tool)
 
         await preload_invoked_skills(
-            text=event.payload.user_message.text,
             tool_manager=tool_manager,  # type: ignore[arg-type]
             history_manager=history_manager,
             logger=logger,
-            skill_choices=[],
+            skill_choices=[SelectableSkill(name="foo", content_id="cid-1")],
         )
 
         history_manager.add_tool_call.assert_called_once()
@@ -108,13 +109,11 @@ class TestPreloadInvokedSkills:
     async def test_forced_skill_choice_preloaded_without_slash_token(
         self, logger: Logger
     ) -> None:
-        event = _make_event("what are the revenue trends?")
         history_manager = MagicMock()
         skill_tool = _make_skill_tool([_make_skill("foo", content="FOO BODY")])
         tool_manager = _FakeToolManager(skill_tool=skill_tool)
 
         await preload_invoked_skills(
-            text=event.payload.user_message.text,
             tool_manager=tool_manager,  # type: ignore[arg-type]
             history_manager=history_manager,
             logger=logger,
@@ -127,14 +126,53 @@ class TestPreloadInvokedSkills:
         assert synthetic_call.arguments == {"skill_name": "foo"}
 
     @pytest.mark.asyncio
-    async def test_duplicate_skill_choices_preload_once(self, logger: Logger) -> None:
-        event = _make_event("what are the revenue trends?")
+    async def test_slash_tokens_in_message_do_not_preload_without_skill_choices(
+        self, logger: Logger
+    ) -> None:
         history_manager = MagicMock()
         skill_tool = _make_skill_tool([_make_skill("foo", content="FOO BODY")])
         tool_manager = _FakeToolManager(skill_tool=skill_tool)
 
         await preload_invoked_skills(
-            text=event.payload.user_message.text,
+            tool_manager=tool_manager,  # type: ignore[arg-type]
+            history_manager=history_manager,
+            logger=logger,
+            skill_choices=[],
+        )
+
+        history_manager.add_tool_call.assert_not_called()
+        history_manager._append_tool_calls_to_history.assert_not_called()
+        history_manager.add_tool_call_results.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_forced_skill_choice_by_content_id_without_name(
+        self, logger: Logger
+    ) -> None:
+        history_manager = MagicMock()
+        skill_tool = _make_skill_tool(
+            [_make_skill("foo", content="FOO BODY", source_content_id="cid-1")]
+        )
+        tool_manager = _FakeToolManager(skill_tool=skill_tool)
+
+        await preload_invoked_skills(
+            tool_manager=tool_manager,  # type: ignore[arg-type]
+            history_manager=history_manager,
+            logger=logger,
+            skill_choices=[SelectableSkill(name="", content_id="cid-1")],
+        )
+
+        history_manager.add_tool_call.assert_called_once()
+        synthetic_call = history_manager.add_tool_call.call_args.args[0]
+        assert isinstance(synthetic_call, LanguageModelFunction)
+        assert synthetic_call.arguments == {"skill_name": "foo"}
+
+    @pytest.mark.asyncio
+    async def test_duplicate_skill_choices_preload_once(self, logger: Logger) -> None:
+        history_manager = MagicMock()
+        skill_tool = _make_skill_tool([_make_skill("foo", content="FOO BODY")])
+        tool_manager = _FakeToolManager(skill_tool=skill_tool)
+
+        await preload_invoked_skills(
             tool_manager=tool_manager,  # type: ignore[arg-type]
             history_manager=history_manager,
             logger=logger,
@@ -143,23 +181,6 @@ class TestPreloadInvokedSkills:
                 SelectableSkill(name="/foo", content_id="cid-2"),
                 SelectableSkill(name="foo", content_id="cid-3"),
             ],
-        )
-
-        history_manager.add_tool_call.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_forced_skills_skip_slash_scan(self, logger: Logger) -> None:
-        event = _make_event("/foo what are the revenue trends?")
-        history_manager = MagicMock()
-        skill_tool = _make_skill_tool([_make_skill("foo", content="FOO BODY")])
-        tool_manager = _FakeToolManager(skill_tool=skill_tool)
-
-        await preload_invoked_skills(
-            text=event.payload.user_message.text,
-            tool_manager=tool_manager,  # type: ignore[arg-type]
-            history_manager=history_manager,
-            logger=logger,
-            skill_choices=[SelectableSkill(name="foo", content_id="cid-1")],
         )
 
         history_manager.add_tool_call.assert_called_once()
@@ -182,12 +203,14 @@ class TestBuildSkill:
             content_key="summarize.md",
             file_text=file_text,
             logger=logger,
+            source_content_id="c1",
         )
 
         assert skill is not None
         assert skill.name == "summarize"
         assert skill.description == "Summarize a document."
         assert skill.content == "# Summarize\nDo the thing."
+        assert skill.source_content_id == "c1"
 
 
 class TestParseFrontmatter:
@@ -249,7 +272,7 @@ class TestConfigureSkillTool:
         return tool
 
     @pytest.mark.asyncio
-    async def test_enabled_without_selectables_excludes_tool(
+    async def test_enabled_without_available_skills_excludes_tool(
         self, logger: Logger
     ) -> None:
         config = self._build_config(is_enabled=True, selectable_skills=[])
@@ -266,7 +289,7 @@ class TestConfigureSkillTool:
         tool_manager.get_tool_by_name.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_enabled_with_selectables_and_empty_registry_excludes_tool(
+    async def test_space_selectables_ignored_without_available_skills(
         self, logger: Logger
     ) -> None:
         selectable_skills = [SelectableSkill(content_id="cid-1", name="Skill 1")]
@@ -287,27 +310,31 @@ class TestConfigureSkillTool:
                 tool_manager=tool_manager,
             )
 
-        mock_load_selectable_skills.assert_awaited_once_with(
-            content_service=content_service,
-            selectable_skills=selectable_skills,
-            logger=logger,
-        )
+        mock_load_selectable_skills.assert_not_called()
         tool_manager.exclude_tool.assert_called_once_with(SkillTool.name)
         tool_manager.get_tool_by_name.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_enabled_with_selectables_populates_tool_registry(
+    async def test_enabled_with_available_skills_populates_tool_registry(
         self, logger: Logger
     ) -> None:
-        selectable_skills = [SelectableSkill(content_id="cid-1", name="Skill 1")]
         config = self._build_config(
-            is_enabled=True, selectable_skills=selectable_skills
+            is_enabled=True,
+            selectable_skills=[
+                SelectableSkill(content_id="space-only", name="Ignored in space"),
+            ],
         )
         content_service = MagicMock()
         tool_manager = MagicMock()
         skill_tool = self._make_skill_tool()
         tool_manager.get_tool_by_name.return_value = skill_tool
         expected_registry = {"foo": _make_skill("foo", content="skill content")}
+        from_message = [
+            ChatEventSkillChoice(content_id="cid-1", scope_id="", name="Skill 1")
+        ]
+        expected_selectable = [
+            SelectableSkill(name="Skill 1", scope_id="", content_id="cid-1")
+        ]
 
         with patch(
             "unique_orchestrator._builders.skill_setup.load_selectable_skills",
@@ -318,31 +345,34 @@ class TestConfigureSkillTool:
                 logger=logger,
                 content_service=content_service,
                 tool_manager=tool_manager,
+                available_skills=from_message,
             )
 
         mock_load_selectable_skills.assert_awaited_once_with(
             content_service=content_service,
-            selectable_skills=selectable_skills,
+            selectable_skills=expected_selectable,
             logger=logger,
         )
         assert skill_tool.skill_registry == expected_registry
         tool_manager.exclude_tool.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_enabled_with_multiple_selectables_loads_full_registry(
+    async def test_enabled_with_multiple_available_skills_loads_full_registry(
         self, logger: Logger
     ) -> None:
-        selectable_skills = [
-            SelectableSkill(content_id="cid-1", name="Skill 1"),
-            SelectableSkill(content_id="cid-2", name="Skill 2"),
-        ]
-        config = self._build_config(
-            is_enabled=True, selectable_skills=selectable_skills
-        )
+        config = self._build_config(is_enabled=True, selectable_skills=[])
         content_service = MagicMock()
         tool_manager = MagicMock()
         skill_tool = self._make_skill_tool()
         tool_manager.get_tool_by_name.return_value = skill_tool
+        from_message = [
+            ChatEventSkillChoice(content_id="cid-1", scope_id="", name="Skill 1"),
+            ChatEventSkillChoice(content_id="cid-2", scope_id="", name="Skill 2"),
+        ]
+        expected_selectable = [
+            SelectableSkill(name="Skill 1", scope_id="", content_id="cid-1"),
+            SelectableSkill(name="Skill 2", scope_id="", content_id="cid-2"),
+        ]
         expected_registry = {
             "foo": _make_skill("foo", content="skill content"),
             "bar": _make_skill("bar", content="other skill content"),
@@ -357,28 +387,32 @@ class TestConfigureSkillTool:
                 logger=logger,
                 content_service=content_service,
                 tool_manager=tool_manager,
+                available_skills=from_message,
             )
 
         mock_load_selectable_skills.assert_awaited_once_with(
             content_service=content_service,
-            selectable_skills=selectable_skills,
+            selectable_skills=expected_selectable,
             logger=logger,
         )
         assert skill_tool.skill_registry == expected_registry
         tool_manager.exclude_tool.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_enabled_with_single_selectable_loads_registry(
+    async def test_enabled_with_single_available_skill_loads_registry(
         self, logger: Logger
     ) -> None:
-        selectable_skills = [SelectableSkill(content_id="cid-1", name="Skill 1")]
-        config = self._build_config(
-            is_enabled=True, selectable_skills=selectable_skills
-        )
+        config = self._build_config(is_enabled=True, selectable_skills=[])
         content_service = MagicMock()
         tool_manager = MagicMock()
         skill_tool = self._make_skill_tool()
         tool_manager.get_tool_by_name.return_value = skill_tool
+        from_message = [
+            ChatEventSkillChoice(content_id="cid-1", scope_id="", name="Skill 1")
+        ]
+        expected_selectable = [
+            SelectableSkill(name="Skill 1", scope_id="", content_id="cid-1")
+        ]
         expected_registry = {"foo": _make_skill("foo", content="skill content")}
 
         with patch(
@@ -390,12 +424,90 @@ class TestConfigureSkillTool:
                 logger=logger,
                 content_service=content_service,
                 tool_manager=tool_manager,
+                available_skills=from_message,
             )
 
         mock_load_selectable_skills.assert_awaited_once_with(
             content_service=content_service,
-            selectable_skills=selectable_skills,
+            selectable_skills=expected_selectable,
             logger=logger,
         )
         assert skill_tool.skill_registry == expected_registry
         tool_manager.exclude_tool.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_message_available_skills_only_source_space_selectables_ignored(
+        self, logger: Logger
+    ) -> None:
+        config = self._build_config(
+            is_enabled=True,
+            selectable_skills=[
+                SelectableSkill(content_id="space-only", name="Space skill"),
+            ],
+        )
+        content_service = MagicMock()
+        tool_manager = MagicMock()
+        skill_tool = self._make_skill_tool()
+        tool_manager.get_tool_by_name.return_value = skill_tool
+        from_message = [
+            ChatEventSkillChoice(
+                content_id="cid-msg",
+                scope_id="scope_1",
+                name="",
+            )
+        ]
+        expected_merged = [
+            SelectableSkill(
+                name="",
+                scope_id="scope_1",
+                content_id="cid-msg",
+            )
+        ]
+        expected_registry = {"foo": _make_skill("foo", content="skill content")}
+
+        with patch(
+            "unique_orchestrator._builders.skill_setup.load_selectable_skills",
+            new=AsyncMock(return_value=expected_registry),
+        ) as mock_load_selectable_skills:
+            await configure_skill_tool(
+                config=config,
+                logger=logger,
+                content_service=content_service,
+                tool_manager=tool_manager,
+                available_skills=from_message,
+            )
+
+        mock_load_selectable_skills.assert_awaited_once_with(
+            content_service=content_service,
+            selectable_skills=expected_merged,
+            logger=logger,
+        )
+        assert skill_tool.skill_registry == expected_registry
+        tool_manager.exclude_tool.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_available_skills_empty_registry_after_load_excludes_tool(
+        self, logger: Logger
+    ) -> None:
+        from_message = [
+            ChatEventSkillChoice(content_id="cid-1", scope_id="", name="Skill 1")
+        ]
+        config = self._build_config(is_enabled=True, selectable_skills=[])
+        tool_manager = MagicMock()
+        content_service = MagicMock()
+
+        with patch(
+            "unique_orchestrator._builders.skill_setup.load_selectable_skills",
+            new=AsyncMock(return_value={}),
+        ) as mock_load_selectable_skills:
+            await configure_skill_tool(
+                config=config,
+                logger=logger,
+                content_service=content_service,
+                tool_manager=tool_manager,
+                available_skills=from_message,
+            )
+
+        mock_load_selectable_skills.assert_awaited_once()
+        tool_manager.exclude_tool.assert_called_once_with(SkillTool.name)
+        tool_manager.get_tool_by_name.assert_not_called()

--- a/unique_orchestrator/tests/test_skill_setup.py
+++ b/unique_orchestrator/tests/test_skill_setup.py
@@ -6,7 +6,7 @@ from logging import Logger
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from unique_skill_tool.schemas import SkillReference, SkillDefinition
+from unique_skill_tool.schemas import SkillDefinition, SkillReference
 from unique_skill_tool.service import SkillTool
 from unique_toolkit.agentic.tools.schemas import ToolCallResponse
 from unique_toolkit.language_model.schemas import LanguageModelFunction
@@ -16,7 +16,7 @@ from unique_orchestrator._builders.skill_setup import (
     _parse_frontmatter,
     configure_skill_tool,
     load_selectable_skills,
-    message_skills_as_selectable,
+    normalize_available_skills_for_tool,
     preload_invoked_skills,
 )
 
@@ -190,10 +190,10 @@ class TestParseFrontmatter:
 
 class TestMessageSkillsAsSelectable:
     def test_empty_input(self) -> None:
-        assert message_skills_as_selectable([]) == []
+        assert normalize_available_skills_for_tool([]) == []
 
     def test_skips_empty_content_id(self) -> None:
-        rows = message_skills_as_selectable(
+        rows = normalize_available_skills_for_tool(
             [
                 SkillReference(content_id="", scope_id="s", name="n"),
                 SkillReference(content_id="cid-1", scope_id="", name="ok"),
@@ -202,7 +202,7 @@ class TestMessageSkillsAsSelectable:
         assert rows == [SkillReference(name="ok", scope_id="", content_id="cid-1")]
 
     def test_dedupes_by_content_id_keeps_first(self) -> None:
-        rows = message_skills_as_selectable(
+        rows = normalize_available_skills_for_tool(
             [
                 SkillReference(content_id="x", scope_id="a", name="first"),
                 SkillReference(content_id="x", scope_id="b", name="second"),
@@ -318,9 +318,7 @@ class TestConfigureSkillTool:
         skill_tool = self._make_skill_tool()
         tool_manager.get_tool_by_name.return_value = skill_tool
         expected_registry = {"foo": _make_skill("foo", content="skill content")}
-        from_message = [
-            SkillReference(content_id="cid-1", scope_id="", name="Skill 1")
-        ]
+        from_message = [SkillReference(content_id="cid-1", scope_id="", name="Skill 1")]
         expected_selectable = [
             SkillReference(name="Skill 1", scope_id="", content_id="cid-1")
         ]
@@ -334,7 +332,7 @@ class TestConfigureSkillTool:
                 logger=logger,
                 content_service=content_service,
                 tool_manager=tool_manager,
-                selectable_skills=message_skills_as_selectable(from_message),
+                selectable_skills=normalize_available_skills_for_tool(from_message),
             )
 
         mock_load_selectable_skills.assert_awaited_once_with(
@@ -376,7 +374,7 @@ class TestConfigureSkillTool:
                 logger=logger,
                 content_service=content_service,
                 tool_manager=tool_manager,
-                selectable_skills=message_skills_as_selectable(from_message),
+                selectable_skills=normalize_available_skills_for_tool(from_message),
             )
 
         mock_load_selectable_skills.assert_awaited_once_with(
@@ -396,9 +394,7 @@ class TestConfigureSkillTool:
         tool_manager = MagicMock()
         skill_tool = self._make_skill_tool()
         tool_manager.get_tool_by_name.return_value = skill_tool
-        from_message = [
-            SkillReference(content_id="cid-1", scope_id="", name="Skill 1")
-        ]
+        from_message = [SkillReference(content_id="cid-1", scope_id="", name="Skill 1")]
         expected_selectable = [
             SkillReference(name="Skill 1", scope_id="", content_id="cid-1")
         ]
@@ -413,7 +409,7 @@ class TestConfigureSkillTool:
                 logger=logger,
                 content_service=content_service,
                 tool_manager=tool_manager,
-                selectable_skills=message_skills_as_selectable(from_message),
+                selectable_skills=normalize_available_skills_for_tool(from_message),
             )
 
         mock_load_selectable_skills.assert_awaited_once_with(
@@ -463,7 +459,7 @@ class TestConfigureSkillTool:
                 logger=logger,
                 content_service=content_service,
                 tool_manager=tool_manager,
-                selectable_skills=message_skills_as_selectable(from_message),
+                selectable_skills=normalize_available_skills_for_tool(from_message),
             )
 
         mock_load_selectable_skills.assert_awaited_once_with(
@@ -478,9 +474,7 @@ class TestConfigureSkillTool:
     async def test_available_skills_empty_registry_after_load_excludes_tool(
         self, logger: Logger
     ) -> None:
-        from_message = [
-            SkillReference(content_id="cid-1", scope_id="", name="Skill 1")
-        ]
+        from_message = [SkillReference(content_id="cid-1", scope_id="", name="Skill 1")]
         config = self._build_config(is_enabled=True, selectable_skills=[])
         tool_manager = MagicMock()
         content_service = MagicMock()
@@ -494,7 +488,7 @@ class TestConfigureSkillTool:
                 logger=logger,
                 content_service=content_service,
                 tool_manager=tool_manager,
-                selectable_skills=message_skills_as_selectable(from_message),
+                selectable_skills=normalize_available_skills_for_tool(from_message),
             )
 
         mock_load_selectable_skills.assert_awaited_once()

--- a/unique_orchestrator/tests/test_skill_setup.py
+++ b/unique_orchestrator/tests/test_skill_setup.py
@@ -6,9 +6,10 @@ from logging import Logger
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from unique_skill_tool.schemas import SkillDefinition, SkillReference
+from unique_skill_tool.schemas import SkillDefinition
 from unique_skill_tool.service import SkillTool
 from unique_toolkit.agentic.tools.schemas import ToolCallResponse
+from unique_toolkit.app.schemas import SkillReference
 from unique_toolkit.language_model.schemas import LanguageModelFunction
 
 from unique_orchestrator._builders.skill_setup import (

--- a/unique_orchestrator/tests/test_skill_setup.py
+++ b/unique_orchestrator/tests/test_skill_setup.py
@@ -21,16 +21,8 @@ from unique_orchestrator._builders.skill_setup import (
 )
 
 
-def _make_skill(
-    name: str,
-    content: str = "skill body",
-) -> SkillDefinition:
-    return SkillDefinition(
-        name=name,
-        description="desc",
-        content=content,
-    )
-
+def _make_skill(name: str, content: str = "skill body") -> SkillDefinition:
+    return SkillDefinition(name=name, description="desc", content=content)
 
 class _FakeToolManager:
     def __init__(self, skill_tool: SkillTool | None) -> None:

--- a/unique_orchestrator/tests/test_skill_setup.py
+++ b/unique_orchestrator/tests/test_skill_setup.py
@@ -134,28 +134,6 @@ class TestPreloadInvokedSkills:
         history_manager.add_tool_call_results.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_forced_skill_choice_by_content_id_without_name(
-        self, logger: Logger
-    ) -> None:
-        history_manager = MagicMock()
-        skill_tool = _make_skill_tool(
-            [_make_skill("foo", content="FOO BODY")]
-        )
-        tool_manager = _FakeToolManager(skill_tool=skill_tool)
-
-        await preload_invoked_skills(
-            tool_manager=tool_manager,  # type: ignore[arg-type]
-            history_manager=history_manager,
-            logger=logger,
-            skill_choices=[SelectableSkill(name="", content_id="cid-1")],
-        )
-
-        history_manager.add_tool_call.assert_called_once()
-        synthetic_call = history_manager.add_tool_call.call_args.args[0]
-        assert isinstance(synthetic_call, LanguageModelFunction)
-        assert synthetic_call.arguments == {"skill_name": "foo"}
-
-    @pytest.mark.asyncio
     async def test_duplicate_skill_choices_preload_once(self, logger: Logger) -> None:
         history_manager = MagicMock()
         skill_tool = _make_skill_tool([_make_skill("foo", content="FOO BODY")])

--- a/unique_orchestrator/tests/test_skill_setup.py
+++ b/unique_orchestrator/tests/test_skill_setup.py
@@ -24,14 +24,11 @@ from unique_orchestrator._builders.skill_setup import (
 def _make_skill(
     name: str,
     content: str = "skill body",
-    *,
-    source_content_id: str = "",
 ) -> SkillDefinition:
     return SkillDefinition(
         name=name,
         description="desc",
         content=content,
-        source_content_id=source_content_id,
     )
 
 
@@ -150,7 +147,7 @@ class TestPreloadInvokedSkills:
     ) -> None:
         history_manager = MagicMock()
         skill_tool = _make_skill_tool(
-            [_make_skill("foo", content="FOO BODY", source_content_id="cid-1")]
+            [_make_skill("foo", content="FOO BODY")]
         )
         tool_manager = _FakeToolManager(skill_tool=skill_tool)
 
@@ -203,14 +200,12 @@ class TestBuildSkill:
             content_key="summarize.md",
             file_text=file_text,
             logger=logger,
-            source_content_id="c1",
         )
 
         assert skill is not None
         assert skill.name == "summarize"
         assert skill.description == "Summarize a document."
         assert skill.content == "# Summarize\nDo the thing."
-        assert skill.source_content_id == "c1"
 
 
 class TestParseFrontmatter:

--- a/unique_orchestrator/tests/test_unique_ai_skill_and_reminders.py
+++ b/unique_orchestrator/tests/test_unique_ai_skill_and_reminders.py
@@ -3,8 +3,8 @@
 These tests exercise the *new* code paths added to ``UniqueAI`` when the
 Skill tool was introduced:
 
-* ``run()`` preloads ``/skill-name`` invocations before the first
-  LLM call.
+* ``run()`` preloads skills from per-turn ``skill_choices`` before the
+  first LLM call (user message text is not scanned for ``/skill-name``).
 * ``_compose_message_plan_execution()`` injects per-turn
   ``tool_system_reminder_for_user_prompt`` strings on the latest
   user message.

--- a/unique_orchestrator/tests/test_unique_ai_skill_and_reminders.py
+++ b/unique_orchestrator/tests/test_unique_ai_skill_and_reminders.py
@@ -4,7 +4,7 @@ These tests exercise the *new* code paths added to ``UniqueAI`` when the
 Skill tool was introduced:
 
 * ``run()`` preloads skills from per-turn ``skill_choices`` before the
-  first LLM call (user message text is not scanned for ``/skill-name``).
+  first LLM call.
 * ``_compose_message_plan_execution()`` injects per-turn
   ``tool_system_reminder_for_user_prompt`` strings on the latest
   user message.

--- a/unique_orchestrator/unique_orchestrator/_builders/skill_setup.py
+++ b/unique_orchestrator/unique_orchestrator/_builders/skill_setup.py
@@ -2,8 +2,7 @@
 
 Loads skill definitions from the knowledge base and registers the
 SkillTool with the tool manager. Which files to load is determined only
-by the chat event's ``available_skills`` (per-message); space
-``selectable_skills`` admin configuration is not used for discovery.
+by the chat event's ``available_skills`` (per-message).
 
 Skill discovery follows the official Agent Skills protocol — see
 https://agentskills.io/home. Each skill is a **folder**
@@ -266,10 +265,9 @@ async def configure_skill_tool(
 ) -> None:
     """Populate the SkillTool's skill registry when it is enabled in ``space.tools``.
 
-    Skills are loaded **only** from the per-message ``available_skills``
+    Skills are loaded from the per-message ``available_skills``
     payload (each entry references a ``SKILL.md`` document via
-    ``content_id``). Space ``selectable_skills`` configuration is not used
-    for discovery.
+    ``content_id``).
     """
     skill_tool_build_config = _find_skill_tool_build_config(config.space.tools)
     if skill_tool_build_config is None or not skill_tool_build_config.is_enabled:
@@ -318,8 +316,7 @@ async def preload_invoked_skills(
 ) -> None:
     """Preload skills selected in ``skill_choices`` before the first model turn.
 
-    Only explicit per-turn ``skill_choices`` are considered; the user
-    message is not scanned for ``/skill-name`` tokens.
+    Only explicit per-turn ``skill_choices`` are considered.
 
     Mirrors the normal mid-loop activation path so preloaded skills are
     indistinguishable from skills the model activates itself:

--- a/unique_orchestrator/unique_orchestrator/_builders/skill_setup.py
+++ b/unique_orchestrator/unique_orchestrator/_builders/skill_setup.py
@@ -309,8 +309,6 @@ async def preload_invoked_skills(
 ) -> None:
     """Preload skills selected in ``skill_choices`` before the first model turn.
 
-    Only explicit per-turn ``skill_choices`` are considered.
-
     Mirrors the normal mid-loop activation path so preloaded skills are
     indistinguishable from skills the model activates itself:
 

--- a/unique_orchestrator/unique_orchestrator/_builders/skill_setup.py
+++ b/unique_orchestrator/unique_orchestrator/_builders/skill_setup.py
@@ -1,7 +1,9 @@
 """Helpers for the Skill tool.
 
 Loads skill definitions from the knowledge base and registers the
-SkillTool with the tool manager.
+SkillTool with the tool manager. Which files to load is determined only
+by the chat event's ``available_skills`` (per-message); space
+``selectable_skills`` admin configuration is not used for discovery.
 
 Skill discovery follows the official Agent Skills protocol — see
 https://agentskills.io/home. Each skill is a **folder**
@@ -41,16 +43,16 @@ from __future__ import annotations
 
 import asyncio
 from logging import Logger
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 import frontmatter
 from pydantic import ValidationError
-from unique_skill_tool.config import SkillToolConfig
 from unique_skill_tool.schemas import SelectableSkill, SkillDefinition
 from unique_skill_tool.service import SkillTool
-from unique_skill_tool.utils import extract_invoked_skills, normalize_skill_name
+from unique_skill_tool.utils import normalize_skill_name
 from unique_toolkit.agentic.tools.config import ToolBuildConfig
 from unique_toolkit.agentic.tools.schemas import ToolCallResponse
+from unique_toolkit.app.schemas import ChatEventSkillChoice
 from unique_toolkit.language_model.schemas import LanguageModelFunction
 
 if TYPE_CHECKING:
@@ -97,12 +99,38 @@ def _parse_frontmatter(*, text: str) -> tuple[dict[str, Any], str]:
     return dict(metadata), body
 
 
+def _message_skills_as_selectable(
+    available_skills: list[ChatEventSkillChoice],
+) -> list[SelectableSkill]:
+    """Map per-message ``available_skills`` to ``SelectableSkill`` rows.
+
+    Deduplicates by ``content_id`` while preserving first-seen order.
+    Entries without a ``content_id`` are skipped.
+    """
+    seen: set[str] = set()
+    out: list[SelectableSkill] = []
+    for choice in available_skills:
+        cid = choice.content_id
+        if not cid or cid in seen:
+            continue
+        seen.add(cid)
+        out.append(
+            SelectableSkill(
+                name=choice.name,
+                scope_id=choice.scope_id,
+                content_id=choice.content_id,
+            )
+        )
+    return out
+
+
 def _build_skill(
     *,
     content_id: str,
     content_key: str,
     file_text: str,
     logger: Logger,
+    source_content_id: str,
 ) -> SkillDefinition | None:
     """Build a ``SkillDefinition`` from the raw file text of a KB document.
 
@@ -135,6 +163,7 @@ def _build_skill(
             name=name,
             description=description,
             content=body,
+            source_content_id=source_content_id,
         )
     except ValidationError as exc:
         logger.warning(
@@ -200,6 +229,7 @@ async def load_selectable_skills(
             content_key=label,
             file_text=file_text,
             logger=logger,
+            source_content_id=entry.content_id,
         )
         if skill is None:
             logger.debug(
@@ -232,28 +262,33 @@ async def configure_skill_tool(
     logger: Logger,
     content_service: ContentService,
     tool_manager: ToolManager | ResponsesApiToolManager,
+    available_skills: list[ChatEventSkillChoice] | None = None,
 ) -> None:
     """Populate the SkillTool's skill registry when it is enabled in ``space.tools``.
 
-    Skills are loaded from ``selectable_skills`` only. Each entry should
-    reference a ``SKILL.md`` document via ``content_id``.
+    Skills are loaded **only** from the per-message ``available_skills``
+    payload (each entry references a ``SKILL.md`` document via
+    ``content_id``). Space ``selectable_skills`` configuration is not used
+    for discovery.
     """
     skill_tool_build_config = _find_skill_tool_build_config(config.space.tools)
     if skill_tool_build_config is None or not skill_tool_build_config.is_enabled:
         return
 
-    skill_config = cast(SkillToolConfig, skill_tool_build_config.configuration)
+    to_load = _message_skills_as_selectable(list(available_skills or []))
+    skill_tool_build_config.configuration.selectable_skills.selected = to_load
 
-    if not skill_config.selectable_skills.selected:
+    if not to_load:
         logger.warning(
-            "SkillTool is enabled but no skills are configured — no skills will be loaded."
+            "SkillTool is enabled but available_skills is empty — "
+            "no skills will be loaded."
         )
         tool_manager.exclude_tool(SkillTool.name)
         return
 
     skill_registry = await load_selectable_skills(
         content_service=content_service,
-        selectable_skills=skill_config.selectable_skills.selected,
+        selectable_skills=to_load,
         logger=logger,
     )
 
@@ -276,58 +311,53 @@ async def configure_skill_tool(
 
 async def preload_invoked_skills(
     *,
-    text: str,
     tool_manager: ToolManager | ResponsesApiToolManager,
     history_manager: HistoryManager,
     logger: Logger,
     skill_choices: list[SelectableSkill],
 ) -> None:
-    """Preload forced and slash-invoked skills before the first model turn.
+    """Preload skills selected in ``skill_choices`` before the first model turn.
+
+    Only explicit per-turn ``skill_choices`` are considered; the user
+    message is not scanned for ``/skill-name`` tokens.
 
     Mirrors the normal mid-loop activation path so preloaded skills are
     indistinguishable from skills the model activates itself:
 
-    1. Resolves forced ``skill_choices`` first.
-    2. If no forced skills are found, pulls every ``/skill-name`` token
-       out of the user message — whether at the start, between words, or
-       at the end — as long as it is properly word-boundaried so URLs and
-       file paths are not mistaken for invocations. Unknown tokens are
-       left as ordinary text.
+    1. Resolves each ``skill_choices`` entry against the registered
+       ``SkillTool`` registry (by normalized name or ``content_id``).
     2. For each matched skill, synthesizes a ``LanguageModelFunction``
        and runs it through the already-registered ``SkillTool`` — the
        exact same code path ``UniqueAI._handle_tool_calls`` uses.
     3. Appends the synthetic assistant tool-call message plus the
        resulting tool-result messages to history, so the first model
        turn sees the skills as already-activated tool calls.
-    ``skill_choices`` are treated as forced skills and loaded even when
-    the user message does not contain ``/skill-name`` tokens. Duplicate
-    choices that resolve to the same registered skill are ignored after
-    the first (same deduplication idea as ``extract_invoked_skills``).
-    User message text is never modified in this preload step.
+
+    Duplicate choices that resolve to the same registered skill are
+    ignored after the first.
     """
     skill_tool = tool_manager.get_tool_by_name(SkillTool.name)
     if not isinstance(skill_tool, SkillTool):
         return
 
-    forced_skills = []
-
-    if skill_choices:
-        seen_forced: set[str] = set()
-        for choice in skill_choices:
-            if not choice.name:
-                continue
+    forced_skills: list[SkillDefinition] = []
+    seen_forced: set[str] = set()
+    for choice in skill_choices:
+        forced_skill: SkillDefinition | None = None
+        if choice.name:
             normalized_name = normalize_skill_name(choice.name)
             forced_skill = skill_tool.skill_registry.get(normalized_name)
-            if forced_skill is None:
-                continue
-            if forced_skill.name in seen_forced:
-                continue
-            seen_forced.add(forced_skill.name)
-            forced_skills.append(forced_skill)
-
-    else:
-        if text:
-            forced_skills = extract_invoked_skills(text, skill_tool.skill_registry)
+        elif choice.content_id:
+            for candidate in skill_tool.skill_registry.values():
+                if candidate.source_content_id == choice.content_id:
+                    forced_skill = candidate
+                    break
+        if forced_skill is None:
+            continue
+        if forced_skill.name in seen_forced:
+            continue
+        seen_forced.add(forced_skill.name)
+        forced_skills.append(forced_skill)
 
     if not forced_skills:
         return

--- a/unique_orchestrator/unique_orchestrator/_builders/skill_setup.py
+++ b/unique_orchestrator/unique_orchestrator/_builders/skill_setup.py
@@ -47,11 +47,12 @@ from typing import TYPE_CHECKING, Any
 
 import frontmatter
 from pydantic import ValidationError
-from unique_skill_tool.schemas import SkillDefinition, SkillReference
+from unique_skill_tool.schemas import SkillDefinition
 from unique_skill_tool.service import SkillTool
 from unique_skill_tool.utils import normalize_skill_name
 from unique_toolkit.agentic.tools.config import ToolBuildConfig
 from unique_toolkit.agentic.tools.schemas import ToolCallResponse
+from unique_toolkit.app.schemas import SkillReference
 from unique_toolkit.language_model.schemas import LanguageModelFunction
 
 if TYPE_CHECKING:

--- a/unique_orchestrator/unique_orchestrator/_builders/skill_setup.py
+++ b/unique_orchestrator/unique_orchestrator/_builders/skill_setup.py
@@ -129,7 +129,6 @@ def _build_skill(
     content_key: str,
     file_text: str,
     logger: Logger,
-    source_content_id: str,
 ) -> SkillDefinition | None:
     """Build a ``SkillDefinition`` from the raw file text of a KB document.
 
@@ -162,7 +161,6 @@ def _build_skill(
             name=name,
             description=description,
             content=body,
-            source_content_id=source_content_id,
         )
     except ValidationError as exc:
         logger.warning(
@@ -228,7 +226,6 @@ async def load_selectable_skills(
             content_key=label,
             file_text=file_text,
             logger=logger,
-            source_content_id=entry.content_id,
         )
         if skill is None:
             logger.debug(
@@ -344,11 +341,6 @@ async def preload_invoked_skills(
         if choice.name:
             normalized_name = normalize_skill_name(choice.name)
             forced_skill = skill_tool.skill_registry.get(normalized_name)
-        elif choice.content_id:
-            for candidate in skill_tool.skill_registry.values():
-                if candidate.source_content_id == choice.content_id:
-                    forced_skill = candidate
-                    break
         if forced_skill is None:
             continue
         if forced_skill.name in seen_forced:

--- a/unique_orchestrator/unique_orchestrator/_builders/skill_setup.py
+++ b/unique_orchestrator/unique_orchestrator/_builders/skill_setup.py
@@ -3,7 +3,7 @@
 Loads skill definitions from the knowledge base and registers the
 SkillTool with the tool manager. Which files to load is determined only
 by the per-message skill list: callers map ``ChatEventPayload.available_skills``
-through ``message_skills_as_selectable`` before ``configure_skill_tool``.
+through ``normalize_available_skills_for_tool`` before ``configure_skill_tool``.
 
 Skill discovery follows the official Agent Skills protocol — see
 https://agentskills.io/home. Each skill is a **folder**
@@ -47,7 +47,7 @@ from typing import TYPE_CHECKING, Any
 
 import frontmatter
 from pydantic import ValidationError
-from unique_skill_tool.schemas import SkillReference, SkillDefinition
+from unique_skill_tool.schemas import SkillDefinition, SkillReference
 from unique_skill_tool.service import SkillTool
 from unique_skill_tool.utils import normalize_skill_name
 from unique_toolkit.agentic.tools.config import ToolBuildConfig
@@ -98,7 +98,7 @@ def _parse_frontmatter(*, text: str) -> tuple[dict[str, Any], str]:
     return dict(metadata), body
 
 
-def message_skills_as_selectable(
+def normalize_available_skills_for_tool(
     available_skills: list[SkillReference],
 ) -> list[SkillReference]:
     """Normalize ``ChatEventPayload.available_skills`` for the Skill tool.
@@ -261,8 +261,7 @@ async def configure_skill_tool(
     tool_manager: ToolManager | ResponsesApiToolManager,
     selectable_skills: list[SkillReference] | None = None,
 ) -> None:
-    """Populate the SkillTool's skill registry when it is enabled in ``space.tools``.
-    """
+    """Populate the SkillTool's skill registry when it is enabled in ``space.tools``."""
     skill_tool_build_config = _find_skill_tool_build_config(config.space.tools)
     if skill_tool_build_config is None or not skill_tool_build_config.is_enabled:
         return

--- a/unique_orchestrator/unique_orchestrator/_builders/skill_setup.py
+++ b/unique_orchestrator/unique_orchestrator/_builders/skill_setup.py
@@ -273,9 +273,10 @@ async def configure_skill_tool(
     if not isinstance(skill_tool_build_config.configuration, SkillToolConfig):
         logger.warning(
             "SkillTool build config has unexpected configuration type '%s' — "
-            "skills will not be loaded.",
+            "skills will not be loaded and the tool will be excluded.",
             type(skill_tool_build_config.configuration).__name__,
         )
+        tool_manager.exclude_tool(SkillTool.name)
         return
 
     skill_tool_build_config.configuration.selectable_skills.selected = to_load

--- a/unique_orchestrator/unique_orchestrator/_builders/skill_setup.py
+++ b/unique_orchestrator/unique_orchestrator/_builders/skill_setup.py
@@ -47,6 +47,7 @@ from typing import TYPE_CHECKING, Any
 
 import frontmatter
 from pydantic import ValidationError
+from unique_skill_tool.config import SkillToolConfig
 from unique_skill_tool.schemas import SkillDefinition
 from unique_skill_tool.service import SkillTool
 from unique_skill_tool.utils import normalize_skill_name
@@ -268,6 +269,15 @@ async def configure_skill_tool(
         return
 
     to_load = list(selectable_skills or [])
+
+    if not isinstance(skill_tool_build_config.configuration, SkillToolConfig):
+        logger.warning(
+            "SkillTool build config has unexpected configuration type '%s' — "
+            "skills will not be loaded.",
+            type(skill_tool_build_config.configuration).__name__,
+        )
+        return
+
     skill_tool_build_config.configuration.selectable_skills.selected = to_load
 
     if not to_load:

--- a/unique_orchestrator/unique_orchestrator/_builders/skill_setup.py
+++ b/unique_orchestrator/unique_orchestrator/_builders/skill_setup.py
@@ -2,7 +2,8 @@
 
 Loads skill definitions from the knowledge base and registers the
 SkillTool with the tool manager. Which files to load is determined only
-by the chat event's ``available_skills`` (per-message).
+by the per-message skill list: callers map ``ChatEventPayload.available_skills``
+through ``message_skills_as_selectable`` before ``configure_skill_tool``.
 
 Skill discovery follows the official Agent Skills protocol — see
 https://agentskills.io/home. Each skill is a **folder**
@@ -46,12 +47,11 @@ from typing import TYPE_CHECKING, Any
 
 import frontmatter
 from pydantic import ValidationError
-from unique_skill_tool.schemas import SelectableSkill, SkillDefinition
+from unique_skill_tool.schemas import SkillReference, SkillDefinition
 from unique_skill_tool.service import SkillTool
 from unique_skill_tool.utils import normalize_skill_name
 from unique_toolkit.agentic.tools.config import ToolBuildConfig
 from unique_toolkit.agentic.tools.schemas import ToolCallResponse
-from unique_toolkit.app.schemas import ChatEventSkillChoice
 from unique_toolkit.language_model.schemas import LanguageModelFunction
 
 if TYPE_CHECKING:
@@ -98,23 +98,24 @@ def _parse_frontmatter(*, text: str) -> tuple[dict[str, Any], str]:
     return dict(metadata), body
 
 
-def _message_skills_as_selectable(
-    available_skills: list[ChatEventSkillChoice],
-) -> list[SelectableSkill]:
-    """Map per-message ``available_skills`` to ``SelectableSkill`` rows.
+def message_skills_as_selectable(
+    available_skills: list[SkillReference],
+) -> list[SkillReference]:
+    """Normalize ``ChatEventPayload.available_skills`` for the Skill tool.
 
-    Deduplicates by ``content_id`` while preserving first-seen order.
-    Entries without a ``content_id`` are skipped.
+    Call this at the orchestration boundary (e.g. when building ``UniqueAI``)
+    before ``configure_skill_tool``. Deduplicates by ``content_id`` while
+    preserving first-seen order. Entries without a ``content_id`` are skipped.
     """
     seen: set[str] = set()
-    out: list[SelectableSkill] = []
+    out: list[SkillReference] = []
     for choice in available_skills:
         cid = choice.content_id
         if not cid or cid in seen:
             continue
         seen.add(cid)
         out.append(
-            SelectableSkill(
+            SkillReference(
                 name=choice.name,
                 scope_id=choice.scope_id,
                 content_id=choice.content_id,
@@ -175,10 +176,10 @@ def _build_skill(
 async def load_selectable_skills(
     *,
     content_service: ContentService,
-    selectable_skills: list[SelectableSkill],
+    selectable_skills: list[SkillReference],
     logger: Logger,
 ) -> dict[str, SkillDefinition]:
-    """Load skills from an explicit list of ``SelectableSkill`` references.
+    """Load skills from an explicit list of ``SkillReference`` references.
 
     Entries with an empty ``content_id`` are skipped (admin UIs commonly
     leave a blank row as a placeholder). Failures are logged and do not
@@ -258,24 +259,20 @@ async def configure_skill_tool(
     logger: Logger,
     content_service: ContentService,
     tool_manager: ToolManager | ResponsesApiToolManager,
-    available_skills: list[ChatEventSkillChoice] | None = None,
+    selectable_skills: list[SkillReference] | None = None,
 ) -> None:
     """Populate the SkillTool's skill registry when it is enabled in ``space.tools``.
-
-    Skills are loaded from the per-message ``available_skills``
-    payload (each entry references a ``SKILL.md`` document via
-    ``content_id``).
     """
     skill_tool_build_config = _find_skill_tool_build_config(config.space.tools)
     if skill_tool_build_config is None or not skill_tool_build_config.is_enabled:
         return
 
-    to_load = _message_skills_as_selectable(list(available_skills or []))
+    to_load = list(selectable_skills or [])
     skill_tool_build_config.configuration.selectable_skills.selected = to_load
 
     if not to_load:
         logger.warning(
-            "SkillTool is enabled but available_skills is empty — "
+            "SkillTool is enabled but selectable_skills is empty — "
             "no skills will be loaded."
         )
         tool_manager.exclude_tool(SkillTool.name)
@@ -309,7 +306,7 @@ async def preload_invoked_skills(
     tool_manager: ToolManager | ResponsesApiToolManager,
     history_manager: HistoryManager,
     logger: Logger,
-    skill_choices: list[SelectableSkill],
+    skill_choices: list[SkillReference],
 ) -> None:
     """Preload skills selected in ``skill_choices`` before the first model turn.
 

--- a/unique_orchestrator/unique_orchestrator/unique_ai.py
+++ b/unique_orchestrator/unique_orchestrator/unique_ai.py
@@ -214,7 +214,6 @@ class UniqueAI:
         run_start = time.perf_counter()
 
         await preload_invoked_skills(
-            text=self._event.payload.user_message.text,
             tool_manager=self._tool_manager,
             history_manager=self._history_manager,
             logger=self._logger,

--- a/unique_orchestrator/unique_orchestrator/unique_ai_builder.py
+++ b/unique_orchestrator/unique_orchestrator/unique_ai_builder.py
@@ -450,6 +450,7 @@ async def _build_responses(
         logger=logger,
         content_service=common_components.content_service,
         tool_manager=tool_manager,
+        available_skills=event.payload.available_skills,
     )
 
     loop_iteration_runner = build_responses_loop_iteration_runner(
@@ -528,6 +529,7 @@ async def _build_completions(
         logger=logger,
         content_service=common_components.content_service,
         tool_manager=tool_manager,
+        available_skills=event.payload.available_skills,
     )
 
     postprocessor_manager = common_components.postprocessor_manager

--- a/unique_orchestrator/unique_orchestrator/unique_ai_builder.py
+++ b/unique_orchestrator/unique_orchestrator/unique_ai_builder.py
@@ -82,7 +82,10 @@ from unique_orchestrator._builders.open_file_setup import (
     configure_file_payload,
     handle_uploaded_file_tool_choices,
 )
-from unique_orchestrator._builders.skill_setup import configure_skill_tool
+from unique_orchestrator._builders.skill_setup import (
+    configure_skill_tool,
+    message_skills_as_selectable,
+)
 from unique_orchestrator.config import UniqueAIConfig
 from unique_orchestrator.unique_ai import UniqueAI
 from unique_orchestrator.utils import filter_uploaded_documents_by_selection
@@ -450,7 +453,7 @@ async def _build_responses(
         logger=logger,
         content_service=common_components.content_service,
         tool_manager=tool_manager,
-        available_skills=event.payload.available_skills,
+        selectable_skills=message_skills_as_selectable(event.payload.available_skills),
     )
 
     loop_iteration_runner = build_responses_loop_iteration_runner(
@@ -529,7 +532,7 @@ async def _build_completions(
         logger=logger,
         content_service=common_components.content_service,
         tool_manager=tool_manager,
-        available_skills=event.payload.available_skills,
+        selectable_skills=message_skills_as_selectable(event.payload.available_skills),
     )
 
     postprocessor_manager = common_components.postprocessor_manager

--- a/unique_orchestrator/unique_orchestrator/unique_ai_builder.py
+++ b/unique_orchestrator/unique_orchestrator/unique_ai_builder.py
@@ -84,7 +84,7 @@ from unique_orchestrator._builders.open_file_setup import (
 )
 from unique_orchestrator._builders.skill_setup import (
     configure_skill_tool,
-    message_skills_as_selectable,
+    normalize_available_skills_for_tool,
 )
 from unique_orchestrator.config import UniqueAIConfig
 from unique_orchestrator.unique_ai import UniqueAI
@@ -453,7 +453,9 @@ async def _build_responses(
         logger=logger,
         content_service=common_components.content_service,
         tool_manager=tool_manager,
-        selectable_skills=message_skills_as_selectable(event.payload.available_skills),
+        selectable_skills=normalize_available_skills_for_tool(
+            event.payload.available_skills
+        ),
     )
 
     loop_iteration_runner = build_responses_loop_iteration_runner(
@@ -532,7 +534,9 @@ async def _build_completions(
         logger=logger,
         content_service=common_components.content_service,
         tool_manager=tool_manager,
-        selectable_skills=message_skills_as_selectable(event.payload.available_skills),
+        selectable_skills=normalize_available_skills_for_tool(
+            event.payload.available_skills
+        ),
     )
 
     postprocessor_manager = common_components.postprocessor_manager

--- a/unique_toolkit/tests/app/test_schemas.py
+++ b/unique_toolkit/tests/app/test_schemas.py
@@ -204,6 +204,35 @@ class TestEventSchemas:
             payload.additional_parameters.user_space_instructions == "some instructions"
         )
 
+    def test_chat_event_payload_deserializes_available_skills(self) -> None:
+        json_data = """{
+            "name": "unique.chat.external-module.chosen",
+            "description": "Test description",
+            "configuration": {"key": "value"},
+            "chatId": "chat1",
+            "assistantId": "assistant1",
+            "userMessage": {
+                "id": "msg1",
+                "text": "Hello",
+                "createdAt": "2023-01-01T00:00:00Z",
+                "originalText": "Hello",
+                "language": "en"
+            },
+            "assistantMessage": {
+                "id": "msg2",
+                "createdAt": "2023-01-01T00:01:00Z"
+            },
+            "availableSkills": [
+                {"contentId": "cont_a", "scopeId": "scope_b"}
+            ]
+        }"""
+        payload = ChatEventPayload.model_validate_json(json_data)
+
+        assert len(payload.available_skills) == 1
+        assert payload.available_skills[0].content_id == "cont_a"
+        assert payload.available_skills[0].scope_id == "scope_b"
+        assert payload.available_skills[0].name == ""
+
     def test_additional_parameters__uploaded_files__object_format_deserialization(self):
         json_data = """{
             "userSpaceInstructions": "",

--- a/unique_toolkit/unique_toolkit/app/schemas.py
+++ b/unique_toolkit/unique_toolkit/app/schemas.py
@@ -215,15 +215,7 @@ class Correlation(BaseModel):
     parent_assistant_id: str
 
 
-class ChatEventSkillChoice(BaseModel):
-    """One selected or available skill on a chat event payload.
-
-    Reference to a specific ``SKILL.md`` in the knowledge base. Used on
-    ``ChatEventPayload`` for ``skill_choices`` and ``available_skills``. Each
-    entry resolves via ``content_id``; ``scope_id`` scopes lookup; ``name`` is
-    the skill file's frontmatter name when known.
-    """
-
+class ChatEventSkill(BaseModel):
     model_config = model_config
 
     name: str = Field(default="", description="Skill name.")
@@ -237,7 +229,7 @@ class ChatEventSkillChoice(BaseModel):
     )
 
 
-SkillReference = ChatEventSkillChoice
+SkillReference = ChatEventSkill
 
 
 class ChatEventPayload(BaseModel):
@@ -259,14 +251,14 @@ class ChatEventPayload(BaseModel):
         default_factory=list,
         description="A list containing the tool names the user has chosen to be activated.",
     )
-    skill_choices: list[ChatEventSkillChoice] = Field(
+    skill_choices: list[ChatEventSkill] = Field(
         default_factory=list,
         description=(
             "A list containing selected skills with ``scope_id``, "
             "``content_id``, and ``name``."
         ),
     )
-    available_skills: list[ChatEventSkillChoice] = Field(
+    available_skills: list[ChatEventSkill] = Field(
         default_factory=list,
         description=(
             "Per-turn skills exposed for this message (``content_id`` + "

--- a/unique_toolkit/unique_toolkit/app/schemas.py
+++ b/unique_toolkit/unique_toolkit/app/schemas.py
@@ -215,13 +215,13 @@ class Correlation(BaseModel):
     parent_assistant_id: str
 
 
-class SkillReference(BaseModel):
-    """Reference to a specific ``SKILL.md`` in the knowledge base.
+class ChatEventSkillChoice(BaseModel):
+    """One selected or available skill on a chat event payload.
 
-    Shared by ``ChatEventPayload`` (per-turn ``skill_choices`` /
-    ``available_skills``) and Skill tool configuration. Each entry resolves
-    via ``content_id``; ``scope_id`` scopes lookup; ``name`` is the skill
-    file's frontmatter name when known.
+    Reference to a specific ``SKILL.md`` in the knowledge base. Used on
+    ``ChatEventPayload`` for ``skill_choices`` and ``available_skills``. Each
+    entry resolves via ``content_id``; ``scope_id`` scopes lookup; ``name`` is
+    the skill file's frontmatter name when known.
     """
 
     model_config = model_config
@@ -238,6 +238,9 @@ class SkillReference(BaseModel):
         default="",
         description="Knowledge base content ID of the ``SKILL.md`` file.",
     )
+
+
+SkillReference = ChatEventSkillChoice
 
 
 class ChatEventPayload(BaseModel):
@@ -259,14 +262,14 @@ class ChatEventPayload(BaseModel):
         default_factory=list,
         description="A list containing the tool names the user has chosen to be activated.",
     )
-    skill_choices: list[SkillReference] = Field(
+    skill_choices: list[ChatEventSkillChoice] = Field(
         default_factory=list,
         description=(
             "A list containing selected skills with ``scope_id``, "
             "``content_id``, and ``name``."
         ),
     )
-    available_skills: list[SkillReference] = Field(
+    available_skills: list[ChatEventSkillChoice] = Field(
         default_factory=list,
         description=(
             "Per-turn skills exposed for this message (``content_id`` + "

--- a/unique_toolkit/unique_toolkit/app/schemas.py
+++ b/unique_toolkit/unique_toolkit/app/schemas.py
@@ -255,6 +255,14 @@ class ChatEventPayload(BaseModel):
             "``content_id``, and ``name``."
         ),
     )
+    available_skills: list[ChatEventSkillChoice] = Field(
+        default_factory=list,
+        description=(
+            "Per-turn skills exposed for this message (``content_id`` + "
+            "``scope_id`` from the client). This list alone drives the "
+            "Skill tool registry for the run."
+        ),
+    )
     disabled_tools: list[str] = Field(
         default_factory=list,
         description="A list containing the tool names of tools that are disabled at the company level",

--- a/unique_toolkit/unique_toolkit/app/schemas.py
+++ b/unique_toolkit/unique_toolkit/app/schemas.py
@@ -215,10 +215,21 @@ class Correlation(BaseModel):
     parent_assistant_id: str
 
 
-class ChatEventSkillChoice(BaseModel):
+class SkillReference(BaseModel):
+    """Reference to a specific ``SKILL.md`` in the knowledge base.
+
+    Shared by ``ChatEventPayload`` (per-turn ``skill_choices`` /
+    ``available_skills``) and Skill tool configuration. Each entry resolves
+    via ``content_id``; ``scope_id`` scopes lookup; ``name`` is the skill
+    file's frontmatter name when known.
+    """
+
     model_config = model_config
 
-    name: str = Field(default="", description="Skill name.")
+    name: str = Field(
+        default="",
+        description="Skill name (from the skill file frontmatter when known).",
+    )
     scope_id: str = Field(
         default="",
         description="Knowledge base scope ID that contains the skill file.",
@@ -248,14 +259,14 @@ class ChatEventPayload(BaseModel):
         default_factory=list,
         description="A list containing the tool names the user has chosen to be activated.",
     )
-    skill_choices: list[ChatEventSkillChoice] = Field(
+    skill_choices: list[SkillReference] = Field(
         default_factory=list,
         description=(
             "A list containing selected skills with ``scope_id``, "
             "``content_id``, and ``name``."
         ),
     )
-    available_skills: list[ChatEventSkillChoice] = Field(
+    available_skills: list[SkillReference] = Field(
         default_factory=list,
         description=(
             "Per-turn skills exposed for this message (``content_id`` + "

--- a/unique_toolkit/unique_toolkit/app/schemas.py
+++ b/unique_toolkit/unique_toolkit/app/schemas.py
@@ -226,10 +226,7 @@ class ChatEventSkillChoice(BaseModel):
 
     model_config = model_config
 
-    name: str = Field(
-        default="",
-        description="Skill name (from the skill file frontmatter when known).",
-    )
+    name: str = Field(default="", description="Skill name.")
     scope_id: str = Field(
         default="",
         description="Knowledge base scope ID that contains the skill file.",


### PR DESCRIPTION
## 🚀 Summary
Refs: https://unique-ch.atlassian.net/browse/UN-18944, https://unique-ch.atlassian.net/browse/UN-20771

Toolkit:
- **`ChatEventPayload.available_skills`** — New per-turn list (`availableSkills` in JSON) of KB skill references (`content_id`, `scope_id`, `name`).
- **`ChatEventSkill` + `SkillReference` alias** — Alias is used in Skill Tool

Orchestrator:
- **`UniqueAI` build path** — Both completions and responses builders pass `normalize_available_skills_for_tool(event.payload.available_skills)` into `configure_skill_tool` so the registry matches the incoming chat event.
- **`normalize_available_skills_for_tool`** — New boundary helper: skips entries without `content_id`, deduplicates by `content_id` while keeping first-seen order, returns clean `SkillReference` instances.
- **`configure_skill_tool(..., selectable_skills=...)`** — Optional per-run list overwrites `SkillToolConfig.selectable_skills.selected` before load; when empty after tool is enable, logs a clearer warning, excludes `SkillTool`.
- **`preload_invoked_skills`** — Drops the user-message `text` argument and **removes `/skill-name` parsing** from the message (`extract_invoked_skills` no longer used here). Preload only resolves explicit `skill_choices` against the registered skill tool.

Skill Tool:
- **`unique_skill_tool`** — Removes the duplicate **`SelectableSkill`** model; config / public API use **`SkillReference`** instead of `SelectableSkill`.

## ✅ Changes

- [x] Added feature / fixed bug / updated docs
- [ ] Refactored code / cleaned up
- [ ] Other (describe below)

## 🧪 Testing

### Before adding additional skill 
test-skill is not triggered
<img width="759" height="410" alt="image" src="https://github.com/user-attachments/assets/4fe2e349-5033-4549-9531-1c3b53303e47" />

<img width="739" height="312" alt="image" src="https://github.com/user-attachments/assets/7324b167-81a7-4246-908a-cc982cf14395" />

### After adding additional skill
test-skill is automatically added and can be triggered
<img width="1243" height="313" alt="image" src="https://github.com/user-attachments/assets/b1022112-9e55-411f-b3b8-90f53490dcf9" />
<img width="767" height="441" alt="image" src="https://github.com/user-attachments/assets/3b720cfa-3459-4b61-a643-dbb16dfa465f" />
<img width="1250" height="417" alt="image" src="https://github.com/user-attachments/assets/89202482-5f9c-4634-89cf-481c44818b4e" />

