### PR TITLE
feat(unique_internal_search): Allow agent to search inside specific files

### DIFF
--- a/tool_packages/unique_internal_search/tests/test_service.py
+++ b/tool_packages/unique_internal_search/tests/test_service.py
@@ -1573,6 +1573,153 @@ class TestInternalSearchTool:
                 assert "language" in params or "properties" in params
 
     @pytest.mark.ai
+    def test_tool_description__no_content_ids__when_flag_off(
+        self,
+        mock_chat_event: Any,
+        mock_logger: Any,
+    ) -> None:
+        """
+        Purpose: Verify content_ids is absent from schema when enable_content_id_filter=False.
+        Why this matters: Ensures the LLM is not exposed to the parameter unless explicitly enabled.
+        Setup summary: Create tool with default config (flag off), assert content_ids not in schema.
+        """
+        config = InternalSearchConfig(enable_content_id_filter=False)
+
+        with (
+            patch(
+                "unique_internal_search.service.ContentService"
+            ) as mock_content_service_class,
+            patch(
+                "unique_internal_search.service.ChunkRelevancySorter"
+            ) as mock_sorter_class,
+        ):
+            mock_content_service = Mock(spec=ContentService)
+            mock_content_service._metadata_filter = None
+            mock_content_service_class.from_event.return_value = mock_content_service
+            mock_sorter_class.from_event.return_value = Mock()
+
+            def setup_tool(self, configuration, event, *args, **kwargs):
+                setattr(self, "_event", event)
+                setattr(self, "logger", mock_logger)
+                setattr(self, "_message_step_logger", None)
+
+            with patch("unique_internal_search.service.Tool.__init__", setup_tool):
+                tool = InternalSearchTool(configuration=config, event=mock_chat_event)
+                setattr(tool, "_event", mock_chat_event)
+
+            result = tool.tool_description()
+
+        assert hasattr(result.parameters, "model_fields")
+        assert "content_ids" not in result.parameters.model_fields  # type: ignore
+
+    @pytest.mark.ai
+    def test_tool_description__content_ids_present__when_flag_on(
+        self,
+        mock_chat_event: Any,
+        mock_logger: Any,
+    ) -> None:
+        """
+        Purpose: Verify content_ids appears as an optional field when enable_content_id_filter=True.
+        Why this matters: Ensures the LLM can pass content_ids only when the feature is enabled.
+        Setup summary: Create tool with flag enabled, assert content_ids is in schema as optional list.
+        """
+        config = InternalSearchConfig(enable_content_id_filter=True)
+
+        with (
+            patch(
+                "unique_internal_search.service.ContentService"
+            ) as mock_content_service_class,
+            patch(
+                "unique_internal_search.service.ChunkRelevancySorter"
+            ) as mock_sorter_class,
+        ):
+            mock_content_service = Mock(spec=ContentService)
+            mock_content_service._metadata_filter = None
+            mock_content_service_class.from_event.return_value = mock_content_service
+            mock_sorter_class.from_event.return_value = Mock()
+
+            def setup_tool(self, configuration, event, *args, **kwargs):
+                setattr(self, "_event", event)
+                setattr(self, "logger", mock_logger)
+                setattr(self, "_message_step_logger", None)
+
+            with patch("unique_internal_search.service.Tool.__init__", setup_tool):
+                tool = InternalSearchTool(configuration=config, event=mock_chat_event)
+                setattr(tool, "_event", mock_chat_event)
+
+            result = tool.tool_description()
+
+        assert hasattr(result.parameters, "model_fields")
+        assert "content_ids" in result.parameters.model_fields  # type: ignore
+        # Field must be optional (default None)
+        field_info = result.parameters.model_fields["content_ids"]  # type: ignore
+        assert field_info.default is None
+
+    @pytest.mark.ai
+    @pytest.mark.asyncio
+    async def test_run__passes_content_ids__to_search(
+        self,
+        mock_chat_event: Any,
+        mock_logger: Any,
+        sample_content_chunks: list[ContentChunk],
+    ) -> None:
+        """
+        Purpose: Verify that content_ids supplied by the LLM are forwarded to search_content_chunks_async.
+        Why this matters: Ensures the LLM can actually scope searches to specific documents end-to-end.
+        Setup summary: Create tool with flag on, call run() with content_ids, assert service receives them.
+        """
+        config = InternalSearchConfig(enable_content_id_filter=True)
+
+        with (
+            patch(
+                "unique_internal_search.service.ContentService"
+            ) as mock_content_service_class,
+            patch(
+                "unique_internal_search.service.ChunkRelevancySorter"
+            ) as mock_sorter_class,
+            patch("unique_internal_search.service.feature_flags") as mock_feature_flags,
+        ):
+            mock_content_service = Mock(spec=ContentService)
+            mock_content_service._metadata_filter = None
+            mock_content_service.search_content_chunks_async = AsyncMock(
+                return_value=sample_content_chunks
+            )
+            mock_content_service_class.from_event.return_value = mock_content_service
+            mock_sorter_class.from_event.return_value = Mock()
+            mock_feature_flags.enable_selected_uploaded_files_un_18215.is_enabled.return_value = False
+            mock_feature_flags.enable_new_answers_ui_un_14411.is_enabled.return_value = False
+
+            def setup_tool(self, configuration, event, *args, **kwargs):
+                setattr(self, "_event", event)
+                setattr(self, "logger", mock_logger)
+                setattr(self, "_message_step_logger", None)
+
+            with (
+                patch("unique_internal_search.service.Tool.__init__", setup_tool),
+                patch.object(
+                    InternalSearchTool,
+                    "tool_progress_reporter",
+                    new_callable=PropertyMock,
+                    return_value=None,
+                ),
+            ):
+                tool = InternalSearchTool(configuration=config, event=mock_chat_event)
+                setattr(tool, "_event", mock_chat_event)
+
+            tool_call = Mock(spec=["id", "arguments"])
+            tool_call.id = "call_123"
+            tool_call.arguments = {
+                "search_string": "quarterly revenue",
+                "content_ids": ["cont_abc123", "cont_def456"],
+            }
+
+            await tool.run(tool_call)
+
+        mock_content_service.search_content_chunks_async.assert_called_once()
+        _, call_kwargs = mock_content_service.search_content_chunks_async.call_args
+        assert call_kwargs["content_ids"] == ["cont_abc123", "cont_def456"]
+
+    @pytest.mark.ai
     def test_tool_description_for_system_prompt__returns_config_value(
         self,
         base_internal_search_config: InternalSearchConfig,

--- a/tool_packages/unique_internal_search/tests/test_uploaded_search_service.py
+++ b/tool_packages/unique_internal_search/tests/test_uploaded_search_service.py
@@ -726,3 +726,169 @@ class TestToolDescriptionForSystemPromptIngestionFilter:
             "**The currently uploaded and searchable documents are the following**"
             in result
         )
+
+
+def _make_uploaded_search_tool(
+    documents: list[Content],
+    config: UploadedSearchConfig,
+    event: ChatEvent,
+    tool_progress_reporter=None,
+) -> UploadedSearchTool:
+    with patch(
+        "unique_internal_search.uploaded_search.service.ContentService"
+    ) as mock_content_service_class:
+        mock_content_service = Mock(spec=ContentService)
+        mock_content_service.get_documents_uploaded_to_chat = Mock(
+            return_value=documents
+        )
+        mock_content_service_class.from_event.return_value = mock_content_service
+        tool = UploadedSearchTool(
+            config=config,
+            event=event,
+            tool_progress_reporter=tool_progress_reporter,
+        )
+    return tool
+
+
+@pytest.mark.ai
+class TestUploadedSearchToolContentIdFilter:
+    """Tests for the enable_content_id_filter feature on UploadedSearchTool."""
+
+    @pytest.mark.ai
+    def test_tool_description__no_content_ids__when_flag_off(
+        self,
+        mock_chat_event: ChatEvent,
+        mock_tool_progress_reporter: ToolProgressReporter,
+        mock_uploaded_documents_valid: list[Content],
+    ) -> None:
+        """
+        Purpose: Verify content_ids is absent from the tool schema when enable_content_id_filter=False.
+        Why this matters: Ensures the LLM is not exposed to the parameter unless explicitly opted in.
+        Setup summary: Create tool with default config (flag off), call tool_description(), assert
+                       content_ids is not a field in the returned model.
+        """
+        config = UploadedSearchConfig(enable_content_id_filter=False)
+        tool = _make_uploaded_search_tool(
+            mock_uploaded_documents_valid,
+            config,
+            mock_chat_event,
+            mock_tool_progress_reporter,
+        )
+
+        result = tool.tool_description()
+
+        assert hasattr(result.parameters, "model_fields")
+        assert "content_ids" not in result.parameters.model_fields  # type: ignore
+
+    @pytest.mark.ai
+    def test_tool_description__content_ids_present__when_flag_on(
+        self,
+        mock_chat_event: ChatEvent,
+        mock_tool_progress_reporter: ToolProgressReporter,
+        mock_uploaded_documents_valid: list[Content],
+    ) -> None:
+        """
+        Purpose: Verify content_ids appears as an optional Literal-typed field when enable_content_id_filter=True.
+        Why this matters: The Literal type constrains the LLM to only supply known document IDs,
+                          preventing hallucinated IDs from reaching the search layer.
+        Setup summary: Create tool with flag on and two valid documents, call tool_description(), assert
+                       content_ids is present, optional (default None), and typed as a Literal of known IDs.
+        """
+        config = UploadedSearchConfig(enable_content_id_filter=True)
+        tool = _make_uploaded_search_tool(
+            mock_uploaded_documents_valid,
+            config,
+            mock_chat_event,
+            mock_tool_progress_reporter,
+        )
+
+        result = tool.tool_description()
+
+        assert hasattr(result.parameters, "model_fields")
+        assert "content_ids" in result.parameters.model_fields  # type: ignore
+        field_info = result.parameters.model_fields["content_ids"]  # type: ignore
+        assert field_info.default is None
+
+    @pytest.mark.ai
+    def test_tool_description__no_content_ids__when_flag_on_but_no_documents(
+        self,
+        mock_chat_event: ChatEvent,
+        mock_tool_progress_reporter: ToolProgressReporter,
+    ) -> None:
+        """
+        Purpose: Verify content_ids is absent from the schema when the flag is on but no valid documents exist.
+        Why this matters: Literal[*()] is invalid — building a schema with zero known IDs would crash
+                          at tool-description time and break the agent for users with no uploads.
+        Setup summary: Create tool with flag on and an empty document list, call tool_description(),
+                       assert content_ids is not in the schema and no exception is raised.
+        """
+        config = UploadedSearchConfig(enable_content_id_filter=True)
+        tool = _make_uploaded_search_tool(
+            [], config, mock_chat_event, mock_tool_progress_reporter
+        )
+
+        result = tool.tool_description()
+
+        assert hasattr(result.parameters, "model_fields")
+        assert "content_ids" not in result.parameters.model_fields  # type: ignore
+
+    @pytest.mark.ai
+    @pytest.mark.asyncio
+    async def test_run__filters_invalid_content_ids(
+        self,
+        mock_chat_event: ChatEvent,
+        mock_uploaded_documents_valid: list[Content],
+    ) -> None:
+        """
+        Purpose: Verify that content_ids not in _valid_documents are silently filtered before forwarding.
+        Why this matters: The LLM schema may not be strict; a hallucinated or stale ID must not
+                          reach the search layer and potentially expose unauthorized content.
+        Setup summary: Create tool with two valid docs, run with one valid + one unknown ID,
+                       assert only the valid ID is forwarded in tool_call.arguments.
+        """
+        config = UploadedSearchConfig(enable_content_id_filter=True)
+        tool = _make_uploaded_search_tool(
+            mock_uploaded_documents_valid, config, mock_chat_event
+        )
+        tool._internal_search_tool.run = AsyncMock(
+            return_value=Mock(spec=["id", "name", "content", "system_reminder"])
+        )
+
+        tool_call = Mock(spec=["id", "arguments"])
+        tool_call.id = "call_001"
+        tool_call.arguments = {
+            "search_string": "annual budget",
+            "content_ids": ["doc_1", "doc_unknown_xyz"],
+        }
+
+        await tool.run(tool_call)
+
+        assert tool_call.arguments["content_ids"] == ["doc_1"]
+
+    @pytest.mark.ai
+    @pytest.mark.asyncio
+    async def test_run__raises__when_all_content_ids_invalid(
+        self,
+        mock_chat_event: ChatEvent,
+        mock_uploaded_documents_valid: list[Content],
+    ) -> None:
+        """
+        Purpose: Verify that a ValueError is raised when every supplied content_id is unknown.
+        Why this matters: Silently returning empty results when all IDs are bad would confuse both
+                          the LLM and the user; a clear error surfaces the misconfiguration immediately.
+        Setup summary: Create tool with two valid docs, run with two unknown IDs, assert ValueError.
+        """
+        config = UploadedSearchConfig(enable_content_id_filter=True)
+        tool = _make_uploaded_search_tool(
+            mock_uploaded_documents_valid, config, mock_chat_event
+        )
+
+        tool_call = Mock(spec=["id", "arguments"])
+        tool_call.id = "call_002"
+        tool_call.arguments = {
+            "search_string": "quarterly results",
+            "content_ids": ["doc_does_not_exist", "another_fake_id"],
+        }
+
+        with pytest.raises(ValueError, match="content_ids"):
+            await tool.run(tool_call)

--- a/tool_packages/unique_internal_search/unique_internal_search/config.py
+++ b/tool_packages/unique_internal_search/unique_internal_search/config.py
@@ -23,6 +23,7 @@ from unique_toolkit.content.schemas import (
 )
 
 from unique_internal_search.prompts import (
+    DEFAULT_CONTENT_IDS_PARAM_DESCRIPTION,
     DEFAULT_LANGUAGE_PARAM_DESCRIPTION,
     DEFAULT_SEARCH_STRING_PARAM_DESCRIPTION,
     DEFAULT_TOOL_DESCRIPTION,
@@ -207,6 +208,18 @@ class InternalSearchConfig(BaseToolConfig):
     enable_multiple_search_strings_execution: bool = Field(
         default=True,
         description="Allow execution of multiple search strings in one call. When set to True, each string is searched individually and results are merged into a single response.",
+    )
+
+    enable_content_id_filter: bool = Field(
+        default=False,
+        description=(
+            "When True, exposes an optional `content_ids` parameter in the tool schema so the LLM can restrict the search to specific documents. "
+        ),
+    )
+
+    param_description_content_ids: str = Field(
+        default=DEFAULT_CONTENT_IDS_PARAM_DESCRIPTION,
+        description="`content_ids` parameter description shown to the LLM.",
     )
 
     metadata_chunk_sections: dict[str, str] = Field(

--- a/tool_packages/unique_internal_search/unique_internal_search/config.py
+++ b/tool_packages/unique_internal_search/unique_internal_search/config.py
@@ -220,15 +220,10 @@ class InternalSearchConfig(BaseToolConfig):
     param_description_content_ids: Annotated[
         str,
         RJSFMetaTag.StringWidget.textarea(
-            rows=int(
-                len(DEFAULT_CONTENT_IDS_PARAM_DESCRIPTION.split("\n")) 
-            )
+            rows=int(len(DEFAULT_CONTENT_IDS_PARAM_DESCRIPTION.split("\n")))
         ),
     ] = get_string_field_with_pattern_validation(
         DEFAULT_CONTENT_IDS_PARAM_DESCRIPTION,
-        description="`content_ids` parameter description shown to the LLM.",
-    )
-        default=DEFAULT_CONTENT_IDS_PARAM_DESCRIPTION,
         description="`content_ids` parameter description shown to the LLM.",
     )
 

--- a/tool_packages/unique_internal_search/unique_internal_search/config.py
+++ b/tool_packages/unique_internal_search/unique_internal_search/config.py
@@ -217,7 +217,17 @@ class InternalSearchConfig(BaseToolConfig):
         ),
     )
 
-    param_description_content_ids: str = Field(
+    param_description_content_ids: Annotated[
+        str,
+        RJSFMetaTag.StringWidget.textarea(
+            rows=int(
+                len(DEFAULT_CONTENT_IDS_PARAM_DESCRIPTION.split("\n")) 
+            )
+        ),
+    ] = get_string_field_with_pattern_validation(
+        DEFAULT_CONTENT_IDS_PARAM_DESCRIPTION,
+        description="`content_ids` parameter description shown to the LLM.",
+    )
         default=DEFAULT_CONTENT_IDS_PARAM_DESCRIPTION,
         description="`content_ids` parameter description shown to the LLM.",
     )

--- a/tool_packages/unique_internal_search/unique_internal_search/prompts.py
+++ b/tool_packages/unique_internal_search/unique_internal_search/prompts.py
@@ -63,6 +63,11 @@ DEFAULT_SEARCH_STRING_PARAM_DESCRIPTION = "An expanded term that is optimized fo
 
 DEFAULT_LANGUAGE_PARAM_DESCRIPTION = "The language that the user wrote the query in"
 
+DEFAULT_CONTENT_IDS_PARAM_DESCRIPTION = (
+    "Optional list of document IDs (e.g cont_sx6neydisjrdvq59q39s89cg) to restrict the search "
+    "to specific documents. Use `null` to search all available documents."
+)
+
 
 DEFAULT_TOOL_RESPONSE_SYSTEM_REMINDER_PROMPT = """
 ## Reminder: Cite Every Fact from These Results

--- a/tool_packages/unique_internal_search/unique_internal_search/service.py
+++ b/tool_packages/unique_internal_search/unique_internal_search/service.py
@@ -168,7 +168,12 @@ class InternalSearchService:
             )
             and chat_only
         ):
-            content_ids = self.selected_uploaded_file_ids
+            if content_ids is not None:
+                content_ids = list(
+                    filter(lambda x: x in self.selected_uploaded_file_ids, content_ids)
+                )
+            else:
+                content_ids = self.selected_uploaded_file_ids
 
         # Run all searches in parallel
         results = await asyncio.gather(
@@ -236,6 +241,7 @@ class InternalSearchService:
         self.debug_info = {
             "searchStrings": search_strings,
             "metadataFilter": metadata_filter,
+            "contentIds": content_ids,
             "chatOnly": chat_only,
         }
         return selected_chunks
@@ -424,6 +430,16 @@ class InternalSearchTool(Tool[InternalSearchConfig], InternalSearchService):
                 Field(description=self.config.param_description_search_string),
             )
 
+        optional_fields: dict = {}
+        if self.config.enable_content_id_filter:
+            optional_fields["content_ids"] = (
+                list[str] | None,
+                Field(
+                    default=None,
+                    description=self.config.param_description_content_ids,
+                ),
+            )
+
         internal_search_tool_input = create_model(
             "InternalSearchToolInput",
             search_string=search_string_field,
@@ -431,6 +447,7 @@ class InternalSearchTool(Tool[InternalSearchConfig], InternalSearchService):
                 str,
                 Field(description=self.config.param_description_language),
             ),
+            **optional_fields,
         )
         return LanguageModelToolDescription(
             name=self.name,

--- a/tool_packages/unique_internal_search/unique_internal_search/uploaded_search/service.py
+++ b/tool_packages/unique_internal_search/unique_internal_search/uploaded_search/service.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from pydantic import Field, create_model
 from typing_extensions import override
 from unique_toolkit import ContentService
@@ -14,6 +16,7 @@ from unique_toolkit.agentic.tools.tool_progress_reporter import (
 )
 from unique_toolkit.app.schemas import BaseEvent, ChatEvent
 from unique_toolkit.chat.service import LanguageModelToolDescription
+from unique_toolkit.content import Content
 from unique_toolkit.language_model.schemas import (
     LanguageModelFunction,
 )
@@ -50,12 +53,28 @@ class UploadedSearchTool(Tool[UploadedSearchConfig]):
         else:
             self._user_query = None
 
+        # This blocking API call should be avoided.
+        # However, we don't have an easy way to pass user uploaded files to the tool currently
+        # Note that this was being done in `tool_description_for_system_prompt` before
+        self._valid_documents = self._compute_valid_documents()
+
     @override
     def display_name(self) -> str:
         return self._display_name
 
     @override
     def tool_description(self) -> LanguageModelToolDescription:
+        optional_fields: dict = {}
+        if self._config.enable_content_id_filter and self._valid_documents:
+            content_id_type = Literal[*(d.id for d in self._valid_documents)]
+            optional_fields["content_ids"] = (
+                list[content_id_type] | None,
+                Field(
+                    default=None,
+                    description=self._config.param_description_content_ids,
+                ),
+            )
+
         internal_search_tool_input = create_model(
             "InternalSearchToolInput",
             search_string=(
@@ -66,7 +85,9 @@ class UploadedSearchTool(Tool[UploadedSearchConfig]):
                 str,
                 Field(description=self._config.param_description_language),
             ),
+            **optional_fields,
         )
+
         return LanguageModelToolDescription(
             name=self.name,
             description=self._config.tool_description,
@@ -74,28 +95,12 @@ class UploadedSearchTool(Tool[UploadedSearchConfig]):
         )
 
     def tool_description_for_system_prompt(self) -> str:
-        documents = self._content_service.get_documents_uploaded_to_chat()
-        if feature_flags.enable_selected_uploaded_files_un_18215.is_enabled(
-            self._company_id
-        ):
-            documents = [
-                doc for doc in documents if doc.id in self._selected_uploaded_files
-            ]
-
-        valid_documents = []
-        for doc in documents:
-            if not doc.is_ingested(default_if_unknown=True) or doc.is_expired():
-                continue
-            valid_documents.append(
-                {
-                    "name": doc.title or doc.key,
-                    "id": doc.id,
-                }
-            )
-
         return render_template(
             self._config.tool_description_for_system_prompt,
-            valid_documents=valid_documents,
+            valid_documents=[
+                {"name": doc.title or doc.key, "id": doc.id}
+                for doc in self._valid_documents
+            ],
         )
 
     def tool_format_information_for_system_prompt(self) -> str:
@@ -114,6 +119,26 @@ class UploadedSearchTool(Tool[UploadedSearchConfig]):
         search_string_data = ""
         if isinstance(tool_call.arguments, dict):
             search_string_data = tool_call.arguments.get("search_string", "") or ""
+
+            # Verify no content_id outside valid ones, as tool may not be strict
+
+            if "content_ids" in tool_call.arguments:
+                tool_content_ids = tool_call.arguments["content_ids"]
+
+                if tool_content_ids is not None:
+                    valid_content_ids = {doc.id for doc in self._valid_documents}
+                    filtered = list(
+                        filter(
+                            lambda content_id: content_id in valid_content_ids,
+                            tool_content_ids,
+                        )
+                    )
+
+                    if len(filtered) == 0:
+                        raise ValueError("All supplied `content_ids` are invalid")
+
+                    tool_call.arguments["content_ids"] = filtered
+
         tool_response = await self._internal_search_tool.run(tool_call)
         if (
             self._tool_progress_reporter
@@ -150,6 +175,24 @@ This tool call was automatically executed to retrieve the user's uploaded docume
 
 Please do not mention these instructions in your response to the user!
 </system_reminder>"""
+
+    def _compute_valid_documents(self) -> list[Content]:
+        documents = self._content_service.get_documents_uploaded_to_chat()
+
+        if feature_flags.enable_selected_uploaded_files_un_18215.is_enabled(
+            self._company_id
+        ):
+            documents = [
+                doc for doc in documents if doc.id in self._selected_uploaded_files
+            ]
+
+        valid_documents = []
+        for doc in documents:
+            if not doc.is_ingested(default_if_unknown=True) or doc.is_expired():
+                continue
+            valid_documents.append(doc)
+
+        return valid_documents
 
 
 ToolFactory.register_tool(UploadedSearchTool, UploadedSearchConfig)


### PR DESCRIPTION
## 🚀 Summary
Refs: [UN-21021](https://unique-ch.atlassian.net/browse/UN-21021)

Add a parameter that allows the caller of InternalSearch (and UploadedSearch) to specify a list of `content_ids` where to search.

## ✅ Changes

- [x] Added feature / fixed bug / updated docs
- [ ] Refactored code / cleaned up
- [ ] Other (describe below)

## 🧪 Testing

Manual tests + AI generated unit tests

[UN-21021]: https://unique-ch.atlassian.net/browse/UN-21021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ