### PR TITLE
fix(toolkit): add enable_html_with_fence_un_17927 FF to opt in to htmlWithSource for HTML files (UN-17927)

### DIFF
--- a/unique_toolkit/tests/agentic/tools/test_code_interpreter_postprocessors_generated_files.py
+++ b/unique_toolkit/tests/agentic/tools/test_code_interpreter_postprocessors_generated_files.py
@@ -936,12 +936,12 @@ def test_build_file_fence__document__uses_fileWithSource_tag() -> None:
 
 
 @pytest.mark.ai
-def test_build_file_fence__html__falls_through_to_fileWithSource() -> None:
+def test_build_file_fence__html__produces_htmlWithSource() -> None:
     """
-    Purpose: HTML ``CodeInterpreterFile`` passed to ``_build_file_fence`` uses
-    ``fileWithSource`` (not a dedicated HTML fence tag).
-    Why this matters: In normal flow HTML is shown via ``HtmlRendering`` blocks and is
-    excluded from fence injection; this path only applies to edge cases (e.g. orphans).
+    Purpose: HTML ``CodeInterpreterFile`` passed to ``_build_file_fence`` uses the
+    dedicated ``htmlWithSource`` fence tag.
+    Why this matters: When the fence FF is on, HTML files render via ``htmlWithSource``
+    so the frontend receives the generating code alongside the content ID.
     """
     file = CodeInterpreterFile(
         filename="report.html", content_id="cont_html1", type="html"
@@ -949,9 +949,9 @@ def test_build_file_fence__html__falls_through_to_fileWithSource() -> None:
     fence = _build_file_fence(
         file, 'open("/mnt/data/report.html", "w").write("<html></html>")', fence_id=3
     )
-    assert fence.startswith("````fileWithSource(")
+    assert fence.startswith("````htmlWithSource(")
     assert "cont_html1" in fence
-    assert "htmlWithSource" not in fence
+    assert "fileWithSource" not in fence
 
 
 @pytest.mark.ai
@@ -1037,12 +1037,13 @@ def test_inject_code_execution_fences__replaces_document_inline_ref__with_fileWi
 
 
 @pytest.mark.ai
-def test_inject_code_execution_fences__html_file__is_not_injected() -> None:
+def test_inject_code_execution_fences__html_file__produces_htmlWithSource() -> None:
     """
-    Purpose: HTML files are rendered via HtmlRendering blocks (not fence injection),
-    so an HTML block passed to _inject_code_execution_fences leaves the text unchanged.
-    Why this matters: In normal flow HTML never reaches fence injection — this guards
-    against accidental regressions where an htmlWithSource fence is emitted.
+    Purpose: HTML files with an inline unique://content ref are wrapped in an
+    ``htmlWithSource`` fence by _inject_code_execution_fences.
+    Why this matters: When the fence FF is on, HTML goes through
+    _replace_container_file_citation (same as other files) and then fence injection
+    converts the inline ref to an htmlWithSource fence.
     """
     block = CodeInterpreterBlock(
         code='open("/mnt/data/page.html", "w").write("<html></html>")',
@@ -1052,15 +1053,14 @@ def test_inject_code_execution_fences__html_file__is_not_injected() -> None:
             )
         ],
     )
-    # HTML produces no unique://content inline ref (it was replaced by HtmlRendering),
-    # so there is nothing for the injector to match.
-    text = "```HtmlRendering\nunique://content/cont_html1\n```"
+    # When fence FF is on, _replace_container_file_citation produces this inline ref.
+    text = "[page.html](unique://content/cont_html1)"
 
     result = _inject_code_execution_fences(text, [block])
 
-    assert "htmlWithSource" not in result
-    assert "HtmlRendering" in result
+    assert "````htmlWithSource(" in result
     assert "cont_html1" in result
+    assert "[page.html](unique://content/cont_html1)" not in result
 
 
 @pytest.mark.ai
@@ -1845,8 +1845,9 @@ def test_apply_postprocessing_to_response__html_uses_HtmlRendering__when_fence_f
     _mock_fence_ff: MagicMock,
 ) -> None:
     """
-    Purpose: HTML always uses _replace_container_html_citation regardless of feature flags.
-    Why this matters: HTML rendering via HtmlRendering blocks is unconditional.
+    Purpose: HTML uses HtmlRendering when the code-execution fence FF is off.
+    Why this matters: Default path — HtmlRendering is the correct output when the
+    code-execution fence feature is disabled (html_fence FF is irrelevant here).
     """
     proc = _make_display_files_postprocessor()
     proc._content_map = {"report.html": "cid_html"}
@@ -1876,13 +1877,14 @@ def test_apply_postprocessing_to_response__html_uses_HtmlRendering__when_fence_f
     "generated_files.feature_flags.enable_code_execution_fence_un_17972.is_enabled",
     return_value=True,
 )
-def test_apply_postprocessing_to_response__html_uses_HtmlRendering__even_when_fence_ff_on(
+def test_apply_postprocessing_to_response__html_uses_HtmlRendering__when_fence_ff_on_but_html_fence_ff_off(
     _mock_fence_ff: MagicMock,
 ) -> None:
     """
-    Purpose: HTML always uses HtmlRendering blocks, even when the fence FF is on.
-    Why this matters: HTML rendering is unconditional; the fence FF only affects
-    non-HTML files (images → imgWithSource, documents → fileWithSource).
+    Purpose: HTML still uses HtmlRendering when the fence FF is on but the html-fence FF
+    (enable_html_with_fence_un_17927) is off (the default).
+    Why this matters: The html-fence FF defaults to False so existing deployments are
+    unaffected when they turn on the code-execution fence FF.
     """
     proc = _make_display_files_postprocessor()
     proc._content_map = {"page.html": "cid_page"}
@@ -1907,6 +1909,51 @@ def test_apply_postprocessing_to_response__html_uses_HtmlRendering__even_when_fe
     assert "HtmlRendering" in message.text
     assert "unique://content/cid_page" in message.text
     assert "htmlWithSource" not in message.text
+
+
+@pytest.mark.ai
+@patch(
+    "unique_toolkit.agentic.tools.openai_builtin.code_interpreter.postprocessors."
+    "generated_files.feature_flags.enable_html_with_fence_un_17927.is_enabled",
+    return_value=True,
+)
+@patch(
+    "unique_toolkit.agentic.tools.openai_builtin.code_interpreter.postprocessors."
+    "generated_files.feature_flags.enable_code_execution_fence_un_17972.is_enabled",
+    return_value=True,
+)
+def test_apply_postprocessing_to_response__html_uses_htmlWithSource__when_both_ffs_on(
+    _mock_fence_ff: MagicMock,
+    _mock_html_fence_ff: MagicMock,
+) -> None:
+    """
+    Purpose: HTML uses htmlWithSource fence injection when BOTH the code-execution
+    fence FF and the html-fence FF (enable_html_with_fence_un_17927) are on.
+    Why this matters: The html-fence FF is the opt-in gate for the new behavior.
+    """
+    proc = _make_display_files_postprocessor()
+    proc._content_map = {"page.html": "cid_page"}
+
+    refs: list[ContentReference] = []
+    message = SimpleNamespace(
+        text="[page.html](sandbox:/mnt/data/page.html)",
+        references=refs,
+    )
+    call = _make_ci_call('open("/mnt/data/page.html", "w").write("x")')
+    ann = _make_annotation("page.html", file_id="f_html", container_id="cntr_x")
+    loop_response = SimpleNamespace(
+        message=message,
+        container_files=[ann],
+        code_interpreter_calls=[call],
+    )
+
+    changed = proc.apply_postprocessing_to_response(loop_response)
+
+    assert changed is True
+    assert len(refs) == 0
+    assert "````htmlWithSource(" in message.text
+    assert "cid_page" in message.text
+    assert "HtmlRendering" not in message.text
 
 
 # ---------------------------------------------------------------------------

--- a/unique_toolkit/unique_toolkit/agentic/feature_flags/feature_flags.py
+++ b/unique_toolkit/unique_toolkit/agentic/feature_flags/feature_flags.py
@@ -81,6 +81,11 @@ class FeatureFlags(BaseSettings):
         description="Emit codeExecution fences in message.text for code interpreter outputs (UN-17972). When disabled, inline file refs are kept as-is. Can be 'true' or comma-separated company IDs.",
     )
 
+    enable_html_with_fence_un_17927: FeatureFlag = Field(
+        default=FeatureFlag(False),
+        description="Render HTML code interpreter files as htmlWithSource fences instead of HtmlRendering blocks (UN-17927). Requires enable_code_execution_fence_un_17972 to also be enabled. Can be 'true' or comma-separated company IDs.",
+    )
+
     enable_web_search_argument_screening_un_18741: FeatureFlag = Field(
         default=FeatureFlag(False),
         description="Enable argument screening agent for web search tool calls (UN-18741). Can be 'true' or comma-separated company IDs.",

--- a/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/postprocessors/generated_files.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/postprocessors/generated_files.py
@@ -503,6 +503,15 @@ class DisplayCodeInterpreterFilesPostProcessor(
         fence_ff_on = feature_flags.enable_code_execution_fence_un_17972.is_enabled(
             self._company_id
         )
+        # HTML uses htmlWithSource only when BOTH the code-execution fence FF AND the
+        # dedicated HTML-fence FF are on. Default (FF off) keeps HtmlRendering so
+        # existing deployments are unaffected.
+        html_fence_ff_on = (
+            fence_ff_on
+            and feature_flags.enable_html_with_fence_un_17927.is_enabled(
+                self._company_id
+            )
+        )
 
         replaced_files: list[str] = []
         missed_files: list[str] = []
@@ -534,7 +543,9 @@ class DisplayCodeInterpreterFilesPostProcessor(
                 )
                 changed |= replaced
 
-            elif is_html:
+            # HTML rendered as HtmlRendering block unless the dedicated html-fence FF
+            # is on (enable_html_with_fence_un_17927). Default keeps HtmlRendering.
+            elif is_html and not html_fence_ff_on:
                 loop_response.message.text, replaced = _replace_container_html_citation(
                     text=loop_response.message.text or "",
                     filename=filename,
@@ -542,6 +553,8 @@ class DisplayCodeInterpreterFilesPostProcessor(
                 )
                 changed |= replaced
 
+            # Non-HTML files, or HTML when html_fence_ff_on → inline content link for
+            # subsequent fence injection (htmlWithSource / imgWithSource / fileWithSource)
             else:
                 loop_response.message.text, replaced = _replace_container_file_citation(
                     text=loop_response.message.text or "",
@@ -563,6 +576,7 @@ class DisplayCodeInterpreterFilesPostProcessor(
             else:
                 missed_files.append(filename)
 
+            # HtmlRendering and htmlWithSource both embed contentId directly — no ContentReference needed
             is_html_rendered = is_html
             if replaced and not (is_image or is_html_rendered or fence_ff_on):
                 loop_response.message.references.append(
@@ -584,13 +598,17 @@ class DisplayCodeInterpreterFilesPostProcessor(
         )
 
         if fence_ff_on:
-            code_blocks = _build_code_blocks(loop_response, self._content_map)
+            code_blocks = _build_code_blocks(
+                loop_response, self._content_map, include_html=html_fence_ff_on
+            )
             self._log.info(
                 "Fence injection — %d code block(s), files: %s",
                 len(code_blocks),
                 [f.filename for b in code_blocks for f in b.files],
             )
-            _warn_unmatched_code_blocks(self._content_map, code_blocks)
+            _warn_unmatched_code_blocks(
+                self._content_map, code_blocks, include_html=html_fence_ff_on
+            )
             text_before = loop_response.message.text
             loop_response.message.text = _inject_code_execution_fences(
                 loop_response.message.text or "",
@@ -971,12 +989,9 @@ def _build_file_fence(file: CodeInterpreterFile, code: str, fence_id: int) -> st
     content_id, a title derived from the filename, the type, and the
     escaped source code.
 
-    HTML is not emitted here in normal flow: it is rendered via ``HtmlRendering`` blocks
-    in message text and excluded from fence injection. If ``type="html"`` is passed (e.g.
-    orphan path), fall through to ``fileWithSource`` like other non-image artifacts.
-
     Format (4 backticks so inner code backticks never close the fence):
       ````imgWithSource(id='{n}', contentId='{id}', title="{title}", code="{escaped_code}")````
+      ````htmlWithSource(id='{n}', contentId='{id}', title="{title}", code="{escaped_code}")````
       ````fileWithSource(id='{n}', contentId='{id}', title="{title}", type="{type}", code="{escaped_code}")````
     """
     title = _file_title(file.filename)
@@ -984,6 +999,8 @@ def _build_file_fence(file: CodeInterpreterFile, code: str, fence_id: int) -> st
     outer = "````"
     if file.type == "image":
         tag = f"imgWithSource(id='{fence_id}', contentId='{file.content_id}', title=\"{title}\", code=\"{escaped}\")"
+    elif file.type == "html":
+        tag = f"htmlWithSource(id='{fence_id}', contentId='{file.content_id}', title=\"{title}\", code=\"{escaped}\")"
     else:
         ftype = _file_frontend_type(file.filename)
         tag = f'fileWithSource(id=\'{fence_id}\', contentId=\'{file.content_id}\', title="{title}", type="{ftype}", code="{escaped}")'
@@ -1007,7 +1024,7 @@ def _inline_ref_pattern(file: CodeInterpreterFile) -> re.Pattern[str]:
 
 
 _FENCE_BLOCK_START = re.compile(
-    r"^[^\n`]+?(````(?:imgWithSource|fileWithSource)\()",
+    r"^[^\n`]+?(````(?:imgWithSource|fileWithSource|htmlWithSource)\()",
     re.MULTILINE,
 )
 
@@ -1017,9 +1034,9 @@ _FENCE_BLOCK_START = re.compile(
 #   - cross-line: 1 or 2 newlines optionally surrounded by horizontal whitespace
 #     (list-item linebreak, or blank-line paragraph gap)
 _CONSECUTIVE_FENCES_RE = re.compile(
-    r"(````(?:imgWithSource|fileWithSource)\([^\n]*\)````)"
+    r"(````(?:imgWithSource|fileWithSource|htmlWithSource)\([^\n]*\)````)"
     r"(?:[^\n`]*|[ \t]*\n{1,2}[ \t]*)"
-    r"(?=````(?:imgWithSource|fileWithSource)\()"
+    r"(?=````(?:imgWithSource|fileWithSource|htmlWithSource)\()"
 )
 
 
@@ -1083,6 +1100,7 @@ def _inject_code_execution_fences(
 def _build_code_blocks(
     loop_response: ResponsesLanguageModelStreamResponse,
     content_map: dict[str, str | None],
+    include_html: bool = False,
 ) -> list[CodeInterpreterBlock]:
     """Map each code interpreter call to the files it produced via /mnt/data/ path matching.
 
@@ -1180,11 +1198,9 @@ def _build_code_blocks(
     # overwritten across executions. Using a dict keyed by filename ensures each
     # file appears exactly once per block (last annotation wins, consistent with
     # the last-writer-wins rule applied in step 1).
-    # HTML files are excluded: they are always rendered via HtmlRendering blocks
-    # and never participate in fence injection.
     block_file_map: dict[int, dict[str, CodeInterpreterFile]] = {}
     for annotation in loop_response.container_files:
-        if _get_file_type(annotation.filename) == "html":
+        if not include_html and _get_file_type(annotation.filename) == "html":
             continue
         content_id = content_map.get(annotation.filename)
         if content_id is None:
@@ -1268,6 +1284,7 @@ def _replace_dangling_sandbox_links(text: str) -> tuple[str, bool]:
 def _warn_unmatched_code_blocks(
     content_map: dict[str, str | None],
     code_blocks: list[CodeInterpreterBlock],
+    include_html: bool = False,
 ) -> None:
     """Warn for files that were uploaded but could not be matched to any code block.
 
@@ -1281,7 +1298,7 @@ def _warn_unmatched_code_blocks(
     for filename, content_id in content_map.items():
         if content_id is None:
             continue
-        if _get_file_type(filename) == "html":
+        if not include_html and _get_file_type(filename) == "html":
             continue
         if filename not in fenced_filenames:
             logger.warning(


### PR DESCRIPTION
## Summary

Re-activates the `htmlWithSource` fence pattern for HTML code interpreter files (UN-17927), behind a new feature flag that defaults to **off** so existing deployments are completely unaffected.

- Adds `enable_html_with_fence_un_17927` feature flag (default `false`)
- When **both** `enable_code_execution_fence_un_17972` and `enable_html_with_fence_un_17927` are `true`, HTML files emitted by the code interpreter render as `` ````htmlWithSource(...)```` `` fences instead of `HtmlRendering` blocks
- All other paths (fence FF off, or html FF off) are unchanged — HTML still uses `HtmlRendering`

## Enabling the new path

To activate `htmlWithSource` for HTML files, set **both** flags in the assistant bundle env:

```
# monorepo: python/assistants/bundles/core/src/.env
FEATURE_FLAG_ENABLE_CODE_EXECUTION_FENCE_UN_17972=true
FEATURE_FLAG_ENABLE_HTML_WITH_FENCE_UN_17927=true
```

Leaving `FEATURE_FLAG_ENABLE_HTML_WITH_FENCE_UN_17927` unset or `false` keeps the current `HtmlRendering` behavior even if the fence FF is on.

## Changes

- **`feature_flags.py`**: `enable_html_with_fence_un_17927` field (default `False`)
- **`generated_files.py`**:
  - Routing: `elif is_html and not html_fence_ff_on:` → `HtmlRendering`; falls through to `else` (→ `htmlWithSource`) only when new FF is on
  - `_build_file_fence`: `elif file.type == "html"` → emits `htmlWithSource` fence
  - `_FENCE_BLOCK_START` / `_CONSECUTIVE_FENCES_RE`: add `htmlWithSource` alternation
  - `_build_code_blocks` / `_warn_unmatched_code_blocks`: `include_html` parameter (default `False` = skip HTML, preserving current behavior; `True` when new FF is on)
- **Tests**: three-way split — fence FF off, fence FF on + html FF off (default), both FFs on

## Test plan

- [x] `poetry run pytest unique_toolkit/tests/agentic/tools/test_code_interpreter_postprocessors_generated_files.py` — 134 passed
- [x] `ruff check` + `ruff format` — clean

## Risk / rollout

- **Zero risk by default** — `enable_html_with_fence_un_17927` is `false`; no existing deployment is affected
- To opt in: set both env vars above per environment
- To roll back: unset / set `FEATURE_FLAG_ENABLE_HTML_WITH_FENCE_UN_17927=false`

Refs: UN-17927

Made with [Cursor](https://cursor.com)