### PR TITLE
feat(unique-skill-tool): load skill by content_id and not name 

### DIFF
--- a/tool_packages/unique_skill_tool/tests/test_skill_tool.py
+++ b/tool_packages/unique_skill_tool/tests/test_skill_tool.py
@@ -39,11 +39,13 @@ def _make_skill(
     name: str = "test-skill",
     description: str = "A test skill",
     content: str = "Do the test thing.",
+    content_id: str = "test-cid",
 ) -> SkillDefinition:
     return SkillDefinition(
         name=name,
         description=description,
         content=content,
+        content_id=content_id,
     )
 
 

--- a/tool_packages/unique_skill_tool/unique_skill_tool/schemas.py
+++ b/tool_packages/unique_skill_tool/unique_skill_tool/schemas.py
@@ -33,3 +33,9 @@ class SkillDefinition(BaseModel):
     content: str = Field(
         description="Full prompt / instructions injected when the skill is invoked.",
     )
+    content_id: str | None = Field(
+        default=None,
+        description=(
+            "Knowledge-base content ID this skill was loaded from."
+        ),
+    )

--- a/tool_packages/unique_skill_tool/unique_skill_tool/schemas.py
+++ b/tool_packages/unique_skill_tool/unique_skill_tool/schemas.py
@@ -35,7 +35,5 @@ class SkillDefinition(BaseModel):
     )
     content_id: str | None = Field(
         default=None,
-        description=(
-            "Knowledge-base content ID this skill was loaded from."
-        ),
+        description=("Knowledge-base content ID this skill was loaded from."),
     )

--- a/tool_packages/unique_skill_tool/unique_skill_tool/schemas.py
+++ b/tool_packages/unique_skill_tool/unique_skill_tool/schemas.py
@@ -33,7 +33,6 @@ class SkillDefinition(BaseModel):
     content: str = Field(
         description="Full prompt / instructions injected when the skill is invoked.",
     )
-    content_id: str | None = Field(
-        default=None,
-        description=("Knowledge-base content ID this skill was loaded from."),
+    content_id: str = Field(
+        description="Knowledge-base content ID this skill was loaded from.",
     )

--- a/unique_orchestrator/tests/test_skill_setup.py
+++ b/unique_orchestrator/tests/test_skill_setup.py
@@ -25,7 +25,7 @@ from unique_orchestrator._builders.skill_setup import (
 def _make_skill(
     name: str,
     content: str = "skill body",
-    content_id: str | None = None,
+    content_id: str = "test-cid",
 ) -> SkillDefinition:
     return SkillDefinition(
         name=name, description="desc", content=content, content_id=content_id

--- a/unique_orchestrator/tests/test_skill_setup.py
+++ b/unique_orchestrator/tests/test_skill_setup.py
@@ -166,9 +166,15 @@ class TestPreloadInvokedSkills:
             history_manager=history_manager,
             logger=logger,
             skill_choices=[
-                SkillReference(name="foo", content_id="cid-1"),  # first: resolves & added
-                SkillReference(name="foo", content_id="cid-1"),  # duplicate: seen_forced skips
-                SkillReference(name="foo", content_id="cid-1"),  # duplicate: seen_forced skips
+                SkillReference(
+                    name="foo", content_id="cid-1"
+                ),  # first: resolves & added
+                SkillReference(
+                    name="foo", content_id="cid-1"
+                ),  # duplicate: seen_forced skips
+                SkillReference(
+                    name="foo", content_id="cid-1"
+                ),  # duplicate: seen_forced skips
             ],
         )
 

--- a/unique_orchestrator/tests/test_skill_setup.py
+++ b/unique_orchestrator/tests/test_skill_setup.py
@@ -22,8 +22,12 @@ from unique_orchestrator._builders.skill_setup import (
 )
 
 
-def _make_skill(name: str, content: str = "skill body") -> SkillDefinition:
-    return SkillDefinition(name=name, description="desc", content=content)
+def _make_skill(
+    name: str,
+    content: str = "skill body",
+    content_id: str | None = None,
+) -> SkillDefinition:
+    return SkillDefinition(name=name, description="desc", content=content, content_id=content_id)
 
 
 class _FakeToolManager:
@@ -73,7 +77,9 @@ class TestPreloadInvokedSkills:
     @pytest.mark.asyncio
     async def test_single_skill_preloaded(self, logger: Logger) -> None:
         history_manager = MagicMock()
-        skill_tool = _make_skill_tool([_make_skill("foo", content="FOO BODY")])
+        skill_tool = _make_skill_tool(
+            [_make_skill("foo", content="FOO BODY", content_id="cid-1")]
+        )
         tool_manager = _FakeToolManager(skill_tool=skill_tool)
 
         await preload_invoked_skills(
@@ -100,8 +106,11 @@ class TestPreloadInvokedSkills:
     async def test_forced_skill_choice_preloaded_without_slash_token(
         self, logger: Logger
     ) -> None:
+        """Payload name without a leading ``/`` resolves via content_id."""
         history_manager = MagicMock()
-        skill_tool = _make_skill_tool([_make_skill("foo", content="FOO BODY")])
+        skill_tool = _make_skill_tool(
+            [_make_skill("foo", content="FOO BODY", content_id="cid-1")]
+        )
         tool_manager = _FakeToolManager(skill_tool=skill_tool)
 
         await preload_invoked_skills(
@@ -138,7 +147,9 @@ class TestPreloadInvokedSkills:
     @pytest.mark.asyncio
     async def test_duplicate_skill_choices_preload_once(self, logger: Logger) -> None:
         history_manager = MagicMock()
-        skill_tool = _make_skill_tool([_make_skill("foo", content="FOO BODY")])
+        skill_tool = _make_skill_tool(
+            [_make_skill("foo", content="FOO BODY", content_id="cid-1")]
+        )
         tool_manager = _FakeToolManager(skill_tool=skill_tool)
 
         await preload_invoked_skills(
@@ -146,16 +157,84 @@ class TestPreloadInvokedSkills:
             history_manager=history_manager,
             logger=logger,
             skill_choices=[
-                SkillReference(name="foo", content_id="cid-1"),
-                SkillReference(name="/foo", content_id="cid-2"),
-                SkillReference(name="foo", content_id="cid-3"),
+                SkillReference(name="foo", content_id="cid-1"),   # resolves by content_id
+                SkillReference(name="/foo", content_id="cid-2"),  # different cid, falls back to name → duplicate
+                SkillReference(name="foo", content_id="cid-3"),   # different cid, falls back to name → duplicate
             ],
         )
 
         history_manager.add_tool_call.assert_called_once()
 
 
-class TestBuildSkill:
+    @pytest.mark.asyncio
+    async def test_content_id_resolves_even_when_payload_name_mismatches(
+        self, logger: Logger
+    ) -> None:
+        """content_id is the primary lookup — a mismatched payload name is irrelevant."""
+        history_manager = MagicMock()
+        skill_tool = _make_skill_tool(
+            [_make_skill("actual-skill-name", content="BODY", content_id="cid-99")]
+        )
+        tool_manager = _FakeToolManager(skill_tool=skill_tool)
+
+        await preload_invoked_skills(
+            tool_manager=tool_manager,  # type: ignore[arg-type]
+            history_manager=history_manager,
+            logger=logger,
+            skill_choices=[
+                SkillReference(name="wrong-display-label", content_id="cid-99")
+            ],
+        )
+
+        history_manager.add_tool_call.assert_called_once()
+        synthetic_call = history_manager.add_tool_call.call_args.args[0]
+        assert isinstance(synthetic_call, LanguageModelFunction)
+        assert synthetic_call.arguments == {"skill_name": "actual-skill-name"}
+
+    @pytest.mark.asyncio
+    async def test_choice_without_content_id_is_skipped(
+        self, logger: Logger
+    ) -> None:
+        """A choice with no content_id is silently ignored."""
+        history_manager = MagicMock()
+        skill_tool = _make_skill_tool(
+            [_make_skill("my-skill", content="BODY", content_id="cid-1")]
+        )
+        tool_manager = _FakeToolManager(skill_tool=skill_tool)
+
+        await preload_invoked_skills(
+            tool_manager=tool_manager,  # type: ignore[arg-type]
+            history_manager=history_manager,
+            logger=logger,
+            skill_choices=[SkillReference(name="my-skill", content_id="")],
+        )
+
+        history_manager.add_tool_call.assert_not_called()
+        history_manager._append_tool_calls_to_history.assert_not_called()
+        history_manager.add_tool_call_results.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_match_on_either_name_or_content_id_skips(
+        self, logger: Logger
+    ) -> None:
+        history_manager = MagicMock()
+        skill_tool = _make_skill_tool(
+            [_make_skill("some-skill", content="BODY", content_id="cid-1")]
+        )
+        tool_manager = _FakeToolManager(skill_tool=skill_tool)
+
+        await preload_invoked_skills(
+            tool_manager=tool_manager,  # type: ignore[arg-type]
+            history_manager=history_manager,
+            logger=logger,
+            skill_choices=[
+                SkillReference(name="unknown-name", content_id="unknown-cid")
+            ],
+        )
+
+        history_manager.add_tool_call.assert_not_called()
+        history_manager._append_tool_calls_to_history.assert_not_called()
+        history_manager.add_tool_call_results.assert_not_called()
     def test_parses_frontmatter_and_body(self, logger: Logger) -> None:
         file_text = (
             "---\n"
@@ -178,6 +257,7 @@ class TestBuildSkill:
         assert skill.name == "summarize"
         assert skill.description == "Summarize a document."
         assert skill.content == "# Summarize\nDo the thing."
+        assert skill.content_id == "c1"
 
 
 class TestParseFrontmatter:

--- a/unique_orchestrator/tests/test_skill_setup.py
+++ b/unique_orchestrator/tests/test_skill_setup.py
@@ -148,6 +148,13 @@ class TestPreloadInvokedSkills:
 
     @pytest.mark.asyncio
     async def test_duplicate_skill_choices_preload_once(self, logger: Logger) -> None:
+        """Three choices that all resolve to the same skill are deduplicated to one call.
+
+        Deduplication is keyed on the resolved skill name (seen_forced).  All
+        three choices carry the same content_id so they each resolve to the same
+        SkillDefinition, exercising the seen_forced guard on the second and third
+        entries.
+        """
         history_manager = MagicMock()
         skill_tool = _make_skill_tool(
             [_make_skill("foo", content="FOO BODY", content_id="cid-1")]
@@ -159,15 +166,9 @@ class TestPreloadInvokedSkills:
             history_manager=history_manager,
             logger=logger,
             skill_choices=[
-                SkillReference(
-                    name="foo", content_id="cid-1"
-                ),  # resolves by content_id
-                SkillReference(
-                    name="/foo", content_id="cid-2"
-                ),  # different cid, falls back to name → duplicate
-                SkillReference(
-                    name="foo", content_id="cid-3"
-                ),  # different cid, falls back to name → duplicate
+                SkillReference(name="foo", content_id="cid-1"),  # first: resolves & added
+                SkillReference(name="foo", content_id="cid-1"),  # duplicate: seen_forced skips
+                SkillReference(name="foo", content_id="cid-1"),  # duplicate: seen_forced skips
             ],
         )
 

--- a/unique_orchestrator/tests/test_skill_setup.py
+++ b/unique_orchestrator/tests/test_skill_setup.py
@@ -27,7 +27,9 @@ def _make_skill(
     content: str = "skill body",
     content_id: str | None = None,
 ) -> SkillDefinition:
-    return SkillDefinition(name=name, description="desc", content=content, content_id=content_id)
+    return SkillDefinition(
+        name=name, description="desc", content=content, content_id=content_id
+    )
 
 
 class _FakeToolManager:
@@ -157,14 +159,19 @@ class TestPreloadInvokedSkills:
             history_manager=history_manager,
             logger=logger,
             skill_choices=[
-                SkillReference(name="foo", content_id="cid-1"),   # resolves by content_id
-                SkillReference(name="/foo", content_id="cid-2"),  # different cid, falls back to name → duplicate
-                SkillReference(name="foo", content_id="cid-3"),   # different cid, falls back to name → duplicate
+                SkillReference(
+                    name="foo", content_id="cid-1"
+                ),  # resolves by content_id
+                SkillReference(
+                    name="/foo", content_id="cid-2"
+                ),  # different cid, falls back to name → duplicate
+                SkillReference(
+                    name="foo", content_id="cid-3"
+                ),  # different cid, falls back to name → duplicate
             ],
         )
 
         history_manager.add_tool_call.assert_called_once()
-
 
     @pytest.mark.asyncio
     async def test_content_id_resolves_even_when_payload_name_mismatches(
@@ -192,9 +199,7 @@ class TestPreloadInvokedSkills:
         assert synthetic_call.arguments == {"skill_name": "actual-skill-name"}
 
     @pytest.mark.asyncio
-    async def test_choice_without_content_id_is_skipped(
-        self, logger: Logger
-    ) -> None:
+    async def test_choice_without_content_id_is_skipped(self, logger: Logger) -> None:
         """A choice with no content_id is silently ignored."""
         history_manager = MagicMock()
         skill_tool = _make_skill_tool(
@@ -235,6 +240,7 @@ class TestPreloadInvokedSkills:
         history_manager.add_tool_call.assert_not_called()
         history_manager._append_tool_calls_to_history.assert_not_called()
         history_manager.add_tool_call_results.assert_not_called()
+
     def test_parses_frontmatter_and_body(self, logger: Logger) -> None:
         file_text = (
             "---\n"

--- a/unique_orchestrator/unique_orchestrator/_builders/skill_setup.py
+++ b/unique_orchestrator/unique_orchestrator/_builders/skill_setup.py
@@ -343,9 +343,7 @@ async def preload_invoked_skills(
 
     # content_id → skill.
     content_id_index: dict[str, SkillDefinition] = {
-        s.content_id: s
-        for s in skill_tool.skill_registry.values()
-        if s.content_id
+        s.content_id: s for s in skill_tool.skill_registry.values() if s.content_id
     }
 
     forced_skills: list[SkillDefinition] = []

--- a/unique_orchestrator/unique_orchestrator/_builders/skill_setup.py
+++ b/unique_orchestrator/unique_orchestrator/_builders/skill_setup.py
@@ -50,7 +50,6 @@ from pydantic import ValidationError
 from unique_skill_tool.config import SkillToolConfig
 from unique_skill_tool.schemas import SkillDefinition
 from unique_skill_tool.service import SkillTool
-from unique_skill_tool.utils import normalize_skill_name
 from unique_toolkit.agentic.tools.config import ToolBuildConfig
 from unique_toolkit.agentic.tools.schemas import ToolCallResponse
 from unique_toolkit.app.schemas import SkillReference
@@ -140,8 +139,8 @@ def _build_skill(
     is rejected by ``SkillDefinition`` rather than silently flowing into
     the OpenAI tool enum where the model could never emit it verbatim.
 
-    ``content_id`` and ``content_key`` are used only for log messages so
-    operators can locate the offending file in the knowledge base.
+    ``content_id`` is stored on the returned definition so it can be used
+    as a lookup key to load the SKILL.md.
     """
     if not file_text.strip():
         return None
@@ -164,6 +163,7 @@ def _build_skill(
             name=name,
             description=description,
             content=body,
+            content_id=content_id,
         )
     except ValidationError as exc:
         logger.warning(
@@ -325,7 +325,8 @@ async def preload_invoked_skills(
     indistinguishable from skills the model activates itself:
 
     1. Resolves each ``skill_choices`` entry against the registered
-       ``SkillTool`` registry (by normalized name or ``content_id``).
+       ``SkillTool`` registry by ``content_id``. Entries without a
+       ``content_id`` are skipped — every skill choice must carry one.
     2. For each matched skill, synthesizes a ``LanguageModelFunction``
        and runs it through the already-registered ``SkillTool`` — the
        exact same code path ``UniqueAI._handle_tool_calls`` uses.
@@ -340,13 +341,19 @@ async def preload_invoked_skills(
     if not isinstance(skill_tool, SkillTool):
         return
 
+    # content_id → skill.
+    content_id_index: dict[str, SkillDefinition] = {
+        s.content_id: s
+        for s in skill_tool.skill_registry.values()
+        if s.content_id
+    }
+
     forced_skills: list[SkillDefinition] = []
     seen_forced: set[str] = set()
     for choice in skill_choices:
         forced_skill: SkillDefinition | None = None
-        if choice.name:
-            normalized_name = normalize_skill_name(choice.name)
-            forced_skill = skill_tool.skill_registry.get(normalized_name)
+        if choice.content_id:
+            forced_skill = content_id_index.get(choice.content_id)
         if forced_skill is None:
             continue
         if forced_skill.name in seen_forced:


### PR DESCRIPTION
## 🚀 Summary
Refs: https://unique-ch.atlassian.net/browse/UN-20837

## Summary
- Skills in `skill_choices` are now resolved exclusively by `content_id` (the stable KB identifier) instead of the payload `name`, which is an unreliable display label that may not match the SKILL.md frontmatter.
- `content_id` is stored on `SkillDefinition` so the lookup index can be built at preload time.
- Choices without a `content_id` are silently skipped (contract enforced by tests).

## Changes
- `unique_skill_tool/schemas.py`: add optional `content_id: str | None` field to `SkillDefinition`
- `unique_orchestrator/_builders/skill_setup.py`: store `content_id` in `_build_skill`; replace name-based loop in `preload_invoked_skills` with a `content_id` index; remove now-unused `normalize_skill_name` import
- `unique_orchestrator/tests/test_skill_setup.py`: wire `content_id` into all skill fixtures; rename/replace tests to reflect `content_id`-first contract; add `test_choice_without_content_id_is_skipped` and `test_content_id_resolves_even_when_payload_name_mismatches`

## ✅ Changes

- [x] Added feature / fixed bug / updated docs
- [ ] Refactored code / cleaned up
- [ ] Other (describe below)

## 🧪 Testing
Skill folder name does not match with name in skill.md file. Frontend is using the folder name, while Python is using the correct name in the md file
<img width="641" height="212" alt="image" src="https://github.com/user-attachments/assets/0e3602f6-badf-403e-947b-3a405469e960" />
<img width="468" height="223" alt="image" src="https://github.com/user-attachments/assets/42c14161-1192-41fa-bae9-f27b5d6cb4f1" />

### triggered by orchestrator
<img width="1284" height="284" alt="image" src="https://github.com/user-attachments/assets/4fca8478-8e2c-4447-b6a7-39181a71d092" />

### Triggered by user with name of folder
<img width="1215" height="216" alt="image" src="https://github.com/user-attachments/assets/7cf8a29f-055c-4872-8dad-ea0fcfbd3dc4" />
