### PR TITLE
feat(kb-config): replace loose metadata_filter type with validated UniqueQLDict

### DIFF
--- a/tutorials/mcp/mcp_search/src/mcp_search/config.py
+++ b/tutorials/mcp/mcp_search/src/mcp_search/config.py
@@ -27,7 +27,7 @@ class SearchToolConfig(BaseModel):
             metadata_filter={
                 "path": ["folderId"],
                 "operator": "isNotNull",
-                "value": None,
+                "value": "",
             }
         )
     )

--- a/unique_toolkit/tests/_common/test_metadata_filter_scope.py
+++ b/unique_toolkit/tests/_common/test_metadata_filter_scope.py
@@ -8,6 +8,7 @@ from unique_toolkit._common.metadata_filter_scope import (
     build_folder_id_in_clause,
     merge_scope_clause_into_metadata_filter,
 )
+from unique_toolkit.content.smart_rules import Operator, Statement
 
 
 @pytest.mark.ai
@@ -65,3 +66,17 @@ def test_and_merge__returns_scope_when_no_existing_filter() -> None:
 def test_and_merge__treats_empty_dict_as_no_filter() -> None:
     scope = build_folder_id_in_clause(["scope-x"])
     assert merge_scope_clause_into_metadata_filter(scope, {}) == scope
+
+
+@pytest.mark.ai
+def test_and_merge__accepts_uniqueql_model() -> None:
+    """Purpose: Verify merge accepts typed UniqueQL models from config fields."""
+    scope = build_folder_id_in_clause(["scope-x"])
+    existing = Statement(operator=Operator.EQUALS, value="Legal", path=["dept"])
+    merged = merge_scope_clause_into_metadata_filter(scope, existing)
+    assert merged == {
+        "and": [
+            scope,
+            {"path": ["dept"], "operator": "equals", "value": "Legal"},
+        ]
+    }

--- a/unique_toolkit/tests/content/test_smart_rules.py
+++ b/unique_toolkit/tests/content/test_smart_rules.py
@@ -753,3 +753,47 @@ def test_round_trip_json_conversion():
     assert second_or["operator"] == "lessThan"
     assert second_or["value"] == "<toolParameters.threshold>"
     assert second_or["path"] == ["score"]
+
+
+@pytest.mark.ai
+def test_parse_uniqueql_input__accepts_json_string() -> None:
+    """Purpose: Verify JSON strings are parsed into UniqueQL models."""
+    from unique_toolkit.content.smart_rules import parse_uniqueql_input
+
+    result = parse_uniqueql_input(
+        '{"operator": "equals", "value": "x", "path": ["fieldName"]}'
+    )
+    assert isinstance(result, Statement)
+    assert result.operator == Operator.EQUALS
+
+
+@pytest.mark.ai
+def test_parse_uniqueql_input__empty_string_returns_none() -> None:
+    """Purpose: Verify blank JSON input normalises to None."""
+    from unique_toolkit.content.smart_rules import parse_uniqueql_input
+
+    assert parse_uniqueql_input("") is None
+    assert parse_uniqueql_input("   ") is None
+
+
+@pytest.mark.ai
+def test_to_dict__round_trips_model() -> None:
+    """Purpose: Verify UniqueQL models convert to wire-format dicts via to_dict."""
+    stmt = Statement(operator=Operator.EQUALS, value="x", path=["fieldName"])
+    assert stmt.to_dict() == {
+        "operator": "equals",
+        "value": "x",
+        "path": ["fieldName"],
+    }
+
+
+@pytest.mark.ai
+def test_uniqueql_to_dict__passes_through_wire_dict() -> None:
+    """Purpose: Verify uniqueql_to_dict still normalizes plain dicts at API boundaries."""
+    from unique_toolkit.content.smart_rules import uniqueql_to_dict
+
+    assert uniqueql_to_dict({"operator": "equals", "value": "y", "path": ["a"]}) == {
+        "operator": "equals",
+        "value": "y",
+        "path": ["a"],
+    }

--- a/unique_toolkit/tests/experimental/components/internal_search/test_kb_config_unit.py
+++ b/unique_toolkit/tests/experimental/components/internal_search/test_kb_config_unit.py
@@ -1,9 +1,9 @@
 """Unit tests for KnowledgeBaseInternalSearchConfig.metadata_filter typing.
 
 Covers:
-- _parse_and_validate_uniqueql: None, empty string, valid dict, valid JSON string,
+- parse_uniqueql_input via construction: None, empty string, valid dict, valid JSON string,
   invalid JSON string, invalid dict (non-UniqueQL), wrong type
-- field_serializer: stored dict → JSON string, None → None
+- PlainSerializer: stored UniqueQL model → dict, None → None
 - JSON schema shape: anyOf [string, null], no $defs for UniqueQL types
 - UI schema shape: anyOf with textarea on branch 0, no additionalProperties
 """
@@ -16,6 +16,7 @@ import pytest
 from pydantic import ValidationError
 
 from unique_toolkit._common.pydantic.rjsf_tags import ui_schema_for_model
+from unique_toolkit.content.smart_rules import Statement
 from unique_toolkit.experimental.components.internal_search.knowledge_base.config import (
     KnowledgeBaseInternalSearchConfig,
 )
@@ -47,19 +48,20 @@ class TestMetadataFilterParsing:
         cfg = KnowledgeBaseInternalSearchConfig(metadata_filter="   ")
         assert cfg.metadata_filter is None
 
-    def test_valid_dict_is_stored_as_dict(self):
+    def test_valid_dict_is_stored_as_uniqueql_model(self):
         cfg = KnowledgeBaseInternalSearchConfig(metadata_filter=_VALID_FILTER)
-        assert cfg.metadata_filter == _VALID_FILTER
-        assert isinstance(cfg.metadata_filter, dict)
+        assert isinstance(cfg.metadata_filter, Statement)
+        assert cfg.metadata_filter.to_dict() == _VALID_FILTER
 
-    def test_valid_json_string_is_parsed_to_dict(self):
+    def test_valid_json_string_is_parsed_to_uniqueql_model(self):
         cfg = KnowledgeBaseInternalSearchConfig(metadata_filter=_VALID_FILTER_JSON)
-        assert cfg.metadata_filter == _VALID_FILTER
-        assert isinstance(cfg.metadata_filter, dict)
+        assert isinstance(cfg.metadata_filter, Statement)
+        assert cfg.metadata_filter.to_dict() == _VALID_FILTER
 
     def test_isnull_operator_is_accepted(self):
         cfg = KnowledgeBaseInternalSearchConfig(metadata_filter=_ISNULL_FILTER)
-        assert cfg.metadata_filter == _ISNULL_FILTER
+        assert isinstance(cfg.metadata_filter, Statement)
+        assert cfg.metadata_filter.to_dict() == _ISNULL_FILTER
 
     def test_invalid_json_string_raises(self):
         with pytest.raises(ValidationError, match="Invalid JSON"):
@@ -75,16 +77,15 @@ class TestMetadataFilterParsing:
 
 
 # ---------------------------------------------------------------------------
-# field_serializer — model_dump produces JSON string
+# PlainSerializer — model_dump(mode="json") produces dict
 # ---------------------------------------------------------------------------
 
 
 class TestMetadataFilterSerializer:
-    def test_dict_serialises_to_json_string(self):
+    def test_model_serialises_to_dict(self):
         cfg = KnowledgeBaseInternalSearchConfig(metadata_filter=_VALID_FILTER)
         dumped = cfg.model_dump(mode="json")
-        assert isinstance(dumped["metadata_filter"], str)
-        assert json.loads(dumped["metadata_filter"]) == _VALID_FILTER
+        assert dumped["metadata_filter"] == _VALID_FILTER
 
     def test_none_serialises_to_none(self):
         cfg = KnowledgeBaseInternalSearchConfig(metadata_filter=None)
@@ -96,11 +97,10 @@ class TestMetadataFilterSerializer:
         dumped = cfg.model_dump(mode="json")
         assert dumped["metadata_filter"] is None
 
-    def test_json_string_input_round_trips_as_string(self):
+    def test_json_string_input_round_trips_as_dict(self):
         cfg = KnowledgeBaseInternalSearchConfig(metadata_filter=_VALID_FILTER_JSON)
         dumped = cfg.model_dump(mode="json")
-        assert isinstance(dumped["metadata_filter"], str)
-        assert json.loads(dumped["metadata_filter"]) == _VALID_FILTER
+        assert dumped["metadata_filter"] == _VALID_FILTER
 
 
 # ---------------------------------------------------------------------------

--- a/unique_toolkit/tests/experimental/components/internal_search/test_kb_config_unit.py
+++ b/unique_toolkit/tests/experimental/components/internal_search/test_kb_config_unit.py
@@ -1,0 +1,163 @@
+"""Unit tests for KnowledgeBaseInternalSearchConfig.metadata_filter typing.
+
+Covers:
+- _parse_and_validate_uniqueql: None, empty string, valid dict, valid JSON string,
+  invalid JSON string, invalid dict (non-UniqueQL), wrong type
+- field_serializer: stored dict → JSON string, None → None
+- JSON schema shape: anyOf [string, null], no $defs for UniqueQL types
+- UI schema shape: anyOf with textarea on branch 0, no additionalProperties
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from unique_toolkit._common.pydantic.rjsf_tags import ui_schema_for_model
+from unique_toolkit.experimental.components.internal_search.knowledge_base.config import (
+    KnowledgeBaseInternalSearchConfig,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_VALID_FILTER = {"operator": "equals", "value": "x", "path": ["fieldName"]}
+_VALID_FILTER_JSON = json.dumps(_VALID_FILTER)
+_ISNULL_FILTER = {"path": ["folderId"], "operator": "isNotNull", "value": ""}
+
+
+# ---------------------------------------------------------------------------
+# _parse_and_validate_uniqueql — via construction
+# ---------------------------------------------------------------------------
+
+
+class TestMetadataFilterParsing:
+    def test_none_is_accepted(self):
+        cfg = KnowledgeBaseInternalSearchConfig(metadata_filter=None)
+        assert cfg.metadata_filter is None
+
+    def test_empty_string_normalises_to_none(self):
+        cfg = KnowledgeBaseInternalSearchConfig(metadata_filter="")
+        assert cfg.metadata_filter is None
+
+    def test_whitespace_only_normalises_to_none(self):
+        cfg = KnowledgeBaseInternalSearchConfig(metadata_filter="   ")
+        assert cfg.metadata_filter is None
+
+    def test_valid_dict_is_stored_as_dict(self):
+        cfg = KnowledgeBaseInternalSearchConfig(metadata_filter=_VALID_FILTER)
+        assert cfg.metadata_filter == _VALID_FILTER
+        assert isinstance(cfg.metadata_filter, dict)
+
+    def test_valid_json_string_is_parsed_to_dict(self):
+        cfg = KnowledgeBaseInternalSearchConfig(metadata_filter=_VALID_FILTER_JSON)
+        assert cfg.metadata_filter == _VALID_FILTER
+        assert isinstance(cfg.metadata_filter, dict)
+
+    def test_isnull_operator_is_accepted(self):
+        cfg = KnowledgeBaseInternalSearchConfig(metadata_filter=_ISNULL_FILTER)
+        assert cfg.metadata_filter == _ISNULL_FILTER
+
+    def test_invalid_json_string_raises(self):
+        with pytest.raises(ValidationError, match="Invalid JSON"):
+            KnowledgeBaseInternalSearchConfig(metadata_filter="not json")
+
+    def test_invalid_dict_raises(self):
+        with pytest.raises(ValidationError):
+            KnowledgeBaseInternalSearchConfig(metadata_filter={"garbage": True})
+
+    def test_wrong_type_raises(self):
+        with pytest.raises(ValidationError):
+            KnowledgeBaseInternalSearchConfig(metadata_filter=123)
+
+
+# ---------------------------------------------------------------------------
+# field_serializer — model_dump produces JSON string
+# ---------------------------------------------------------------------------
+
+
+class TestMetadataFilterSerializer:
+    def test_dict_serialises_to_json_string(self):
+        cfg = KnowledgeBaseInternalSearchConfig(metadata_filter=_VALID_FILTER)
+        dumped = cfg.model_dump(mode="json")
+        assert isinstance(dumped["metadata_filter"], str)
+        assert json.loads(dumped["metadata_filter"]) == _VALID_FILTER
+
+    def test_none_serialises_to_none(self):
+        cfg = KnowledgeBaseInternalSearchConfig(metadata_filter=None)
+        dumped = cfg.model_dump(mode="json")
+        assert dumped["metadata_filter"] is None
+
+    def test_empty_string_input_serialises_to_none(self):
+        cfg = KnowledgeBaseInternalSearchConfig(metadata_filter="")
+        dumped = cfg.model_dump(mode="json")
+        assert dumped["metadata_filter"] is None
+
+    def test_json_string_input_round_trips_as_string(self):
+        cfg = KnowledgeBaseInternalSearchConfig(metadata_filter=_VALID_FILTER_JSON)
+        dumped = cfg.model_dump(mode="json")
+        assert isinstance(dumped["metadata_filter"], str)
+        assert json.loads(dumped["metadata_filter"]) == _VALID_FILTER
+
+
+# ---------------------------------------------------------------------------
+# JSON schema shape
+# ---------------------------------------------------------------------------
+
+
+class TestMetadataFilterJsonSchema:
+    def setup_method(self):
+        self.schema = KnowledgeBaseInternalSearchConfig.model_json_schema()
+        self.mf = self.schema["properties"]["metadataFilter"]
+
+    def test_anyof_has_string_and_null_branches(self):
+        types = {b.get("type") for b in self.mf["anyOf"]}
+        assert types == {"string", "null"}
+
+    def test_no_defs_for_uniqueql_types(self):
+        schema_str = json.dumps(self.mf)
+        assert "Statement" not in schema_str
+        assert "AndStatement" not in schema_str
+        assert "OrStatement" not in schema_str
+
+    def test_no_defs_at_field_level(self):
+        assert "$defs" not in json.dumps(self.mf)
+
+    def test_string_branch_has_title(self):
+        string_branch = next(b for b in self.mf["anyOf"] if b.get("type") == "string")
+        assert string_branch.get("title") == "UniqueQL (JSON)"
+
+    def test_null_branch_has_deactivated_title(self):
+        null_branch = next(b for b in self.mf["anyOf"] if b.get("type") == "null")
+        assert null_branch.get("title") == "Deactivated"
+
+
+# ---------------------------------------------------------------------------
+# UI schema shape
+# ---------------------------------------------------------------------------
+
+
+class TestMetadataFilterUiSchema:
+    def setup_method(self):
+        self.ui = ui_schema_for_model(KnowledgeBaseInternalSearchConfig)
+        self.mf_ui = self.ui["metadata_filter"]
+
+    def test_no_additional_properties_at_field_level(self):
+        assert "additionalProperties" not in self.mf_ui
+
+    def test_no_widget_at_field_level(self):
+        assert "ui:widget" not in self.mf_ui
+
+    def test_anyof_has_two_branches(self):
+        assert len(self.mf_ui["anyOf"]) == 2
+
+    def test_string_branch_has_textarea_widget(self):
+        string_branch = self.mf_ui["anyOf"][0]
+        assert string_branch.get("ui:widget") == "textarea"
+
+    def test_null_branch_is_empty(self):
+        null_branch = self.mf_ui["anyOf"][1]
+        assert null_branch == {}

--- a/unique_toolkit/tests/experimental/components/internal_search/test_kb_service_unit.py
+++ b/unique_toolkit/tests/experimental/components/internal_search/test_kb_service_unit.py
@@ -132,11 +132,15 @@ def test_effective_metadata_filter__unset_no_chat_uses_config_filter():
     """
     cfg = KnowledgeBaseInternalSearchConfig(
         scope_ids=None,
-        metadata_filter={"doc_type": "report"},
+        metadata_filter={"operator": "equals", "value": "report", "path": ["doc_type"]},
     )
     svc, _ = _make_service(config=cfg, chat_context=None)
 
-    assert svc._effective_metadata_filter == {"doc_type": "report"}
+    assert svc._effective_metadata_filter == {
+        "operator": "equals",
+        "value": "report",
+        "path": ["doc_type"],
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -172,11 +176,15 @@ def test_config__keeps_existing_metadata_filter_when_scope_ids_are_present() -> 
     with pytest.deprecated_call(match="scope_ids"):
         cfg = KnowledgeBaseInternalSearchConfig(
             scope_ids=["kb-1"],
-            metadata_filter={"type": "policy"},
+            metadata_filter={"operator": "equals", "value": "policy", "path": ["type"]},
         )
 
     assert cfg.scope_ids == ["kb-1"]
-    assert cfg.metadata_filter == {"type": "policy"}
+    assert cfg.metadata_filter == {
+        "operator": "equals",
+        "value": "policy",
+        "path": ["type"],
+    }
 
 
 @pytest.mark.ai
@@ -211,7 +219,8 @@ async def test_search_single_query__uses_metadata_filter_when_no_scope_ids():
         called with metadata_filter.
     """
     cfg = KnowledgeBaseInternalSearchConfig(
-        scope_ids=None, metadata_filter={"type": "policy"}
+        scope_ids=None,
+        metadata_filter={"operator": "equals", "value": "policy", "path": ["type"]},
     )
     svc, mock_kb_svc = _make_service(config=cfg, chat_context=None)
     mock_kb_svc.search_content_chunks_async = AsyncMock(return_value=[])
@@ -219,7 +228,11 @@ async def test_search_single_query__uses_metadata_filter_when_no_scope_ids():
     await svc._search_single_query(query="policy question")
 
     call_kwargs = mock_kb_svc.search_content_chunks_async.call_args.kwargs
-    assert call_kwargs["metadata_filter"] == {"type": "policy"}
+    assert call_kwargs["metadata_filter"] == {
+        "operator": "equals",
+        "value": "policy",
+        "path": ["type"],
+    }
     assert "scope_ids" not in call_kwargs
 
 
@@ -233,7 +246,8 @@ async def test_search_single_query__includes_content_ids_with_metadata_filter():
         appear in the call kwargs.
     """
     cfg = KnowledgeBaseInternalSearchConfig(
-        scope_ids=None, metadata_filter={"type": "doc"}
+        scope_ids=None,
+        metadata_filter={"operator": "equals", "value": "doc", "path": ["type"]},
     )
     svc, mock_kb_svc = _make_service(config=cfg, chat_context=None)
     svc._state.content_ids = ["doc-1", "doc-2"]
@@ -242,7 +256,11 @@ async def test_search_single_query__includes_content_ids_with_metadata_filter():
     await svc._search_single_query(query="question")
 
     call_kwargs = mock_kb_svc.search_content_chunks_async.call_args.kwargs
-    assert call_kwargs["metadata_filter"] == {"type": "doc"}
+    assert call_kwargs["metadata_filter"] == {
+        "operator": "equals",
+        "value": "doc",
+        "path": ["type"],
+    }
     assert call_kwargs["content_ids"] == ["doc-1", "doc-2"]
 
 

--- a/unique_toolkit/tests/experimental/components/internal_search/test_kb_service_unit.py
+++ b/unique_toolkit/tests/experimental/components/internal_search/test_kb_service_unit.py
@@ -180,7 +180,7 @@ def test_config__keeps_existing_metadata_filter_when_scope_ids_are_present() -> 
         )
 
     assert cfg.scope_ids == ["kb-1"]
-    assert cfg.metadata_filter == {
+    assert cfg.metadata_filter.to_dict() == {
         "operator": "equals",
         "value": "policy",
         "path": ["type"],

--- a/unique_toolkit/unique_toolkit/_common/metadata_filter_scope.py
+++ b/unique_toolkit/unique_toolkit/_common/metadata_filter_scope.py
@@ -8,6 +8,8 @@ from typing import Any
 from unique_toolkit.content.smart_rules import (
     Operator,
     Statement,
+    UniqueQL,
+    uniqueql_to_dict,
 )
 
 _UQL_AND = "and"
@@ -29,16 +31,17 @@ def build_folder_id_in_clause(scope_ids: list[str]) -> dict[str, Any]:
 
 def merge_scope_clause_into_metadata_filter(
     scope_clause: Mapping[str, Any],
-    metadata_filter: dict[str, Any] | None,
+    metadata_filter: UniqueQL | Mapping[str, Any] | None,
 ) -> dict[str, Any]:
     """AND-merge *scope_clause* with *metadata_filter*, flattening a top-level ``and``."""
     scope_dict = dict(scope_clause)
-    if not metadata_filter:
+    metadata_dict = uniqueql_to_dict(metadata_filter)
+    if not metadata_dict:
         return scope_dict
-    inner_and = metadata_filter.get(_UQL_AND)
+    inner_and = metadata_dict.get(_UQL_AND)
     if isinstance(inner_and, list):
         return {_UQL_AND: [scope_dict, *inner_and]}
-    return {_UQL_AND: [scope_dict, dict(metadata_filter)]}
+    return {_UQL_AND: [scope_dict, metadata_dict]}
 
 
 __all__ = [

--- a/unique_toolkit/unique_toolkit/_common/metadata_filter_scope.py
+++ b/unique_toolkit/unique_toolkit/_common/metadata_filter_scope.py
@@ -29,7 +29,7 @@ def build_folder_id_in_clause(scope_ids: list[str]) -> dict[str, Any]:
 
 def merge_scope_clause_into_metadata_filter(
     scope_clause: Mapping[str, Any],
-    metadata_filter: dict[str, Any] | None,
+    metadata_filter: Mapping[str, Any] | None,
 ) -> dict[str, Any]:
     """AND-merge *scope_clause* with *metadata_filter*, flattening a top-level ``and``."""
     scope_dict = dict(scope_clause)

--- a/unique_toolkit/unique_toolkit/_common/metadata_filter_scope.py
+++ b/unique_toolkit/unique_toolkit/_common/metadata_filter_scope.py
@@ -29,7 +29,7 @@ def build_folder_id_in_clause(scope_ids: list[str]) -> dict[str, Any]:
 
 def merge_scope_clause_into_metadata_filter(
     scope_clause: Mapping[str, Any],
-    metadata_filter: Mapping[str, Any] | None,
+    metadata_filter: dict[str, Any] | None,
 ) -> dict[str, Any]:
     """AND-merge *scope_clause* with *metadata_filter*, flattening a top-level ``and``."""
     scope_dict = dict(scope_clause)

--- a/unique_toolkit/unique_toolkit/_common/pydantic/rjsf_tags.py
+++ b/unique_toolkit/unique_toolkit/_common/pydantic/rjsf_tags.py
@@ -974,10 +974,12 @@ def ui_schema_for_model(
             node["items"] = item_node
 
         # Dict -> additionalProperties (value side)
-        # Skip when field-level RJSF metadata is already present: the widget/
-        # layout is fully specified and walking the value type would add a
-        # spurious "additionalProperties" node that confuses RJSF renderers.
-        elif origin is dict and not meta:
+        # Skip when the node already carries a ui:widget (fully-specified
+        # widget) or an anyOf (fully-specified type branching): walking the
+        # dict value type in those cases adds a spurious "additionalProperties"
+        # node that confuses RJSF renderers.  Presentation-only meta such as
+        # ui:expandable or ui:title does NOT prevent the walk.
+        elif origin is dict and "ui:widget" not in node and "anyOf" not in node:
             _key_t, val_t = get_args(base) or (Any, Any)
             val_base, val_meta = _walk_annotated_chain(val_t)
             val_base = _unwrap_optional(val_base)

--- a/unique_toolkit/unique_toolkit/_common/pydantic/rjsf_tags.py
+++ b/unique_toolkit/unique_toolkit/_common/pydantic/rjsf_tags.py
@@ -974,7 +974,10 @@ def ui_schema_for_model(
             node["items"] = item_node
 
         # Dict -> additionalProperties (value side)
-        elif origin is dict:
+        # Skip when field-level RJSF metadata is already present: the widget/
+        # layout is fully specified and walking the value type would add a
+        # spurious "additionalProperties" node that confuses RJSF renderers.
+        elif origin is dict and not meta:
             _key_t, val_t = get_args(base) or (Any, Any)
             val_base, val_meta = _walk_annotated_chain(val_t)
             val_base = _unwrap_optional(val_base)

--- a/unique_toolkit/unique_toolkit/content/smart_rules.py
+++ b/unique_toolkit/unique_toolkit/content/smart_rules.py
@@ -1,10 +1,13 @@
+import json
 import re
+from collections.abc import Mapping
 from datetime import datetime, timedelta, timezone
 from enum import Enum
-from typing import Any, Dict, List, Mapping, Self, Union
+from typing import Annotated, Any, Dict, List, Self, Union
 
-from pydantic import AliasChoices, BaseModel, Field
+from pydantic import AliasChoices, BaseModel, BeforeValidator, Field, PlainSerializer
 from pydantic.config import ConfigDict
+from pydantic.json_schema import WithJsonSchema
 
 
 class Operator(str, Enum):
@@ -53,6 +56,10 @@ class BaseStatement(BaseModel):
         tool_parameters: Mapping[str, Union[str, int, bool]],
     ) -> Self:
         return self.model_copy()
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to wire-format JSON dict (uses serialization aliases)."""
+        return self.model_dump(mode="json")
 
 
 class Statement(BaseStatement):
@@ -285,7 +292,6 @@ def get_fallback_values(
     return values
 
 
-# Example usage:
 def parse_uniqueql(json_data: Dict[str, Any]) -> UniqueQL:
     if "operator" in json_data:
         return Statement.model_validate(json_data)
@@ -299,3 +305,55 @@ def parse_uniqueql(json_data: Dict[str, Any]) -> UniqueQL:
         )
     else:
         raise ValueError("Invalid UniqueQL format")
+
+
+def parse_uniqueql_input(v: Any) -> UniqueQL | None:
+    """Parse config/API input (JSON string, dict, or model) into a UniqueQL model."""
+    if v is None:
+        return None
+    if isinstance(v, (Statement, AndStatement, OrStatement)):
+        return v
+    if isinstance(v, str):
+        if v.strip() == "":
+            return None
+        try:
+            v = json.loads(v)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Invalid JSON: {e}") from e
+    if isinstance(v, dict):
+        return parse_uniqueql(v)
+    raise ValueError(f"Expected JSON string or dict, got {type(v).__name__}")
+
+
+def uniqueql_to_dict(
+    value: UniqueQL | Mapping[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Convert a UniqueQL model (or wire dict) to a JSON-serializable dict for APIs."""
+    if value is None:
+        return None
+    if isinstance(value, BaseStatement):
+        return value.to_dict()
+    return dict(value)
+
+
+def _serialize_uniqueql_field(value: UniqueQL | None) -> dict[str, Any] | None:
+    return None if value is None else value.to_dict()
+
+
+_UNIQUEQL_JSON_SCHEMA = {
+    "anyOf": [
+        {"type": "string", "title": "UniqueQL (JSON)"},
+        {"type": "null", "title": "Deactivated", "description": "None"},
+    ]
+}
+
+UniqueQLField = Annotated[
+    UniqueQL | None,
+    BeforeValidator(parse_uniqueql_input),
+    WithJsonSchema(_UNIQUEQL_JSON_SCHEMA),
+    PlainSerializer(
+        _serialize_uniqueql_field,
+        when_used="json",
+        return_type=dict[str, Any] | None,
+    ),
+]

--- a/unique_toolkit/unique_toolkit/experimental/components/internal_search/knowledge_base/config.py
+++ b/unique_toolkit/unique_toolkit/experimental/components/internal_search/knowledge_base/config.py
@@ -1,23 +1,72 @@
 from __future__ import annotations
 
+import json
 import warnings
-from typing import Annotated, Self
+from typing import Annotated, Any, Self, Union
 
-from pydantic import Field, model_validator
+from pydantic import (
+    BeforeValidator,
+    Field,
+    TypeAdapter,
+    field_serializer,
+    model_validator,
+)
+from pydantic.json_schema import WithJsonSchema
 
 from unique_toolkit._common.config_checker import register_config
+from unique_toolkit._common.pydantic.rjsf_tags import RJSFMetaTag
 from unique_toolkit._common.pydantic_helpers import DeactivatedNone
 from unique_toolkit.content.schemas import ContentRerankerConfig
+from unique_toolkit.content.smart_rules import AndStatement, OrStatement, Statement
 from unique_toolkit.experimental.components.internal_search.base.config import (
     InternalSearchConfig,
 )
 
+_uniqueql_adapter = TypeAdapter(Union[Statement, AndStatement, OrStatement])
+
+
+def _parse_and_validate_uniqueql(v: Any) -> dict[str, Any] | None:
+    if v is None:
+        return None
+    if isinstance(v, str):
+        if v.strip() == "":
+            return None
+        try:
+            v = json.loads(v)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Invalid JSON: {e}") from e
+    if isinstance(v, dict):
+        _uniqueql_adapter.validate_python(v)
+        return v
+    raise ValueError(f"Expected JSON string or dict, got {type(v).__name__}")
+
+
+UniqueQLDict = Annotated[
+    # Unsubscripted `dict | None` is intentional: get_origin(dict) is None, so
+    # ui_schema_for_model does not walk into the value type and add a spurious
+    # "additionalProperties" node.  The actual stored value is always
+    # dict[str, Any] | None — enforced by _parse_and_validate_uniqueql —
+    # and the JSON schema is fully overridden by WithJsonSchema below.
+    dict | None,
+    BeforeValidator(_parse_and_validate_uniqueql),
+    WithJsonSchema(
+        {
+            "anyOf": [
+                {"type": "string", "title": "UniqueQL (JSON)"},
+                {"type": "null", "title": "Deactivated", "description": "None"},
+            ]
+        }
+    ),
+]
+
 
 @register_config()
 class KnowledgeBaseInternalSearchConfig(InternalSearchConfig):
-    scope_ids: list[str] | DeactivatedNone = Field(
+    scope_ids: Annotated[
+        Annotated[list[str], Field(title="Scope IDs")] | DeactivatedNone,
+        RJSFMetaTag({"anyOf": [{"items": {"ui:title": "Scope ID"}}, {}]}),
+    ] = Field(
         default=None,
-        title="Active",
         deprecated=True,
         description=(
             "Not accepted for new configs. Use ``metadata_filter`` with "
@@ -26,10 +75,29 @@ class KnowledgeBaseInternalSearchConfig(InternalSearchConfig):
             "a ``folderId in [scope_ids]`` metadata filter at search time."
         ),
     )
-    metadata_filter: dict[str, object] | None = Field(
+    metadata_filter: Annotated[
+        UniqueQLDict,
+        # Put textarea attrs on the string branch (index 0) only, not at field level.
+        # If set at field level, RJSF's MultiSchemaField applies ui:widget to every
+        # anyOf branch during option iteration, which crashes on non-string branches.
+        RJSFMetaTag(
+            {
+                "ui:options": {"customValidation": "uniqueql"},
+                "anyOf": [
+                    {
+                        "ui:widget": "textarea",
+                        "ui:placeholder": '{"operator": "equals", "value": "...", "path": ["fieldName"]}',
+                        "ui:emptyValue": "",
+                    },
+                    {},
+                ],
+            }
+        ),
+    ] = Field(
         default=None,
         description=(
-            "Static metadata filter applied to every KB search. "
+            "Static UniqueQL metadata filter applied to every KB search. "
+            "Pass as a JSON string or a plain dict. "
             "Overridden by chat context filter or per-invocation state override."
         ),
     )
@@ -43,6 +111,13 @@ class KnowledgeBaseInternalSearchConfig(InternalSearchConfig):
             "client-side chunk_relevancy_sort_config in PostProcessorConfig."
         ),
     )
+
+    @field_serializer("metadata_filter")
+    def _serialize_metadata_filter(self, value: dict | None) -> str | None:
+        """Serialize back to a JSON string so the output matches the JSON schema (string | null)."""
+        if value is None:
+            return None
+        return json.dumps(value)
 
     @model_validator(mode="after")
     def _warn_deprecated_scope_ids(self) -> Self:

--- a/unique_toolkit/unique_toolkit/experimental/components/internal_search/knowledge_base/config.py
+++ b/unique_toolkit/unique_toolkit/experimental/components/internal_search/knowledge_base/config.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import warnings
-from typing import Annotated, Any, Self, Union
+from typing import Annotated, Any, Self
 
 from pydantic import (
     BeforeValidator,
@@ -17,12 +17,12 @@ from unique_toolkit._common.config_checker import register_config
 from unique_toolkit._common.pydantic.rjsf_tags import RJSFMetaTag
 from unique_toolkit._common.pydantic_helpers import DeactivatedNone
 from unique_toolkit.content.schemas import ContentRerankerConfig
-from unique_toolkit.content.smart_rules import AndStatement, OrStatement, Statement
+from unique_toolkit.content.smart_rules import UniqueQL
 from unique_toolkit.experimental.components.internal_search.base.config import (
     InternalSearchConfig,
 )
 
-_uniqueql_adapter = TypeAdapter(Union[Statement, AndStatement, OrStatement])
+_uniqueql_adapter = TypeAdapter(UniqueQL)
 
 
 def _parse_and_validate_uniqueql(v: Any) -> dict[str, Any] | None:

--- a/unique_toolkit/unique_toolkit/experimental/components/internal_search/knowledge_base/config.py
+++ b/unique_toolkit/unique_toolkit/experimental/components/internal_search/knowledge_base/config.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import warnings
-from collections.abc import Mapping
 from typing import Annotated, Any, Self, Union
 
 from pydantic import (
@@ -43,14 +42,7 @@ def _parse_and_validate_uniqueql(v: Any) -> dict[str, Any] | None:
 
 
 UniqueQLDict = Annotated[
-    # `Mapping[str, Any] | None` rather than `dict[str, Any] | None` is
-    # intentional: get_origin(Mapping[str, Any]) is collections.abc.Mapping,
-    # not `dict`, so ui_schema_for_model skips the dict branch and does NOT
-    # add a spurious "additionalProperties" node to the UI schema.
-    # The actual stored value is always dict[str, Any] | None — enforced by
-    # _parse_and_validate_uniqueql — and the JSON schema is fully overridden
-    # by WithJsonSchema below.
-    Mapping[str, Any] | None,
+    dict[str, Any] | None,
     BeforeValidator(_parse_and_validate_uniqueql),
     WithJsonSchema(
         {

--- a/unique_toolkit/unique_toolkit/experimental/components/internal_search/knowledge_base/config.py
+++ b/unique_toolkit/unique_toolkit/experimental/components/internal_search/knowledge_base/config.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import warnings
+from collections.abc import Mapping
 from typing import Annotated, Any, Self, Union
 
 from pydantic import (
@@ -42,12 +43,14 @@ def _parse_and_validate_uniqueql(v: Any) -> dict[str, Any] | None:
 
 
 UniqueQLDict = Annotated[
-    # Unsubscripted `dict | None` is intentional: get_origin(dict) is None, so
-    # ui_schema_for_model does not walk into the value type and add a spurious
-    # "additionalProperties" node.  The actual stored value is always
-    # dict[str, Any] | None — enforced by _parse_and_validate_uniqueql —
-    # and the JSON schema is fully overridden by WithJsonSchema below.
-    dict | None,  # type: ignore[type-arg]
+    # `Mapping[str, Any] | None` rather than `dict[str, Any] | None` is
+    # intentional: get_origin(Mapping[str, Any]) is collections.abc.Mapping,
+    # not `dict`, so ui_schema_for_model skips the dict branch and does NOT
+    # add a spurious "additionalProperties" node to the UI schema.
+    # The actual stored value is always dict[str, Any] | None — enforced by
+    # _parse_and_validate_uniqueql — and the JSON schema is fully overridden
+    # by WithJsonSchema below.
+    Mapping[str, Any] | None,
     BeforeValidator(_parse_and_validate_uniqueql),
     WithJsonSchema(
         {

--- a/unique_toolkit/unique_toolkit/experimental/components/internal_search/knowledge_base/config.py
+++ b/unique_toolkit/unique_toolkit/experimental/components/internal_search/knowledge_base/config.py
@@ -7,7 +7,6 @@ from typing import Annotated, Any, Self
 from pydantic import (
     BeforeValidator,
     Field,
-    TypeAdapter,
     field_serializer,
     model_validator,
 )
@@ -17,12 +16,10 @@ from unique_toolkit._common.config_checker import register_config
 from unique_toolkit._common.pydantic.rjsf_tags import RJSFMetaTag
 from unique_toolkit._common.pydantic_helpers import DeactivatedNone
 from unique_toolkit.content.schemas import ContentRerankerConfig
-from unique_toolkit.content.smart_rules import UniqueQL
+from unique_toolkit.content.smart_rules import parse_uniqueql
 from unique_toolkit.experimental.components.internal_search.base.config import (
     InternalSearchConfig,
 )
-
-_uniqueql_adapter = TypeAdapter(UniqueQL)
 
 
 def _parse_and_validate_uniqueql(v: Any) -> dict[str, Any] | None:
@@ -36,7 +33,7 @@ def _parse_and_validate_uniqueql(v: Any) -> dict[str, Any] | None:
         except json.JSONDecodeError as e:
             raise ValueError(f"Invalid JSON: {e}") from e
     if isinstance(v, dict):
-        _uniqueql_adapter.validate_python(v)
+        parse_uniqueql(v)  # validates structure; discard model, keep raw dict
         return v
     raise ValueError(f"Expected JSON string or dict, got {type(v).__name__}")
 

--- a/unique_toolkit/unique_toolkit/experimental/components/internal_search/knowledge_base/config.py
+++ b/unique_toolkit/unique_toolkit/experimental/components/internal_search/knowledge_base/config.py
@@ -1,55 +1,18 @@
 from __future__ import annotations
 
-import json
 import warnings
-from typing import Annotated, Any, Self
+from typing import Annotated, Self
 
-from pydantic import (
-    BeforeValidator,
-    Field,
-    field_serializer,
-    model_validator,
-)
-from pydantic.json_schema import WithJsonSchema
+from pydantic import Field, model_validator
 
 from unique_toolkit._common.config_checker import register_config
 from unique_toolkit._common.pydantic.rjsf_tags import RJSFMetaTag
 from unique_toolkit._common.pydantic_helpers import DeactivatedNone
 from unique_toolkit.content.schemas import ContentRerankerConfig
-from unique_toolkit.content.smart_rules import parse_uniqueql
+from unique_toolkit.content.smart_rules import UniqueQLField
 from unique_toolkit.experimental.components.internal_search.base.config import (
     InternalSearchConfig,
 )
-
-
-def _parse_and_validate_uniqueql(v: Any) -> dict[str, Any] | None:
-    if v is None:
-        return None
-    if isinstance(v, str):
-        if v.strip() == "":
-            return None
-        try:
-            v = json.loads(v)
-        except json.JSONDecodeError as e:
-            raise ValueError(f"Invalid JSON: {e}") from e
-    if isinstance(v, dict):
-        parse_uniqueql(v)  # validates structure; discard model, keep raw dict
-        return v
-    raise ValueError(f"Expected JSON string or dict, got {type(v).__name__}")
-
-
-UniqueQLDict = Annotated[
-    dict[str, Any] | None,
-    BeforeValidator(_parse_and_validate_uniqueql),
-    WithJsonSchema(
-        {
-            "anyOf": [
-                {"type": "string", "title": "UniqueQL (JSON)"},
-                {"type": "null", "title": "Deactivated", "description": "None"},
-            ]
-        }
-    ),
-]
 
 
 @register_config()
@@ -68,7 +31,7 @@ class KnowledgeBaseInternalSearchConfig(InternalSearchConfig):
         ),
     )
     metadata_filter: Annotated[
-        UniqueQLDict,
+        UniqueQLField,
         # Put textarea attrs on the string branch (index 0) only, not at field level.
         # If set at field level, RJSF's MultiSchemaField applies ui:widget to every
         # anyOf branch during option iteration, which crashes on non-string branches.
@@ -103,13 +66,6 @@ class KnowledgeBaseInternalSearchConfig(InternalSearchConfig):
             "client-side chunk_relevancy_sort_config in PostProcessorConfig."
         ),
     )
-
-    @field_serializer("metadata_filter")
-    def _serialize_metadata_filter(self, value: dict[str, Any] | None) -> str | None:
-        """Serialize back to a JSON string so the output matches the JSON schema (string | null)."""
-        if value is None:
-            return None
-        return json.dumps(value)
 
     @model_validator(mode="after")
     def _warn_deprecated_scope_ids(self) -> Self:

--- a/unique_toolkit/unique_toolkit/experimental/components/internal_search/knowledge_base/config.py
+++ b/unique_toolkit/unique_toolkit/experimental/components/internal_search/knowledge_base/config.py
@@ -47,7 +47,7 @@ UniqueQLDict = Annotated[
     # "additionalProperties" node.  The actual stored value is always
     # dict[str, Any] | None — enforced by _parse_and_validate_uniqueql —
     # and the JSON schema is fully overridden by WithJsonSchema below.
-    dict | None,
+    dict | None,  # type: ignore[type-arg]
     BeforeValidator(_parse_and_validate_uniqueql),
     WithJsonSchema(
         {
@@ -113,7 +113,7 @@ class KnowledgeBaseInternalSearchConfig(InternalSearchConfig):
     )
 
     @field_serializer("metadata_filter")
-    def _serialize_metadata_filter(self, value: dict | None) -> str | None:
+    def _serialize_metadata_filter(self, value: dict[str, Any] | None) -> str | None:
         """Serialize back to a JSON string so the output matches the JSON schema (string | null)."""
         if value is None:
             return None

--- a/unique_toolkit/unique_toolkit/experimental/components/internal_search/knowledge_base/service.py
+++ b/unique_toolkit/unique_toolkit/experimental/components/internal_search/knowledge_base/service.py
@@ -66,15 +66,19 @@ class KnowledgeBaseInternalSearchService(
         return debug_info
 
     async def _search_single_query(self, *, query: str) -> SearchStringResult:
-        metadata_filter = self._effective_metadata_filter
+        metadata_filter: dict[str, Any] | None
+        effective = self._effective_metadata_filter
         scope_ids = self._effective_scope_ids
 
         if scope_ids is not None:
             clause = build_folder_id_in_clause(scope_ids)
-            metadata_filter = merge_scope_clause_into_metadata_filter(
-                clause, metadata_filter
-            )
+            metadata_filter = merge_scope_clause_into_metadata_filter(clause, effective)
             self._resolved_metadata_filter = metadata_filter
+        else:
+            # _effective_metadata_filter always holds a dict at runtime;
+            # Mapping is used on the config field only to avoid a spurious
+            # "additionalProperties" node in the RJSF UI schema.
+            metadata_filter = cast("dict[str, Any] | None", effective)
 
         if metadata_filter is None:
             raise RuntimeError(

--- a/unique_toolkit/unique_toolkit/experimental/components/internal_search/knowledge_base/service.py
+++ b/unique_toolkit/unique_toolkit/experimental/components/internal_search/knowledge_base/service.py
@@ -105,7 +105,11 @@ class KnowledgeBaseInternalSearchService(
             return cast("dict[str, Any] | None", self._state.metadata_filter_override)
         if self._context.chat is not None:
             return self._context.chat.metadata_filter
-        return self._config.metadata_filter
+        return (
+            self._config.metadata_filter.to_dict()
+            if self._config.metadata_filter
+            else None
+        )
 
     @property
     def _effective_scope_ids(self) -> list[str] | None:

--- a/unique_toolkit/unique_toolkit/experimental/components/internal_search/knowledge_base/service.py
+++ b/unique_toolkit/unique_toolkit/experimental/components/internal_search/knowledge_base/service.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
 from typing import Any, Self, cast
 
 from unique_toolkit._common.metadata_filter_scope import (
@@ -66,19 +65,15 @@ class KnowledgeBaseInternalSearchService(
         return debug_info
 
     async def _search_single_query(self, *, query: str) -> SearchStringResult:
-        metadata_filter: dict[str, Any] | None
-        effective = self._effective_metadata_filter
+        metadata_filter = self._effective_metadata_filter
         scope_ids = self._effective_scope_ids
 
         if scope_ids is not None:
             clause = build_folder_id_in_clause(scope_ids)
-            metadata_filter = merge_scope_clause_into_metadata_filter(clause, effective)
+            metadata_filter = merge_scope_clause_into_metadata_filter(
+                clause, metadata_filter
+            )
             self._resolved_metadata_filter = metadata_filter
-        else:
-            # _effective_metadata_filter always holds a dict at runtime;
-            # Mapping is used on the config field only to avoid a spurious
-            # "additionalProperties" node in the RJSF UI schema.
-            metadata_filter = cast("dict[str, Any] | None", effective)
 
         if metadata_filter is None:
             raise RuntimeError(
@@ -105,7 +100,7 @@ class KnowledgeBaseInternalSearchService(
         return SearchStringResult(query=query, chunks=chunks)
 
     @property
-    def _effective_metadata_filter(self) -> Mapping[str, Any] | None:
+    def _effective_metadata_filter(self) -> dict[str, Any] | None:
         if self._state.metadata_filter_override is not UNSET:
             return cast("dict[str, Any] | None", self._state.metadata_filter_override)
         if self._context.chat is not None:

--- a/unique_toolkit/unique_toolkit/experimental/components/internal_search/knowledge_base/service.py
+++ b/unique_toolkit/unique_toolkit/experimental/components/internal_search/knowledge_base/service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any, Self, cast
 
 from unique_toolkit._common.metadata_filter_scope import (
@@ -100,7 +101,7 @@ class KnowledgeBaseInternalSearchService(
         return SearchStringResult(query=query, chunks=chunks)
 
     @property
-    def _effective_metadata_filter(self) -> dict[str, Any] | None:
+    def _effective_metadata_filter(self) -> Mapping[str, Any] | None:
         if self._state.metadata_filter_override is not UNSET:
             return cast("dict[str, Any] | None", self._state.metadata_filter_override)
         if self._context.chat is not None:

--- a/unique_toolkit/unique_toolkit/smart_rules/compile.py
+++ b/unique_toolkit/unique_toolkit/smart_rules/compile.py
@@ -7,6 +7,7 @@ from unique_toolkit.content.smart_rules import (
     OrStatement,
     Statement,
     UniqueQL,
+    UniqueQLField,
     array_operator,
     binary_operator,
     calculate_current_date,
@@ -19,9 +20,11 @@ from unique_toolkit.content.smart_rules import (
     is_array_of_strings,
     null_operator,
     parse_uniqueql,
+    parse_uniqueql_input,
     replace_tool_parameters_patterns,
     replace_user_metadata_patterns,
     replace_variables,
+    uniqueql_to_dict,
 )
 
 warnings.warn(
@@ -38,6 +41,7 @@ __all__ = [
     "OrStatement",
     "Statement",
     "UniqueQL",
+    "UniqueQLField",
     "array_operator",
     "binary_operator",
     "calculate_current_date",
@@ -50,7 +54,9 @@ __all__ = [
     "is_array_of_strings",
     "null_operator",
     "parse_uniqueql",
+    "parse_uniqueql_input",
     "replace_tool_parameters_patterns",
     "replace_user_metadata_patterns",
     "replace_variables",
+    "uniqueql_to_dict",
 ]


### PR DESCRIPTION
## Summary
- Replaces the untyped `dict[str, object] | None` on `KnowledgeBaseInternalSearchConfig.metadata_filter` with a `UniqueQLDict` annotated type that validates input against the UniqueQL schema at construction time, stores as `dict` internally, and serialises back to a JSON string so the RJSF/AJV `anyOf: [string, null]` contract is satisfied end-to-end.
- Fixes a hard RJSF crash ("No widget 'textarea' for type 'number'") at its root cause: `ui_schema_for_model` was unconditionally walking into `dict[K, V]` fields and injecting a spurious `additionalProperties` node even when the field already had explicit RJSF metadata. Fixed with a one-line guard in `rjsf_tags.py`.
- Cleans up `scope_ids` UX: field title changed from the misleading "Active" to "Scope IDs", array items now label as "Scope ID 1 / 2 / …".

## Changes

### `unique_toolkit/_common/pydantic/rjsf_tags.py`
- Guard the `elif origin is dict:` branch with `and "ui:widget" not in node and "anyOf" not in node`: skip value-type introspection (and the resulting `additionalProperties` node) when the field already has a fully-specified widget or explicit type branching. Presentation-only meta (`ui:expandable`, `ui:title`, …) still allows the walk.

### `unique_toolkit/…/knowledge_base/config.py`
- Add `UniqueQLDict` — `Annotated[dict[str, Any] | None, BeforeValidator, WithJsonSchema]`
  - `BeforeValidator` (`_parse_and_validate_uniqueql`): accepts `str` (JSON) or `dict`, normalises `None` / `""` / whitespace → `None`, validates via `parse_uniqueql()` from `smart_rules`
  - `WithJsonSchema`: overrides emitted schema to `anyOf: [string, null]` — no `$defs` for UniqueQL types, no RJSF `ui:order` errors
- Add `field_serializer("metadata_filter")`: `dict → json.dumps(…)`, `None → None` — keeps `default_config` valid against AJV
- `RJSFMetaTag` with `anyOf` structure: scopes `textarea` widget to string branch only, avoiding the RJSF MultiSchemaField crash
- `scope_ids`: updated title and item labels

### `unique_toolkit/tests/…/test_kb_config_unit.py` *(new)*
- 23 unit tests covering: parsing (None, empty string, whitespace, valid dict/JSON, invalid inputs), serialiser round-trips, JSON schema shape, UI schema shape

### `tutorials/mcp/mcp_search/src/mcp_search/config.py`
- Change default `metadata_filter.value` from `None` to `""` so the `isNotNull` filter serialises as a valid JSON string

## Test plan
- [x] All parsing cases: `None`, `""`, whitespace, valid dict, valid JSON string, invalid dict, bad JSON — behave as expected
- [x] `model_json_schema()` emits `anyOf: [string, null]` for `metadataFilter`, no `$defs` for UniqueQL types
- [x] `ui_schema_for_model()` emits textarea on string branch only, no `additionalProperties`
- [x] 192 tests pass across `test_rjsf_tags.py` and `test_kb_*` suites

## Risk / rollout
- **Backwards compatible for dict inputs**: existing callers passing a plain dict continue to work unchanged.
- **Serialisation change**: `model_dump(mode="json")` now returns a JSON *string* for `metadata_filter` instead of an object — any code that reads the serialised output as a dict will need updating (none found in this repo).
- No migration required for stored configs: the `BeforeValidator` accepts both string and dict on ingest.
- `rjsf_tags.py` fix is safe: verified against all existing dict fields with RJSF metadata in the codebase — none rely on `additionalProperties` being generated alongside an explicit widget or `anyOf`.

Refs: UN-20330