### PR TITLE
feat(web-search): add citation manifest support

### DIFF
--- a/unique_sdk/tests/cli/test_cli.py
+++ b/unique_sdk/tests/cli/test_cli.py
@@ -136,6 +136,20 @@ class TestClickCLI:
         assert result.exit_code == 0
         assert "Invalid metadata" in result.output
 
+    @patch("unique_sdk.Search.create")
+    def test_search_api_error_exits_nonzero(self, mock: MagicMock) -> None:
+        """Bugbot regression: ``search:``-prefixed error strings must map
+        to a non-zero exit code so shells / scripts can detect failures —
+        mirroring the existing ``web-search`` behaviour.
+        """
+        from unique_sdk import APIError
+
+        mock.side_effect = APIError("boom")
+        runner = CliRunner()
+        result = runner.invoke(main, ["search", "query"])
+        assert result.exit_code == 1
+        assert "search:" in result.output
+
     def test_upload_nonexistent(self) -> None:
         runner = CliRunner()
         result = runner.invoke(main, ["upload", "/nonexistent/file.pdf"])

--- a/unique_sdk/tests/cli/test_search.py
+++ b/unique_sdk/tests/cli/test_search.py
@@ -1,0 +1,449 @@
+"""Tests for the unique-cli search subcommand and its citation manifest.
+
+Structured to mirror ``tests/cli/test_web_search.py`` from PR #1733 — both
+commands write to ``.unique/`` JSONL manifests via shared helpers in
+``unique_sdk.cli.commands._citation_manifest``, so the test layout stays
+symmetric.
+
+Unlike web-search, which dedupes manifest entries by URL, KB search
+appends one manifest line per result every time. That is intentional:
+each ContentChunk is a distinct citation target (different page range,
+different chunk_id, ...), so URL-based dedup would collapse chunks that
+the runner expects to keep separate. The
+``test_kb_does_not_dedupe_repeated_results`` case below exists so future
+readers don't accidentally introduce parity with the web-search path.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import unique_sdk
+from unique_sdk.cli.commands._citation_manifest import (
+    UnsafeRefsLogPathError,
+    _append_turn_refs_manifest_entry,
+    _assert_safe_refs_log_path,
+    _locked_turn_refs_manifest,
+    _read_turn_refs_manifest,
+)
+from unique_sdk.cli.commands.search import (
+    SEARCH_ERROR_PREFIX,
+    _build_metadata_filter,
+    _format_source_block,
+    _result_to_chunk_payload,
+    cmd_search,
+    is_error_output,
+)
+from unique_sdk.cli.config import Config
+from unique_sdk.cli.state import ShellState
+
+
+def _config() -> Config:
+    return Config(
+        user_id="u1",
+        company_id="c1",
+        api_key="key",
+        app_id="app",
+        api_base="https://example.com",
+    )
+
+
+def _state(path: str = "/", scope_id: str | None = None) -> ShellState:
+    s = ShellState(_config())
+    s._path = path
+    s._scope_id = scope_id
+    return s
+
+
+@pytest.fixture(autouse=True)
+def _isolate_turn_refs_manifest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pin every test's cwd into ``tmp_path``.
+
+    ``cmd_search`` defaults the manifest path to ``<cwd>/.unique/turn-refs.jsonl``;
+    isolating cwd keeps concurrent tests from clobbering each other's
+    manifest and matches the autouse fixture pattern in
+    ``test_web_search.py``.
+    """
+    monkeypatch.chdir(tmp_path)
+
+
+def _make_search_result(
+    *,
+    content_id: str = "cont_abc",
+    chunk_id: str = "chunk_xyz",
+    text: str = "...the quarterly revenue analysis shows a 15% increase...",
+    order: int = 0,
+    key: str | None = "annual-report.pdf",
+    url: str | None = None,
+    title: str | None = "annual-report.pdf",
+    start_page: int | None = 12,
+    end_page: int | None = 13,
+    metadata: dict[str, Any] | None = None,
+    created_at: str | None = "2026-01-01T00:00:00Z",
+    updated_at: str | None = "2026-01-02T00:00:00Z",
+) -> MagicMock:
+    """Stand-in for a ``unique_sdk.Search`` result with the attrs we read."""
+    result = MagicMock()
+    result.id = content_id
+    result.chunkId = chunk_id
+    result.text = text
+    result.order = order
+    result.key = key
+    result.url = url
+    result.title = title
+    result.startPage = start_page
+    result.endPage = end_page
+    result.metadata = metadata
+    result.createdAt = created_at
+    result.updatedAt = updated_at
+    return result
+
+
+class TestBuildMetadataFilter:
+    def test_none_returns_none(self) -> None:
+        assert _build_metadata_filter(None, None) is None
+
+    def test_folder_only(self) -> None:
+        result = _build_metadata_filter("scope_abc", None)
+        assert result is not None
+        assert result["path"] == ["folderIdPath"]
+        assert "scope_abc" in result["value"]
+
+    def test_metadata_only(self) -> None:
+        result = _build_metadata_filter(None, [("dept", "Legal")])
+        assert result is not None
+        assert result["path"] == ["dept"]
+        assert result["value"] == "Legal"
+
+    def test_combined_is_anded(self) -> None:
+        result = _build_metadata_filter("scope_abc", [("dept", "Legal")])
+        assert result is not None
+        assert "and" in result
+
+
+class TestFormatSourceBlock:
+    def test_block_shape(self) -> None:
+        block = _format_source_block(1, _make_search_result())
+        assert block.startswith("<source1>\n")
+        assert block.endswith("\n</source1>")
+        assert "<|document|>annual-report.pdf</|document|>" in block
+        assert "<|page|>12-13</|page|>" in block
+        assert "<|info|>cont_abc</|info|>" in block
+
+    def test_single_page_block(self) -> None:
+        block = _format_source_block(3, _make_search_result(start_page=5, end_page=5))
+        assert "<|page|>5</|page|>" in block
+
+    def test_block_without_pages(self) -> None:
+        block = _format_source_block(
+            7, _make_search_result(start_page=None, end_page=None)
+        )
+        assert "<|page|>" not in block
+
+    def test_block_uses_key_when_title_missing(self) -> None:
+        block = _format_source_block(
+            2, _make_search_result(title=None, key="fallback.txt")
+        )
+        assert "<|document|>fallback.txt</|document|>" in block
+
+    def test_block_falls_back_to_content_id(self) -> None:
+        block = _format_source_block(
+            4, _make_search_result(title=None, key=None, content_id="cont_only")
+        )
+        assert "<|document|>content cont_only</|document|>" in block
+
+
+class TestResultToChunkPayload:
+    def test_emits_all_camelcase_keys(self) -> None:
+        payload = _result_to_chunk_payload(
+            _make_search_result(
+                metadata={"department": "Finance"},
+            )
+        )
+        assert payload == {
+            "id": "cont_abc",
+            "chunkId": "chunk_xyz",
+            "text": "...the quarterly revenue analysis shows a 15% increase...",
+            "order": 0,
+            "key": "annual-report.pdf",
+            "url": None,
+            "title": "annual-report.pdf",
+            "startPage": 12,
+            "endPage": 13,
+            "metadata": {"department": "Finance"},
+            "createdAt": "2026-01-01T00:00:00Z",
+            "updatedAt": "2026-01-02T00:00:00Z",
+        }
+
+    def test_non_dict_metadata_is_dropped(self) -> None:
+        result = _make_search_result(metadata="not-a-dict")  # type: ignore[arg-type]
+        assert _result_to_chunk_payload(result)["metadata"] is None
+
+
+class TestCmdSearchCitations:
+    @patch("unique_sdk.Search.create")
+    def test_happy_path_writes_block_and_manifest(self, mock: MagicMock) -> None:
+        mock.return_value = [_make_search_result()]
+
+        out = cmd_search(_state(), "quarterly revenue")
+
+        assert "Found 1 result(s):" in out
+        assert "<source1>" in out
+        assert "</source1>" in out
+        assert "<|document|>annual-report.pdf</|document|>" in out
+        assert "<|page|>12-13</|page|>" in out
+        assert "<|info|>cont_abc</|info|>" in out
+
+        manifest = Path.cwd() / ".unique" / "turn-refs.jsonl"
+        lines = manifest.read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 1
+        entry = json.loads(lines[0])
+        assert entry == {
+            "id": "cont_abc",
+            "chunkId": "chunk_xyz",
+            "text": "...the quarterly revenue analysis shows a 15% increase...",
+            "order": 0,
+            "key": "annual-report.pdf",
+            "url": None,
+            "title": "annual-report.pdf",
+            "startPage": 12,
+            "endPage": 13,
+            "metadata": None,
+            "createdAt": "2026-01-01T00:00:00Z",
+            "updatedAt": "2026-01-02T00:00:00Z",
+        }
+
+    @patch("unique_sdk.Search.create")
+    def test_numbering_continues_across_two_calls(self, mock: MagicMock) -> None:
+        mock.side_effect = [
+            [
+                _make_search_result(content_id="cont_a", chunk_id="chunk_a"),
+                _make_search_result(content_id="cont_b", chunk_id="chunk_b"),
+            ],
+            [
+                _make_search_result(content_id="cont_c", chunk_id="chunk_c"),
+            ],
+        ]
+
+        first = cmd_search(_state(), "query one")
+        second = cmd_search(_state(), "query two")
+
+        assert "<source1>" in first
+        assert "<source2>" in first
+        assert "<source3>" in second
+
+        manifest = Path.cwd() / ".unique" / "turn-refs.jsonl"
+        ids = [
+            json.loads(line)["id"]
+            for line in manifest.read_text(encoding="utf-8").splitlines()
+        ]
+        assert ids == ["cont_a", "cont_b", "cont_c"]
+
+    @patch("unique_sdk.Search.create")
+    def test_kb_does_not_dedupe_repeated_results(self, mock: MagicMock) -> None:
+        # NOTE: unique-cli web-search dedupes results by URL so the same URL
+        # keeps the same `websourceN`. KB search intentionally does NOT
+        # dedupe — each ContentChunk is its own citation target (page
+        # range, chunk_id differ in general). If a future change tries to
+        # add URL- or id-based dedup here, drop it: the runner relies on
+        # one manifest line per `<sourceN>` block emitted to the LLM.
+        same = _make_search_result(content_id="cont_dup", chunk_id="chunk_dup")
+        mock.return_value = [same, same]
+
+        out = cmd_search(_state(), "duplicate")
+
+        assert "<source1>" in out
+        assert "<source2>" in out
+        manifest = Path.cwd() / ".unique" / "turn-refs.jsonl"
+        assert len(manifest.read_text(encoding="utf-8").splitlines()) == 2
+
+    @patch("unique_sdk.Search.create")
+    def test_malformed_existing_manifest_lines_are_skipped(
+        self, mock: MagicMock
+    ) -> None:
+        manifest_dir = Path.cwd() / ".unique"
+        manifest_dir.mkdir()
+        manifest = manifest_dir / "turn-refs.jsonl"
+        manifest.write_text(
+            "\n".join(
+                [
+                    json.dumps({"id": "cont_pre", "text": "previous"}),
+                    "not-json",
+                    "{not even close}",
+                    "",
+                    json.dumps({"id": "cont_pre2", "text": "still here"}),
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        mock.return_value = [_make_search_result(content_id="cont_new")]
+        out = cmd_search(_state(), "query")
+
+        # 2 valid pre-existing entries + 1 new = the new block must be source3.
+        assert "<source3>" in out
+        ids = [
+            json.loads(line)["id"]
+            for line in manifest.read_text(encoding="utf-8").splitlines()
+            if line.strip().startswith("{") and "id" in line
+        ]
+        assert ids[-1] == "cont_new"
+
+    @patch("unique_sdk.Search.create")
+    def test_empty_results_no_manifest_write(self, mock: MagicMock) -> None:
+        mock.return_value = []
+        out = cmd_search(_state(), "no hits")
+        assert "No results found" in out
+        assert not (Path.cwd() / ".unique").exists()
+
+    @patch("unique_sdk.Search.create")
+    def test_api_error_returns_prefix_and_writes_nothing(self, mock: MagicMock) -> None:
+        mock.side_effect = ValueError("boom")
+        out = cmd_search(_state(), "fail")
+        assert out.startswith(SEARCH_ERROR_PREFIX)
+        assert "boom" in out
+        assert not (Path.cwd() / ".unique").exists()
+
+    @patch("unique_sdk.Search.create")
+    def test_symlinked_unique_dir_returns_error_and_skips_write(
+        self, mock: MagicMock, tmp_path: Path
+    ) -> None:
+        # Replace .unique with a symlink to a sibling dir to exercise the
+        # _assert_safe_refs_log_path guard. The command should refuse to
+        # write and surface a "search: ..." error string.
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+        unique_dir = Path.cwd() / ".unique"
+        os.symlink(elsewhere, unique_dir, target_is_directory=True)
+
+        mock.return_value = [_make_search_result()]
+        out = cmd_search(_state(), "query")
+
+        assert out.startswith(SEARCH_ERROR_PREFIX)
+        # No manifest in the real target dir either — the safety check
+        # fires before the write happens.
+        assert not (elsewhere / "turn-refs.jsonl").exists()
+
+
+class TestIsErrorOutput:
+    def test_error_string_is_error(self) -> None:
+        assert is_error_output(f"{SEARCH_ERROR_PREFIX} something failed") is True
+
+    def test_normal_output_is_not_error(self) -> None:
+        assert is_error_output("Found 1 result(s):\n<source1>...</source1>") is False
+
+
+class TestCitationManifestHelpers:
+    """Direct tests of the shared `_citation_manifest` module."""
+
+    def test_read_skips_blank_and_invalid_lines(self, tmp_path: Path) -> None:
+        manifest = tmp_path / ".unique" / "turn-refs.jsonl"
+        manifest.parent.mkdir()
+        manifest.write_text(
+            "\n".join(
+                [
+                    "",
+                    "not json",
+                    json.dumps({"id": "a"}),
+                    json.dumps(["array", "is", "skipped"]),
+                    json.dumps({"id": "b"}),
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        entries = _read_turn_refs_manifest(manifest)
+        assert [e["id"] for e in entries] == ["a", "b"]
+
+    def test_append_creates_parent_dir(self, tmp_path: Path) -> None:
+        manifest = tmp_path / ".unique" / "turn-refs.jsonl"
+        _append_turn_refs_manifest_entry(manifest, {"id": "first"})
+        _append_turn_refs_manifest_entry(manifest, {"id": "second"})
+        lines = manifest.read_text(encoding="utf-8").splitlines()
+        assert [json.loads(line)["id"] for line in lines] == ["first", "second"]
+
+    def test_assert_safe_rejects_symlinked_parent(self, tmp_path: Path) -> None:
+        real_dir = tmp_path / "real"
+        real_dir.mkdir()
+        link_dir = tmp_path / "link_to_real"
+        os.symlink(real_dir, link_dir, target_is_directory=True)
+        manifest = link_dir / "turn-refs.jsonl"
+
+        with pytest.raises(UnsafeRefsLogPathError):
+            _assert_safe_refs_log_path(manifest)
+
+    def test_locked_manifest_runs_critical_section(self, tmp_path: Path) -> None:
+        manifest = tmp_path / ".unique" / "turn-refs.jsonl"
+        with _locked_turn_refs_manifest(manifest, lock_filename="turn-refs.lock"):
+            _append_turn_refs_manifest_entry(manifest, {"id": "under-lock"})
+        lock_file = manifest.parent / "turn-refs.lock"
+        assert lock_file.exists()
+        assert json.loads(manifest.read_text(encoding="utf-8").splitlines()[0]) == {
+            "id": "under-lock"
+        }
+
+
+class TestContentChunkRoundTrip:
+    """Verify the manifest line shape rehydrates as a ``ContentChunk``.
+
+    Skipped when ``unique_toolkit`` is not installed in the test
+    environment — the SDK package on CI does not pull it in, so this
+    test depends on having the workspace toolkit available locally.
+    """
+
+    def test_manifest_line_rehydrates_as_content_chunk(self) -> None:
+        pytest.importorskip("unique_toolkit")
+        from unique_toolkit.content.schemas import ContentChunk
+
+        payload = _result_to_chunk_payload(
+            _make_search_result(
+                metadata={"key": "annual-report.pdf", "mimeType": "application/pdf"},
+            )
+        )
+        line = json.dumps(payload, default=str)
+        chunk = ContentChunk.model_validate(json.loads(line))
+
+        assert chunk.id == "cont_abc"
+        assert chunk.chunk_id == "chunk_xyz"
+        assert chunk.text.startswith("...the quarterly")
+        assert chunk.title == "annual-report.pdf"
+        assert chunk.start_page == 12
+        assert chunk.end_page == 13
+        assert chunk.metadata is not None
+        assert chunk.metadata.key == "annual-report.pdf"
+        assert chunk.metadata.mime_type == "application/pdf"
+
+
+class TestCmdSearchCallShapes:
+    """Existing happy-path call-shape coverage, kept here so the new module
+    is self-contained alongside test_commands.py (no extra surface)."""
+
+    @patch("unique_sdk.Search.create")
+    def test_scope_id_passed_through(self, mock: MagicMock) -> None:
+        mock.return_value = []
+        cmd_search(_state("/R", "scope_r"), "q")
+        assert mock.call_args[1]["scopeIds"] == ["scope_r"]
+
+    @patch("unique_sdk.Search.create")
+    def test_uses_workspace_scope_ids_when_no_folder(self, mock: MagicMock) -> None:
+        mock.return_value = []
+        s = _state()
+        s.workspace_scope_ids = ["scope_ws1", "scope_ws2"]
+        cmd_search(s, "q")
+        assert mock.call_args[1]["scopeIds"] == ["scope_ws1", "scope_ws2"]
+
+    @patch("unique_sdk.Search.create")
+    def test_api_error_includes_prefix(self, mock: MagicMock) -> None:
+        mock.side_effect = unique_sdk.APIError("oops")
+        out = cmd_search(_state(), "q")
+        assert out.startswith(SEARCH_ERROR_PREFIX)
+        assert "oops" in out

--- a/unique_sdk/tests/cli/test_search.py
+++ b/unique_sdk/tests/cli/test_search.py
@@ -62,15 +62,15 @@ def _state(path: str = "/", scope_id: str | None = None) -> ShellState:
 
 
 @pytest.fixture(autouse=True)
-def _isolate_turn_refs_manifest(
+def _isolate_kb_search_refs_manifest(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Pin every test's cwd into ``tmp_path``.
 
-    ``cmd_search`` defaults the manifest path to ``<cwd>/.unique/turn-refs.jsonl``;
-    isolating cwd keeps concurrent tests from clobbering each other's
-    manifest and matches the autouse fixture pattern in
-    ``test_web_search.py``.
+    ``cmd_search`` defaults the manifest path to
+    ``<cwd>/.unique/kb-search-refs.jsonl``; isolating cwd keeps concurrent
+    tests from clobbering each other's manifest and matches the autouse
+    fixture pattern in ``test_web_search.py``.
     """
     monkeypatch.chdir(tmp_path)
 
@@ -202,7 +202,7 @@ class TestCmdSearchCitations:
         assert "<|page|>12-13</|page|>" in out
         assert "<|info|>cont_abc</|info|>" in out
 
-        manifest = Path.cwd() / ".unique" / "turn-refs.jsonl"
+        manifest = Path.cwd() / ".unique" / "kb-search-refs.jsonl"
         lines = manifest.read_text(encoding="utf-8").splitlines()
         assert len(lines) == 1
         entry = json.loads(lines[0])
@@ -240,7 +240,7 @@ class TestCmdSearchCitations:
         assert "<source2>" in first
         assert "<source3>" in second
 
-        manifest = Path.cwd() / ".unique" / "turn-refs.jsonl"
+        manifest = Path.cwd() / ".unique" / "kb-search-refs.jsonl"
         ids = [
             json.loads(line)["id"]
             for line in manifest.read_text(encoding="utf-8").splitlines()
@@ -262,7 +262,7 @@ class TestCmdSearchCitations:
 
         assert "<source1>" in out
         assert "<source2>" in out
-        manifest = Path.cwd() / ".unique" / "turn-refs.jsonl"
+        manifest = Path.cwd() / ".unique" / "kb-search-refs.jsonl"
         assert len(manifest.read_text(encoding="utf-8").splitlines()) == 2
 
     @patch("unique_sdk.Search.create")
@@ -271,7 +271,7 @@ class TestCmdSearchCitations:
     ) -> None:
         manifest_dir = Path.cwd() / ".unique"
         manifest_dir.mkdir()
-        manifest = manifest_dir / "turn-refs.jsonl"
+        manifest = manifest_dir / "kb-search-refs.jsonl"
         manifest.write_text(
             "\n".join(
                 [
@@ -331,7 +331,7 @@ class TestCmdSearchCitations:
         assert out.startswith(SEARCH_ERROR_PREFIX)
         # No manifest in the real target dir either — the safety check
         # fires before the write happens.
-        assert not (elsewhere / "turn-refs.jsonl").exists()
+        assert not (elsewhere / "kb-search-refs.jsonl").exists()
 
 
 class TestIsErrorOutput:
@@ -346,7 +346,7 @@ class TestCitationManifestHelpers:
     """Direct tests of the shared `_citation_manifest` module."""
 
     def test_read_skips_blank_and_invalid_lines(self, tmp_path: Path) -> None:
-        manifest = tmp_path / ".unique" / "turn-refs.jsonl"
+        manifest = tmp_path / ".unique" / "kb-search-refs.jsonl"
         manifest.parent.mkdir()
         manifest.write_text(
             "\n".join(
@@ -365,7 +365,7 @@ class TestCitationManifestHelpers:
         assert [e["id"] for e in entries] == ["a", "b"]
 
     def test_append_creates_parent_dir(self, tmp_path: Path) -> None:
-        manifest = tmp_path / ".unique" / "turn-refs.jsonl"
+        manifest = tmp_path / ".unique" / "kb-search-refs.jsonl"
         _append_turn_refs_manifest_entry(manifest, {"id": "first"})
         _append_turn_refs_manifest_entry(manifest, {"id": "second"})
         lines = manifest.read_text(encoding="utf-8").splitlines()
@@ -376,16 +376,16 @@ class TestCitationManifestHelpers:
         real_dir.mkdir()
         link_dir = tmp_path / "link_to_real"
         os.symlink(real_dir, link_dir, target_is_directory=True)
-        manifest = link_dir / "turn-refs.jsonl"
+        manifest = link_dir / "kb-search-refs.jsonl"
 
         with pytest.raises(UnsafeRefsLogPathError):
             _assert_safe_refs_log_path(manifest)
 
     def test_locked_manifest_runs_critical_section(self, tmp_path: Path) -> None:
-        manifest = tmp_path / ".unique" / "turn-refs.jsonl"
-        with _locked_turn_refs_manifest(manifest, lock_filename="turn-refs.lock"):
+        manifest = tmp_path / ".unique" / "kb-search-refs.jsonl"
+        with _locked_turn_refs_manifest(manifest, lock_filename="kb-search-refs.lock"):
             _append_turn_refs_manifest_entry(manifest, {"id": "under-lock"})
-        lock_file = manifest.parent / "turn-refs.lock"
+        lock_file = manifest.parent / "kb-search-refs.lock"
         assert lock_file.exists()
         assert json.loads(manifest.read_text(encoding="utf-8").splitlines()[0]) == {
             "id": "under-lock"

--- a/unique_sdk/tests/cli/test_web_search.py
+++ b/unique_sdk/tests/cli/test_web_search.py
@@ -381,6 +381,78 @@ class TestCitationManifest:
 
         assert annotated["results"] == []
 
+    def test_non_dict_results_are_logged_and_dropped(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Bugbot A7: non-dict result entries must be visible in logs, not
+        silently swallowed, so missing citations are diagnosable.
+        """
+        payload = _make_search_payload(
+            results=[
+                "not-a-dict",
+                {"url": "https://a", "title": "A", "snippet": "s", "content": ""},
+            ]
+        )
+
+        with caplog.at_level("WARNING", logger="unique_sdk.cli.commands.web_search"):
+            annotated = _annotate_web_results_for_citations(
+                payload,
+                refs_log_path=tmp_path / ".unique" / "web-refs.jsonl",
+            )
+
+        annotated_urls = [r.get("url") for r in annotated["results"]]
+        assert annotated_urls == ["https://a"]
+        assert any(
+            "skipping non-dict web result" in record.getMessage()
+            for record in caplog.records
+        )
+
+
+class TestFormatterRowLabel:
+    """Bugbot A6: the human formatter's row label must come from the
+    citation key (``sourceNumber``) when present, so what the LLM reads in
+    the table matches the ``[websourceN]`` marker it is told to emit.
+    """
+
+    def test_search_formatter_uses_source_number(self, tmp_path: Path) -> None:
+        payload = _make_search_payload(
+            results=[
+                {"url": "https://a", "title": "A", "snippet": "", "content": ""},
+                {"url": "https://b", "title": "B", "snippet": "", "content": ""},
+            ]
+        )
+        annotated = _annotate_web_results_for_citations(
+            payload,
+            refs_log_path=tmp_path / ".unique" / "web-refs.jsonl",
+        )
+        annotated["results"][0]["sourceNumber"] = 7
+        annotated["results"][0]["citation"] = "websource7"
+
+        out = _format_search_results(annotated)
+
+        assert "  7. A [websource7]" in out
+        assert "  1. A" not in out
+
+    def test_crawl_formatter_uses_source_number(self, tmp_path: Path) -> None:
+        payload = _make_crawl_payload(
+            results=[
+                {"url": "https://a", "content": "hello", "error": None},
+            ]
+        )
+        annotated = _annotate_web_results_for_citations(
+            payload,
+            refs_log_path=tmp_path / ".unique" / "web-refs.jsonl",
+        )
+        annotated["results"][0]["sourceNumber"] = 4
+        annotated["results"][0]["citation"] = "websource4"
+
+        out = _format_crawl_results(annotated)
+
+        assert "  4. https://a [websource4]" in out
+        assert "  1. https://a" not in out
+
 
 class TestCmdWebSearch:
     @patch("unique_sdk.WebSearch.search")

--- a/unique_sdk/tests/cli/test_web_search.py
+++ b/unique_sdk/tests/cli/test_web_search.py
@@ -370,6 +370,17 @@ class TestCitationManifest:
 
         assert annotated["results"][0]["sourceNumber"] == 2
 
+    def test_null_results_are_treated_as_empty(self, tmp_path: Path) -> None:
+        payload = _make_search_payload()
+        payload["results"] = None
+
+        annotated = _annotate_web_results_for_citations(
+            payload,
+            refs_log_path=tmp_path / ".unique" / "web-refs.jsonl",
+        )
+
+        assert annotated["results"] == []
+
 
 class TestCmdWebSearch:
     @patch("unique_sdk.WebSearch.search")

--- a/unique_sdk/tests/cli/test_web_search.py
+++ b/unique_sdk/tests/cli/test_web_search.py
@@ -15,6 +15,7 @@ from unique_sdk.cli.cli import main as cli_main
 from unique_sdk.cli.commands.web_search import (
     WEB_CRAWL_ERROR_PREFIX,
     WEB_SEARCH_ERROR_PREFIX,
+    _annotate_web_results_for_citations,
     _format_crawl_results,
     _format_crawl_results_json,
     _format_search_results,
@@ -51,6 +52,11 @@ def _config() -> Config:
 
 def _state() -> ShellState:
     return ShellState(_config())
+
+
+@pytest.fixture(autouse=True)
+def _isolate_web_refs_manifest(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
 
 
 def _make_search_payload(
@@ -186,13 +192,31 @@ class TestSearchFormatting:
 
     def test_search_json_envelope(self) -> None:
         payload = _make_search_payload(
-            results=[{"url": "u", "title": "t", "snippet": "s", "content": ""}]
+            results=[
+                {
+                    "url": "u",
+                    "title": "t",
+                    "snippet": "s",
+                    "content": "",
+                    "sourceNumber": 1,
+                    "citation": "websource1",
+                }
+            ]
         )
         parsed = json.loads(_format_search_results_json(payload))
         assert parsed == {
             "engine": "Google",
             "query": "q",
-            "results": [{"url": "u", "title": "t", "snippet": "s", "content": ""}],
+            "results": [
+                {
+                    "url": "u",
+                    "title": "t",
+                    "snippet": "s",
+                    "content": "",
+                    "sourceNumber": 1,
+                    "citation": "websource1",
+                }
+            ],
         }
 
 
@@ -220,13 +244,131 @@ class TestCrawlFormatting:
 
     def test_crawl_json_envelope(self) -> None:
         payload = _make_crawl_payload(
-            results=[{"url": "u", "content": "c", "error": None}]
+            results=[
+                {
+                    "url": "u",
+                    "content": "c",
+                    "error": None,
+                    "sourceNumber": 1,
+                    "citation": "websource1",
+                }
+            ]
         )
         parsed = json.loads(_format_crawl_results_json(payload))
         assert parsed == {
             "crawler": "BasicCrawler",
-            "results": [{"url": "u", "content": "c", "error": None}],
+            "results": [
+                {
+                    "url": "u",
+                    "content": "c",
+                    "error": None,
+                    "sourceNumber": 1,
+                    "citation": "websource1",
+                }
+            ],
         }
+
+
+class TestCitationManifest:
+    def test_annotates_results_and_writes_manifest(self, tmp_path: Path) -> None:
+        payload = _make_search_payload(
+            results=[
+                {
+                    "url": "https://example.com/a",
+                    "title": "A",
+                    "snippet": "Snippet A",
+                    "content": "",
+                }
+            ]
+        )
+        manifest = tmp_path / ".unique" / "web-refs.jsonl"
+
+        annotated = _annotate_web_results_for_citations(payload, refs_log_path=manifest)
+
+        assert annotated["results"][0]["sourceNumber"] == 1
+        assert annotated["results"][0]["citation"] == "websource1"
+        entries = [
+            json.loads(line)
+            for line in manifest.read_text(encoding="utf-8").splitlines()
+        ]
+        assert entries == [
+            {
+                "sourceNumber": 1,
+                "url": "https://example.com/a",
+                "title": "A",
+                "snippet": "Snippet A",
+                "content": "",
+                "error": None,
+            }
+        ]
+
+    def test_reuses_source_number_for_crawled_url(self, tmp_path: Path) -> None:
+        manifest = tmp_path / ".unique" / "web-refs.jsonl"
+        _annotate_web_results_for_citations(
+            _make_search_payload(
+                results=[
+                    {
+                        "url": "https://example.com/a",
+                        "title": "A",
+                        "snippet": "Snippet A",
+                        "content": "",
+                    }
+                ]
+            ),
+            refs_log_path=manifest,
+        )
+
+        annotated = _annotate_web_results_for_citations(
+            _make_crawl_payload(
+                results=[
+                    {
+                        "url": "https://example.com/a",
+                        "content": "# Full page",
+                        "error": None,
+                    }
+                ]
+            ),
+            refs_log_path=manifest,
+        )
+
+        assert annotated["results"][0]["sourceNumber"] == 1
+        entries = [
+            json.loads(line)
+            for line in manifest.read_text(encoding="utf-8").splitlines()
+        ]
+        assert [entry["sourceNumber"] for entry in entries] == [1, 1]
+
+    def test_source_numbering_continues_across_calls(self, tmp_path: Path) -> None:
+        manifest = tmp_path / ".unique" / "web-refs.jsonl"
+        _annotate_web_results_for_citations(
+            _make_search_payload(
+                results=[
+                    {
+                        "url": "https://example.com/a",
+                        "title": "A",
+                        "snippet": "Snippet A",
+                        "content": "",
+                    }
+                ]
+            ),
+            refs_log_path=manifest,
+        )
+
+        annotated = _annotate_web_results_for_citations(
+            _make_search_payload(
+                results=[
+                    {
+                        "url": "https://example.com/b",
+                        "title": "B",
+                        "snippet": "Snippet B",
+                        "content": "",
+                    }
+                ]
+            ),
+            refs_log_path=manifest,
+        )
+
+        assert annotated["results"][0]["sourceNumber"] == 2
 
 
 class TestCmdWebSearch:
@@ -332,7 +474,15 @@ class TestCmdWebCrawl:
         out = cmd_web_crawl(_state(), ["u"], output_json=True)
         parsed = json.loads(out)
         assert parsed["crawler"] == "BasicCrawler"
-        assert parsed["results"] == [{"url": "u", "content": "c", "error": None}]
+        assert parsed["results"] == [
+            {
+                "url": "u",
+                "content": "c",
+                "error": None,
+                "sourceNumber": 1,
+                "citation": "websource1",
+            }
+        ]
 
     @patch("unique_sdk.WebCrawl.crawl")
     def test_cmd_web_crawl_api_error(self, mock_crawl: MagicMock) -> None:

--- a/unique_sdk/unique_sdk/cli/cli.py
+++ b/unique_sdk/unique_sdk/cli/cli.py
@@ -26,7 +26,12 @@ from unique_sdk.cli.commands.scheduled_tasks import (
     cmd_schedule_list,
     cmd_schedule_update,
 )
-from unique_sdk.cli.commands.search import cmd_search
+from unique_sdk.cli.commands.search import (
+    cmd_search,
+)
+from unique_sdk.cli.commands.search import (
+    is_error_output as _is_search_error_output,
+)
 from unique_sdk.cli.commands.web_search import (
     cmd_web_crawl,
     cmd_web_search,
@@ -385,9 +390,12 @@ def search(
             k, v = kv.split("=", 1)
             parsed_metadata.append((k, v))
 
-    click.echo(
-        cmd_search(state, query, folder=folder, metadata=parsed_metadata, limit=limit)
+    output = cmd_search(
+        state, query, folder=folder, metadata=parsed_metadata, limit=limit
     )
+    click.echo(output)
+    if _is_search_error_output(output):
+        ctx.exit(1)
 
 
 @main.command()

--- a/unique_sdk/unique_sdk/cli/commands/_citation_manifest.py
+++ b/unique_sdk/unique_sdk/cli/commands/_citation_manifest.py
@@ -28,7 +28,6 @@ from typing import Any
 __all__ = [
     "UnsafeRefsLogPathError",
     "_append_turn_refs_manifest_entry",
-    "_assert_safe_refs_log_path",
     "_locked_turn_refs_manifest",
     "_read_turn_refs_manifest",
 ]
@@ -51,6 +50,13 @@ def _assert_safe_refs_log_path(refs_log_path: Path) -> None:
     well-known handoff path used by another process (the runner) running
     in the same workspace. Following symlinks here would let a malicious
     workspace redirect writes elsewhere.
+
+    Writer-side counterpart to the reader-side check at
+    ``swappable_intelligence.runner.CodingAgentRunner._is_safe_turn_refs_log_path``
+    in ``monorepo``. The two run in different processes (this one in the
+    agent's bash sandbox, the reader in assistants-core) so they cannot
+    share code; keep the rejection policy aligned across the two when
+    either is edited.
     """
     refs_log_dir = refs_log_path.parent
     if refs_log_dir.is_symlink() or (

--- a/unique_sdk/unique_sdk/cli/commands/_citation_manifest.py
+++ b/unique_sdk/unique_sdk/cli/commands/_citation_manifest.py
@@ -52,7 +52,7 @@ def _assert_safe_refs_log_path(refs_log_path: Path) -> None:
     workspace redirect writes elsewhere.
 
     Writer-side counterpart to the reader-side check at
-    ``swappable_intelligence.runner.CodingAgentRunner._is_safe_kb_search_refs_log_path``
+    ``swappable_intelligence.runner.CodingAgentRunner._is_safe_refs_log_path``
     in ``monorepo``. The two run in different processes (this one in the
     agent's bash sandbox, the reader in assistants-core) so they cannot
     share code; keep the rejection policy aligned across the two when

--- a/unique_sdk/unique_sdk/cli/commands/_citation_manifest.py
+++ b/unique_sdk/unique_sdk/cli/commands/_citation_manifest.py
@@ -1,0 +1,171 @@
+"""Shared helpers for the per-turn citation refs manifest under ``.unique/``.
+
+Both ``unique-cli search`` (KB) and ``unique-cli web-search`` (web) append
+to a small per-turn JSONL file inside the current workspace's ``.unique``
+directory so that the Swappable Intelligence runner can later substitute
+``[sourceN]`` / ``[websourceN]`` markers in the LLM answer with footnotes
+and reference chips.
+
+The handshake is symmetric across the two callers — the file name, lock
+file name, and on-disk layout differ, but the safety + locking +
+read/append semantics are identical. This module owns that machinery so
+neither caller has to maintain its own copy.
+
+Each caller passes its own ``refs_log_path`` (absolute path) and lock
+filename in. Nothing in this module is web- or KB-specific.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+
+class UnsafeRefsLogPathError(OSError):
+    """Raised when the internal refs log path would follow a symlink.
+
+    Callers should treat this as a hard failure for the current command —
+    refuse to render results, and surface the error via the caller's
+    usual ``<prefix>: <message>`` error string convention.
+    """
+
+
+def _assert_safe_refs_log_path(refs_log_path: Path) -> None:
+    """Reject symlinks for the parent dir, the manifest, or any file at
+    the same path that is not a regular file.
+
+    This is intentionally strict: the manifest path is a fixed,
+    well-known handoff path used by another process (the runner) running
+    in the same workspace. Following symlinks here would let a malicious
+    workspace redirect writes elsewhere.
+    """
+    refs_log_dir = refs_log_path.parent
+    if refs_log_dir.is_symlink() or (
+        refs_log_dir.exists() and not refs_log_dir.is_dir()
+    ):
+        raise UnsafeRefsLogPathError(
+            f"refusing unsafe refs log directory: {refs_log_dir}"
+        )
+    if refs_log_path.is_symlink():
+        raise UnsafeRefsLogPathError(f"refusing unsafe refs log file: {refs_log_path}")
+    if refs_log_path.exists() and not refs_log_path.is_file():
+        raise UnsafeRefsLogPathError(f"refusing unsafe refs log file: {refs_log_path}")
+
+
+def _read_turn_refs_manifest(refs_log_path: Path) -> list[dict[str, Any]]:
+    """Return all valid JSON object lines from the manifest, in order.
+
+    Blank lines and lines that fail to parse as a JSON object are
+    silently skipped — this matches the runner's tolerance for malformed
+    lines and keeps a stray partial write from breaking the next call.
+    """
+    _assert_safe_refs_log_path(refs_log_path)
+    if not refs_log_path.is_file():
+        return []
+    try:
+        raw_lines = refs_log_path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        raise UnsafeRefsLogPathError(
+            f"failed to read refs log: {refs_log_path}"
+        ) from exc
+
+    entries: list[dict[str, Any]] = []
+    for raw in raw_lines:
+        if not raw.strip():
+            continue
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            entries.append(payload)
+    return entries
+
+
+def _append_turn_refs_manifest_entry(
+    refs_log_path: Path,
+    payload: dict[str, Any],
+) -> None:
+    """Append one JSON object as a single line, creating parents if needed.
+
+    Uses ``O_NOFOLLOW`` and a 0o600 mode so a symlink swap between the
+    safety check and the open call still fails closed.
+    """
+    _assert_safe_refs_log_path(refs_log_path)
+    try:
+        refs_log_path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise UnsafeRefsLogPathError(
+            f"failed to create refs log directory: {refs_log_path.parent}"
+        ) from exc
+    _assert_safe_refs_log_path(refs_log_path)
+    flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    try:
+        fd = os.open(refs_log_path, flags, 0o600)
+    except OSError as exc:
+        raise UnsafeRefsLogPathError(
+            f"failed to open refs log safely: {refs_log_path}"
+        ) from exc
+    try:
+        with os.fdopen(fd, "a", encoding="utf-8") as fp:
+            fp.write(json.dumps(payload, default=str, ensure_ascii=False) + "\n")
+    except OSError as exc:
+        raise UnsafeRefsLogPathError(
+            f"failed to write refs log: {refs_log_path}"
+        ) from exc
+
+
+@contextmanager
+def _locked_turn_refs_manifest(
+    refs_log_path: Path,
+    *,
+    lock_filename: str,
+) -> Iterator[None]:
+    """Hold an ``fcntl.flock`` on a sibling lock file for the duration of
+    a read-existing → compute-next-number → append-new sequence.
+
+    The lock file lives in the same ``.unique`` directory as the manifest
+    so concurrent ``unique-cli`` invocations from the same workspace
+    serialise their appends and never race the source-number counter.
+    """
+    lock_path = refs_log_path.parent / lock_filename
+    _assert_safe_refs_log_path(lock_path)
+    try:
+        refs_log_path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise UnsafeRefsLogPathError(
+            f"failed to create refs log directory: {refs_log_path.parent}"
+        ) from exc
+    _assert_safe_refs_log_path(lock_path)
+
+    flags = os.O_RDWR | os.O_CREAT
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    try:
+        fd = os.open(lock_path, flags, 0o600)
+    except OSError as exc:
+        raise UnsafeRefsLogPathError(
+            f"failed to open refs lock safely: {lock_path}"
+        ) from exc
+
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+    except OSError as exc:
+        os.close(fd)
+        raise UnsafeRefsLogPathError(
+            f"failed to lock refs manifest: {lock_path}"
+        ) from exc
+
+    try:
+        yield
+    finally:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        except OSError:
+            pass
+        os.close(fd)

--- a/unique_sdk/unique_sdk/cli/commands/_citation_manifest.py
+++ b/unique_sdk/unique_sdk/cli/commands/_citation_manifest.py
@@ -20,10 +20,18 @@ from __future__ import annotations
 import fcntl
 import json
 import os
-from collections.abc import Iterator
+from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
+
+__all__ = [
+    "UnsafeRefsLogPathError",
+    "_append_turn_refs_manifest_entry",
+    "_assert_safe_refs_log_path",
+    "_locked_turn_refs_manifest",
+    "_read_turn_refs_manifest",
+]
 
 
 class UnsafeRefsLogPathError(OSError):
@@ -126,7 +134,7 @@ def _locked_turn_refs_manifest(
     refs_log_path: Path,
     *,
     lock_filename: str,
-) -> Iterator[None]:
+) -> Generator[None, None, None]:
     """Hold an ``fcntl.flock`` on a sibling lock file for the duration of
     a read-existing → compute-next-number → append-new sequence.
 

--- a/unique_sdk/unique_sdk/cli/commands/_citation_manifest.py
+++ b/unique_sdk/unique_sdk/cli/commands/_citation_manifest.py
@@ -52,7 +52,7 @@ def _assert_safe_refs_log_path(refs_log_path: Path) -> None:
     workspace redirect writes elsewhere.
 
     Writer-side counterpart to the reader-side check at
-    ``swappable_intelligence.runner.CodingAgentRunner._is_safe_turn_refs_log_path``
+    ``swappable_intelligence.runner.CodingAgentRunner._is_safe_kb_search_refs_log_path``
     in ``monorepo``. The two run in different processes (this one in the
     agent's bash sandbox, the reader in assistants-core) so they cannot
     share code; keep the rejection policy aligned across the two when

--- a/unique_sdk/unique_sdk/cli/commands/search.py
+++ b/unique_sdk/unique_sdk/cli/commands/search.py
@@ -1,15 +1,38 @@
-"""Search command: combined search with folder/metadata filters."""
+"""Search command: combined KB search with folder/metadata filters.
+
+Always emits results wrapped in ``<sourceN>...</sourceN>`` blocks and
+appends a per-turn ContentChunk-shaped manifest at
+``<cwd>/.unique/turn-refs.jsonl``. The Swappable Intelligence runner
+reads that manifest after the turn to convert ``[sourceN]`` markers in
+the LLM answer into ``<sup>N</sup>`` footnotes plus clickable reference
+chips on the Unique platform.
+
+The manifest format is identical to the legacy ``bundled_skills/kb-search``
+``search.py`` from the monorepo — that bundle is being retired in favor of
+this CLI command.
+"""
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 import unique_sdk
 from unique_sdk import UQLCombinator, UQLOperator
-from unique_sdk.cli.formatting import format_search_results
+from unique_sdk.cli.commands._citation_manifest import (
+    UnsafeRefsLogPathError,
+    _append_turn_refs_manifest_entry,
+    _locked_turn_refs_manifest,
+    _read_turn_refs_manifest,
+)
 from unique_sdk.cli.state import ShellState
 
 DEFAULT_LIMIT = 200
+
+SEARCH_ERROR_PREFIX = "search:"
+
+_REFS_LOG_RELATIVE_PATH = Path(".unique") / "turn-refs.jsonl"
+_LOCK_FILENAME = "turn-refs.lock"
 
 
 def _build_metadata_filter(
@@ -66,14 +89,125 @@ def _resolve_folder_to_scope_id(state: ShellState, folder: str) -> str:
     return scope_id
 
 
+def _format_source_block(source_number: int, result: Any) -> str:
+    """Render one search result as a ``<sourceN>...</sourceN>`` block.
+
+    Mirrors the legacy ``unique_ai`` source format that the Swappable
+    Intelligence runner's reference post-processor recognises — ``<sourceN>``
+    open/close tags with ``<|document|>``, ``<|page|>``, ``<|info|>``
+    sub-sections. The chunk-level metadata (startPage, endPage, url, etc.)
+    is captured in full in the JSONL manifest for the runner to consume;
+    only the human-relevant bits appear in the on-screen block.
+    """
+    title = (
+        getattr(result, "title", None)
+        or getattr(result, "key", None)
+        or f"content {getattr(result, 'id', '?')}"
+    )
+    content_id = getattr(result, "id", "") or ""
+    text = getattr(result, "text", "") or ""
+    start_page = getattr(result, "startPage", 0) or 0
+    end_page = getattr(result, "endPage", 0) or 0
+
+    sections: list[str] = []
+    sections.append(f"<|document|>{title}</|document|>")
+    if start_page and end_page and start_page > 0 and end_page > 0:
+        page_range = (
+            str(start_page) if start_page == end_page else f"{start_page}-{end_page}"
+        )
+        sections.append(f"<|page|>{page_range}</|page|>")
+    if content_id:
+        sections.append(f"<|info|>{content_id}</|info|>")
+    sections.append(text.strip())
+
+    body = "\n".join(sections)
+    return f"<source{source_number}>\n{body}\n</source{source_number}>"
+
+
+def _result_to_chunk_payload(result: Any) -> dict[str, Any]:
+    """Convert a ``unique_sdk.Search`` result into a ContentChunk-shaped dict.
+
+    Keys are camelCase aliases of ``unique_toolkit.content.ContentChunk``
+    fields so the runner can rehydrate them via
+    ``ContentChunk.model_validate(...)``. All keys are emitted (with
+    ``None`` when absent) to keep the per-line shape stable.
+    """
+
+    def _get(name: str, default: Any = None) -> Any:
+        return getattr(result, name, default)
+
+    metadata = _get("metadata")
+    return {
+        "id": _get("id", "") or "",
+        "chunkId": _get("chunkId"),
+        "text": _get("text", "") or "",
+        "order": _get("order", 0) or 0,
+        "key": _get("key"),
+        "url": _get("url"),
+        "title": _get("title"),
+        "startPage": _get("startPage"),
+        "endPage": _get("endPage"),
+        "metadata": metadata if isinstance(metadata, dict) else None,
+        "createdAt": _get("createdAt"),
+        "updatedAt": _get("updatedAt"),
+    }
+
+
+def _format_results_with_citations(
+    results: list[Any],
+    *,
+    refs_log_path: Path,
+) -> str:
+    """Number, format, and persist each result inside one locked critical section.
+
+    Reads the existing manifest under lock so ``sourceN`` numbering keeps
+    growing across multiple ``unique-cli search`` invocations within the
+    same turn — the runner truncates the manifest at turn start, so the
+    first call in a turn starts at 1.
+    """
+    if not results:
+        return "No results found."
+
+    with _locked_turn_refs_manifest(refs_log_path, lock_filename=_LOCK_FILENAME):
+        existing_entries = _read_turn_refs_manifest(refs_log_path)
+        starting_number = len(existing_entries) + 1
+
+        blocks: list[str] = []
+        for offset, result in enumerate(results):
+            source_number = starting_number + offset
+            blocks.append(_format_source_block(source_number, result))
+            _append_turn_refs_manifest_entry(
+                refs_log_path,
+                _result_to_chunk_payload(result),
+            )
+
+    return f"Found {len(results)} result(s):\n\n" + "\n\n".join(blocks)
+
+
 def cmd_search(
     state: ShellState,
     query: str,
     folder: str | None = None,
     metadata: list[tuple[str, str]] | None = None,
     limit: int = DEFAULT_LIMIT,
+    *,
+    refs_log_path: Path | None = None,
 ) -> str:
-    """Execute a combined search with optional folder and metadata filters."""
+    """Execute a combined search with optional folder and metadata filters.
+
+    Args:
+        state: Shell state carrying user/company credentials and cwd.
+        query: Search string.
+        folder: Optional folder path, name, or scope ID. Overrides
+            ``state.scope_id`` and ``state.workspace_scope_ids``.
+        metadata: Optional ``[(key, value), ...]`` metadata filters
+            combined with AND.
+        limit: Maximum number of results.
+        refs_log_path: Override the per-turn citation manifest path —
+            for tests; production callers leave this ``None`` so the
+            manifest lives at ``<cwd>/.unique/turn-refs.jsonl`` and the
+            Swappable Intelligence runner can find it.
+    """
     try:
         folder_scope_id: str | None = None
         if folder:
@@ -108,7 +242,21 @@ def cmd_search(
             **search_params,
         )
 
-        return format_search_results(results)
-
     except (ValueError, unique_sdk.APIError) as e:
-        return f"search: {e}"
+        return f"{SEARCH_ERROR_PREFIX} {e}"
+
+    log_path = refs_log_path or (Path.cwd() / _REFS_LOG_RELATIVE_PATH)
+    try:
+        return _format_results_with_citations(results, refs_log_path=log_path)
+    except UnsafeRefsLogPathError as exc:
+        return f"{SEARCH_ERROR_PREFIX} {exc}"
+
+
+def is_error_output(output: str) -> bool:
+    """Return ``True`` when ``output`` is a CLI error message.
+
+    Mirrors :func:`unique_sdk.cli.commands.web_search.is_error_output` so
+    the Click layer can translate a returned error string into a non-zero
+    exit code without changing the existing string-returning contract.
+    """
+    return output.startswith(SEARCH_ERROR_PREFIX)

--- a/unique_sdk/unique_sdk/cli/commands/search.py
+++ b/unique_sdk/unique_sdk/cli/commands/search.py
@@ -2,10 +2,10 @@
 
 Always emits results wrapped in ``<sourceN>...</sourceN>`` blocks and
 appends a per-turn ContentChunk-shaped manifest at
-``<cwd>/.unique/turn-refs.jsonl``. The Swappable Intelligence runner
-reads that manifest after the turn to convert ``[sourceN]`` markers in
-the LLM answer into ``<sup>N</sup>`` footnotes plus clickable reference
-chips on the Unique platform.
+``<cwd>/.unique/kb-search-refs.jsonl``. The Swappable Intelligence
+runner reads that manifest after the turn to convert ``[sourceN]``
+markers in the LLM answer into ``<sup>N</sup>`` footnotes plus
+clickable reference chips on the Unique platform.
 
 The manifest format is identical to the legacy ``bundled_skills/kb-search``
 ``search.py`` from the monorepo — that bundle is being retired in favor of
@@ -31,8 +31,8 @@ DEFAULT_LIMIT = 200
 
 SEARCH_ERROR_PREFIX = "search:"
 
-_REFS_LOG_RELATIVE_PATH = Path(".unique") / "turn-refs.jsonl"
-_LOCK_FILENAME = "turn-refs.lock"
+_REFS_LOG_RELATIVE_PATH = Path(".unique") / "kb-search-refs.jsonl"
+_LOCK_FILENAME = "kb-search-refs.lock"
 
 
 def _build_metadata_filter(
@@ -205,8 +205,8 @@ def cmd_search(
         limit: Maximum number of results.
         refs_log_path: Override the per-turn citation manifest path —
             for tests; production callers leave this ``None`` so the
-            manifest lives at ``<cwd>/.unique/turn-refs.jsonl`` and the
-            Swappable Intelligence runner can find it.
+            manifest lives at ``<cwd>/.unique/kb-search-refs.jsonl`` and
+            the Swappable Intelligence runner can find it.
     """
     try:
         folder_scope_id: str | None = None

--- a/unique_sdk/unique_sdk/cli/commands/web_search.py
+++ b/unique_sdk/unique_sdk/cli/commands/web_search.py
@@ -17,8 +17,10 @@ Override precedence (highest first):
 
 from __future__ import annotations
 
+import fcntl
 import json
 import os
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, cast
 
@@ -34,6 +36,7 @@ DEFAULT_PARALLEL = 10
 _SNIPPET_PREVIEW_LIMIT = 200
 _CONTENT_PREVIEW_LIMIT = 500
 _WEB_REFS_LOG_RELATIVE_PATH = Path(".unique") / "web-refs.jsonl"
+_WEB_REFS_LOCK_FILENAME = "web-refs.lock"
 
 WEB_SEARCH_ERROR_PREFIX = "web-search:"
 WEB_CRAWL_ERROR_PREFIX = "web-crawl:"
@@ -69,8 +72,10 @@ def _read_web_refs_manifest(
         return []
     try:
         raw_lines = refs_log_path.read_text(encoding="utf-8").splitlines()
-    except OSError:
-        return []
+    except OSError as exc:
+        raise UnsafeWebRefsLogPathError(
+            f"failed to read web refs log: {refs_log_path}"
+        ) from exc
 
     entries: list[dict[str, Any]] = []
     for raw in raw_lines:
@@ -109,7 +114,12 @@ def _append_web_refs_manifest_entry(
     payload: dict[str, Any],
 ) -> None:
     _assert_safe_web_refs_log_path(refs_log_path)
-    refs_log_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        refs_log_path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise UnsafeWebRefsLogPathError(
+            f"failed to create web refs log directory: {refs_log_path.parent}"
+        ) from exc
     _assert_safe_web_refs_log_path(refs_log_path)
     flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND
     flags |= getattr(os, "O_NOFOLLOW", 0)
@@ -119,8 +129,54 @@ def _append_web_refs_manifest_entry(
         raise UnsafeWebRefsLogPathError(
             f"failed to open web refs log safely: {refs_log_path}"
         ) from exc
-    with os.fdopen(fd, "a", encoding="utf-8") as fp:
-        fp.write(json.dumps(payload, default=str, ensure_ascii=False) + "\n")
+    try:
+        with os.fdopen(fd, "a", encoding="utf-8") as fp:
+            fp.write(json.dumps(payload, default=str, ensure_ascii=False) + "\n")
+    except OSError as exc:
+        raise UnsafeWebRefsLogPathError(
+            f"failed to write web refs log: {refs_log_path}"
+        ) from exc
+
+
+@contextmanager
+def _locked_web_refs_manifest(
+    refs_log_path: Path,
+) -> Any:
+    lock_path = refs_log_path.parent / _WEB_REFS_LOCK_FILENAME
+    _assert_safe_web_refs_log_path(lock_path)
+    try:
+        refs_log_path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise UnsafeWebRefsLogPathError(
+            f"failed to create web refs log directory: {refs_log_path.parent}"
+        ) from exc
+    _assert_safe_web_refs_log_path(lock_path)
+
+    flags = os.O_RDWR | os.O_CREAT
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    try:
+        fd = os.open(lock_path, flags, 0o600)
+    except OSError as exc:
+        raise UnsafeWebRefsLogPathError(
+            f"failed to open web refs lock safely: {lock_path}"
+        ) from exc
+
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+    except OSError as exc:
+        os.close(fd)
+        raise UnsafeWebRefsLogPathError(
+            f"failed to lock web refs manifest: {lock_path}"
+        ) from exc
+
+    try:
+        yield
+    finally:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        except OSError:
+            pass
+        os.close(fd)
 
 
 def _annotate_web_results_for_citations(
@@ -130,41 +186,42 @@ def _annotate_web_results_for_citations(
 ) -> dict[str, Any]:
     """Add per-turn web citation numbers and append the refs manifest."""
     refs_log_path = refs_log_path or (Path.cwd() / _WEB_REFS_LOG_RELATIVE_PATH)
-    entries = _read_web_refs_manifest(refs_log_path)
-    source_numbers_by_url = _source_numbers_by_url(entries)
-    annotated = dict(payload)
-    annotated_results: list[dict[str, Any]] = []
+    with _locked_web_refs_manifest(refs_log_path):
+        entries = _read_web_refs_manifest(refs_log_path)
+        source_numbers_by_url = _source_numbers_by_url(entries)
+        annotated = dict(payload)
+        annotated_results: list[dict[str, Any]] = []
 
-    for raw_result in payload.get("results", []):
-        if not isinstance(raw_result, dict):
-            continue
-        result = dict(raw_result)
-        url = str(result.get("url") or "").strip()
-        if not url:
+        for raw_result in payload.get("results", []):
+            if not isinstance(raw_result, dict):
+                continue
+            result = dict(raw_result)
+            url = str(result.get("url") or "").strip()
+            if not url:
+                annotated_results.append(result)
+                continue
+
+            source_number = source_numbers_by_url.get(url)
+            if source_number is None:
+                source_number = _next_source_number(entries)
+                source_numbers_by_url[url] = source_number
+                entries.append({"sourceNumber": source_number, "url": url})
+
+            result["sourceNumber"] = source_number
+            result["citation"] = f"websource{source_number}"
+            manifest_entry = {
+                "sourceNumber": source_number,
+                "url": url,
+                "title": result.get("title"),
+                "snippet": result.get("snippet"),
+                "content": result.get("content"),
+                "error": result.get("error"),
+            }
+            _append_web_refs_manifest_entry(refs_log_path, manifest_entry)
             annotated_results.append(result)
-            continue
 
-        source_number = source_numbers_by_url.get(url)
-        if source_number is None:
-            source_number = _next_source_number(entries)
-            source_numbers_by_url[url] = source_number
-            entries.append({"sourceNumber": source_number, "url": url})
-
-        result["sourceNumber"] = source_number
-        result["citation"] = f"websource{source_number}"
-        manifest_entry = {
-            "sourceNumber": source_number,
-            "url": url,
-            "title": result.get("title"),
-            "snippet": result.get("snippet"),
-            "content": result.get("content"),
-            "error": result.get("error"),
-        }
-        _append_web_refs_manifest_entry(refs_log_path, manifest_entry)
-        annotated_results.append(result)
-
-    annotated["results"] = annotated_results
-    return annotated
+        annotated["results"] = annotated_results
+        return annotated
 
 
 def _format_search_results(payload: dict[str, Any]) -> str:

--- a/unique_sdk/unique_sdk/cli/commands/web_search.py
+++ b/unique_sdk/unique_sdk/cli/commands/web_search.py
@@ -17,14 +17,17 @@ Override precedence (highest first):
 
 from __future__ import annotations
 
-import fcntl
 import json
-import os
-from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, cast
 
 import unique_sdk
+from unique_sdk.cli.commands._citation_manifest import (
+    UnsafeRefsLogPathError,
+    _append_turn_refs_manifest_entry,
+    _locked_turn_refs_manifest,
+    _read_turn_refs_manifest,
+)
 from unique_sdk.cli.commands.web_search_config import (
     ConfigOverrides,
     WebSearchCLIConfigError,
@@ -40,54 +43,6 @@ _WEB_REFS_LOCK_FILENAME = "web-refs.lock"
 
 WEB_SEARCH_ERROR_PREFIX = "web-search:"
 WEB_CRAWL_ERROR_PREFIX = "web-crawl:"
-
-
-class UnsafeWebRefsLogPathError(OSError):
-    """Raised when the internal web refs log path would follow a symlink."""
-
-
-def _assert_safe_web_refs_log_path(refs_log_path: Path) -> None:
-    refs_log_dir = refs_log_path.parent
-    if refs_log_dir.is_symlink() or (
-        refs_log_dir.exists() and not refs_log_dir.is_dir()
-    ):
-        raise UnsafeWebRefsLogPathError(
-            f"refusing unsafe web refs log directory: {refs_log_dir}"
-        )
-    if refs_log_path.is_symlink():
-        raise UnsafeWebRefsLogPathError(
-            f"refusing unsafe web refs log file: {refs_log_path}"
-        )
-    if refs_log_path.exists() and not refs_log_path.is_file():
-        raise UnsafeWebRefsLogPathError(
-            f"refusing unsafe web refs log file: {refs_log_path}"
-        )
-
-
-def _read_web_refs_manifest(
-    refs_log_path: Path,
-) -> list[dict[str, Any]]:
-    _assert_safe_web_refs_log_path(refs_log_path)
-    if not refs_log_path.is_file():
-        return []
-    try:
-        raw_lines = refs_log_path.read_text(encoding="utf-8").splitlines()
-    except OSError as exc:
-        raise UnsafeWebRefsLogPathError(
-            f"failed to read web refs log: {refs_log_path}"
-        ) from exc
-
-    entries: list[dict[str, Any]] = []
-    for raw in raw_lines:
-        if not raw.strip():
-            continue
-        try:
-            payload = json.loads(raw)
-        except json.JSONDecodeError:
-            continue
-        if isinstance(payload, dict):
-            entries.append(payload)
-    return entries
 
 
 def _source_numbers_by_url(entries: list[dict[str, Any]]) -> dict[str, int]:
@@ -109,85 +64,23 @@ def _next_source_number(entries: list[dict[str, Any]]) -> int:
     return max(source_numbers, default=0) + 1
 
 
-def _append_web_refs_manifest_entry(
-    refs_log_path: Path,
-    payload: dict[str, Any],
-) -> None:
-    _assert_safe_web_refs_log_path(refs_log_path)
-    try:
-        refs_log_path.parent.mkdir(parents=True, exist_ok=True)
-    except OSError as exc:
-        raise UnsafeWebRefsLogPathError(
-            f"failed to create web refs log directory: {refs_log_path.parent}"
-        ) from exc
-    _assert_safe_web_refs_log_path(refs_log_path)
-    flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND
-    flags |= getattr(os, "O_NOFOLLOW", 0)
-    try:
-        fd = os.open(refs_log_path, flags, 0o600)
-    except OSError as exc:
-        raise UnsafeWebRefsLogPathError(
-            f"failed to open web refs log safely: {refs_log_path}"
-        ) from exc
-    try:
-        with os.fdopen(fd, "a", encoding="utf-8") as fp:
-            fp.write(json.dumps(payload, default=str, ensure_ascii=False) + "\n")
-    except OSError as exc:
-        raise UnsafeWebRefsLogPathError(
-            f"failed to write web refs log: {refs_log_path}"
-        ) from exc
-
-
-@contextmanager
-def _locked_web_refs_manifest(
-    refs_log_path: Path,
-) -> Any:
-    lock_path = refs_log_path.parent / _WEB_REFS_LOCK_FILENAME
-    _assert_safe_web_refs_log_path(lock_path)
-    try:
-        refs_log_path.parent.mkdir(parents=True, exist_ok=True)
-    except OSError as exc:
-        raise UnsafeWebRefsLogPathError(
-            f"failed to create web refs log directory: {refs_log_path.parent}"
-        ) from exc
-    _assert_safe_web_refs_log_path(lock_path)
-
-    flags = os.O_RDWR | os.O_CREAT
-    flags |= getattr(os, "O_NOFOLLOW", 0)
-    try:
-        fd = os.open(lock_path, flags, 0o600)
-    except OSError as exc:
-        raise UnsafeWebRefsLogPathError(
-            f"failed to open web refs lock safely: {lock_path}"
-        ) from exc
-
-    try:
-        fcntl.flock(fd, fcntl.LOCK_EX)
-    except OSError as exc:
-        os.close(fd)
-        raise UnsafeWebRefsLogPathError(
-            f"failed to lock web refs manifest: {lock_path}"
-        ) from exc
-
-    try:
-        yield
-    finally:
-        try:
-            fcntl.flock(fd, fcntl.LOCK_UN)
-        except OSError:
-            pass
-        os.close(fd)
-
-
 def _annotate_web_results_for_citations(
     payload: dict[str, Any],
     *,
     refs_log_path: Path | None = None,
 ) -> dict[str, Any]:
-    """Add per-turn web citation numbers and append the refs manifest."""
+    """Add per-turn web citation numbers and append the refs manifest.
+
+    Web results are deduped by URL: the same URL keeps the same
+    ``sourceNumber`` across consecutive ``search`` / ``crawl`` calls in
+    the same turn, so the crawled-content row carries the same citation
+    marker the search-snippet row already advertised.
+    """
     refs_log_path = refs_log_path or (Path.cwd() / _WEB_REFS_LOG_RELATIVE_PATH)
-    with _locked_web_refs_manifest(refs_log_path):
-        entries = _read_web_refs_manifest(refs_log_path)
+    with _locked_turn_refs_manifest(
+        refs_log_path, lock_filename=_WEB_REFS_LOCK_FILENAME
+    ):
+        entries = _read_turn_refs_manifest(refs_log_path)
         source_numbers_by_url = _source_numbers_by_url(entries)
         annotated = dict(payload)
         annotated_results: list[dict[str, Any]] = []
@@ -217,7 +110,7 @@ def _annotate_web_results_for_citations(
                 "content": result.get("content"),
                 "error": result.get("error"),
             }
-            _append_web_refs_manifest_entry(refs_log_path, manifest_entry)
+            _append_turn_refs_manifest_entry(refs_log_path, manifest_entry)
             annotated_results.append(result)
 
         annotated["results"] = annotated_results
@@ -448,7 +341,7 @@ def cmd_web_search(
 
     try:
         payload = _annotate_web_results_for_citations(_payload_from_resource(resource))
-    except UnsafeWebRefsLogPathError as exc:
+    except UnsafeRefsLogPathError as exc:
         return f"{WEB_SEARCH_ERROR_PREFIX} {exc}"
     if output_json:
         return _format_search_results_json(payload)
@@ -512,7 +405,7 @@ def cmd_web_crawl(
 
     try:
         payload = _annotate_web_results_for_citations(_payload_from_resource(resource))
-    except UnsafeWebRefsLogPathError as exc:
+    except UnsafeRefsLogPathError as exc:
         return f"{WEB_CRAWL_ERROR_PREFIX} {exc}"
     if output_json:
         return _format_crawl_results_json(payload)

--- a/unique_sdk/unique_sdk/cli/commands/web_search.py
+++ b/unique_sdk/unique_sdk/cli/commands/web_search.py
@@ -124,6 +124,36 @@ def _annotate_web_results_for_citations(
         return annotated
 
 
+def _row_label_for_result(result: dict[str, Any], fallback_index: int) -> int:
+    """Return the human row label for a single result.
+
+    In the happy path ``_annotate_web_results_for_citations`` runs before
+    the formatter and stamps every dict result with an ``int``
+    ``sourceNumber`` that matches the ``[websourceN]`` marker the LLM is
+    told to emit; the formatter then surfaces that same number as the row
+    label so the on-screen list and the citation namespace agree.
+
+    The ``fallback_index`` branch only fires when ``sourceNumber`` is
+    missing or non-int — i.e. a contract violation from the annotator
+    (or annotation was skipped). We never want the formatter to crash,
+    but the fallback row label deliberately *will not* match a
+    ``[websourceN]`` marker, so the agent would cite a number that is
+    not in the manifest. Warn loudly so the bug is observable instead of
+    silently degrading citations.
+    """
+    source_number = result.get("sourceNumber")
+    if isinstance(source_number, int):
+        return source_number
+    _LOGGER.warning(
+        "web result is missing a numeric `sourceNumber` after citation "
+        "annotation; falling back to row index %d. URL=%r — this row will "
+        "not be citable as [websourceN].",
+        fallback_index,
+        result.get("url"),
+    )
+    return fallback_index
+
+
 def _format_search_results(payload: dict[str, Any]) -> str:
     """Render a /web-search-api/search response for terminal display."""
     results: list[dict[str, Any]] = payload.get("results", [])
@@ -144,8 +174,7 @@ def _format_search_results(payload: dict[str, Any]) -> str:
 
         citation = result.get("citation")
         citation_suffix = f" [{citation}]" if citation else ""
-        source_number = result.get("sourceNumber")
-        row_label = source_number if isinstance(source_number, int) else i
+        row_label = _row_label_for_result(result, i)
         lines.append(f"  {row_label}. {title}{citation_suffix}")
         lines.append(f"     {url}")
 
@@ -193,8 +222,7 @@ def _format_crawl_results(payload: dict[str, Any]) -> str:
 
         citation = entry.get("citation")
         citation_suffix = f" [{citation}]" if citation else ""
-        source_number = entry.get("sourceNumber")
-        row_label = source_number if isinstance(source_number, int) else i
+        row_label = _row_label_for_result(entry, i)
         lines.append(f"  {row_label}. {url}{citation_suffix}")
         if error:
             lines.append(f"     ERROR: {error}")

--- a/unique_sdk/unique_sdk/cli/commands/web_search.py
+++ b/unique_sdk/unique_sdk/cli/commands/web_search.py
@@ -18,6 +18,8 @@ Override precedence (highest first):
 from __future__ import annotations
 
 import json
+import os
+from pathlib import Path
 from typing import Any, cast
 
 import unique_sdk
@@ -31,9 +33,138 @@ from unique_sdk.cli.state import ShellState
 DEFAULT_PARALLEL = 10
 _SNIPPET_PREVIEW_LIMIT = 200
 _CONTENT_PREVIEW_LIMIT = 500
+_WEB_REFS_LOG_RELATIVE_PATH = Path(".unique") / "web-refs.jsonl"
 
 WEB_SEARCH_ERROR_PREFIX = "web-search:"
 WEB_CRAWL_ERROR_PREFIX = "web-crawl:"
+
+
+class UnsafeWebRefsLogPathError(OSError):
+    """Raised when the internal web refs log path would follow a symlink."""
+
+
+def _assert_safe_web_refs_log_path(refs_log_path: Path) -> None:
+    refs_log_dir = refs_log_path.parent
+    if refs_log_dir.is_symlink() or (
+        refs_log_dir.exists() and not refs_log_dir.is_dir()
+    ):
+        raise UnsafeWebRefsLogPathError(
+            f"refusing unsafe web refs log directory: {refs_log_dir}"
+        )
+    if refs_log_path.is_symlink():
+        raise UnsafeWebRefsLogPathError(
+            f"refusing unsafe web refs log file: {refs_log_path}"
+        )
+    if refs_log_path.exists() and not refs_log_path.is_file():
+        raise UnsafeWebRefsLogPathError(
+            f"refusing unsafe web refs log file: {refs_log_path}"
+        )
+
+
+def _read_web_refs_manifest(
+    refs_log_path: Path,
+) -> list[dict[str, Any]]:
+    _assert_safe_web_refs_log_path(refs_log_path)
+    if not refs_log_path.is_file():
+        return []
+    try:
+        raw_lines = refs_log_path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return []
+
+    entries: list[dict[str, Any]] = []
+    for raw in raw_lines:
+        if not raw.strip():
+            continue
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            entries.append(payload)
+    return entries
+
+
+def _source_numbers_by_url(entries: list[dict[str, Any]]) -> dict[str, int]:
+    by_url: dict[str, int] = {}
+    for entry in entries:
+        url = entry.get("url")
+        source_number = entry.get("sourceNumber")
+        if isinstance(url, str) and isinstance(source_number, int):
+            by_url.setdefault(url.strip(), source_number)
+    return by_url
+
+
+def _next_source_number(entries: list[dict[str, Any]]) -> int:
+    source_numbers = [
+        entry["sourceNumber"]
+        for entry in entries
+        if isinstance(entry.get("sourceNumber"), int)
+    ]
+    return max(source_numbers, default=0) + 1
+
+
+def _append_web_refs_manifest_entry(
+    refs_log_path: Path,
+    payload: dict[str, Any],
+) -> None:
+    _assert_safe_web_refs_log_path(refs_log_path)
+    refs_log_path.parent.mkdir(parents=True, exist_ok=True)
+    _assert_safe_web_refs_log_path(refs_log_path)
+    flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    try:
+        fd = os.open(refs_log_path, flags, 0o600)
+    except OSError as exc:
+        raise UnsafeWebRefsLogPathError(
+            f"failed to open web refs log safely: {refs_log_path}"
+        ) from exc
+    with os.fdopen(fd, "a", encoding="utf-8") as fp:
+        fp.write(json.dumps(payload, default=str, ensure_ascii=False) + "\n")
+
+
+def _annotate_web_results_for_citations(
+    payload: dict[str, Any],
+    *,
+    refs_log_path: Path | None = None,
+) -> dict[str, Any]:
+    """Add per-turn web citation numbers and append the refs manifest."""
+    refs_log_path = refs_log_path or (Path.cwd() / _WEB_REFS_LOG_RELATIVE_PATH)
+    entries = _read_web_refs_manifest(refs_log_path)
+    source_numbers_by_url = _source_numbers_by_url(entries)
+    annotated = dict(payload)
+    annotated_results: list[dict[str, Any]] = []
+
+    for raw_result in payload.get("results", []):
+        if not isinstance(raw_result, dict):
+            continue
+        result = dict(raw_result)
+        url = str(result.get("url") or "").strip()
+        if not url:
+            annotated_results.append(result)
+            continue
+
+        source_number = source_numbers_by_url.get(url)
+        if source_number is None:
+            source_number = _next_source_number(entries)
+            source_numbers_by_url[url] = source_number
+            entries.append({"sourceNumber": source_number, "url": url})
+
+        result["sourceNumber"] = source_number
+        result["citation"] = f"websource{source_number}"
+        manifest_entry = {
+            "sourceNumber": source_number,
+            "url": url,
+            "title": result.get("title"),
+            "snippet": result.get("snippet"),
+            "content": result.get("content"),
+            "error": result.get("error"),
+        }
+        _append_web_refs_manifest_entry(refs_log_path, manifest_entry)
+        annotated_results.append(result)
+
+    annotated["results"] = annotated_results
+    return annotated
 
 
 def _format_search_results(payload: dict[str, Any]) -> str:
@@ -54,7 +185,9 @@ def _format_search_results(payload: dict[str, Any]) -> str:
         snippet = (result.get("snippet") or "").replace("\n", " ").strip()
         content = result.get("content") or ""
 
-        lines.append(f"  {i}. {title}")
+        citation = result.get("citation")
+        citation_suffix = f" [{citation}]" if citation else ""
+        lines.append(f"  {i}. {title}{citation_suffix}")
         lines.append(f"     {url}")
 
         if snippet:
@@ -99,7 +232,9 @@ def _format_crawl_results(payload: dict[str, Any]) -> str:
         content = entry.get("content") or ""
         error = entry.get("error")
 
-        lines.append(f"  {i}. {url}")
+        citation = entry.get("citation")
+        citation_suffix = f" [{citation}]" if citation else ""
+        lines.append(f"  {i}. {url}{citation_suffix}")
         if error:
             lines.append(f"     ERROR: {error}")
         elif content.strip():
@@ -254,7 +389,10 @@ def cmd_web_search(
     except (ValueError, unique_sdk.APIError) as exc:
         return f"{WEB_SEARCH_ERROR_PREFIX} {exc}"
 
-    payload = _payload_from_resource(resource)
+    try:
+        payload = _annotate_web_results_for_citations(_payload_from_resource(resource))
+    except UnsafeWebRefsLogPathError as exc:
+        return f"{WEB_SEARCH_ERROR_PREFIX} {exc}"
     if output_json:
         return _format_search_results_json(payload)
     return _format_search_results(payload)
@@ -315,7 +453,10 @@ def cmd_web_crawl(
     except (ValueError, unique_sdk.APIError) as exc:
         return f"{WEB_CRAWL_ERROR_PREFIX} {exc}"
 
-    payload = _payload_from_resource(resource)
+    try:
+        payload = _annotate_web_results_for_citations(_payload_from_resource(resource))
+    except UnsafeWebRefsLogPathError as exc:
+        return f"{WEB_CRAWL_ERROR_PREFIX} {exc}"
     if output_json:
         return _format_crawl_results_json(payload)
     return _format_crawl_results(payload)

--- a/unique_sdk/unique_sdk/cli/commands/web_search.py
+++ b/unique_sdk/unique_sdk/cli/commands/web_search.py
@@ -192,7 +192,7 @@ def _annotate_web_results_for_citations(
         annotated = dict(payload)
         annotated_results: list[dict[str, Any]] = []
 
-        for raw_result in payload.get("results", []):
+        for raw_result in payload.get("results") or []:
             if not isinstance(raw_result, dict):
                 continue
             result = dict(raw_result)

--- a/unique_sdk/unique_sdk/cli/commands/web_search.py
+++ b/unique_sdk/unique_sdk/cli/commands/web_search.py
@@ -18,6 +18,7 @@ Override precedence (highest first):
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 from typing import Any, cast
 
@@ -34,6 +35,8 @@ from unique_sdk.cli.commands.web_search_config import (
     load_overrides,
 )
 from unique_sdk.cli.state import ShellState
+
+_LOGGER = logging.getLogger(__name__)
 
 DEFAULT_PARALLEL = 10
 _SNIPPET_PREVIEW_LIMIT = 200
@@ -87,6 +90,10 @@ def _annotate_web_results_for_citations(
 
         for raw_result in payload.get("results") or []:
             if not isinstance(raw_result, dict):
+                _LOGGER.warning(
+                    "skipping non-dict web result while annotating citations: %r",
+                    raw_result,
+                )
                 continue
             result = dict(raw_result)
             url = str(result.get("url") or "").strip()
@@ -137,7 +144,9 @@ def _format_search_results(payload: dict[str, Any]) -> str:
 
         citation = result.get("citation")
         citation_suffix = f" [{citation}]" if citation else ""
-        lines.append(f"  {i}. {title}{citation_suffix}")
+        source_number = result.get("sourceNumber")
+        row_label = source_number if isinstance(source_number, int) else i
+        lines.append(f"  {row_label}. {title}{citation_suffix}")
         lines.append(f"     {url}")
 
         if snippet:
@@ -184,7 +193,9 @@ def _format_crawl_results(payload: dict[str, Any]) -> str:
 
         citation = entry.get("citation")
         citation_suffix = f" [{citation}]" if citation else ""
-        lines.append(f"  {i}. {url}{citation_suffix}")
+        source_number = entry.get("sourceNumber")
+        row_label = source_number if isinstance(source_number, int) else i
+        lines.append(f"  {row_label}. {url}{citation_suffix}")
         if error:
             lines.append(f"     ERROR: {error}")
         elif content.strip():

--- a/unique_sdk/unique_sdk/cli/skills/unique-cli-search/SKILL.md
+++ b/unique_sdk/unique_sdk/cli/skills/unique-cli-search/SKILL.md
@@ -15,7 +15,7 @@ description: >-
 
 # Unique CLI -- Knowledge Base Search
 
-Search the Unique knowledge base using combined vector + full-text search via the `unique-cli search` command. Every invocation wraps each result in a `<sourceN>...</sourceN>` block and records a per-turn citation manifest at `.unique/turn-refs.jsonl`, so any fact you cite as `[sourceN]` is rendered with a footnote and a clickable reference chip in the chat UI.
+Search the Unique knowledge base using combined vector + full-text search via the `unique-cli search` command. Every invocation wraps each result in a `<sourceN>...</sourceN>` block and records a per-turn citation manifest at `.unique/kb-search-refs.jsonl`, so any fact you cite as `[sourceN]` is rendered with a footnote and a clickable reference chip in the chat UI.
 
 > **Limitation:** Excel (`.xlsx`/`.xls`), CSV (`.csv`), and image files are **not** full-text indexed. They will not appear in search results. To find these files, use the `unique-cli-file-management` skill and browse folders with `unique-cli ls` to locate them by name.
 

--- a/unique_sdk/unique_sdk/cli/skills/unique-cli-search/SKILL.md
+++ b/unique_sdk/unique_sdk/cli/skills/unique-cli-search/SKILL.md
@@ -2,7 +2,9 @@
 name: unique-cli-search
 description: >-
   Search the Unique AI Platform knowledge base using the unique-cli search
-  command. Use when the user asks to find, search, or query documents
+  command, with automatic per-turn citation tracking so cited facts render
+  as clickable reference chips and `<sup>N</sup>` footnotes on the Unique
+  platform. Use whenever the user asks to find, search, or query documents
   or content on Unique, including filtering by folder or metadata.
   NOTE: This search uses combined vector + full-text indexing. Excel
   (.xlsx/.xls), CSV (.csv), and image files are NOT full-text indexed,
@@ -13,7 +15,7 @@ description: >-
 
 # Unique CLI -- Knowledge Base Search
 
-Search the Unique knowledge base using combined vector + full-text search via the `unique-cli search` command.
+Search the Unique knowledge base using combined vector + full-text search via the `unique-cli search` command. Every invocation wraps each result in a `<sourceN>...</sourceN>` block and records a per-turn citation manifest at `.unique/turn-refs.jsonl`, so any fact you cite as `[sourceN]` is rendered with a footnote and a clickable reference chip in the chat UI.
 
 > **Limitation:** Excel (`.xlsx`/`.xls`), CSV (`.csv`), and image files are **not** full-text indexed. They will not appear in search results. To find these files, use the `unique-cli-file-management` skill and browse folders with `unique-cli ls` to locate them by name.
 
@@ -76,16 +78,44 @@ unique-cli search <query> [--folder <path|scope_id>] [--metadata <key=value>]...
 
 ## Output Format
 
-```
-Found 15 result(s):
+Each result is rendered as a `<sourceN>...</sourceN>` block. `N` is **1-based**, unique within the current turn, and **continues across multiple `unique-cli search` calls in the same turn** — the first call in a turn starts at `<source1>`, a follow-up call that returns three more results emits `<source4>`, `<source5>`, `<source6>`, and so on.
 
-    1. annual-report.pdf (p.12-13)  [cont_abc123]
-       ...the quarterly revenue analysis shows a 15% increase...
-    2. Q1/financials.xlsx (p.1)  [cont_def456]
-       ...revenue breakdown by quarter indicates strong growth...
+```
+Found 2 result(s):
+
+<source1>
+<|document|>annual-report.pdf</|document|>
+<|page|>12-13</|page|>
+<|info|>cont_abc123</|info|>
+...the quarterly revenue analysis shows a 15% increase...
+</source1>
+
+<source2>
+<|document|>Q1/financials.xlsx</|document|>
+<|page|>1</|page|>
+<|info|>cont_def456</|info|>
+...revenue breakdown by quarter indicates strong growth...
+</source2>
 ```
 
-Each result shows: index, title, page range, content ID, and a text snippet.
+Each block carries the document title, page range (when known), content ID, and a text snippet. The full chunk metadata (`chunkId`, `url`, `startPage`, `endPage`, ...) is captured in the per-turn manifest and not duplicated on screen.
+
+## Citation Rules
+
+Cite a fact from `unique-cli search` results with `[sourceN]`, where `N` matches the number on the `<sourceN>` block you read it from. The Unique platform's Swappable Intelligence runner converts each `[sourceN]` marker in your final answer into a `<sup>N</sup>` footnote and a clickable reference chip; without `unique-cli search`, KB facts in your answer appear as plain text only, with no footnote and no chip — so this is the only way to make KB citations render correctly on the platform.
+
+```
+The company's quarterly revenue rose 15% year over year [source1],
+driven by strong growth in the EMEA segment [source2].
+```
+
+**Rules** (enforced by the platform's reference post-processor):
+
+1. **`[sourceN]` is for KB results only.** Web results from `unique-cli web-search` use `[websourceN]` instead — never mix the two namespaces.
+2. Only cite numbers you saw in the **current** turn's `unique-cli search` output. Numbers from previous turns are stale and will be silently dropped.
+3. Write `source` in singular form with the number in digits: `[source1]`, `[source2]` — not `[Source 1]` or `[source one]`.
+4. Prefer citing each fact with a single, most-relevant source.
+5. Do not invent source numbers for remembered or inferred facts.
 
 ## Scripting with Search
 

--- a/unique_sdk/unique_sdk/cli/skills/unique-cli-web-search/SKILL.md
+++ b/unique_sdk/unique_sdk/cli/skills/unique-cli-web-search/SKILL.md
@@ -23,12 +23,12 @@ Two-phase web research from the terminal, backed by the Unique AI Platform's pub
 
 ## Two-Phase Workflow (preferred for AI agents)
 
-1. `unique-cli web-search search "<query>" --json` → candidate URLs with snippets.
+1. `unique-cli web-search search "<query>" --json` → candidate URLs with snippets and citation keys.
 2. Review titles + snippets, pick the URLs that look relevant.
-3. `unique-cli web-search crawl <selected-urls>` → full page content for those URLs.
-4. Reason over the crawled content and respond with proper citations.
+3. `unique-cli web-search crawl <selected-urls> --json` → full page content for those URLs, reusing citation keys for URLs returned by search.
+4. Reason over the crawled content and cite web facts with `[websourceN]`.
 
-This sequencing is much cheaper than crawling everything up-front and is the recommended pattern when an LLM is the consumer.
+This sequencing is much cheaper than crawling everything up-front and is the recommended pattern when an LLM is the consumer. In Swappable Intelligence, the CLI also writes `.unique/web-refs.jsonl`; the platform converts cited `[websourceN]` markers into external reference chips in the final answer.
 
 ```bash
 unique-cli web-search search "EU AI Act enforcement timeline" --json \
@@ -194,7 +194,9 @@ Found 3 result(s):
       "url": "https://example.com/article",
       "title": "Example Page Title",
       "snippet": "A short snippet describing the page content...",
-      "content": ""
+      "content": "",
+      "sourceNumber": 1,
+      "citation": "websource1"
     }
   ]
 }
@@ -210,6 +212,9 @@ Found 3 result(s):
 >   | jq -r '.results[].url' \
 >   | unique-cli web-search crawl --stdin
 > ```
+
+Use the `citation` value in final prose, wrapped in square brackets, e.g.
+`The regulation applies in phases [websource1].`
 
 ### `crawl` (text)
 
@@ -234,7 +239,9 @@ Crawled 2 URL(s):
     {
       "url": "https://example.com/article",
       "content": "Full page content as markdown...",
-      "error": null
+      "error": null,
+      "sourceNumber": 1,
+      "citation": "websource1"
     },
     {
       "url": "https://other.com/page",
@@ -274,7 +281,7 @@ jq -r '.results[0:3][].url' /tmp/hits.json \
   | unique-cli web-search crawl --stdin --json \
   > /tmp/pages.json
 
-# 3. Reason over /tmp/pages.json and respond with citations.
+# 3. Reason over /tmp/pages.json and cite supported web facts as [websourceN].
 ```
 
 ### One-shot search-with-content (no manual selection)
@@ -346,6 +353,18 @@ for entry in pages.results:
 
 Both classes have `*_async` variants (`WebSearch.search_async`,
 `WebCrawl.crawl_async`) for async contexts.
+
+## Citation Rules
+
+- Use `[websourceN]` for public web citations, where `N` is the `sourceNumber`
+  returned by `unique-cli web-search`.
+- Do not use `[sourceN]` for web results; `[sourceN]` is reserved for internal
+  knowledge-base citations.
+- Only cite source numbers from the current turn's command output.
+- The same URL keeps the same `sourceNumber` across search and crawl calls in a
+  turn, so cite the crawled content with the same marker that the search result
+  used.
+- Never invent citation markers for remembered or inferred facts.
 
 ## Prerequisites
 

--- a/unique_sdk/unique_sdk/cli/skills/unique-cli-web-search/SKILL.md
+++ b/unique_sdk/unique_sdk/cli/skills/unique-cli-web-search/SKILL.md
@@ -259,7 +259,9 @@ Crawled 2 URL(s):
 
 In one-shot mode, the CLI exits **`0`** on success and **`1`** on
 failures (config-file errors, invalid JSON overrides, API errors,
-missing URLs for `crawl`). Error messages are prefixed with
+missing URLs for `crawl`, and citation-manifest I/O failures — e.g.
+when `.unique/web-refs.jsonl` cannot be written or its parent
+directory is unsafe). Error messages are prefixed with
 `web-search:` or `web-crawl:` so they're easy to grep.
 
 ```bash

--- a/unique_sdk/unique_sdk/cli/skills/unique-cli-web-search/SKILL.md
+++ b/unique_sdk/unique_sdk/cli/skills/unique-cli-web-search/SKILL.md
@@ -174,11 +174,11 @@ discriminator:
 engine: Google    query: 'quarterly earnings 2026'
 Found 3 result(s):
 
-  1. Example Page Title
+  1. Example Page Title [websource1]
      https://example.com/article
      A short snippet describing the page content...
 
-  2. Another Relevant Result
+  2. Another Relevant Result [websource2]
      https://another.com/page
      [4523 chars of content]    # only when --include-content
 ```
@@ -222,11 +222,11 @@ Use the `citation` value in final prose, wrapped in square brackets, e.g.
 crawler: BasicCrawler
 Crawled 2 URL(s):
 
-  1. https://example.com/article
+  1. https://example.com/article [websource1]
      [4523 chars]
      Full page content preview, truncated to ~500 characters...
 
-  2. https://other.com/page
+  2. https://other.com/page [websource2]
      ERROR: HTTP 503 from upstream
 ```
 
@@ -246,7 +246,9 @@ Crawled 2 URL(s):
     {
       "url": "https://other.com/page",
       "content": "",
-      "error": "HTTP 503 from upstream"
+      "error": "HTTP 503 from upstream",
+      "sourceNumber": 2,
+      "citation": "websource2"
     }
   ]
 }

--- a/unique_sdk/unique_sdk/cli/skills/unique-cli-web-search/SKILL.md
+++ b/unique_sdk/unique_sdk/cli/skills/unique-cli-web-search/SKILL.md
@@ -1,23 +1,27 @@
 ---
 name: unique-cli-web-search
 description: >-
-  ALWAYS use this skill when the user asks to search the public web,
-  research a topic online, look up news/articles/regulations, fetch the
-  contents of one or more URLs, or perform any "two-phase" web research
-  (search → review snippets → crawl selected URLs for full content).
-  Routes through the Unique AI Platform's `/web-search-api` endpoints
-  via `unique-cli web-search`, so the engine (Google, Brave, Tavily,
-  Jina, Firecrawl, …) and crawler are resolved server-side from the
-  current environment — you never need to manage engine API keys
-  yourself. Use this instead of fabricating answers from training data
-  whenever fresh / source-cited information is needed. Do NOT use this
-  skill for the internal knowledge base (`unique-cli search`) or for
-  arbitrary tool execution (`unique-cli mcp`).
+  Search the public web and crawl URLs via the Unique AI Platform's
+  `unique-cli web-search` command, with automatic per-turn citation
+  tracking so cited web facts render as clickable external reference
+  chips and `<sup>N</sup>` footnotes on the Unique platform. ALWAYS use
+  this skill when the user asks to search the public web, research a
+  topic online, look up news/articles/regulations, fetch the contents
+  of one or more URLs, or perform any "two-phase" web research (search
+  → review snippets → crawl selected URLs for full content). Routes
+  through the Unique AI Platform's `/web-search-api` endpoints, so the
+  engine (Google, Brave, Tavily, Jina, Firecrawl, …) and crawler are
+  resolved server-side from the current environment — you never need
+  to manage engine API keys yourself. Use this instead of fabricating
+  answers from training data whenever fresh / source-cited information
+  is needed. Do NOT use this skill for the internal knowledge base
+  (`unique-cli search`) or for arbitrary tool execution (`unique-cli
+  mcp`).
 ---
 
 # Unique CLI -- Web Search & Crawl
 
-Two-phase web research from the terminal, backed by the Unique AI Platform's public `/web-search-api`. Phase 1 (`search`) queries a search engine and returns URLs + snippets. Phase 2 (`crawl`) fetches the full page content for the URLs you actually want to read. The two-phase split lets you (or an LLM) review titles and snippets cheaply before paying the latency cost of full-page crawling.
+Two-phase web research from the terminal, backed by the Unique AI Platform's public `/web-search-api`. Phase 1 (`search`) queries a search engine and returns URLs + snippets. Phase 2 (`crawl`) fetches the full page content for the URLs you actually want to read. The two-phase split lets you (or an LLM) review titles and snippets cheaply before paying the latency cost of full-page crawling. Every invocation annotates each result with a `sourceNumber` / `citation: "websourceN"` and records a per-turn citation manifest at `.unique/web-refs.jsonl`, so any fact you cite as `[websourceN]` is rendered with a footnote and a clickable external reference chip in the chat UI.
 
 > **Server-side engine/crawler.** Unlike `unique-websearch`, this CLI does not instantiate engines locally — it just posts to the Unique platform, which resolves the engine and crawler from `ACTIVE_SEARCH_ENGINES` / `ACTIVE_INHOUSE_CRAWLERS` server-side. **You do not need any engine API keys** (Google, Brave, Tavily, etc.) on the client.
 
@@ -213,9 +217,6 @@ Found 3 result(s):
 >   | unique-cli web-search crawl --stdin
 > ```
 
-Use the `citation` value in final prose, wrapped in square brackets, e.g.
-`The regulation applies in phases [websource1].`
-
 ### `crawl` (text)
 
 ```
@@ -358,15 +359,20 @@ Both classes have `*_async` variants (`WebSearch.search_async`,
 
 ## Citation Rules
 
-- Use `[websourceN]` for public web citations, where `N` is the `sourceNumber`
-  returned by `unique-cli web-search`.
-- Do not use `[sourceN]` for web results; `[sourceN]` is reserved for internal
-  knowledge-base citations.
-- Only cite source numbers from the current turn's command output.
-- The same URL keeps the same `sourceNumber` across search and crawl calls in a
-  turn, so cite the crawled content with the same marker that the search result
-  used.
-- Never invent citation markers for remembered or inferred facts.
+Cite a fact from `unique-cli web-search` results with `[websourceN]`, where `N` matches the `sourceNumber` (also surfaced as the `citation: "websourceN"` field) the command emitted alongside the result. The Unique platform's Swappable Intelligence runner converts each `[websourceN]` marker in your final answer into a `<sup>N</sup>` footnote and a clickable external reference chip; without `unique-cli web-search`, web facts in your answer appear as plain text only, with no footnote and no chip — so this is the only way to make web citations render correctly on the platform.
+
+```
+The regulation enters into force in August 2026 [websource1],
+with phased obligations through 2028 [websource2].
+```
+
+**Rules** (enforced by the platform's reference post-processor, which reads `.unique/web-refs.jsonl` rather than your prose):
+
+1. **`[websourceN]` is for public web citations only.** Knowledge-base results from `unique-cli search` use `[sourceN]` instead — never mix the two namespaces, and never use `[sourceN]` for web results.
+2. Only cite numbers you saw in the **current** turn's `unique-cli web-search` output. Numbers from previous turns are stale and will be silently dropped.
+3. Write `websource` in singular form with the number in digits: `[websource1]`, `[websource2]` — not `[Websource 1]` or `[websource one]`.
+4. The same URL keeps the same `[websourceN]` across `search` and `crawl` calls in a turn, so cite a fact from the crawled page with the marker the search snippet already advertised.
+5. Do not invent source numbers for remembered or inferred facts.
 
 ## Prerequisites
 


### PR DESCRIPTION
**Jira:** [UN-21086](https://unique-ch.atlassian.net/browse/UN-21086)

## Summary
- Add citation keys to `unique-cli web-search` search/crawl output.
- Write per-turn web reference metadata to `.unique/web-refs.jsonl` so Swappable Intelligence can attach platform reference chips.
- Document `[websourceN]` citation usage in the web-search skill.

## Test plan
- `uv run --with ruff ruff format unique_sdk/cli/commands/web_search.py tests/cli/test_web_search.py`
- `uv run --with ruff ruff check unique_sdk/cli/commands/web_search.py tests/cli/test_web_search.py`
- `uv run --no-sync --with pytest --with python-dotenv pytest tests/cli/test_web_search.py -q`


Made with [Cursor](https://cursor.com)

[UN-21086]: https://unique-ch.atlassian.net/browse/UN-21086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ