### PR TITLE
feat(sdk): add assistantId to MCP CallToolParams

### DIFF
--- a/unique_sdk/unique_sdk/api_resources/_mcp.py
+++ b/unique_sdk/unique_sdk/api_resources/_mcp.py
@@ -58,6 +58,7 @@ class MCP(APIResource["MCP"]):
         messageId: str
         chatId: str
         arguments: dict[str, Any]
+        assistantId: NotRequired[str | None]
 
     # Response fields.
     #


### PR DESCRIPTION
## Summary
- Extends `MCP.CallToolParams` with an optional `assistantId` field so callers can forward the current assistant context when invoking MCP tools.
- Required by the toolkit layer to scope MCP tool results to the current assistant.

## Changes
- `unique_sdk/unique_sdk/api_resources/_mcp.py` — added `assistantId: NotRequired[str | None]` to `CallToolParams`

## Test plan
- [ ] Pre-commit hooks pass (ruff lint + format)
- [ ] Field is `NotRequired` — no breaking change for existing callers

## Risk / rollout
- Purely additive; no existing call sites are affected.
- Must be released to PyPI before the dependent toolkit PR can ship.

Refs: UN-20676