### PR TITLE
feat(unique-toolkit): allow sub-agents to take orchestrator control

### DIFF
--- a/unique_sdk/tests/test_chat_in_space.py
+++ b/unique_sdk/tests/test_chat_in_space.py
@@ -1,0 +1,76 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from unique_sdk.utils.chat_in_space import send_message_and_wait_for_completion
+
+
+@pytest.mark.asyncio
+async def test_send_message_and_wait_for_completion__calls_update_hook_for_changed_assistant_messages() -> (
+    None
+):
+    on_message_update = AsyncMock()
+    placeholder = {
+        "id": "assistant-msg",
+        "chatId": "chat-1",
+        "role": "ASSISTANT",
+        "text": None,
+        "originalText": None,
+        "completedAt": None,
+        "stoppedStreamingAt": None,
+        "references": None,
+        "assessment": None,
+    }
+    in_progress = {
+        "id": "assistant-msg",
+        "chatId": "chat-1",
+        "role": "ASSISTANT",
+        "text": "partial",
+        "originalText": "partial",
+        "completedAt": None,
+        "stoppedStreamingAt": None,
+        "references": None,
+        "assessment": None,
+    }
+    duplicate = {**in_progress}
+    completed = {
+        **in_progress,
+        "text": "final",
+        "originalText": "final",
+        "completedAt": "2026-01-01T00:00:00Z",
+    }
+
+    with (
+        patch(
+            "unique_sdk.utils.chat_in_space.Space.create_message_async",
+            new_callable=AsyncMock,
+            return_value={"id": "user-msg", "chatId": "chat-1"},
+        ),
+        patch(
+            "unique_sdk.utils.chat_in_space.Space.get_latest_message_async",
+            new_callable=AsyncMock,
+            side_effect=[placeholder, in_progress, duplicate, completed],
+        ),
+        patch(
+            "unique_sdk.utils.chat_in_space.Message.retrieve_async",
+            new_callable=AsyncMock,
+            return_value={"debugInfo": {"trace": "ok"}},
+        ),
+        patch("unique_sdk.utils.chat_in_space.asyncio.sleep", new_callable=AsyncMock),
+    ):
+        response = await send_message_and_wait_for_completion(
+            user_id="user-1",
+            company_id="company-1",
+            assistant_id="assistant-1",
+            text="hello",
+            poll_interval=0.01,
+            max_wait=1,
+            stop_condition="completedAt",
+            on_message_update=on_message_update,
+        )
+
+    assert response["text"] == "final"
+    assert response["debugInfo"] == {"trace": "ok"}
+    assert on_message_update.await_count == 2
+    assert on_message_update.await_args_list[0].args == (in_progress,)
+    assert on_message_update.await_args_list[1].args == (completed,)

--- a/unique_sdk/unique_sdk/utils/chat_in_space.py
+++ b/unique_sdk/unique_sdk/utils/chat_in_space.py
@@ -1,6 +1,6 @@
 import asyncio
 import warnings
-from collections.abc import Sequence
+from collections.abc import Awaitable, Callable, Sequence
 from typing import Any, Literal
 
 from unique_sdk.api_resources._message import Message
@@ -24,6 +24,7 @@ async def send_message_and_wait_for_completion(
     max_wait: float = 60.0,
     stop_condition: Literal["stoppedStreamingAt", "completedAt"] = "stoppedStreamingAt",
     correlation: "Space.Correlation | None" = None,
+    on_message_update: Callable[["Space.Message"], Awaitable[None]] | None = None,
 ) -> "Space.Message":
     """
     Sends a prompt asynchronously and polls for completion. (until stoppedStreamingAt is not None)
@@ -42,6 +43,8 @@ async def send_message_and_wait_for_completion(
         stop_condition: Defines when to expect a response back, when the assistant stop streaming or when it completes the message. (default: "stoppedStreamingAt")
         correlation: Optional correlation data to link this message to a parent message in another chat.
             Should contain: parentMessageId, parentChatId, parentAssistantId.
+        on_message_update: Optional async callback called whenever the latest assistant
+            message changes while waiting for completion.
 
     Returns:
         The completed Space.Message.
@@ -61,8 +64,21 @@ async def send_message_and_wait_for_completion(
     message_id = response.get("id")
 
     max_attempts = int(max_wait // poll_interval)
+    last_update_signature: tuple[str | None, str | None] | None = None
     for _ in range(max_attempts):
         answer = await Space.get_latest_message_async(user_id, company_id, chat_id)
+        if (
+            on_message_update is not None
+            and answer.get("role") == "ASSISTANT"
+            and answer.get("text") is not None
+        ):
+            update_signature = (
+                answer.get("id"),
+                answer.get("text"),
+            )
+            if update_signature != last_update_signature:
+                await on_message_update(answer)
+                last_update_signature = update_signature
         if answer.get(stop_condition) is not None:
             try:
                 user_message = await Message.retrieve_async(

--- a/unique_toolkit/docs/agentic_framework/tool_manager.md
+++ b/unique_toolkit/docs/agentic_framework/tool_manager.md
@@ -4,10 +4,10 @@ This document explains how the Tool Manager organizes, exposes, and executes too
 
 Key capabilities:
 - Load and filter tools from configuration and the users choices
-- Respects Tool exclusivity, weather it is enabled by the admin or weather the user choose the tool as a must (forced tools)
+- Respects Tool exclusivity, whether it is enabled by the admin or whether the user chose the tool as a must (forced tools)
 - Expose tool definitions and prompt enhancements for the LLM
 - Detects if a tool requests a handoff so it “takes control”  (e.g., deep research)
-- Execute selected tools in parallel with tool-call deduplication and max-call limits
+- Execute selected non-conflicting tools in parallel with tool-call deduplication and max-call limits
 - it returns the ToolCallResponses of all the tools to the orchestrator for further rounds with the LLM and additional processing like preparation for referencing or collection of debug info.
 
 
@@ -149,62 +149,89 @@ def _convert_to_forced_tool(self, tool_name: str) -> dict[str, Any]:
 
 ## 🧠 Control-Taking Tools (e.g., Deep Research)
 
-Some tools request a handover from the main orchestrator so they can “take control” of the session. The orchestrator can check this before deciding weather to yield control or to continue its flow.
+Some tools request a handover from the main orchestrator so they can “take control” of the session. The orchestrator can check this before deciding whether to yield control or to continue its flow.
 
 Check if any selected call belongs to a control-taking tool:
 ```{.python #tool-manager-does-tool-take-control}
-def does_a_tool_take_control(self, tool_calls: list[LanguageModelFunction]) -> bool:
+def _get_tool_calls_that_take_control(
+    self, tool_calls: list[LanguageModelFunction]
+) -> list[LanguageModelFunction]:
+    tools = []
     for tool_call in tool_calls:
         tool_instance = self.get_tool_by_name(tool_call.name)
         if tool_instance and tool_instance.takes_control():
-            return True
-    return False
+            tools.append(tool_call)
+
+    return tools
+
+def does_a_tool_take_control(self, tool_calls: list[LanguageModelFunction]) -> bool:
+    return len(self._get_tool_calls_that_take_control(tool_calls)) > 0
 ```
 
 
 ## ⚙️ Tool Execution Workflow
 
-The orchestrator receives the information from the LLM on what tools to be executed in oder for the llm to receive the requested information.
+The orchestrator receives the information from the LLM on what tools to be executed in order for the LLM to receive the requested information.
 The Tool Manager handles the execution of selected tools with the following steps:
 
 1. **Deduplication**: It removes duplicate tool calls from the LLM, ensuring identical calls (e.g., same tool with identical parameters) are executed only once. This prevents redundant processing caused by occasional LLM errors.
 
-2. **Call Limit Enforcement**: A maximum of two tool calls is allowed per execution round. This prevents overloading the system with excessive requests.
+2. **Call Limit Enforcement**: The configured maximum number of tool calls is allowed per execution round. This prevents overloading the system with excessive requests.
 
-3. **Parallel Execution**: Tools are executed concurrently to save time, as individual tool calls can be time-intensive.
+3. **Take-Control Conflict Guard**: If a batch contains more than one call and any call belongs to a tool that takes control, no tools in the batch are executed. The manager returns a conflict response for every call: the take-control tool response explains that it must be called alone, and sibling responses explain which tool(s) caused the batch to be rejected.
 
-4. **Result Handling**: Once the tools return their responses, the Tool Manager:
+4. **Parallel Execution**: When no take-control conflict exists, tools are executed concurrently to save time, as individual tool calls can be time-intensive.
+
+5. **Result Handling**: Once the tools return their responses, the Tool Manager:
    - Sends the results back to the orchestrator.
    - Updates the call history.
    - Extracts references and debug information for further use.
 
-This streamlined process ensures efficient, accurate, and manageable tool execution.",
+This streamlined process ensures efficient, accurate, and manageable tool execution.
 ```{.python #tool-manager-execute-selected-tools}
+def _take_control_conflict_response(
+    self,
+    tool_call: LanguageModelFunction,
+    take_control_names: list[str],
+) -> ToolCallResponse:
+    if tool_call.name in take_control_names:
+        content = (
+            f"ERROR: Tool `{tool_call.name}` directly returns its response to the user and therefore must be called on its own. "
+            "None of the tools in this batch were executed. "
+            f"You may recover by first calling the other tools, then calling `{tool_call.name}` alone."
+        )
+    else:
+        names = ", ".join(f"`{n}`" for n in take_control_names)
+        content = f"ERROR: Not executed because the following tool(s) must be called on their own: {names}"
+
+    return ToolCallResponse(
+        id=tool_call.id,
+        name=tool_call.name,
+        content=content,
+    )
+
 async def execute_selected_tools(
     self,
     tool_calls: list[LanguageModelFunction],
 ) -> list[ToolCallResponse]:
-    tool_calls = tool_calls
+    if len(tool_calls) > 1:
+        take_control_tools = [
+            t.name for t in self._get_tool_calls_that_take_control(tool_calls)
+        ]
 
-    tool_calls = self.filter_duplicate_tool_calls(
-        tool_calls=tool_calls,
-    )
-    num_tool_calls = len(tool_calls)
+        if len(take_control_tools) > 0:
+            self._logger.warning(
+                "Tool(s) %s take control and cannot be called alongside other tools. "
+                "Returning error for all %d tool calls.",
+                take_control_tools,
+                len(tool_calls),
+            )
+            return [
+                self._take_control_conflict_response(tool_call, take_control_tools)
+                for tool_call in tool_calls
+            ]
 
-    if num_tool_calls > self._config.max_tool_calls:
-        self._logger.warning(
-            (
-                "Number of tool calls %s exceeds the allowed maximum of %s."
-                "The tool calls will be reduced to the first %s."
-            ),
-            num_tool_calls,
-            self._config.max_tool_calls,
-            self._config.max_tool_calls,
-        )
-        tool_calls = tool_calls[: self._config.max_tool_calls]
-
-    tool_call_responses = await self._execute_parallelized(
-        tool_calls=tool_calls, loop_iteration=loop_iteration)
+    tool_call_responses = await self._execute_parallelized(tool_calls)
     return tool_call_responses
 ```
 

--- a/unique_toolkit/tests/agentic/tools/test_sub_agent_assessment_forwarding.py
+++ b/unique_toolkit/tests/agentic/tools/test_sub_agent_assessment_forwarding.py
@@ -1,0 +1,243 @@
+"""
+Unit tests for SubAgentTool's assessment forwarding when passthrough is enabled.
+
+These tests bypass the SubAgentTool constructor (which requires a full ChatEvent
+and ChatService) and exercise the assessment-forwarding helpers in isolation.
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from unique_toolkit.agentic.tools.a2a.tool.config import (
+    SubAgentPassthroughConfig,
+    SubAgentToolConfig,
+)
+from unique_toolkit.agentic.tools.a2a.tool.service import SubAgentTool
+from unique_toolkit.chat.schemas import (
+    ChatMessageAssessmentLabel,
+    ChatMessageAssessmentStatus,
+    ChatMessageAssessmentType,
+)
+
+
+@pytest.fixture
+def assessment_dict() -> dict[str, Any]:
+    """A well-formed Space.Assessment-like dict with all required keys."""
+    return {
+        "id": "a-1",
+        "createdAt": "2026-01-01T00:00:00Z",
+        "updatedAt": "2026-01-01T00:00:00Z",
+        "messageId": "m-1",
+        "status": ChatMessageAssessmentStatus.DONE.value,
+        "explanation": "Looks good",
+        "label": ChatMessageAssessmentLabel.GREEN.value,
+        "type": ChatMessageAssessmentType.HALLUCINATION.value,
+        "title": "Hallucination check",
+        "companyId": "c-1",
+        "userId": "u-1",
+        "isVisible": True,
+        "createdBy": "u-1",
+    }
+
+
+@pytest.fixture
+def passthrough_tool() -> SubAgentTool:
+    """
+    Build a SubAgentTool without invoking its real __init__.
+
+    The real constructor needs a full ChatEvent and instantiates ChatService /
+    MessageStepLogger; for the helpers under test we only need `_chat_service`
+    (mocked) and `config`.
+    """
+    tool: SubAgentTool = SubAgentTool.__new__(SubAgentTool)
+    tool.config = SubAgentToolConfig(  # type: ignore[attr-defined]
+        passthrough_config=SubAgentPassthroughConfig(
+            enabled=True, include_assessments=True
+        ),
+    )
+
+    chat_service = MagicMock()
+    chat_service._assistant_message_id = "assistant-msg-id"
+    chat_service.create_message_assessment_async = AsyncMock()
+    chat_service.modify_assistant_message_async = AsyncMock()
+    tool._chat_service = chat_service
+    return tool
+
+
+@pytest.mark.ai
+@pytest.mark.asyncio
+async def test_forward_sub_agent_assessments__no_op__when_list_empty(
+    passthrough_tool: SubAgentTool,
+) -> None:
+    """
+    Purpose: Verify _forward_sub_agent_assessments returns immediately on empty input.
+    Why this matters: An empty list is common (sub-agent ran no assessments); we must
+        not issue an SDK call in that case — it would create a pointless network round trip.
+    Setup summary: Call the helper with an empty list, assert no chat-service calls were made.
+    """
+    # Arrange
+    chat_service = passthrough_tool._chat_service
+
+    # Act
+    await passthrough_tool._forward_sub_agent_assessments([])
+
+    # Assert
+    chat_service.create_message_assessment_async.assert_not_called()
+
+
+@pytest.mark.ai
+@pytest.mark.asyncio
+async def test_forward_sub_agent_assessments__forwards_each_assessment__on_happy_path(
+    passthrough_tool: SubAgentTool,
+    assessment_dict: dict[str, Any],
+) -> None:
+    """
+    Purpose: Verify each well-formed assessment results in one create_message_assessment_async call
+        on the orchestrator's assistant message ID, with the SDK enum strings mapped to the
+        typed Chat enums.
+    Why this matters: Forwarding assessments is the whole point of the include_assessments flag;
+        missing or mis-typed calls would silently drop quality signals from the sub-agent.
+    Setup summary: Build two assessments (one GREEN, one RED), call the helper, then inspect
+        the recorded kwargs of each create_message_assessment_async call.
+    """
+    # Arrange
+    chat_service = passthrough_tool._chat_service
+    red_assessment = {
+        **assessment_dict,
+        "id": "a-2",
+        "label": ChatMessageAssessmentLabel.RED.value,
+        "explanation": "Hallucination detected",
+        "isVisible": False,
+    }
+
+    # Act
+    await passthrough_tool._forward_sub_agent_assessments(
+        [assessment_dict, red_assessment]  # type: ignore[list-item]
+    )
+
+    # Assert
+    assert chat_service.create_message_assessment_async.await_count == 2
+    first_call_kwargs = chat_service.create_message_assessment_async.await_args_list[
+        0
+    ].kwargs
+    assert first_call_kwargs["assistant_message_id"] == "assistant-msg-id"
+    assert first_call_kwargs["status"] == ChatMessageAssessmentStatus.DONE
+    assert first_call_kwargs["type"] == ChatMessageAssessmentType.HALLUCINATION
+    assert first_call_kwargs["label"] == ChatMessageAssessmentLabel.GREEN
+    assert first_call_kwargs["title"] == "Hallucination check"
+    assert first_call_kwargs["explanation"] == "Looks good"
+    assert first_call_kwargs["is_visible"] is True
+
+    second_call_kwargs = chat_service.create_message_assessment_async.await_args_list[
+        1
+    ].kwargs
+    assert second_call_kwargs["label"] == ChatMessageAssessmentLabel.RED
+    assert second_call_kwargs["explanation"] == "Hallucination detected"
+    assert second_call_kwargs["is_visible"] is False
+
+
+@pytest.mark.ai
+@pytest.mark.asyncio
+async def test_forward_sub_agent_assessments__continues_other_assessments__when_one_has_bad_enum(
+    passthrough_tool: SubAgentTool,
+    assessment_dict: dict[str, Any],
+) -> None:
+    """
+    Purpose: Verify a single assessment with an unrecognized enum value (here: an unknown
+        `type` outside HALLUCINATION/COMPLIANCE) does not abort the batch — well-formed
+        peers still get forwarded.
+    Why this matters: Sub-agents may return assessment types the toolkit doesn't recognize.
+        We don't want one bad apple to block the entire forwarding pass and lose every
+        signal the orchestrator could have surfaced.
+    Setup summary: Build two assessments — one valid, one with `type='UNKNOWN'` — call the
+        helper, assert only the valid one resulted in a chat-service call.
+    """
+    # Arrange
+    chat_service = passthrough_tool._chat_service
+    bad_assessment = {
+        **assessment_dict,
+        "id": "a-bad",
+        "type": "UNKNOWN_TYPE_NOT_IN_ENUM",
+    }
+
+    # Act
+    await passthrough_tool._forward_sub_agent_assessments(
+        [bad_assessment, assessment_dict]  # type: ignore[list-item]
+    )
+
+    # Assert
+    # Each task is executed via SafeTaskExecutor; the bad one is logged-and-swallowed,
+    # so only the good assessment results in a successful chat-service call.
+    assert chat_service.create_message_assessment_async.await_count == 1
+    good_kwargs = chat_service.create_message_assessment_async.await_args.kwargs
+    assert good_kwargs["type"] == ChatMessageAssessmentType.HALLUCINATION
+
+
+@pytest.mark.ai
+@pytest.mark.asyncio
+async def test_display_sub_agent_response__skips_assessment_forwarding__when_flag_off(
+    passthrough_tool: SubAgentTool,
+    assessment_dict: dict[str, Any],
+) -> None:
+    """
+    Purpose: Verify _display_sub_agent_response does not forward assessments when
+        passthrough_config.include_assessments is False, even if the sub-agent returned them.
+    Why this matters: include_assessments is the explicit opt-out; respecting it is required
+        to avoid leaking sub-agent quality signals into the orchestrator output when the
+        operator disabled that behavior.
+    Setup summary: Flip include_assessments to False, run _display_sub_agent_response with a
+        response carrying assessments, and assert no create_message_assessment_async calls.
+    """
+    # Arrange
+    passthrough_tool.config = SubAgentToolConfig(  # type: ignore[attr-defined]
+        passthrough_config=SubAgentPassthroughConfig(
+            enabled=True, include_assessments=False
+        ),
+    )
+    chat_service = passthrough_tool._chat_service
+    response = {
+        "text": "Sub agent answer",
+        "originalText": "Sub agent answer",
+        "references": None,
+        "assessment": [assessment_dict],
+    }
+
+    # Act
+    await passthrough_tool._display_sub_agent_response(response)  # type: ignore[arg-type]
+
+    # Assert
+    chat_service.modify_assistant_message_async.assert_awaited_once()
+    chat_service.create_message_assessment_async.assert_not_called()
+
+
+@pytest.mark.ai
+@pytest.mark.asyncio
+async def test_display_sub_agent_response__forwards_assessments__when_flag_on(
+    passthrough_tool: SubAgentTool,
+    assessment_dict: dict[str, Any],
+) -> None:
+    """
+    Purpose: Verify _display_sub_agent_response calls modify_assistant_message_async first and
+        then forwards the assessments when include_assessments is True.
+    Why this matters: The streamed message and the forwarded assessments together make up the
+        passthrough contract; both must happen on a happy-path response.
+    Setup summary: Provide a response with one assessment and assert both chat-service methods
+        were called.
+    """
+    # Arrange
+    chat_service = passthrough_tool._chat_service
+    response = {
+        "text": "Streamed text",
+        "originalText": "Streamed text",
+        "references": None,
+        "assessment": [assessment_dict],
+    }
+
+    # Act
+    await passthrough_tool._display_sub_agent_response(response)  # type: ignore[arg-type]
+
+    # Assert
+    chat_service.modify_assistant_message_async.assert_awaited_once()
+    chat_service.create_message_assessment_async.assert_awaited_once()

--- a/unique_toolkit/tests/agentic/tools/test_sub_agent_passthrough_config.py
+++ b/unique_toolkit/tests/agentic/tools/test_sub_agent_passthrough_config.py
@@ -1,0 +1,117 @@
+"""
+Unit tests for the passthrough_config validators added to SubAgentToolConfig
+and ExtendedSubAgentToolConfig.
+"""
+
+import logging
+
+import pytest
+
+from unique_toolkit.agentic.tools.a2a.config import ExtendedSubAgentToolConfig
+from unique_toolkit.agentic.tools.a2a.postprocessing import (
+    SubAgentDisplayConfig,
+    SubAgentResponseDisplayMode,
+)
+from unique_toolkit.agentic.tools.a2a.tool.config import (
+    SubAgentPassthroughConfig,
+    SubAgentToolConfig,
+)
+
+
+@pytest.mark.ai
+def test_sub_agent_tool_config__raises__when_passthrough_enabled_with_returns_content_chunks() -> (
+    None
+):
+    """
+    Purpose: Verify our validator rejects passthrough + returns_content_chunks together.
+    Why this matters: The two modes are conceptually incompatible — passthrough writes a final
+        assistant message, while returns_content_chunks expects the orchestrator to keep using
+        the sub-agent output as structured tool data. Allowing both would yield garbage output.
+    Setup summary: Construct config with both flags on, assert our validator raises ValueError
+        with the message we authored.
+    """
+    # Arrange / Act / Assert
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        SubAgentToolConfig(
+            passthrough_config=SubAgentPassthroughConfig(enabled=True),
+            returns_content_chunks=True,
+        )
+
+
+@pytest.mark.ai
+def test_sub_agent_tool_config__overrides_use_sub_agent_references__when_passthrough_enabled(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    Purpose: Verify our validator force-disables use_sub_agent_references when passthrough is on.
+    Why this matters: Passthrough streams the sub-agent message verbatim, so the
+        sub-agent reference rewriting pass would corrupt the output if left on.
+        We deliberately mutate the field and warn rather than raising so existing configs keep
+        working without changes.
+    Setup summary: Set both passthrough.enabled=True and use_sub_agent_references=True,
+        assert references flag is flipped to False and our warning is logged.
+    """
+    # Arrange / Act
+    with caplog.at_level(
+        logging.WARNING, logger="unique_toolkit.agentic.tools.a2a.tool.config"
+    ):
+        cfg = SubAgentToolConfig(
+            passthrough_config=SubAgentPassthroughConfig(enabled=True),
+            use_sub_agent_references=True,
+        )
+
+    # Assert
+    assert cfg.use_sub_agent_references is False
+    assert any("use_sub_agent_references" in r.message for r in caplog.records)
+
+
+@pytest.mark.ai
+def test_extended_config__forces_display_mode_hidden__when_passthrough_enabled(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    Purpose: Verify our validator overrides response_display_config.mode to HIDDEN when
+        passthrough is on.
+    Why this matters: Passthrough writes the sub-agent answer directly into the assistant
+        message; if the post-processing display layer were also active, the answer would
+        get rendered twice (once by passthrough, once by display).
+    Setup summary: Construct ExtendedSubAgentToolConfig with passthrough enabled and a
+        non-hidden display mode; assert our validator flips display mode to HIDDEN and warns.
+    """
+    # Arrange / Act
+    with caplog.at_level(
+        logging.WARNING, logger="unique_toolkit.agentic.tools.a2a.config"
+    ):
+        cfg = ExtendedSubAgentToolConfig(
+            passthrough_config=SubAgentPassthroughConfig(enabled=True),
+            response_display_config=SubAgentDisplayConfig(
+                mode=SubAgentResponseDisplayMode.PLAIN,
+            ),
+        )
+
+    # Assert
+    assert cfg.response_display_config.mode == SubAgentResponseDisplayMode.HIDDEN
+    assert any("response_display_config.mode" in r.message for r in caplog.records)
+
+
+@pytest.mark.ai
+def test_extended_config__keeps_display_mode__when_passthrough_disabled() -> None:
+    """
+    Purpose: Verify our validator does NOT touch response_display_config.mode when passthrough
+        is off.
+    Why this matters: The HIDDEN-override is scoped to the passthrough case; outside it,
+        the operator-chosen display mode must survive — testing the negative branch protects
+        against an accidental inversion of the validator's guard.
+    Setup summary: Construct config with passthrough disabled and an explicit display mode;
+        assert the mode is preserved.
+    """
+    # Arrange / Act
+    cfg = ExtendedSubAgentToolConfig(
+        passthrough_config=SubAgentPassthroughConfig(enabled=False),
+        response_display_config=SubAgentDisplayConfig(
+            mode=SubAgentResponseDisplayMode.DETAILS_OPEN,
+        ),
+    )
+
+    # Assert
+    assert cfg.response_display_config.mode == SubAgentResponseDisplayMode.DETAILS_OPEN

--- a/unique_toolkit/tests/agentic/tools/test_sub_agent_tool.py
+++ b/unique_toolkit/tests/agentic/tools/test_sub_agent_tool.py
@@ -2,7 +2,10 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
-from unique_toolkit.agentic.tools.a2a.tool.config import SubAgentToolConfig
+from unique_toolkit.agentic.tools.a2a.tool.config import (
+    SubAgentPassthroughConfig,
+    SubAgentToolConfig,
+)
 from unique_toolkit.agentic.tools.a2a.tool.service import SubAgentTool
 from unique_toolkit.agentic.tools.factory import ToolFactory
 from unique_toolkit.agentic.tools.schemas import ToolCallResponse
@@ -833,6 +836,74 @@ class TestSubAgentToolRun:
         # Last call should be FAILED status
         last_call = calls[-1]
         assert last_call.kwargs["status"] == MessageLogStatus.FAILED
+
+    @pytest.mark.ai
+    @pytest.mark.asyncio
+    async def test_run__passes_streaming_update_hook__when_passthrough_enabled_AI(
+        self,
+        mock_chat_event: ChatEvent,
+    ) -> None:
+        config = SubAgentToolConfig(
+            assistant_id="sub_agent_assistant_123",
+            tool_description="A test sub agent tool",
+            passthrough_config=SubAgentPassthroughConfig(
+                enabled=True,
+                include_assessments=False,
+            ),
+        )
+        tool = SubAgentTool(
+            configuration=config,
+            event=mock_chat_event,
+            name="TestSubAgent",
+            display_name="Test Sub Agent",
+        )
+        tool._chat_service = Mock()
+        tool._chat_service._assistant_message_id = "assistant_message_202"
+        tool._chat_service.modify_assistant_message_async = AsyncMock()
+        tool._chat_service.create_message_assessment_async = AsyncMock()
+        tool._message_step_logger = Mock()
+        tool._message_step_logger.create_or_update_message_log = Mock(
+            return_value=Mock()
+        )
+        tool_call = LanguageModelFunction(
+            id="call_123",
+            name="TestSubAgent",
+            arguments={"user_message": "test message"},
+        )
+        mock_response = {
+            "text": "Sub agent response",
+            "originalText": "Sub agent response",
+            "assessment": [],
+            "chatId": "sub_agent_chat_999",
+            "references": None,
+        }
+
+        with (
+            patch(
+                "unique_toolkit.agentic.tools.a2a.tool.service.feature_flags.enable_new_answers_ui_un_14411.is_enabled",
+                return_value=True,
+            ),
+            patch(
+                "unique_toolkit.agentic.tools.a2a.tool.service.send_message_and_wait_for_completion",
+                new_callable=AsyncMock,
+                return_value=mock_response,
+            ) as mock_send,
+            patch.object(
+                tool, "_get_chat_id", new_callable=AsyncMock, return_value=None
+            ),
+            patch.object(
+                tool, "_save_chat_id", new_callable=AsyncMock, return_value=None
+            ),
+        ):
+            await tool.run(tool_call)
+
+        assert (
+            mock_send.await_args.kwargs["on_message_update"]
+            == tool._publish_sub_agent_response_update
+        )
+        final_update = tool._chat_service.modify_assistant_message_async.await_args
+        assert final_update.kwargs["content"] == "Sub agent response"
+        assert final_update.kwargs["set_completed_at"] is True
 
 
 class TestSubAgentToolDebugInfo:

--- a/unique_toolkit/tests/agentic/tools/test_tool_manager.py
+++ b/unique_toolkit/tests/agentic/tools/test_tool_manager.py
@@ -1831,6 +1831,145 @@ async def test_tool_manager__execute_selected_tools__handles_exceptions(
 
 
 @pytest.mark.ai
+@pytest.mark.asyncio
+async def test_tool_manager__execute_selected_tools__returns_conflict_error_for_take_control_in_batch(
+    logger,
+    base_event,
+    tool_progress_reporter,
+    mcp_manager,
+    a2a_manager,
+) -> None:
+    """
+    Purpose: Verify that when a take-control tool is called alongside other tools in the same
+        batch, execute_selected_tools refuses to run any of them and returns a conflict
+        error response for every call.
+    Why this matters: A take-control tool ends the orchestrator loop by writing the final
+        assistant message itself. Running it in parallel with other tools would race —
+        either the others' output is lost (the loop ended) or the assistant message gets
+        clobbered. The toolkit prevents that by short-circuiting the whole batch and
+        feeding the LLM a recovery hint.
+    Setup summary: Register a control_tool + mock_tool, build a tool call list containing
+        both, and assert both responses are conflict errors that name the take-control tool.
+    """
+    # Arrange
+    tool_configs = [
+        ToolBuildConfig(
+            name="control_tool",
+            configuration=MockToolConfig(),
+            display_name="Control Tool",
+            icon=ToolIcon.ANALYTICS,
+            selection_policy=ToolSelectionPolicy.BY_USER,
+            is_exclusive=False,
+            is_enabled=True,
+        ),
+        ToolBuildConfig(
+            name="mock_tool",
+            configuration=MockToolConfig(),
+            display_name="Mock Tool",
+            icon=ToolIcon.BOOK,
+            selection_policy=ToolSelectionPolicy.BY_USER,
+            is_exclusive=False,
+            is_enabled=True,
+        ),
+    ]
+    config = ToolManagerConfig(tools=tool_configs, max_tool_calls=10)
+    tool_manager = ToolManager(
+        logger=logger,
+        config=config,
+        event=base_event,
+        tool_progress_reporter=tool_progress_reporter,
+        mcp_manager=mcp_manager,
+        a2a_manager=a2a_manager,
+    )
+    tool_calls = [
+        LanguageModelFunction(
+            id="call_control",
+            name="control_tool",
+            arguments={"query": "ctrl"},
+        ),
+        LanguageModelFunction(
+            id="call_mock",
+            name="mock_tool",
+            arguments={"query": "other"},
+        ),
+    ]
+
+    # Act
+    responses = await tool_manager.execute_selected_tools(tool_calls)
+
+    # Assert
+    assert len(responses) == 2
+    by_id = {r.id: r for r in responses}
+
+    control_response = by_id["call_control"]
+    assert "control_tool" in control_response.content
+    # The control tool gets the "called on its own" hint
+    assert (
+        "alone" in control_response.content or "on its own" in control_response.content
+    )
+
+    other_response = by_id["call_mock"]
+    # The other tool gets a "not executed because of X" hint that names control_tool
+    assert "control_tool" in other_response.content
+    assert "Not executed" in other_response.content
+
+
+@pytest.mark.ai
+@pytest.mark.asyncio
+async def test_tool_manager__execute_selected_tools__runs_take_control_tool_alone(
+    logger,
+    base_event,
+    tool_progress_reporter,
+    mcp_manager,
+    a2a_manager,
+) -> None:
+    """
+    Purpose: Verify a take-control tool runs normally when it's the only call in the batch.
+    Why this matters: The conflict guard must only fire when there are siblings; a solo
+        take-control call is the supported happy path and must execute without interference.
+    Setup summary: Register a control_tool, submit it as the only tool call, assert the
+        successful tool response comes through (not a conflict error).
+    """
+    # Arrange
+    tool_configs = [
+        ToolBuildConfig(
+            name="control_tool",
+            configuration=MockToolConfig(),
+            display_name="Control Tool",
+            icon=ToolIcon.ANALYTICS,
+            selection_policy=ToolSelectionPolicy.BY_USER,
+            is_exclusive=False,
+            is_enabled=True,
+        ),
+    ]
+    config = ToolManagerConfig(tools=tool_configs, max_tool_calls=10)
+    tool_manager = ToolManager(
+        logger=logger,
+        config=config,
+        event=base_event,
+        tool_progress_reporter=tool_progress_reporter,
+        mcp_manager=mcp_manager,
+        a2a_manager=a2a_manager,
+    )
+    tool_calls = [
+        LanguageModelFunction(
+            id="call_control",
+            name="control_tool",
+            arguments={"query": "ctrl"},
+        ),
+    ]
+
+    # Act
+    responses = await tool_manager.execute_selected_tools(tool_calls)
+
+    # Assert
+    assert len(responses) == 1
+    assert responses[0].id == "call_control"
+    # MockControlTool.run returns "Control response" — not a conflict error.
+    assert responses[0].content == "Control response"
+
+
+@pytest.mark.ai
 def test_responses_api_tool_manager__get_tool_by_name__can_return_builtin(
     logger,
     base_event,

--- a/unique_toolkit/unique_toolkit/agentic/tools/a2a/config.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/a2a/config.py
@@ -1,8 +1,16 @@
-from pydantic import Field
+import logging
+from typing import Self
+
+from pydantic import Field, model_validator
 
 from unique_toolkit.agentic.tools.a2a.evaluation import SubAgentEvaluationConfig
-from unique_toolkit.agentic.tools.a2a.postprocessing import SubAgentDisplayConfig
+from unique_toolkit.agentic.tools.a2a.postprocessing import (
+    SubAgentDisplayConfig,
+    SubAgentResponseDisplayMode,
+)
 from unique_toolkit.agentic.tools.a2a.tool import SubAgentToolConfig
+
+_LOGGER = logging.getLogger(__name__)
 
 
 # SubAgentToolConfig with display and evaluation configs
@@ -15,3 +23,19 @@ class ExtendedSubAgentToolConfig(SubAgentToolConfig):
         default_factory=SubAgentEvaluationConfig,
         description="Configuration for handling assessments of the sub-agent response.",
     )
+
+    @model_validator(mode="after")
+    def _ensure_response_display_config_off_when_sub_agent_response_passthrough(
+        self,
+    ) -> Self:
+        if (
+            self.response_passthrough
+            and self.response_display_config.mode != SubAgentResponseDisplayMode.HIDDEN
+        ):
+            _LOGGER.warning(
+                "SubAgent (assistant_id=%r): `response_passthrough=True` but `response_display_config.mode` is not HIDDEN. "
+                "Overriding `response_display_config.mode` to HIDDEN.",
+                self.assistant_id,
+            )
+            self.response_display_config.mode = SubAgentResponseDisplayMode.HIDDEN
+        return self

--- a/unique_toolkit/unique_toolkit/agentic/tools/a2a/config.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/a2a/config.py
@@ -29,11 +29,11 @@ class ExtendedSubAgentToolConfig(SubAgentToolConfig):
         self,
     ) -> Self:
         if (
-            self.response_passthrough
+            self.passthrough_config.enabled
             and self.response_display_config.mode != SubAgentResponseDisplayMode.HIDDEN
         ):
             _LOGGER.warning(
-                "SubAgent (assistant_id=%r): `response_passthrough=True` but `response_display_config.mode` is not HIDDEN. "
+                "SubAgent (assistant_id=%r): `passthrough_config.enabled=True` but `response_display_config.mode` is not HIDDEN. "
                 "Overriding `response_display_config.mode` to HIDDEN.",
                 self.assistant_id,
             )

--- a/unique_toolkit/unique_toolkit/agentic/tools/a2a/tool/__init__.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/a2a/tool/__init__.py
@@ -1,4 +1,7 @@
-from unique_toolkit.agentic.tools.a2a.tool.config import SubAgentToolConfig
+from unique_toolkit.agentic.tools.a2a.tool.config import (
+    SubAgentPassthroughConfig,
+    SubAgentToolConfig,
+)
 from unique_toolkit.agentic.tools.a2a.tool.service import SubAgentTool
 
-__all__ = ["SubAgentTool", "SubAgentToolConfig"]
+__all__ = ["SubAgentPassthroughConfig", "SubAgentTool", "SubAgentToolConfig"]

--- a/unique_toolkit/unique_toolkit/agentic/tools/a2a/tool/config.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/a2a/tool/config.py
@@ -209,6 +209,7 @@ class SubAgentToolConfig(BaseToolConfig):
     passthrough_config: SubAgentPassthroughConfig = Field(
         default_factory=SubAgentPassthroughConfig,
         description="Configuration for streaming the sub-agent response directly back to the user.",
+        title="Direct Streaming Configuration",
     )
 
     system_reminders_config: list[

--- a/unique_toolkit/unique_toolkit/agentic/tools/a2a/tool/config.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/a2a/tool/config.py
@@ -107,6 +107,19 @@ This is the message that will be sent to the sub-agent.
 """.strip()
 
 
+class SubAgentPassthroughConfig(BaseModel):
+    model_config = get_configuration_dict()
+
+    enabled: bool = Field(
+        default=False,
+        description="If set, this sub agent's response will be directly displayed to the user once the agent is called, ending the orchestrator loop.",
+    )
+    include_assessments: bool = Field(
+        default=True,
+        description="If set, this sub agent's assessments will be added to the main agent response.",
+    )
+
+
 class SubAgentToolConfig(BaseToolConfig):
     model_config = get_configuration_dict()
 
@@ -193,9 +206,9 @@ class SubAgentToolConfig(BaseToolConfig):
         default=False,
         description="If set, the sub-agent response will be interpreted as a list of content chunks.",
     )
-    response_passthrough: bool = Field(
-        default=False,
-        description="If set, this sub agent's response will be directly displayed to the user once called, ending the orchestrator loop.",
+    passthrough_config: SubAgentPassthroughConfig = Field(
+        default_factory=SubAgentPassthroughConfig,
+        description="Configuration for streaming the sub-agent response directly back to the user.",
     )
 
     system_reminders_config: list[
@@ -222,10 +235,10 @@ class SubAgentToolConfig(BaseToolConfig):
     def _ensure_response_passthrough_and_returns_content_chunks_mutually_exclusive(
         self,
     ) -> Self:
-        if self.response_passthrough and self.returns_content_chunks:
+        if self.passthrough_config.enabled and self.returns_content_chunks:
             raise ValueError(
                 f"SubAgent (assistant_id={self.assistant_id!r}): "
-                "`response_passthrough` and `returns_content_chunks` are mutually exclusive."
+                "`passthrough_config.enabled` and `returns_content_chunks` are mutually exclusive."
             )
         return self
 
@@ -233,9 +246,9 @@ class SubAgentToolConfig(BaseToolConfig):
     def _ensure_use_sub_agent_references_off_when_tool_response_passthrough(
         self,
     ) -> Self:
-        if self.response_passthrough and self.use_sub_agent_references:
+        if self.passthrough_config.enabled and self.use_sub_agent_references:
             _LOGGER.warning(
-                "SubAgent (assistant_id=%r): `response_passthrough=True` and `use_sub_agent_references=True`. "
+                "SubAgent (assistant_id=%r): `passthrough_config.enabled=True` and `use_sub_agent_references=True`. "
                 "`use_sub_agent_references` will be overridden to False.",
                 self.assistant_id,
             )

--- a/unique_toolkit/unique_toolkit/agentic/tools/a2a/tool/config.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/a2a/tool/config.py
@@ -1,8 +1,9 @@
+import logging
 import re
 from enum import StrEnum
-from typing import Annotated, Generic, Literal, TypeVar
+from typing import Annotated, Generic, Literal, Self, TypeVar
 
-from pydantic import Field, field_validator
+from pydantic import Field, field_validator, model_validator
 from pydantic.main import BaseModel
 
 from unique_toolkit._common.pydantic.rjsf_tags import RJSFMetaTag
@@ -24,6 +25,9 @@ class SystemReminderConfig(BaseModel, Generic[T]):
     model_config = get_configuration_dict()
 
     type: T
+
+
+_LOGGER = logging.getLogger(__name__)
 
 
 _SYSTEM_REMINDER_FIELD_DESCRIPTION = """
@@ -127,11 +131,6 @@ class SubAgentToolConfig(BaseToolConfig):
         description="The list of tool names that will be forced to be called for this sub-agent.",
     )
 
-    @field_validator("forced_tools", mode="before")
-    @classmethod
-    def _coerce_forced_tools_none(cls, v: list[str] | None) -> list[str]:
-        return v if v is not None else []
-
     tool_description_for_system_prompt: Annotated[
         str, RJSFMetaTag.StringWidget.textarea(rows=3)
     ] = Field(
@@ -171,10 +170,12 @@ class SubAgentToolConfig(BaseToolConfig):
     poll_interval: Annotated[float, RJSFMetaTag.NumberWidget.updown()] = Field(
         default=1.0,
         description="Time interval in seconds between polling attempts when waiting for sub-agent response.",
+        gt=0,
     )
     max_wait: Annotated[float, RJSFMetaTag.NumberWidget.updown()] = Field(
         default=120.0,
         description="Maximum time in seconds to wait for the sub-agent response before timing out.",
+        gt=0,
     )
     stop_condition: Literal["stoppedStreamingAt", "completedAt"] = Field(
         default="completedAt",
@@ -188,14 +189,13 @@ class SubAgentToolConfig(BaseToolConfig):
         description="Optional: A custom JSON schema to send to the llm as the tool input schema.",
     )
 
-    @field_validator("tool_input_json_schema", mode="before")
-    @classmethod
-    def _coerce_tool_input_json_schema_none(cls, v: str | None) -> str:
-        return v if v is not None else ""
-
     returns_content_chunks: bool = Field(
         default=False,
         description="If set, the sub-agent response will be interpreted as a list of content chunks.",
+    )
+    response_passthrough: bool = Field(
+        default=False,
+        description="If set, this sub agent's response will be directly displayed to the user once called, ending the orchestrator loop.",
     )
 
     system_reminders_config: list[
@@ -207,3 +207,38 @@ class SubAgentToolConfig(BaseToolConfig):
         default=[],
         description="Configuration for the system reminders to add to the tool response.",
     )
+
+    @field_validator("forced_tools", mode="before")
+    @classmethod
+    def _coerce_forced_tools_none(cls, v: list[str] | None) -> list[str]:
+        return v if v is not None else []
+
+    @field_validator("tool_input_json_schema", mode="before")
+    @classmethod
+    def _coerce_tool_input_json_schema_none(cls, v: str | None) -> str:
+        return v if v is not None else ""
+
+    @model_validator(mode="after")
+    def _ensure_response_passthrough_and_returns_content_chunks_mutually_exclusive(
+        self,
+    ) -> Self:
+        if self.response_passthrough and self.returns_content_chunks:
+            raise ValueError(
+                f"SubAgent (assistant_id={self.assistant_id!r}): "
+                "`response_passthrough` and `returns_content_chunks` are mutually exclusive."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _ensure_use_sub_agent_references_off_when_tool_response_passthrough(
+        self,
+    ) -> Self:
+        if self.response_passthrough and self.use_sub_agent_references:
+            _LOGGER.warning(
+                "SubAgent (assistant_id=%r): `response_passthrough=True` and `use_sub_agent_references=True`. "
+                "`use_sub_agent_references` will be overridden to False.",
+                self.assistant_id,
+            )
+            self.use_sub_agent_references = False
+
+        return self

--- a/unique_toolkit/unique_toolkit/agentic/tools/a2a/tool/config.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/a2a/tool/config.py
@@ -144,6 +144,11 @@ class SubAgentToolConfig(BaseToolConfig):
         description="The list of tool names that will be forced to be called for this sub-agent.",
     )
 
+    @field_validator("forced_tools", mode="before")
+    @classmethod
+    def _coerce_forced_tools_none(cls, v: list[str] | None) -> list[str]:
+        return v if v is not None else []
+
     tool_description_for_system_prompt: Annotated[
         str, RJSFMetaTag.StringWidget.textarea(rows=3)
     ] = Field(
@@ -202,6 +207,11 @@ class SubAgentToolConfig(BaseToolConfig):
         description="Optional: A custom JSON schema to send to the llm as the tool input schema.",
     )
 
+    @field_validator("tool_input_json_schema", mode="before")
+    @classmethod
+    def _coerce_tool_input_json_schema_none(cls, v: str | None) -> str:
+        return v if v is not None else ""
+
     returns_content_chunks: bool = Field(
         default=False,
         description="If set, the sub-agent response will be interpreted as a list of content chunks.",
@@ -221,16 +231,6 @@ class SubAgentToolConfig(BaseToolConfig):
         default=[],
         description="Configuration for the system reminders to add to the tool response.",
     )
-
-    @field_validator("forced_tools", mode="before")
-    @classmethod
-    def _coerce_forced_tools_none(cls, v: list[str] | None) -> list[str]:
-        return v if v is not None else []
-
-    @field_validator("tool_input_json_schema", mode="before")
-    @classmethod
-    def _coerce_tool_input_json_schema_none(cls, v: str | None) -> str:
-        return v if v is not None else ""
 
     @model_validator(mode="after")
     def _ensure_response_passthrough_and_returns_content_chunks_mutually_exclusive(

--- a/unique_toolkit/unique_toolkit/agentic/tools/a2a/tool/config.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/a2a/tool/config.py
@@ -209,7 +209,7 @@ class SubAgentToolConfig(BaseToolConfig):
     passthrough_config: SubAgentPassthroughConfig = Field(
         default_factory=SubAgentPassthroughConfig,
         description="Configuration for streaming the sub-agent response directly back to the user.",
-        title="Direct Streaming Configuration",
+        title="Direct Streaming Configuration (Experimental)",
     )
 
     system_reminders_config: list[

--- a/unique_toolkit/unique_toolkit/agentic/tools/a2a/tool/service.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/a2a/tool/service.py
@@ -11,6 +11,7 @@ from pydantic import Field, TypeAdapter, create_model
 from unique_sdk.api_resources._space import Space
 from unique_sdk.utils.chat_in_space import send_message_and_wait_for_completion
 
+from unique_toolkit._common.execution import SafeTaskExecutor
 from unique_toolkit._common.referencing import (
     get_all_ref_numbers,
     get_detection_pattern_for_ref,
@@ -41,7 +42,13 @@ from unique_toolkit.agentic.tools.tool_progress_reporter import (
     ToolProgressReporter,
 )
 from unique_toolkit.app import ChatEvent
-from unique_toolkit.chat.schemas import MessageLog, MessageLogStatus
+from unique_toolkit.chat.schemas import (
+    ChatMessageAssessmentLabel,
+    ChatMessageAssessmentStatus,
+    ChatMessageAssessmentType,
+    MessageLog,
+    MessageLogStatus,
+)
 from unique_toolkit.chat.service import ChatService
 from unique_toolkit.content import ContentChunk, ContentReference
 from unique_toolkit.language_model import (
@@ -148,7 +155,7 @@ class SubAgentTool(Tool[SubAgentToolConfig]):
 
     @override
     def takes_control(self) -> bool:
-        return self.config.response_passthrough
+        return self.config.passthrough_config.enabled
 
     @override
     def evaluation_check_list(self) -> list[EvaluationMetricName]:
@@ -277,7 +284,7 @@ class SubAgentTool(Tool[SubAgentToolConfig]):
                     active_message_log=active_message_log,
                 )
 
-                if self.config.response_passthrough:
+                if self.config.passthrough_config.enabled:
                     await self._display_sub_agent_response(response)
 
                 return ToolCallResponse(
@@ -319,6 +326,37 @@ class SubAgentTool(Tool[SubAgentToolConfig]):
                 for ref in response["references"] or []
             ],
             set_completed_at=True,
+        )
+
+        if self.config.passthrough_config.include_assessments:
+            await self._forward_sub_agent_assessments(response["assessment"] or [])
+
+    async def _forward_sub_agent_assessments(
+        self,
+        assessments: list[unique_sdk.Space.Assessment],
+    ) -> None:
+        async def _create_one_assessment(
+            assessment: unique_sdk.Space.Assessment,
+        ) -> None:
+            await self._chat_service.create_message_assessment_async(
+                assistant_message_id=self._chat_service._assistant_message_id,
+                status=ChatMessageAssessmentStatus(assessment["status"]),
+                type=ChatMessageAssessmentType(assessment["type"]),
+                title=assessment["title"],
+                explanation=assessment["explanation"],
+                label=ChatMessageAssessmentLabel(assessment["label"]),
+                is_visible=assessment["isVisible"],
+            )
+
+        if not assessments:
+            return
+
+        task_executor = SafeTaskExecutor(logger=logger)
+        await asyncio.gather(
+            *(
+                task_executor.execute_async(_create_one_assessment, a)
+                for a in assessments
+            ),
         )
 
     async def _get_chat_id(self) -> str | None:

--- a/unique_toolkit/unique_toolkit/agentic/tools/a2a/tool/service.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/a2a/tool/service.py
@@ -226,6 +226,7 @@ class SubAgentTool(Tool[SubAgentToolConfig]):
                 self._should_run_evaluation |= (
                     response["assessment"] is not None
                     and len(response["assessment"]) > 0
+                    and not self.config.passthrough_config.enabled
                 )  # Run evaluation if any sub agent returned an assessment
 
                 self._notify_watcher(response, sequence_number, timestamp)

--- a/unique_toolkit/unique_toolkit/agentic/tools/a2a/tool/service.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/a2a/tool/service.py
@@ -43,7 +43,7 @@ from unique_toolkit.agentic.tools.tool_progress_reporter import (
 from unique_toolkit.app import ChatEvent
 from unique_toolkit.chat.schemas import MessageLog, MessageLogStatus
 from unique_toolkit.chat.service import ChatService
-from unique_toolkit.content import ContentChunk
+from unique_toolkit.content import ContentChunk, ContentReference
 from unique_toolkit.language_model import (
     LanguageModelFunction,
     LanguageModelToolDescription,
@@ -145,6 +145,10 @@ class SubAgentTool(Tool[SubAgentToolConfig]):
     @override
     def tool_format_information_for_user_prompt(self) -> str:
         return self.config.tool_format_information_for_user_prompt
+
+    @override
+    def takes_control(self) -> bool:
+        return self.config.response_passthrough
 
     @override
     def evaluation_check_list(self) -> list[EvaluationMetricName]:
@@ -273,6 +277,9 @@ class SubAgentTool(Tool[SubAgentToolConfig]):
                     active_message_log=active_message_log,
                 )
 
+                if self.config.response_passthrough:
+                    await self._display_sub_agent_response(response)
+
                 return ToolCallResponse(
                     id=tool_call.id,
                     name=tool_call.name,
@@ -302,6 +309,17 @@ class SubAgentTool(Tool[SubAgentToolConfig]):
                 active_message_log=active_message_log,
             )
             raise e
+
+    async def _display_sub_agent_response(self, response: Space.Message) -> None:
+        await self._chat_service.modify_assistant_message_async(
+            content=response["text"],
+            original_content=response["originalText"],
+            references=[
+                ContentReference.from_sdk_reference(ref)
+                for ref in response["references"] or []
+            ],
+            set_completed_at=True,
+        )
 
     async def _get_chat_id(self) -> str | None:
         if not self.config.reuse_chat:

--- a/unique_toolkit/unique_toolkit/agentic/tools/a2a/tool/service.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/a2a/tool/service.py
@@ -318,6 +318,17 @@ class SubAgentTool(Tool[SubAgentToolConfig]):
             raise e
 
     async def _display_sub_agent_response(self, response: Space.Message) -> None:
+        await self._publish_sub_agent_response(response, set_completed_at=True)
+
+        if self.config.passthrough_config.include_assessments:
+            await self._forward_sub_agent_assessments(response["assessment"] or [])
+
+    async def _publish_sub_agent_response(
+        self,
+        response: Space.Message,
+        *,
+        set_completed_at: bool,
+    ) -> None:
         await self._chat_service.modify_assistant_message_async(
             content=response["text"],
             original_content=response["originalText"],
@@ -325,11 +336,20 @@ class SubAgentTool(Tool[SubAgentToolConfig]):
                 ContentReference.from_sdk_reference(ref)
                 for ref in response["references"] or []
             ],
-            set_completed_at=True,
+            set_completed_at=set_completed_at,
         )
 
-        if self.config.passthrough_config.include_assessments:
-            await self._forward_sub_agent_assessments(response["assessment"] or [])
+    async def _publish_sub_agent_response_update(
+        self,
+        response: Space.Message,
+    ) -> None:
+        try:
+            await self._publish_sub_agent_response(response, set_completed_at=False)
+        except Exception:
+            logger.warning(
+                "Failed to publish streaming sub agent passthrough update",
+                exc_info=True,
+            )
 
     async def _forward_sub_agent_assessments(
         self,
@@ -444,6 +464,12 @@ class SubAgentTool(Tool[SubAgentToolConfig]):
         active_message_log: MessageLog | None = None,
     ) -> unique_sdk.Space.Message:
         try:
+            on_message_update = (
+                self._publish_sub_agent_response_update
+                if self.config.passthrough_config.enabled
+                else None
+            )
+
             return await send_message_and_wait_for_completion(
                 user_id=self._user_id,
                 assistant_id=self.config.assistant_id,
@@ -459,6 +485,7 @@ class SubAgentTool(Tool[SubAgentToolConfig]):
                     parentChatId=self._event.payload.chat_id,
                     parentAssistantId=self.config.assistant_id,
                 ),
+                on_message_update=on_message_update,
             )
         except TimeoutError as e:
             await self._notify_progress(

--- a/unique_toolkit/unique_toolkit/agentic/tools/tool_manager.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/tool_manager.py
@@ -334,7 +334,7 @@ class _ToolManager(Generic[_ApiMode]):
     ) -> ToolCallResponse:
         if tool_call.name in take_control_names:
             content = (
-                f"ERROR: Tool `{tool_call.name}` directly return its response to the user and therefore must be called on its own. "
+                f"ERROR: Tool `{tool_call.name}` directly returns its response to the user and therefore must be called on its own. "
                 "None of the tools in this batch were executed. "
                 f"You may recover by first calling the other tools, then calling `{tool_call.name}` alone."
             )

--- a/unique_toolkit/unique_toolkit/agentic/tools/tool_manager.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/tool_manager.py
@@ -310,20 +310,65 @@ class _ToolManager(Generic[_ApiMode]):
         if tool.name not in self._tool_choices:
             self._tool_choices.append(tool.name)
 
-    def does_a_tool_take_control(self, tool_calls: list[LanguageModelFunction]) -> bool:
+    def _get_tool_calls_that_take_control(
+        self, tool_calls: list[LanguageModelFunction]
+    ) -> list[LanguageModelFunction]:
+        tools = []
         for tool_call in tool_calls:
             tool_instance = self.get_tool_by_name(tool_call.name)
             if tool_instance and tool_instance.takes_control():
-                return True
-        return False
+                tools.append(tool_call)
+
+        return tools
+
+    def does_a_tool_take_control(self, tool_calls: list[LanguageModelFunction]) -> bool:
+        return len(self._get_tool_calls_that_take_control(tool_calls)) > 0
 
     def get_evaluation_check_list(self) -> list[EvaluationMetricName]:
         return list(self._tool_evaluation_check_list)
+
+    def _take_control_conflict_response(
+        self,
+        tool_call: LanguageModelFunction,
+        take_control_names: list[str],
+    ) -> ToolCallResponse:
+        if tool_call.name in take_control_names:
+            content = (
+                f"ERROR: Tool `{tool_call.name}` directly return its response to the user and therefore must be called on its own. "
+                "None of the tools in this batch were executed. "
+                f"You may recover by first calling the other tools, then calling `{tool_call.name}` alone."
+            )
+        else:
+            names = ", ".join(f"`{n}`" for n in take_control_names)
+            content = f"ERROR: Not executed because the following tool(s) must be called on their own: {names}"
+
+        return ToolCallResponse(
+            id=tool_call.id,
+            name=tool_call.name,
+            content=content,
+        )
 
     async def execute_selected_tools(
         self,
         tool_calls: list[LanguageModelFunction],
     ) -> list[ToolCallResponse]:
+        if len(tool_calls) > 1:
+            take_control_tools = [
+                t.name for t in self._get_tool_calls_that_take_control(tool_calls)
+            ]
+
+            if len(take_control_tools) > 0:
+                self._logger.warning(
+                    "Tool(s) %s take control and cannot be called alongside other tools. "
+                    "Returning error for all %d tool calls.",
+                    take_control_tools,
+                    len(tool_calls),
+                )
+                return [
+                    self._take_control_conflict_response(tool_call, take_control_tools)
+                    for tool_call in tool_calls
+                ]
+
         tool_call_responses = await self._execute_parallelized(tool_calls)
         return tool_call_responses
 

--- a/unique_toolkit/unique_toolkit/content/schemas.py
+++ b/unique_toolkit/unique_toolkit/content/schemas.py
@@ -223,7 +223,8 @@ class ContentReference(BaseModel):
 
     @classmethod
     def from_sdk_reference(
-        cls, reference: unique_sdk.Message.Reference | unique_sdk.Space.Reference
+        cls,
+        reference: unique_sdk.Message.Reference | unique_sdk.Space.Reference,
     ) -> "ContentReference":
         kwargs: dict[str, Any] = {
             "name": reference["name"],


### PR DESCRIPTION
## 🚀 Summary
Refs: [UN-21112](https://unique-ch.atlassian.net/browse/UN-21112)

Lets a sub-agent's reply stream straight back to the user, ending the orchestrator loop. Optionally forwards the sub-agent's message assessments along with it.


## ✅ Changes

- [x] New \`SubAgentPassthroughConfig\` (\`enabled\` + \`include_assessments\`) on \`SubAgentToolConfig\`
- [x] \`SubAgentTool\` streams text/refs via \`modify_assistant_message_async\` and forwards assessments
- [x] \`ToolManager\` returns a conflict error if a take-control tool is called alongside others

## 🧪 Testing

Unit tests under \`tests/agentic/tools/\` for the config validators, assessment forwarding, and the take-control batch guard.
Manual local tests.

[UN-21112]: https://unique-ch.atlassian.net/browse/UN-21112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ