### PR TITLE
feat(uqadm): KB folder admin and space access/ingestion commands

### DIFF
--- a/uqadm/README.md
+++ b/uqadm/README.md
@@ -1,8 +1,9 @@
 # uqadm
 
-Admin CLI for the Unique platform. It groups four command families:
+Admin CLI for the Unique platform. It groups these command families:
 
-- **`space`** — list, export, diff, migrate, upsert, and delete assistant spaces.
+- **`space`** — list, export, diff, migrate, upsert, access grants, ingestion settings, and delete assistant spaces.
+- **`kb`** — knowledge-base folders: create paths, grant group access, set folder ingestion config.
 - **`chat`** — send messages to an assistant and inspect chat history.
 - **`env`** — manage named credential slots stored in `~/.uqadm/envs/`.
 - **`install`** — one-time bootstrap: create directories, install shell completion, set up your first slot.
@@ -323,6 +324,40 @@ uqadm space migrate --source "qa:space_src123" --destination "prod:" --dry-run
 
 Supported URL path markers: `/space/<id>`, `/custom-space/<id>`, `/swappable-intelligence-space/<id>`.
 
+### `space access-grant SPACE_ID`
+
+Add **user or group** entries to a space ACL via ``Space.add_space_access``. The API **merges** new entries with existing access; it does not replace the full ACL.
+
+```bash
+uqadm space access-grant asst_abc --group grp_1 --group grp_2
+uqadm space access-grant asst_abc --user user_1 --type MANAGE --slot qa
+```
+
+| Option | Description |
+|--------|-------------|
+| `SPACE_ID` | Space id or URL (same rules as ``space export``). |
+| `--group ID` | Repeat for each group. |
+| `--user ID` | Repeat for each user. |
+| `--type` | `USE` (default), `MANAGE`, or `UPLOAD`. |
+| `--slot SLOT` | Credential slot (default: configured default). |
+
+### `space ingestion-set SPACE_ID CONFIG_FILE`
+
+Load a JSON/YAML **mapping** from disk and assign it to **``settings.ingestionConfig``** on the assistant. Other top-level ``settings`` keys are preserved (shallow merge); the file content **replaces** the previous ``ingestionConfig`` object.
+
+Folder-level ingestion (knowledge base) uses a different shape; use ``uqadm kb ingestion set`` for scopes/folders.
+
+```bash
+uqadm space ingestion-set asst_abc ./ingestion.json
+uqadm space ingestion-set asst_abc ./ingestion.yaml --slot prod --dry-run
+```
+
+| Option | Description |
+|--------|-------------|
+| `CONFIG_FILE` | ``.json``, ``.yaml``, or ``.yml``; root must be a mapping. |
+| `--dry-run` | Print which ``settings`` keys would be sent without PATCHing. |
+| `--slot SLOT` | Credential slot (default: configured default). |
+
 ### `space delete SPACE_ID`
 
 Delete a space (prompts for confirmation unless `-y`).
@@ -339,6 +374,53 @@ uqadm space delete space_old123 --dry-run
 | `--slot SLOT` | Credential slot (default: configured default slot). |
 | `-y`, `--yes` | Skip the confirmation prompt. |
 | `--dry-run` | Fetch and describe what would be deleted, without deleting. |
+
+---
+
+## `uqadm kb`
+
+Manage **knowledge-base folder** paths and metadata via ``unique_sdk.Folder``.
+
+```bash
+uqadm kb --help
+```
+
+### `kb mkdir`
+
+Create one or more folder paths. Pass paths as arguments, with ``--path`` (repeatable), and/or ``--paths-file`` (one path per line; ``#`` starts a comment). Use ``--parent-scope-id`` with relative path segments instead of absolute ``paths``.
+
+```bash
+uqadm kb mkdir /Dept/HR /Dept/Legal
+uqadm kb mkdir --paths-file folders.txt --slot qa
+uqadm kb mkdir rel/sub --parent-scope-id scope_parent123
+uqadm kb mkdir /Private --no-inherit-access
+```
+
+| Option | Description |
+|--------|-------------|
+| `--paths-file` | Text file of paths (one per line). |
+| `--path` | Single path (repeatable). |
+| `--parent-scope-id` | Use ``relativePaths`` under this scope. |
+| `--inherit-access / --no-inherit-access` | Passed to ``Folder.create_paths`` (default: inherit). |
+| `--slot SLOT` | Credential slot. |
+
+### `kb access grant`
+
+Grant **group** ``READ`` or ``WRITE`` on a folder. By default the change **applies to subfolders** (``applyToSubScopes``); pass ``--no-subfolders`` for this folder only.
+
+```bash
+uqadm kb access grant --folder-path /Dept/HR --group grp_1 --permission READ
+uqadm kb access grant --scope-id scope_abc --group grp_1 --group grp_2 --permission WRITE --no-subfolders
+```
+
+### `kb ingestion set CONFIG_FILE`
+
+Apply **folder** ingestion settings from a JSON/YAML file (mapping root) using ``Folder.update_ingestion_config``. Default applies to **subfolders**; use ``--no-subfolders`` for this folder only.
+
+```bash
+uqadm kb ingestion set ./folder-ingest.json --folder-path /Dept/HR
+uqadm kb ingestion set ./ingest.yaml --scope-id scope_abc --slot qa
+```
 
 ---
 

--- a/uqadm/tests/space/test_upsert.py
+++ b/uqadm/tests/space/test_upsert.py
@@ -8,7 +8,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from uqadm.space.upsert import cmd_upsert, load_space_snapshot, snapshot_format_for_path
+from uqadm.core.payload_files import snapshot_format_for_path
+from uqadm.space.upsert import cmd_upsert, load_space_snapshot
 
 
 def _minimal_create_snapshot() -> dict[str, object]:

--- a/uqadm/tests/test_cli_help.py
+++ b/uqadm/tests/test_cli_help.py
@@ -80,6 +80,7 @@ def test_top_level_help_shows_commands_and_globals() -> None:
     invoke_help = _make_help_invoker()
     result_output = invoke_help(["--help"])
     assert "space" in result_output
+    assert "kb" in result_output
     assert "chat" in result_output
     assert "env" in result_output
     assert "install" in result_output
@@ -118,6 +119,74 @@ def test_env_help_shows_subcommands() -> None:
     assert "show" in result_output
     assert "set-default" in result_output
     assert "delete" in result_output
+
+
+def test_kb_mkdir_help_shows_paths_file() -> None:
+    invoke_help = _make_help_invoker()
+    result_output = invoke_help(["kb", "mkdir", "--help"])
+    assert "--paths-file" in result_output
+    assert "--slot" in result_output
+    assert "Examples:" in result_output
+
+
+def test_kb_root_help_lists_access_and_ingestion_summaries() -> None:
+    invoke_help = _make_help_invoker()
+    result_output = invoke_help(["kb", "--help"])
+    assert "Folder.add_access" in result_output
+    assert "Folder.update_ingestion_config" in result_output
+    assert "access" in result_output
+    assert "ingestion" in result_output
+
+
+def test_kb_access_subgroup_help_shows_summary() -> None:
+    invoke_help = _make_help_invoker()
+    result_output = invoke_help(["kb", "access", "--help"])
+    assert "Folder.add_access" in result_output
+    assert "grant" in result_output
+
+
+def test_kb_ingestion_subgroup_help_shows_summary() -> None:
+    invoke_help = _make_help_invoker()
+    result_output = invoke_help(["kb", "ingestion", "--help"])
+    assert "Folder.update_ingestion_config" in result_output
+    assert "set" in result_output
+
+
+def test_kb_access_grant_help() -> None:
+    invoke_help = _make_help_invoker()
+    result_output = invoke_help(["kb", "access", "grant", "--help"])
+    assert "--folder-path" in result_output
+    assert "--group" in result_output
+    assert "applyToSubScopes" in result_output or "subfolders" in result_output
+    assert "Examples:" in result_output
+    assert "uqadm kb access grant" in result_output
+
+
+def test_kb_ingestion_set_help() -> None:
+    invoke_help = _make_help_invoker()
+    result_output = invoke_help(["kb", "ingestion", "set", "--help"])
+    assert "CONFIG_FILE" in result_output
+    assert "ingestionConfig" in result_output
+    assert "Examples:" in result_output
+    assert "uqadm kb ingestion set" in result_output
+
+
+def test_space_access_grant_help() -> None:
+    invoke_help = _make_help_invoker()
+    result_output = invoke_help(["space", "access-grant", "--help"])
+    assert "SPACE_ID" in result_output
+    assert "--group" in result_output
+    assert "add_space_access" in result_output
+    assert "Examples:" in result_output
+
+
+def test_space_ingestion_set_help() -> None:
+    invoke_help = _make_help_invoker()
+    result_output = invoke_help(["space", "ingestion-set", "--help"])
+    assert "CONFIG_FILE" in result_output
+    assert "--dry-run" in result_output
+    assert "settings" in result_output.lower()
+    assert "Examples:" in result_output
 
 
 def test_version_flag() -> None:

--- a/uqadm/tests/test_kb.py
+++ b/uqadm/tests/test_kb.py
@@ -1,0 +1,117 @@
+"""Tests for ``uqadm kb`` command helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from uqadm.kb.access import cmd_access_grant
+from uqadm.kb.ingestion import cmd_ingestion_set
+from uqadm.kb.mkdir import cmd_mkdir
+
+
+def _cfg() -> MagicMock:
+    return MagicMock(user_id="u1", company_id="c1")
+
+
+def test_mkdir_exits_when_no_paths() -> None:
+    with pytest.raises(SystemExit) as ei:
+        cmd_mkdir(
+            _cfg(),
+            extra_paths=[],
+            paths_file=None,
+            parent_scope_id=None,
+            inherit_access=True,
+        )
+    assert ei.value.code == 2
+
+
+@patch("uqadm.kb.mkdir.Folder.create_paths")
+def test_mkdir_calls_api_with_paths(mock_cp: MagicMock, tmp_path: Path) -> None:
+    mock_cp.return_value = {"createdFolders": [{"id": "s1", "name": "n"}]}
+    f = tmp_path / "p.txt"
+    f.write_text("/A/B\n", encoding="utf-8")
+    cmd_mkdir(
+        _cfg(),
+        extra_paths=("/X",),
+        paths_file=f,
+        parent_scope_id=None,
+        inherit_access=False,
+    )
+    mock_cp.assert_called_once()
+    call_kw = mock_cp.call_args[1]
+    assert call_kw["paths"] == ["/A/B", "/X"]
+    assert call_kw["inheritAccess"] is False
+
+
+@patch("uqadm.kb.mkdir.Folder.create_paths")
+def test_mkdir_parent_scope_relative(mock_cp: MagicMock) -> None:
+    mock_cp.return_value = {"createdFolders": []}
+    cmd_mkdir(
+        _cfg(),
+        extra_paths=("rel/a",),
+        paths_file=None,
+        parent_scope_id="parent_scope",
+        inherit_access=True,
+    )
+    mock_cp.assert_called_once()
+    kw = mock_cp.call_args[1]
+    assert kw["parentScopeId"] == "parent_scope"
+    assert kw["relativePaths"] == ["rel/a"]
+
+
+@patch("uqadm.kb.access.Folder.add_access")
+def test_access_grant_scope_and_groups(mock_aa: MagicMock) -> None:
+    cmd_access_grant(
+        _cfg(),
+        folder_path=None,
+        scope_id="sc1",
+        group_ids=("g1", "g2"),
+        permission="WRITE",
+        apply_to_subfolders=True,
+    )
+    mock_aa.assert_called_once_with(
+        "u1",
+        "c1",
+        scopeId="sc1",
+        scopeAccesses=[
+            {"entityId": "g1", "entityType": "GROUP", "type": "WRITE"},
+            {"entityId": "g2", "entityType": "GROUP", "type": "WRITE"},
+        ],
+        applyToSubScopes=True,
+    )
+
+
+def test_access_grant_requires_folder_xor_scope() -> None:
+    with pytest.raises(SystemExit) as ei:
+        cmd_access_grant(
+            _cfg(),
+            folder_path="/a",
+            scope_id="s",
+            group_ids=("g1",),
+            permission="READ",
+            apply_to_subfolders=True,
+        )
+    assert ei.value.code == 2
+
+
+@patch("uqadm.kb.ingestion.Folder.update_ingestion_config")
+def test_ingestion_set_from_file(mock_uic: MagicMock, tmp_path: Path) -> None:
+    p = tmp_path / "ing.json"
+    p.write_text('{"uniqueIngestionMode": "FULL"}', encoding="utf-8")
+    cmd_ingestion_set(
+        _cfg(),
+        config_path=p,
+        folder_path="/Docs",
+        scope_id=None,
+        apply_to_subfolders=False,
+    )
+    mock_uic.assert_called_once_with(
+        "u1",
+        "c1",
+        ingestionConfig={"uniqueIngestionMode": "FULL"},
+        applyToSubScopes=False,
+        folderPath="/Docs",
+    )

--- a/uqadm/tests/test_kb.py
+++ b/uqadm/tests/test_kb.py
@@ -115,3 +115,191 @@ def test_ingestion_set_from_file(mock_uic: MagicMock, tmp_path: Path) -> None:
         applyToSubScopes=False,
         folderPath="/Docs",
     )
+
+
+def test_access_grant_requires_groups() -> None:
+    with pytest.raises(SystemExit) as ei:
+        cmd_access_grant(
+            _cfg(),
+            folder_path="/Docs",
+            scope_id=None,
+            group_ids=(),
+            permission="READ",
+            apply_to_subfolders=True,
+        )
+    assert ei.value.code == 2
+
+
+@patch("uqadm.kb.access.Folder.add_access")
+def test_access_grant_folder_path(mock_aa: MagicMock) -> None:
+    cmd_access_grant(
+        _cfg(),
+        folder_path="/Docs",
+        scope_id=None,
+        group_ids=("g1",),
+        permission="READ",
+        apply_to_subfolders=False,
+    )
+    mock_aa.assert_called_once_with(
+        "u1",
+        "c1",
+        folderPath="/Docs",
+        scopeAccesses=[
+            {"entityId": "g1", "entityType": "GROUP", "type": "READ"},
+        ],
+        applyToSubScopes=False,
+    )
+
+
+@patch("uqadm.kb.access.Folder.add_access", side_effect=RuntimeError("api down"))
+def test_access_grant_api_failure(
+    mock_aa: MagicMock, capsys: pytest.CaptureFixture[str]
+) -> None:
+    with pytest.raises(SystemExit) as ei:
+        cmd_access_grant(
+            _cfg(),
+            folder_path="/Docs",
+            scope_id=None,
+            group_ids=("g1",),
+            permission="READ",
+            apply_to_subfolders=True,
+        )
+    assert ei.value.code == 1
+    mock_aa.assert_called_once()
+    err = capsys.readouterr().err
+    assert "add_access failed" in err
+
+
+@patch("uqadm.kb.mkdir.Folder.create_paths", side_effect=OSError("disk"))
+def test_mkdir_api_failure(
+    mock_cp: MagicMock, capsys: pytest.CaptureFixture[str]
+) -> None:
+    with pytest.raises(SystemExit) as ei:
+        cmd_mkdir(
+            _cfg(),
+            extra_paths=("/X",),
+            paths_file=None,
+            parent_scope_id=None,
+            inherit_access=True,
+        )
+    assert ei.value.code == 1
+    assert "create_paths failed" in capsys.readouterr().err
+
+
+@patch("uqadm.kb.mkdir.Folder.create_paths")
+def test_mkdir_no_new_folders_message(
+    mock_cp: MagicMock, capsys: pytest.CaptureFixture[str]
+) -> None:
+    mock_cp.return_value = {"createdFolders": []}
+    cmd_mkdir(
+        _cfg(),
+        extra_paths=("/exists",),
+        paths_file=None,
+        parent_scope_id=None,
+        inherit_access=True,
+    )
+    assert "No new folders" in capsys.readouterr().out
+
+
+def test_ingestion_set_requires_folder_xor_scope() -> None:
+    with pytest.raises(SystemExit) as ei:
+        cmd_ingestion_set(
+            _cfg(),
+            config_path=Path("unused.json"),
+            folder_path="/a",
+            scope_id="s",
+            apply_to_subfolders=True,
+        )
+    assert ei.value.code == 2
+
+
+def test_ingestion_set_invalid_json(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    p = tmp_path / "bad.json"
+    p.write_text("{not json", encoding="utf-8")
+    with pytest.raises(SystemExit) as ei:
+        cmd_ingestion_set(
+            _cfg(),
+            config_path=p,
+            folder_path="/Docs",
+            scope_id=None,
+            apply_to_subfolders=True,
+        )
+    assert ei.value.code == 2
+    assert "Invalid JSON" in capsys.readouterr().err
+
+
+def test_ingestion_set_invalid_yaml(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    p = tmp_path / "bad.yaml"
+    p.write_text("key: [unclosed", encoding="utf-8")
+    with pytest.raises(SystemExit) as ei:
+        cmd_ingestion_set(
+            _cfg(),
+            config_path=p,
+            folder_path="/Docs",
+            scope_id=None,
+            apply_to_subfolders=True,
+        )
+    assert ei.value.code == 2
+    assert "Invalid YAML" in capsys.readouterr().err
+
+
+def test_ingestion_set_non_mapping_root(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    p = tmp_path / "arr.json"
+    p.write_text("[]", encoding="utf-8")
+    with pytest.raises(SystemExit) as ei:
+        cmd_ingestion_set(
+            _cfg(),
+            config_path=p,
+            folder_path="/Docs",
+            scope_id=None,
+            apply_to_subfolders=True,
+        )
+    assert ei.value.code == 2
+    assert "mapping" in capsys.readouterr().err
+
+
+@patch("uqadm.kb.ingestion.Folder.update_ingestion_config")
+def test_ingestion_set_scope_id(mock_uic: MagicMock, tmp_path: Path) -> None:
+    p = tmp_path / "ing.json"
+    p.write_text("{}", encoding="utf-8")
+    cmd_ingestion_set(
+        _cfg(),
+        config_path=p,
+        folder_path=None,
+        scope_id="scope_1",
+        apply_to_subfolders=True,
+    )
+    mock_uic.assert_called_once_with(
+        "u1",
+        "c1",
+        ingestionConfig={},
+        applyToSubScopes=True,
+        scopeId="scope_1",
+    )
+
+
+@patch(
+    "uqadm.kb.ingestion.Folder.update_ingestion_config",
+    side_effect=RuntimeError("fail"),
+)
+def test_ingestion_set_api_failure(
+    mock_uic: MagicMock, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    p = tmp_path / "ing.json"
+    p.write_text("{}", encoding="utf-8")
+    with pytest.raises(SystemExit) as ei:
+        cmd_ingestion_set(
+            _cfg(),
+            config_path=p,
+            folder_path="/Docs",
+            scope_id=None,
+            apply_to_subfolders=False,
+        )
+    assert ei.value.code == 1
+    assert "update_ingestion_config failed" in capsys.readouterr().err

--- a/uqadm/tests/test_kb_cli.py
+++ b/uqadm/tests/test_kb_cli.py
@@ -1,0 +1,113 @@
+"""CLI integration tests for ``uqadm kb`` Typer commands."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from uqadm.cli import app
+from uqadm.core.env import MissingSlotEnvFileError
+from uqadm.core.slot import MissingDefaultSlotError
+
+
+def _runner() -> CliRunner:
+    return CliRunner()
+
+
+@patch("uqadm.kb.cmd_mkdir")
+@patch("uqadm.kb.config_for_slot")
+@patch("uqadm.kb.resolve_slot", return_value="qa")
+def test_kb_mkdir_cli_invokes_helper(
+    mock_resolve: MagicMock,
+    mock_cfg: MagicMock,
+    mock_mkdir: MagicMock,
+) -> None:
+    mock_cfg.return_value = MagicMock(user_id="u1", company_id="c1")
+    result = _runner().invoke(app, ["kb", "mkdir", "/A", "/B", "--slot", "qa"])
+    assert result.exit_code == 0
+    mock_resolve.assert_called_once_with("qa")
+    mock_cfg.assert_called_once()
+    mock_mkdir.assert_called_once()
+    call_kw = mock_mkdir.call_args.kwargs
+    assert call_kw["extra_paths"] == ["/A", "/B"]
+
+
+@patch("uqadm.kb.resolve_slot", side_effect=MissingDefaultSlotError("no default"))
+def test_kb_mkdir_missing_default_slot_exits_2(mock_resolve: MagicMock) -> None:
+    result = _runner().invoke(app, ["kb", "mkdir", "/A"])
+    assert result.exit_code == 2
+    assert "no default" in (result.output or result.stderr or "")
+
+
+@patch("uqadm.kb.config_for_slot", side_effect=MissingSlotEnvFileError("missing env"))
+@patch("uqadm.kb.resolve_slot", return_value="qa")
+def test_kb_mkdir_missing_env_exits_2(
+    mock_resolve: MagicMock, mock_cfg: MagicMock
+) -> None:
+    result = _runner().invoke(app, ["kb", "mkdir", "/A", "--slot", "qa"])
+    assert result.exit_code == 2
+    assert "missing env" in (result.output or result.stderr or "")
+
+
+@patch("uqadm.kb.cmd_access_grant")
+@patch("uqadm.kb.config_for_slot")
+@patch("uqadm.kb.resolve_slot", return_value="qa")
+def test_kb_access_grant_cli(
+    mock_resolve: MagicMock,
+    mock_cfg: MagicMock,
+    mock_grant: MagicMock,
+) -> None:
+    mock_cfg.return_value = MagicMock()
+    result = _runner().invoke(
+        app,
+        [
+            "kb",
+            "access",
+            "grant",
+            "--folder-path",
+            "/HR",
+            "--group",
+            "g1",
+            "--permission",
+            "WRITE",
+        ],
+    )
+    assert result.exit_code == 0
+    mock_grant.assert_called_once()
+    kw = mock_grant.call_args.kwargs
+    assert kw["folder_path"] == "/HR"
+    assert kw["group_ids"] == ("g1",)
+    assert kw["permission"] == "WRITE"
+
+
+@patch("uqadm.kb.cmd_ingestion_set")
+@patch("uqadm.kb.config_for_slot")
+@patch("uqadm.kb.resolve_slot", return_value="qa")
+def test_kb_ingestion_set_cli(
+    mock_resolve: MagicMock,
+    mock_cfg: MagicMock,
+    mock_set: MagicMock,
+    tmp_path: Path,
+) -> None:
+    cfg_file = tmp_path / "ing.json"
+    cfg_file.write_text("{}", encoding="utf-8")
+    mock_cfg.return_value = MagicMock()
+    result = _runner().invoke(
+        app,
+        [
+            "kb",
+            "ingestion",
+            "set",
+            str(cfg_file),
+            "--scope-id",
+            "scope_x",
+            "--no-subfolders",
+        ],
+    )
+    assert result.exit_code == 0
+    mock_set.assert_called_once()
+    kw = mock_set.call_args.kwargs
+    assert kw["scope_id"] == "scope_x"
+    assert kw["apply_to_subfolders"] is False

--- a/uqadm/tests/test_payload_files.py
+++ b/uqadm/tests/test_payload_files.py
@@ -1,0 +1,54 @@
+"""Tests for ``uqadm.core.payload_files``."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from uqadm.core.payload_files import (
+    load_json_or_yaml_mapping,
+    read_path_list_file,
+    snapshot_format_for_path,
+)
+
+
+def test_snapshot_format_rejects_bad_suffix() -> None:
+    with pytest.raises(ValueError, match=r"\.json"):
+        snapshot_format_for_path(Path("doc.txt"))
+
+
+def test_load_json_mapping(tmp_path: Path) -> None:
+    p = tmp_path / "c.json"
+    p.write_text(json.dumps({"a": 1}), encoding="utf-8")
+    assert load_json_or_yaml_mapping(p) == {"a": 1}
+
+
+def test_load_yaml_mapping(tmp_path: Path) -> None:
+    p = tmp_path / "c.yaml"
+    p.write_text(yaml.safe_dump({"x": "y"}), encoding="utf-8")
+    assert load_json_or_yaml_mapping(p) == {"x": "y"}
+
+
+def test_load_mapping_rejects_array_root(tmp_path: Path) -> None:
+    p = tmp_path / "a.json"
+    p.write_text("[1]", encoding="utf-8")
+    with pytest.raises(ValueError, match=r"mapping"):
+        load_json_or_yaml_mapping(p)
+
+
+def test_read_path_list_file_strips_comments(tmp_path: Path) -> None:
+    p = tmp_path / "paths.txt"
+    p.write_text(
+        " /a/b \n\n# skip\n/c/d # tail comment\n",
+        encoding="utf-8",
+    )
+    assert read_path_list_file(p) == ["/a/b", "/c/d"]
+
+
+def test_read_path_list_file_empty_ok(tmp_path: Path) -> None:
+    p = tmp_path / "empty.txt"
+    p.write_text("# only comment\n", encoding="utf-8")
+    assert read_path_list_file(p) == []

--- a/uqadm/tests/test_space_access_ingestion.py
+++ b/uqadm/tests/test_space_access_ingestion.py
@@ -93,3 +93,113 @@ def test_space_ingestion_dry_run_skips_patch(
         dry_run=True,
     )
     mock_up.assert_not_called()
+
+
+@patch(
+    "uqadm.space.access_grant.Space.add_space_access",
+    side_effect=RuntimeError("denied"),
+)
+def test_space_access_grant_api_failure(
+    mock_add: MagicMock, capsys: pytest.CaptureFixture[str]
+) -> None:
+    with pytest.raises(SystemExit) as ei:
+        cmd_space_access_grant(
+            _cfg(),
+            space_id="asst_1",
+            group_ids=("g1",),
+            user_ids=(),
+            access_type="USE",
+        )
+    assert ei.value.code == 1
+    assert "add_space_access failed" in capsys.readouterr().err
+
+
+def test_space_ingestion_invalid_json(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    p = tmp_path / "bad.json"
+    p.write_text("{", encoding="utf-8")
+    with pytest.raises(SystemExit) as ei:
+        cmd_space_ingestion_set(
+            _cfg(),
+            space_id="asst_x",
+            config_path=p,
+            dry_run=False,
+        )
+    assert ei.value.code == 2
+    assert "Invalid JSON" in capsys.readouterr().err
+
+
+def test_space_ingestion_invalid_yaml(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    p = tmp_path / "bad.yaml"
+    p.write_text("x: [", encoding="utf-8")
+    with pytest.raises(SystemExit) as ei:
+        cmd_space_ingestion_set(
+            _cfg(),
+            space_id="asst_x",
+            config_path=p,
+            dry_run=False,
+        )
+    assert ei.value.code == 2
+    assert "Invalid YAML" in capsys.readouterr().err
+
+
+def test_space_ingestion_non_mapping_root(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    p = tmp_path / "arr.json"
+    p.write_text("[]", encoding="utf-8")
+    with pytest.raises(SystemExit) as ei:
+        cmd_space_ingestion_set(
+            _cfg(),
+            space_id="asst_x",
+            config_path=p,
+            dry_run=False,
+        )
+    assert ei.value.code == 2
+    assert "mapping" in capsys.readouterr().err
+
+
+@patch(
+    "uqadm.space.ingestion_set.Space.get_space", side_effect=RuntimeError("not found")
+)
+def test_space_ingestion_get_space_failure(
+    mock_get: MagicMock, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    p = tmp_path / "ing.json"
+    p.write_text("{}", encoding="utf-8")
+    with pytest.raises(SystemExit) as ei:
+        cmd_space_ingestion_set(
+            _cfg(),
+            space_id="asst_x",
+            config_path=p,
+            dry_run=False,
+        )
+    assert ei.value.code == 1
+    assert "get_space failed" in capsys.readouterr().err
+
+
+@patch(
+    "uqadm.space.ingestion_set.Space.update_space",
+    side_effect=RuntimeError("patch fail"),
+)
+@patch("uqadm.space.ingestion_set.Space.get_space", return_value={"settings": {}})
+def test_space_ingestion_update_failure(
+    mock_get: MagicMock,
+    mock_up: MagicMock,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    p = tmp_path / "ing.json"
+    p.write_text('{"mode": "full"}', encoding="utf-8")
+    with pytest.raises(SystemExit) as ei:
+        cmd_space_ingestion_set(
+            _cfg(),
+            space_id="asst_x",
+            config_path=p,
+            dry_run=False,
+        )
+    assert ei.value.code == 1
+    assert "update_space failed" in capsys.readouterr().err

--- a/uqadm/tests/test_space_access_ingestion.py
+++ b/uqadm/tests/test_space_access_ingestion.py
@@ -1,0 +1,95 @@
+"""Tests for space access grant and ingestion set helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from uqadm.space.access_grant import cmd_space_access_grant
+from uqadm.space.ingestion_set import cmd_space_ingestion_set
+
+
+def _cfg() -> MagicMock:
+    return MagicMock(user_id="u1", company_id="c1")
+
+
+def test_space_access_grant_requires_principal() -> None:
+    with pytest.raises(SystemExit) as ei:
+        cmd_space_access_grant(
+            _cfg(),
+            space_id="asst_1",
+            group_ids=(),
+            user_ids=(),
+            access_type="USE",
+        )
+    assert ei.value.code == 2
+
+
+@patch("uqadm.space.access_grant.Space.add_space_access")
+def test_space_access_grant_groups_and_users(mock_add: MagicMock) -> None:
+    cmd_space_access_grant(
+        _cfg(),
+        space_id="asst_1",
+        group_ids=("g1",),
+        user_ids=("u9",),
+        access_type="MANAGE",
+    )
+    mock_add.assert_called_once_with(
+        "u1",
+        "c1",
+        "asst_1",
+        access=[
+            {"entityId": "g1", "entityType": "GROUP", "type": "MANAGE"},
+            {"entityId": "u9", "entityType": "USER", "type": "MANAGE"},
+        ],
+    )
+
+
+@patch("uqadm.space.ingestion_set.Space.update_space")
+@patch("uqadm.space.ingestion_set.Space.get_space")
+def test_space_ingestion_set_merges_settings(
+    mock_get: MagicMock,
+    mock_up: MagicMock,
+    tmp_path: Path,
+) -> None:
+    mock_get.return_value = {
+        "settings": {"deviceAvailability": "ALL", "ingestionConfig": {"old": True}},
+    }
+    p = tmp_path / "ing.yaml"
+    p.write_text("chunkStrategy: fixed\n", encoding="utf-8")
+    cmd_space_ingestion_set(
+        _cfg(),
+        space_id="asst_x",
+        config_path=p,
+        dry_run=False,
+    )
+    mock_up.assert_called_once_with(
+        "u1",
+        "c1",
+        "asst_x",
+        settings={
+            "deviceAvailability": "ALL",
+            "ingestionConfig": {"chunkStrategy": "fixed"},
+        },
+    )
+
+
+@patch("uqadm.space.ingestion_set.Space.update_space")
+@patch("uqadm.space.ingestion_set.Space.get_space")
+def test_space_ingestion_dry_run_skips_patch(
+    mock_get: MagicMock,
+    mock_up: MagicMock,
+    tmp_path: Path,
+) -> None:
+    mock_get.return_value = {"settings": None}
+    p = tmp_path / "ing.json"
+    p.write_text("{}", encoding="utf-8")
+    cmd_space_ingestion_set(
+        _cfg(),
+        space_id="asst_x",
+        config_path=p,
+        dry_run=True,
+    )
+    mock_up.assert_not_called()

--- a/uqadm/tests/test_space_cli_commands.py
+++ b/uqadm/tests/test_space_cli_commands.py
@@ -1,0 +1,111 @@
+"""CLI integration tests for new ``uqadm space`` commands."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from uqadm.cli import app
+
+
+def _runner() -> CliRunner:
+    return CliRunner()
+
+
+@patch("uqadm.space.cmd_space_access_grant")
+@patch("uqadm.space.config_for_slot")
+@patch("uqadm.space.resolve_slot", return_value="qa")
+def test_space_access_grant_cli(
+    mock_resolve: MagicMock,
+    mock_cfg: MagicMock,
+    mock_grant: MagicMock,
+) -> None:
+    mock_cfg.return_value = MagicMock()
+    result = _runner().invoke(
+        app,
+        [
+            "space",
+            "access-grant",
+            "asst_abc",
+            "--group",
+            "g1",
+            "--type",
+            "MANAGE",
+            "--slot",
+            "qa",
+        ],
+    )
+    assert result.exit_code == 0
+    mock_grant.assert_called_once()
+    kw = mock_grant.call_args.kwargs
+    assert kw["space_id"] == "asst_abc"
+    assert kw["group_ids"] == ("g1",)
+    assert kw["access_type"] == "MANAGE"
+
+
+@patch("uqadm.space.cmd_space_access_grant")
+@patch("uqadm.space.config_for_slot")
+@patch("uqadm.space.resolve_slot", return_value="qa")
+def test_space_access_grant_invalid_space_id_exits_2(
+    mock_resolve: MagicMock,
+    mock_cfg: MagicMock,
+    mock_grant: MagicMock,
+) -> None:
+    mock_cfg.return_value = MagicMock()
+    result = _runner().invoke(
+        app,
+        ["space", "access-grant", "1:", "--group", "g1", "--slot", "qa"],
+    )
+    assert result.exit_code == 2
+    mock_grant.assert_not_called()
+
+
+@patch("uqadm.space.cmd_space_ingestion_set")
+@patch("uqadm.space.config_for_slot")
+@patch("uqadm.space.resolve_slot", return_value="qa")
+def test_space_ingestion_set_cli(
+    mock_resolve: MagicMock,
+    mock_cfg: MagicMock,
+    mock_set: MagicMock,
+    tmp_path: Path,
+) -> None:
+    cfg_file = tmp_path / "ing.yaml"
+    cfg_file.write_text("chunkStrategy: fixed\n", encoding="utf-8")
+    mock_cfg.return_value = MagicMock()
+    result = _runner().invoke(
+        app,
+        [
+            "space",
+            "ingestion-set",
+            "asst_xyz",
+            str(cfg_file),
+            "--dry-run",
+        ],
+    )
+    assert result.exit_code == 0
+    mock_set.assert_called_once()
+    kw = mock_set.call_args.kwargs
+    assert kw["space_id"] == "asst_xyz"
+    assert kw["dry_run"] is True
+
+
+@patch("uqadm.space.cmd_space_ingestion_set")
+@patch("uqadm.space.config_for_slot")
+@patch("uqadm.space.resolve_slot", return_value="qa")
+def test_space_ingestion_set_invalid_space_id_exits_2(
+    mock_resolve: MagicMock,
+    mock_cfg: MagicMock,
+    mock_set: MagicMock,
+    tmp_path: Path,
+) -> None:
+    cfg_file = tmp_path / "ing.json"
+    cfg_file.write_text("{}", encoding="utf-8")
+    mock_cfg.return_value = MagicMock()
+    result = _runner().invoke(
+        app,
+        ["space", "ingestion-set", "", str(cfg_file)],
+    )
+    assert result.exit_code == 2
+    mock_set.assert_not_called()

--- a/uqadm/uqadm/cli.py
+++ b/uqadm/uqadm/cli.py
@@ -13,15 +13,17 @@ from uqadm.chat import chat_app
 from uqadm.core.env import MissingSlotEnvFileError
 from uqadm.env import env_app
 from uqadm.install import install_command
+from uqadm.kb import kb_app
 from uqadm.space import space_app
 
 app = typer.Typer(
     name="uqadm",
-    help="Unique admin CLI — space admin (uses same UNIQUE_* env as unique-cli).",
+    help="Unique admin CLI — space and knowledge-base admin (uses same UNIQUE_* env as unique-cli).",
     context_settings={"help_option_names": ["-h", "--help"]},
 )
 
 app.add_typer(space_app, name="space")
+app.add_typer(kb_app, name="kb")
 app.add_typer(chat_app, name="chat")
 app.add_typer(env_app, name="env")
 app.command("install")(install_command)

--- a/uqadm/uqadm/core/payload_files.py
+++ b/uqadm/uqadm/core/payload_files.py
@@ -1,0 +1,45 @@
+"""Load JSON/YAML mapping files and newline-separated path lists."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Literal
+
+import yaml
+
+
+def snapshot_format_for_path(path: Path) -> Literal["json", "yaml"]:
+    """Return file format from ``path`` suffix, or raise ``ValueError`` if invalid."""
+    suffix = path.suffix.lower()
+    if suffix == ".json":
+        return "json"
+    if suffix in (".yaml", ".yml"):
+        return "yaml"
+    raise ValueError(f"File must end with .json, .yaml, or .yml (got: {path.name!r}).")
+
+
+def load_json_or_yaml_mapping(path: Path) -> dict[str, Any]:
+    """Load a JSON or YAML file whose root must be a mapping."""
+    fmt = snapshot_format_for_path(path)
+    raw_text = path.read_text(encoding="utf-8")
+    if fmt == "json":
+        data = json.loads(raw_text)
+    else:
+        data = yaml.safe_load(raw_text)
+    if not isinstance(data, dict):
+        detail = type(data).__name__
+        raise ValueError(f"Document root must be a mapping (got {detail}).")
+    return dict(data)
+
+
+def read_path_list_file(path: Path) -> list[str]:
+    """Read non-empty folder paths: one per line, ``#`` starts an end-of-line comment."""
+    raw_text = path.read_text(encoding="utf-8")
+    result: list[str] = []
+    for line in raw_text.splitlines():
+        content = line.split("#", 1)[0].strip()
+        if not content:
+            continue
+        result.append(content)
+    return result

--- a/uqadm/uqadm/kb/__init__.py
+++ b/uqadm/uqadm/kb/__init__.py
@@ -1,0 +1,279 @@
+"""Knowledge base (folder) administration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Annotated, Literal, Optional
+
+import typer
+
+from uqadm.core.env import MissingSlotEnvFileError, config_for_slot
+from uqadm.core.slot import MissingDefaultSlotError, resolve_slot
+from uqadm.kb.access import cmd_access_grant
+from uqadm.kb.ingestion import cmd_ingestion_set
+from uqadm.kb.mkdir import cmd_mkdir
+
+kb_app = typer.Typer(
+    name="kb",
+    help=(
+        "Knowledge-base folder administration: create paths (Folder.create_paths), "
+        "grant group access (Folder.add_access), set ingestion (Folder.update_ingestion_config)."
+    ),
+    no_args_is_help=True,
+)
+
+_ACCESS_SUBHELP = (
+    "Grant READ/WRITE to groups on folder scopes. Wraps Folder.add_access; "
+    "by default applies to subfolders (see grant --no-subfolders)."
+)
+_INGESTION_SUBHELP = (
+    "Load folder ingestion settings from a JSON/YAML file. Wraps "
+    "Folder.update_ingestion_config (not the same shape as space settings.ingestionConfig)."
+)
+
+_SLOT_HELP = (
+    "Credential slot: loads .{SLOT}.env or {SLOT}.env. "
+    "Omit to use the configured default (see `uqadm env set-default`)."
+)
+
+
+def _get_cwd(ctx: typer.Context) -> Path | None:
+    return (ctx.obj or {}).get("cwd")
+
+
+def _resolve(slot: str | None) -> str:
+    try:
+        return resolve_slot(slot)
+    except MissingDefaultSlotError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(2)
+
+
+def _load_cfg(slot: str, cwd: Path | None):  # type: ignore[no-untyped-def]
+    try:
+        return config_for_slot(slot, cwd=cwd)
+    except MissingSlotEnvFileError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(2)
+
+
+@kb_app.command("mkdir", short_help="Create folder paths in the knowledge base.")
+def kb_mkdir(
+    ctx: typer.Context,
+    paths: Annotated[
+        Optional[list[str]],
+        typer.Argument(
+            help="Folder paths to create (repeat or combine with --paths-file).",
+        ),
+    ] = None,
+    slot: Annotated[Optional[str], typer.Option("--slot", help=_SLOT_HELP)] = None,
+    paths_file: Annotated[
+        Optional[Path],
+        typer.Option(
+            "--paths-file",
+            help="Text file: one path per line; ``#`` starts a comment.",
+            exists=True,
+            dir_okay=False,
+            readable=True,
+        ),
+    ] = None,
+    path_option: Annotated[
+        Optional[list[str]],
+        typer.Option(
+            "--path",
+            help="Folder path (repeatable).",
+        ),
+    ] = None,
+    parent_scope_id: Annotated[
+        Optional[str],
+        typer.Option(
+            "--parent-scope-id",
+            help="Create ``relativePaths`` under this parent scope instead of absolute ``paths``.",
+        ),
+    ] = None,
+    inherit_access: Annotated[
+        bool,
+        typer.Option(
+            "--inherit-access/--no-inherit-access",
+            help="Whether new folders inherit parent access (default: inherit).",
+        ),
+    ] = True,
+) -> None:
+    """Create folder paths in the tenant KB.
+
+    Uses ``Folder.create_paths``. Pass absolute paths, or ``--parent-scope-id`` with
+    relative segments. Combine positional paths, ``--path``, and/or ``--paths-file``.
+
+    Examples:
+
+      uqadm kb mkdir /Dept/HR /Dept/Legal
+      uqadm kb mkdir --path /Reports/2024 --path /Reports/2025 --slot qa
+      uqadm kb mkdir --paths-file folders.txt
+      uqadm kb mkdir rel/sub --parent-scope-id scope_parent123
+      uqadm kb mkdir /Private --no-inherit-access
+    """
+    resolved_slot = _resolve(slot)
+    cfg = _load_cfg(resolved_slot, _get_cwd(ctx))
+    combined = (paths or []) + (path_option or [])
+    cmd_mkdir(
+        cfg,
+        extra_paths=combined,
+        paths_file=paths_file,
+        parent_scope_id=parent_scope_id,
+        inherit_access=inherit_access,
+    )
+
+
+access_app = typer.Typer(
+    help=_ACCESS_SUBHELP,
+    short_help="Grant group access on KB folders (Folder.add_access).",
+    no_args_is_help=True,
+)
+
+
+@access_app.command(
+    "grant",
+    short_help="Grant group READ/WRITE on a folder (subfolders included by default).",
+)
+def kb_access_grant(
+    ctx: typer.Context,
+    slot: Annotated[Optional[str], typer.Option("--slot", help=_SLOT_HELP)] = None,
+    folder_path: Annotated[
+        Optional[str],
+        typer.Option(
+            "--folder-path",
+            help="Folder path (mutually exclusive with --scope-id).",
+        ),
+    ] = None,
+    scope_id: Annotated[
+        Optional[str],
+        typer.Option(
+            "--scope-id",
+            help="Folder scope id (mutually exclusive with --folder-path).",
+        ),
+    ] = None,
+    group: Annotated[
+        Optional[list[str]],
+        typer.Option(
+            "--group",
+            help="Group id (repeatable).",
+        ),
+    ] = None,
+    permission: Annotated[
+        Literal["READ", "WRITE"],
+        typer.Option(
+            "--permission",
+            help="Group access level for the folder scope(s).",
+            show_default=True,
+        ),
+    ] = "READ",
+    no_subfolders: Annotated[
+        bool,
+        typer.Option(
+            "--no-subfolders",
+            help="Do not apply to descendant folders (default: apply to subfolders).",
+        ),
+    ] = False,
+) -> None:
+    """Grant one or more groups access to a folder scope.
+
+    Requires exactly one of ``--folder-path`` or ``--scope-id``. Repeating ``--group``
+    adds multiple groups in one call. Unless ``--no-subfolders`` is set, the API
+    applies the same access to descendant folders (``applyToSubScopes``).
+
+    Examples:
+
+      uqadm kb access grant --folder-path /Dept/HR --group grp_1
+      uqadm kb access grant --folder-path /Dept/HR --group grp_1 --group grp_2 --permission WRITE
+      uqadm kb access grant --scope-id scope_abc --group grp_1 --slot qa
+      uqadm kb access grant --folder-path /Dept/HR --group grp_1 --no-subfolders
+    """
+    resolved_slot = _resolve(slot)
+    cfg = _load_cfg(resolved_slot, _get_cwd(ctx))
+    cmd_access_grant(
+        cfg,
+        folder_path=folder_path,
+        scope_id=scope_id,
+        group_ids=tuple(group or []),
+        permission=permission,
+        apply_to_subfolders=not no_subfolders,
+    )
+
+
+kb_app.add_typer(access_app, name="access")
+
+ingestion_app = typer.Typer(
+    help=_INGESTION_SUBHELP,
+    short_help="Folder ingestion JSON/YAML (Folder.update_ingestion_config).",
+    no_args_is_help=True,
+)
+
+
+@ingestion_app.command(
+    "set",
+    short_help="Apply ingestion config from CONFIG_FILE to a folder scope.",
+)
+def kb_ingestion_set(
+    ctx: typer.Context,
+    config_file: Annotated[
+        Path,
+        typer.Argument(
+            metavar="CONFIG_FILE",
+            help=(
+                "JSON or YAML file; root must be a mapping. Sent as folder "
+                "ingestionConfig (Folder.update_ingestion_config; differs from "
+                "``uqadm space ingestion-set``)."
+            ),
+            exists=True,
+            dir_okay=False,
+            readable=True,
+        ),
+    ],
+    slot: Annotated[Optional[str], typer.Option("--slot", help=_SLOT_HELP)] = None,
+    folder_path: Annotated[
+        Optional[str],
+        typer.Option(
+            "--folder-path", help="Folder path (mutually exclusive with --scope-id)."
+        ),
+    ] = None,
+    scope_id: Annotated[
+        Optional[str],
+        typer.Option(
+            "--scope-id",
+            help="Folder scope id (mutually exclusive with --folder-path).",
+        ),
+    ] = None,
+    no_subfolders: Annotated[
+        bool,
+        typer.Option(
+            "--no-subfolders",
+            help="Do not apply to descendant folders (default: apply to subfolders).",
+        ),
+    ] = False,
+) -> None:
+    """Patch folder ingestion using a JSON or YAML mapping file.
+
+    The file root must be an object; it is sent as ``ingestionConfig``. Requires
+    exactly one of ``--folder-path`` or ``--scope-id``. By default the patch
+    applies to subfolders unless ``--no-subfolders`` is set.
+
+    For assistant-level chat ingestion, use ``uqadm space ingestion-set`` instead.
+
+    Examples:
+
+      uqadm kb ingestion set ./folder-ingest.json --folder-path /Dept/HR
+      uqadm kb ingestion set ./ingest.yaml --scope-id scope_abc --slot qa
+      uqadm kb ingestion set ./ingest.json --folder-path /Dept/HR --no-subfolders
+    """
+    resolved_slot = _resolve(slot)
+    cfg = _load_cfg(resolved_slot, _get_cwd(ctx))
+    cmd_ingestion_set(
+        cfg,
+        config_path=config_file,
+        folder_path=folder_path,
+        scope_id=scope_id,
+        apply_to_subfolders=not no_subfolders,
+    )
+
+
+kb_app.add_typer(ingestion_app, name="ingestion")

--- a/uqadm/uqadm/kb/access.py
+++ b/uqadm/uqadm/kb/access.py
@@ -1,0 +1,71 @@
+"""Grant group access on knowledge-base folders."""
+
+from __future__ import annotations
+
+import sys
+from typing import Any, Literal, cast
+
+import typer
+from unique_sdk import Folder
+from unique_sdk.cli.config import Config
+
+from uqadm.core.auth_debug import echo_credential_debug_if_auth_failure
+
+FolderPerm = Literal["READ", "WRITE"]
+
+
+def cmd_access_grant(
+    cfg: Config,
+    *,
+    folder_path: str | None,
+    scope_id: str | None,
+    group_ids: tuple[str, ...],
+    permission: FolderPerm,
+    apply_to_subfolders: bool,
+) -> None:
+    if bool(folder_path) == bool(scope_id):
+        typer.echo(
+            "Specify exactly one of --folder-path or --scope-id.",
+            err=True,
+        )
+        sys.exit(2)
+    if not group_ids:
+        typer.echo("Provide at least one --group.", err=True)
+        sys.exit(2)
+
+    accesses = [
+        {
+            "entityId": gid,
+            "entityType": "GROUP",
+            "type": permission,
+        }
+        for gid in group_ids
+    ]
+    payload: dict[str, Any] = {
+        "scopeAccesses": accesses,
+        "applyToSubScopes": apply_to_subfolders,
+    }
+    if scope_id:
+        payload["scopeId"] = scope_id
+    else:
+        payload["folderPath"] = folder_path
+
+    try:
+        Folder.add_access(
+            cfg.user_id,
+            cfg.company_id,
+            **cast(Any, payload),
+        )
+    except Exception as exc:
+        typer.echo(f"add_access failed: {exc}", err=True)
+        echo_credential_debug_if_auth_failure(cfg, exc, label="kb access grant")
+        sys.exit(1)
+
+    typer.echo(
+        f"Granted {permission} to {len(group_ids)} group(s)"
+        + (
+            " (including subfolders)."
+            if apply_to_subfolders
+            else " (this folder only)."
+        )
+    )

--- a/uqadm/uqadm/kb/ingestion.py
+++ b/uqadm/uqadm/kb/ingestion.py
@@ -1,0 +1,73 @@
+"""Apply ingestion configuration to knowledge-base folders."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, cast
+
+import typer
+import yaml
+from unique_sdk import Folder
+from unique_sdk.cli.config import Config
+
+from uqadm.core.auth_debug import echo_credential_debug_if_auth_failure
+from uqadm.core.payload_files import load_json_or_yaml_mapping
+
+
+def cmd_ingestion_set(
+    cfg: Config,
+    *,
+    config_path: Path,
+    folder_path: str | None,
+    scope_id: str | None,
+    apply_to_subfolders: bool,
+) -> None:
+    if bool(folder_path) == bool(scope_id):
+        typer.echo(
+            "Specify exactly one of --folder-path or --scope-id.",
+            err=True,
+        )
+        sys.exit(2)
+
+    try:
+        ingestion_config = load_json_or_yaml_mapping(config_path)
+    except json.JSONDecodeError as exc:
+        typer.echo(f"Invalid JSON in config file: {exc}", err=True)
+        sys.exit(2)
+    except yaml.YAMLError as exc:
+        typer.echo(f"Invalid YAML in config file: {exc}", err=True)
+        sys.exit(2)
+    except ValueError as exc:
+        typer.echo(str(exc), err=True)
+        sys.exit(2)
+
+    payload: dict[str, Any] = {
+        "ingestionConfig": ingestion_config,
+        "applyToSubScopes": apply_to_subfolders,
+    }
+    if scope_id:
+        payload["scopeId"] = scope_id
+    else:
+        payload["folderPath"] = folder_path
+
+    try:
+        Folder.update_ingestion_config(
+            cfg.user_id,
+            cfg.company_id,
+            **cast(Any, payload),
+        )
+    except Exception as exc:
+        typer.echo(f"update_ingestion_config failed: {exc}", err=True)
+        echo_credential_debug_if_auth_failure(cfg, exc, label="kb ingestion set")
+        sys.exit(1)
+
+    typer.echo(
+        "Ingestion config updated"
+        + (
+            " (including subfolders)."
+            if apply_to_subfolders
+            else " (this folder only)."
+        )
+    )

--- a/uqadm/uqadm/kb/mkdir.py
+++ b/uqadm/uqadm/kb/mkdir.py
@@ -1,0 +1,74 @@
+"""Create knowledge-base folder paths."""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any, cast
+
+import typer
+from unique_sdk import Folder
+from unique_sdk.cli.config import Config
+
+from uqadm.core.auth_debug import echo_credential_debug_if_auth_failure
+from uqadm.core.payload_files import read_path_list_file
+
+
+def _collect_paths(
+    extra_paths: Sequence[str],
+    paths_file: Path | None,
+) -> list[str]:
+    collected: list[str] = []
+    if paths_file is not None:
+        collected.extend(read_path_list_file(paths_file))
+    collected.extend(extra_paths)
+    seen: set[str] = set()
+    unique: list[str] = []
+    for p in collected:
+        if p not in seen:
+            seen.add(p)
+            unique.append(p)
+    return unique
+
+
+def cmd_mkdir(
+    cfg: Config,
+    *,
+    extra_paths: Sequence[str],
+    paths_file: Path | None,
+    parent_scope_id: str | None,
+    inherit_access: bool,
+) -> None:
+    paths = _collect_paths(extra_paths, paths_file)
+    if not paths:
+        typer.echo(
+            "Provide at least one path (--path or positional) and/or --paths-file.",
+            err=True,
+        )
+        sys.exit(2)
+
+    params: dict[str, Any] = {"inheritAccess": inherit_access}
+    if parent_scope_id:
+        params["parentScopeId"] = parent_scope_id
+        params["relativePaths"] = paths
+    else:
+        params["paths"] = paths
+
+    try:
+        result = Folder.create_paths(
+            cfg.user_id,
+            cfg.company_id,
+            **cast(Any, params),
+        )
+    except Exception as exc:
+        typer.echo(f"create_paths failed: {exc}", err=True)
+        echo_credential_debug_if_auth_failure(cfg, exc, label="kb mkdir")
+        sys.exit(1)
+
+    created = result.get("createdFolders") or []
+    if not created:
+        typer.echo("No new folders reported by the API (paths may already exist).")
+        return
+    for folder in created:
+        typer.echo(f"{folder.get('id', '?')}\t{folder.get('name', '')}")

--- a/uqadm/uqadm/space/__init__.py
+++ b/uqadm/uqadm/space/__init__.py
@@ -3,15 +3,17 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Annotated, Optional
+from typing import Annotated, List, Literal, Optional
 
 import typer
 
 from uqadm.core.env import MissingSlotEnvFileError, config_for_slot
 from uqadm.core.slot import MissingDefaultSlotError, resolve_slot
+from uqadm.space.access_grant import cmd_space_access_grant
 from uqadm.space.delete import cmd_delete
 from uqadm.space.diff import cmd_diff
 from uqadm.space.export import cmd_export
+from uqadm.space.ingestion_set import cmd_space_ingestion_set
 from uqadm.space.list import cmd_list
 from uqadm.space.migrate import cmd_migrate
 from uqadm.space.upsert import cmd_upsert
@@ -243,6 +245,128 @@ def space_migrate(
         dry_run=dry_run,
         with_knowledge=with_knowledge,
         cwd=_get_cwd(ctx),
+    )
+
+
+@space_app.command(
+    "access-grant",
+    short_help="Add user/group space access (merged with existing ACL).",
+)
+def space_access_grant(
+    ctx: typer.Context,
+    space_id: Annotated[
+        str,
+        typer.Argument(
+            metavar="SPACE_ID",
+            help="Space id or URL (e.g. assistant_abc or https://host/.../space/assistant_abc).",
+        ),
+    ],
+    slot: Annotated[Optional[str], typer.Option("--slot", help=_SLOT_HELP)] = None,
+    group: Annotated[
+        Optional[List[str]],
+        typer.Option("--group", help="Group id (repeatable)."),
+    ] = None,
+    user: Annotated[
+        Optional[List[str]],
+        typer.Option("--user", help="User id (repeatable)."),
+    ] = None,
+    access_type: Annotated[
+        Literal["USE", "MANAGE", "UPLOAD"],
+        typer.Option(
+            "--type",
+            help="Access level for every ``--group`` / ``--user`` on this call.",
+            show_default=True,
+        ),
+    ] = "USE",
+) -> None:
+    """Add USE / MANAGE / UPLOAD entries for users and/or groups.
+
+    Each run posts to ``Space.add_space_access``; entries are merged with the existing
+    ACL rather than replacing it. Repeat ``--group`` / ``--user`` for multiple principals.
+
+    Examples:
+
+      uqadm space access-grant asst_abc --group grp_1
+      uqadm space access-grant asst_abc --group grp_1 --group grp_2
+      uqadm space access-grant asst_abc --user user_1 --type MANAGE --slot qa
+    """
+    from uqadm.core.endpoint import EndpointParseError, parse_bare_endpoint
+
+    resolved_slot = _resolve(slot)
+    cfg = _load_cfg(resolved_slot, _get_cwd(ctx))
+    try:
+        sid = parse_bare_endpoint(space_id)
+    except EndpointParseError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(2)
+    cmd_space_access_grant(
+        cfg,
+        space_id=sid,
+        group_ids=tuple(group or []),
+        user_ids=tuple(user or []),
+        access_type=access_type,
+    )
+
+
+@space_app.command(
+    "ingestion-set",
+    short_help="Merge settings.ingestionConfig from a JSON/YAML file.",
+)
+def space_ingestion_set(
+    ctx: typer.Context,
+    space_id: Annotated[
+        str,
+        typer.Argument(
+            metavar="SPACE_ID",
+            help="Space id or URL to patch.",
+        ),
+    ],
+    config_file: Annotated[
+        Path,
+        typer.Argument(
+            metavar="CONFIG_FILE",
+            exists=True,
+            dir_okay=False,
+            readable=True,
+            help=(
+                "JSON or YAML file whose root is a mapping; becomes "
+                "settings.ingestionConfig (assistant chat/file ingestion, not folder API)."
+            ),
+        ),
+    ],
+    slot: Annotated[Optional[str], typer.Option("--slot", help=_SLOT_HELP)] = None,
+    dry_run: Annotated[
+        bool,
+        typer.Option("--dry-run", help="Show which settings keys would be patched."),
+    ] = False,
+) -> None:
+    """Merge ``settings.ingestionConfig`` from a JSON/YAML file.
+
+    Fetches the space, shallow-merges top-level ``settings``, and sets
+    ``ingestionConfig`` to the file contents (replacing the previous object).
+    Use ``--dry-run`` to print which settings keys would be sent. For KB folder
+    ingestion, use ``uqadm kb ingestion set``.
+
+    Examples:
+
+      uqadm space ingestion-set asst_abc ./ingestion.json
+      uqadm space ingestion-set asst_abc ./ingestion.yaml --slot prod
+      uqadm space ingestion-set asst_abc ./ingestion.json --dry-run
+    """
+    from uqadm.core.endpoint import EndpointParseError, parse_bare_endpoint
+
+    resolved_slot = _resolve(slot)
+    cfg = _load_cfg(resolved_slot, _get_cwd(ctx))
+    try:
+        sid = parse_bare_endpoint(space_id)
+    except EndpointParseError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(2)
+    cmd_space_ingestion_set(
+        cfg,
+        space_id=sid,
+        config_path=config_file,
+        dry_run=dry_run,
     )
 
 

--- a/uqadm/uqadm/space/access_grant.py
+++ b/uqadm/uqadm/space/access_grant.py
@@ -1,0 +1,66 @@
+"""Grant user or group access to an assistant space."""
+
+from __future__ import annotations
+
+import sys
+from typing import Literal, cast
+
+import typer
+from unique_sdk import Space
+from unique_sdk.cli.config import Config
+
+from uqadm.core.auth_debug import echo_credential_debug_if_auth_failure
+
+SpaceAccessType = Literal["USE", "MANAGE", "UPLOAD"]
+
+
+def cmd_space_access_grant(
+    cfg: Config,
+    *,
+    space_id: str,
+    group_ids: tuple[str, ...],
+    user_ids: tuple[str, ...],
+    access_type: SpaceAccessType,
+) -> None:
+    if not group_ids and not user_ids:
+        typer.echo("Provide at least one --group and/or --user.", err=True)
+        sys.exit(2)
+
+    access = cast(
+        "list[Space.AccessEntry]",
+        [
+            *(
+                {
+                    "entityId": gid,
+                    "entityType": "GROUP",
+                    "type": access_type,
+                }
+                for gid in group_ids
+            ),
+            *(
+                {
+                    "entityId": uid,
+                    "entityType": "USER",
+                    "type": access_type,
+                }
+                for uid in user_ids
+            ),
+        ],
+    )
+
+    try:
+        Space.add_space_access(
+            cfg.user_id,
+            cfg.company_id,
+            space_id,
+            access=access,
+        )
+    except Exception as exc:
+        typer.echo(f"add_space_access failed: {exc}", err=True)
+        echo_credential_debug_if_auth_failure(cfg, exc, label="space access grant")
+        sys.exit(1)
+
+    typer.echo(
+        f"Added {len(access)} access entr(y/ies) ({access_type}) "
+        "(merged with existing ACL on the server)."
+    )

--- a/uqadm/uqadm/space/ingestion_set.py
+++ b/uqadm/uqadm/space/ingestion_set.py
@@ -1,0 +1,72 @@
+"""Set assistant space ingestion settings from a config file."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, cast
+
+import typer
+import yaml
+from unique_sdk import Space
+from unique_sdk.cli.config import Config
+
+from uqadm.core.auth_debug import echo_credential_debug_if_auth_failure
+from uqadm.core.payload_files import load_json_or_yaml_mapping
+
+
+def cmd_space_ingestion_set(
+    cfg: Config,
+    *,
+    space_id: str,
+    config_path: Path,
+    dry_run: bool,
+) -> None:
+    try:
+        ingestion = load_json_or_yaml_mapping(config_path)
+    except json.JSONDecodeError as exc:
+        typer.echo(f"Invalid JSON in config file: {exc}", err=True)
+        sys.exit(2)
+    except yaml.YAMLError as exc:
+        typer.echo(f"Invalid YAML in config file: {exc}", err=True)
+        sys.exit(2)
+    except ValueError as exc:
+        typer.echo(str(exc), err=True)
+        sys.exit(2)
+
+    try:
+        current = Space.get_space(cfg.user_id, cfg.company_id, space_id)
+    except Exception as exc:
+        typer.echo(f"get_space failed: {exc}", err=True)
+        echo_credential_debug_if_auth_failure(
+            cfg, exc, label="space ingestion get_space"
+        )
+        sys.exit(1)
+
+    raw_settings = current.get("settings")
+    base: dict[str, Any]
+    if isinstance(raw_settings, dict):
+        base = dict(raw_settings)
+    else:
+        base = {}
+    new_settings = {**base, "ingestionConfig": ingestion}
+
+    if dry_run:
+        keys = sorted(new_settings.keys())
+        typer.echo(f"Dry-run: would patch settings keys on {space_id!r}: {keys!r}.")
+        return
+
+    try:
+        Space.update_space(
+            cfg.user_id,
+            cfg.company_id,
+            space_id,
+            settings=cast("dict[str, Any]", new_settings),
+        )
+    except Exception as exc:
+        typer.echo(f"update_space failed: {exc}", err=True)
+        echo_credential_debug_if_auth_failure(cfg, exc, label="space ingestion set")
+        sys.exit(1)
+
+    typer.echo(f"Updated settings.ingestionConfig on space {space_id!r}.")

--- a/uqadm/uqadm/space/upsert.py
+++ b/uqadm/uqadm/space/upsert.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import sys
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any
 
 import typer
 import yaml
@@ -13,6 +13,7 @@ from unique_sdk import Space
 
 from uqadm.core.auth_debug import echo_credential_debug_if_auth_failure
 from uqadm.core.env import config_for_slot
+from uqadm.core.payload_files import load_json_or_yaml_mapping
 from uqadm.space.migrate import (
     build_create_params,
     build_module_updates_from_pairs,
@@ -22,30 +23,9 @@ from uqadm.space.migrate import (
 )
 
 
-def snapshot_format_for_path(path: Path) -> Literal["json", "yaml"]:
-    """Return file format from ``path`` suffix, or raise ``ValueError`` if invalid."""
-    suffix = path.suffix.lower()
-    if suffix == ".json":
-        return "json"
-    if suffix in (".yaml", ".yml"):
-        return "yaml"
-    raise ValueError(
-        f"Snapshot file must end with .json, .yaml, or .yml (got: {path.name!r})."
-    )
-
-
 def load_space_snapshot(path: Path) -> dict[str, Any]:
     """Load a JSON or YAML space snapshot from disk."""
-    fmt = snapshot_format_for_path(path)
-    raw_text = path.read_text(encoding="utf-8")
-    if fmt == "json":
-        data = json.loads(raw_text)
-    else:
-        data = yaml.safe_load(raw_text)
-    if not isinstance(data, dict):
-        detail = type(data).__name__
-        raise ValueError(f"Snapshot root must be a mapping (got {detail}).")
-    return dict(data)
+    return load_json_or_yaml_mapping(path)
 
 
 def _emit_snapshot_warnings(snapshot: dict[str, Any]) -> None:


### PR DESCRIPTION
## Summary

- Add **`uqadm kb`** commands for knowledge-base folder administration: `mkdir`, `access grant`, and `ingestion set` (file-based payloads via shared JSON/YAML helpers).
- Extend **`uqadm space`** with `access-grant` and `ingestion-set` for assistant space group access and `settings.ingestionConfig` updates.
- Extract shared **`payload_files`** utilities used by space upsert and kb commands; add pytest coverage, CLI help examples, and README documentation.

## Commands

| Area | Command | Purpose |
|------|---------|---------|
| KB | `uqadm kb mkdir` | Create folder paths under a scope |
| KB | `uqadm kb access grant` | Grant group access on folders |
| KB | `uqadm kb ingestion set` | Set folder ingestion config from file |
| Space | `uqadm space access-grant` | Grant group access on a space |
| Space | `uqadm space ingestion-set` | Merge `settings.ingestionConfig` on a space |

## Test plan

- [x] `cd uqadm && uv run ruff check . && uv run ruff format --check .`
- [x] `cd uqadm && uv run pytest` (137 tests)
- [x] `cd uqadm && uv run basedpyright`
- [ ] Manual smoke on QA: `uqadm kb mkdir`, `uqadm kb access grant`, `uqadm space ingestion-set` against a test scope/space

## Notes

- KB folder ingestion is separate from assistant `settings.ingestionConfig` (space export/migrate already carries the latter via full `settings`).
- `scopeRules` migration and `kb access revoke` are out of scope for this PR.


Made with [Cursor](https://cursor.com)