### PR TITLE
fix(unique_sdk/cli): register Office Open-XML MIME types for upload

### DIFF
--- a/unique_sdk/unique_sdk/cli/commands/files.py
+++ b/unique_sdk/unique_sdk/cli/commands/files.py
@@ -12,6 +12,19 @@ from unique_sdk.cli.formatting import format_content_info
 from unique_sdk.cli.state import ShellState
 from unique_sdk.utils.file_io import download_content, upload_file
 
+# Python's stdlib mimetypes does not register the modern Office Open-XML
+# formats by default, so .xlsx/.docx/.pptx fall back to
+# application/octet-stream which the platform's ingestion API rejects with
+# "Invalid file type". Register them once at import time so guess_type()
+# returns the correct value for every CLI upload.
+_OFFICE_OPEN_XML_MIME_TYPES: dict[str, str] = {
+    ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    ".pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+}
+for _ext, _type in _OFFICE_OPEN_XML_MIME_TYPES.items():
+    mimetypes.add_type(_type, _ext)
+
 
 def _resolve_content_id(state: ShellState, name_or_id: str) -> tuple[str, str]:
     """Resolve a file name or content ID to (content_id, display_name).


### PR DESCRIPTION
## Summary

- Python's stdlib `mimetypes` doesn't register `.xlsx`, `.docx`, or `.pptx` by default, so `mimetypes.guess_type()` returns `None` and `cmd_upload` falls back to `application/octet-stream` — which the platform's ingestion API rejects with `Invalid file type`.
- Register the three Office Open-XML types via `mimetypes.add_type()` at module import time so every CLI upload (and any other code path that calls `mimetypes.guess_type()` after the CLI is imported) gets the correct value.
- Touches only `unique_sdk/unique_sdk/cli/commands/files.py`. No public API changes.

### Mappings registered

| Extension | MIME type |
| --- | --- |
| `.xlsx` | `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` |
| `.docx` | `application/vnd.openxmlformats-officedocument.wordprocessingml.document` |
| `.pptx` | `application/vnd.openxmlformats-officedocument.presentationml.presentation` |

## Test plan

- [x] `ruff check` and `ruff format --check` pass on the changed file.
- [x] Manual verification:
  ```
  python -c "
  import unique_sdk.cli.commands.files  # noqa: F401
  import mimetypes
  for ext in ['.xlsx', '.docx', '.pptx', '.pdf', '.csv', '.xls']:
      print(f'{ext:6s} -> {mimetypes.guess_type(\"file\" + ext)[0]}')
  "
  ```
  Output:
  ```
  .xlsx  -> application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
  .docx  -> application/vnd.openxmlformats-officedocument.wordprocessingml.document
  .pptx  -> application/vnd.openxmlformats-officedocument.presentationml.presentation
  .pdf   -> application/pdf
  .csv   -> text/csv
  .xls   -> application/vnd.ms-excel
  ```
- [x] End-to-end: `unique-cli upload test_upload.xlsx` succeeded after the fix (previously failed with `Invalid file type`).

## Notes for reviewers

- `mimetypes.add_type()` is idempotent and process-local — no risk of leaking into other consumers of the SDK that don't import the CLI.
- The fix is intentionally scoped to the CLI module rather than `unique_sdk.utils.file_io.upload_file()`, because that helper takes `mime_type` as an explicit parameter and never guesses; only the CLI's auto-detection path is affected.

Made with [Cursor](https://cursor.com)