### PR TITLE
feat(toolkit): pass assistantId in MCP callTool requests

### DIFF
--- a/unique_toolkit/tests/agentic/tools/test_mcp_tool_wrapper.py
+++ b/unique_toolkit/tests/agentic/tools/test_mcp_tool_wrapper.py
@@ -685,6 +685,7 @@ class TestMCPToolWrapperRun:
                 messageId="assistant_message_202",
                 chatId=mock_chat_event.payload.chat_id,
                 arguments={"query": "test", "limit": 5},
+                assistantId="assistant_101",
             )
 
     @pytest.mark.ai

--- a/unique_toolkit/unique_toolkit/agentic/tools/mcp/tool_wrapper.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/mcp/tool_wrapper.py
@@ -387,6 +387,7 @@ class MCPToolWrapper(Tool[MCPToolConfig]):
                 messageId=self._event.payload.assistant_message.id,
                 chatId=self._event.payload.chat_id,
                 arguments=arguments,
+                assistantId=self._event.payload.assistant_id,
             )
 
             self.logger.debug(f"Result: {result}")


### PR DESCRIPTION
## Summary
- Forwards `assistantId` from the chat event payload when invoking MCP tools via the SDK.
- Enables the backend `ChatContextProvider` to include `unique.app/chat/assistant-id` in `_meta`, allowing tools like `mcp_search` to scope results to the current assistant.

## Changes
- `unique_toolkit/unique_toolkit/agentic/tools/mcp/tool_wrapper.py` — passes `assistantId=self._event.payload.assistant_id` in `_call_mcp_tool_via_sdk`
- `unique_toolkit/tests/agentic/tools/test_mcp_tool_wrapper.py` — updated `test_run__calls_sdk_with_correct_parameters__AI` to assert `assistantId` is forwarded

## Test plan
- [ ] `test_run__calls_sdk_with_correct_parameters__AI` asserts `assistantId="assistant_101"` is included in the SDK call
- [ ] Pre-commit hooks pass (ruff lint + format)

## Risk / rollout
- Depends on [PR #1700](https://github.com/Unique-AG/ai/pull/1700) (`unique-sdk` release with `CallToolParams.assistantId`) being merged and published first.
- Once PR #1700 is released, rebase this branch onto `main` before merging.

Refs: UN-20676