### PR TITLE
feat(cli): add citation tracking to unique-cli search

### DIFF
--- a/unique_sdk/tests/cli/test_search.py
+++ b/unique_sdk/tests/cli/test_search.py
@@ -1,0 +1,449 @@
+"""Tests for the unique-cli search subcommand and its citation manifest.
+
+Structured to mirror ``tests/cli/test_web_search.py`` from PR #1733 — both
+commands write to ``.unique/`` JSONL manifests via shared helpers in
+``unique_sdk.cli.commands._citation_manifest``, so the test layout stays
+symmetric.
+
+Unlike web-search, which dedupes manifest entries by URL, KB search
+appends one manifest line per result every time. That is intentional:
+each ContentChunk is a distinct citation target (different page range,
+different chunk_id, ...), so URL-based dedup would collapse chunks that
+the runner expects to keep separate. The
+``test_kb_does_not_dedupe_repeated_results`` case below exists so future
+readers don't accidentally introduce parity with the web-search path.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import unique_sdk
+from unique_sdk.cli.commands._citation_manifest import (
+    UnsafeRefsLogPathError,
+    _append_turn_refs_manifest_entry,
+    _assert_safe_refs_log_path,
+    _locked_turn_refs_manifest,
+    _read_turn_refs_manifest,
+)
+from unique_sdk.cli.commands.search import (
+    SEARCH_ERROR_PREFIX,
+    _build_metadata_filter,
+    _format_source_block,
+    _result_to_chunk_payload,
+    cmd_search,
+    is_error_output,
+)
+from unique_sdk.cli.config import Config
+from unique_sdk.cli.state import ShellState
+
+
+def _config() -> Config:
+    return Config(
+        user_id="u1",
+        company_id="c1",
+        api_key="key",
+        app_id="app",
+        api_base="https://example.com",
+    )
+
+
+def _state(path: str = "/", scope_id: str | None = None) -> ShellState:
+    s = ShellState(_config())
+    s._path = path
+    s._scope_id = scope_id
+    return s
+
+
+@pytest.fixture(autouse=True)
+def _isolate_turn_refs_manifest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pin every test's cwd into ``tmp_path``.
+
+    ``cmd_search`` defaults the manifest path to ``<cwd>/.unique/turn-refs.jsonl``;
+    isolating cwd keeps concurrent tests from clobbering each other's
+    manifest and matches the autouse fixture pattern in
+    ``test_web_search.py``.
+    """
+    monkeypatch.chdir(tmp_path)
+
+
+def _make_search_result(
+    *,
+    content_id: str = "cont_abc",
+    chunk_id: str = "chunk_xyz",
+    text: str = "...the quarterly revenue analysis shows a 15% increase...",
+    order: int = 0,
+    key: str | None = "annual-report.pdf",
+    url: str | None = None,
+    title: str | None = "annual-report.pdf",
+    start_page: int | None = 12,
+    end_page: int | None = 13,
+    metadata: dict[str, Any] | None = None,
+    created_at: str | None = "2026-01-01T00:00:00Z",
+    updated_at: str | None = "2026-01-02T00:00:00Z",
+) -> MagicMock:
+    """Stand-in for a ``unique_sdk.Search`` result with the attrs we read."""
+    result = MagicMock()
+    result.id = content_id
+    result.chunkId = chunk_id
+    result.text = text
+    result.order = order
+    result.key = key
+    result.url = url
+    result.title = title
+    result.startPage = start_page
+    result.endPage = end_page
+    result.metadata = metadata
+    result.createdAt = created_at
+    result.updatedAt = updated_at
+    return result
+
+
+class TestBuildMetadataFilter:
+    def test_none_returns_none(self) -> None:
+        assert _build_metadata_filter(None, None) is None
+
+    def test_folder_only(self) -> None:
+        result = _build_metadata_filter("scope_abc", None)
+        assert result is not None
+        assert result["path"] == ["folderIdPath"]
+        assert "scope_abc" in result["value"]
+
+    def test_metadata_only(self) -> None:
+        result = _build_metadata_filter(None, [("dept", "Legal")])
+        assert result is not None
+        assert result["path"] == ["dept"]
+        assert result["value"] == "Legal"
+
+    def test_combined_is_anded(self) -> None:
+        result = _build_metadata_filter("scope_abc", [("dept", "Legal")])
+        assert result is not None
+        assert "and" in result
+
+
+class TestFormatSourceBlock:
+    def test_block_shape(self) -> None:
+        block = _format_source_block(1, _make_search_result())
+        assert block.startswith("<source1>\n")
+        assert block.endswith("\n</source1>")
+        assert "<|document|>annual-report.pdf</|document|>" in block
+        assert "<|page|>12-13</|page|>" in block
+        assert "<|info|>cont_abc</|info|>" in block
+
+    def test_single_page_block(self) -> None:
+        block = _format_source_block(3, _make_search_result(start_page=5, end_page=5))
+        assert "<|page|>5</|page|>" in block
+
+    def test_block_without_pages(self) -> None:
+        block = _format_source_block(
+            7, _make_search_result(start_page=None, end_page=None)
+        )
+        assert "<|page|>" not in block
+
+    def test_block_uses_key_when_title_missing(self) -> None:
+        block = _format_source_block(
+            2, _make_search_result(title=None, key="fallback.txt")
+        )
+        assert "<|document|>fallback.txt</|document|>" in block
+
+    def test_block_falls_back_to_content_id(self) -> None:
+        block = _format_source_block(
+            4, _make_search_result(title=None, key=None, content_id="cont_only")
+        )
+        assert "<|document|>content cont_only</|document|>" in block
+
+
+class TestResultToChunkPayload:
+    def test_emits_all_camelcase_keys(self) -> None:
+        payload = _result_to_chunk_payload(
+            _make_search_result(
+                metadata={"department": "Finance"},
+            )
+        )
+        assert payload == {
+            "id": "cont_abc",
+            "chunkId": "chunk_xyz",
+            "text": "...the quarterly revenue analysis shows a 15% increase...",
+            "order": 0,
+            "key": "annual-report.pdf",
+            "url": None,
+            "title": "annual-report.pdf",
+            "startPage": 12,
+            "endPage": 13,
+            "metadata": {"department": "Finance"},
+            "createdAt": "2026-01-01T00:00:00Z",
+            "updatedAt": "2026-01-02T00:00:00Z",
+        }
+
+    def test_non_dict_metadata_is_dropped(self) -> None:
+        result = _make_search_result(metadata="not-a-dict")  # type: ignore[arg-type]
+        assert _result_to_chunk_payload(result)["metadata"] is None
+
+
+class TestCmdSearchCitations:
+    @patch("unique_sdk.Search.create")
+    def test_happy_path_writes_block_and_manifest(self, mock: MagicMock) -> None:
+        mock.return_value = [_make_search_result()]
+
+        out = cmd_search(_state(), "quarterly revenue")
+
+        assert "Found 1 result(s):" in out
+        assert "<source1>" in out
+        assert "</source1>" in out
+        assert "<|document|>annual-report.pdf</|document|>" in out
+        assert "<|page|>12-13</|page|>" in out
+        assert "<|info|>cont_abc</|info|>" in out
+
+        manifest = Path.cwd() / ".unique" / "turn-refs.jsonl"
+        lines = manifest.read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 1
+        entry = json.loads(lines[0])
+        assert entry == {
+            "id": "cont_abc",
+            "chunkId": "chunk_xyz",
+            "text": "...the quarterly revenue analysis shows a 15% increase...",
+            "order": 0,
+            "key": "annual-report.pdf",
+            "url": None,
+            "title": "annual-report.pdf",
+            "startPage": 12,
+            "endPage": 13,
+            "metadata": None,
+            "createdAt": "2026-01-01T00:00:00Z",
+            "updatedAt": "2026-01-02T00:00:00Z",
+        }
+
+    @patch("unique_sdk.Search.create")
+    def test_numbering_continues_across_two_calls(self, mock: MagicMock) -> None:
+        mock.side_effect = [
+            [
+                _make_search_result(content_id="cont_a", chunk_id="chunk_a"),
+                _make_search_result(content_id="cont_b", chunk_id="chunk_b"),
+            ],
+            [
+                _make_search_result(content_id="cont_c", chunk_id="chunk_c"),
+            ],
+        ]
+
+        first = cmd_search(_state(), "query one")
+        second = cmd_search(_state(), "query two")
+
+        assert "<source1>" in first
+        assert "<source2>" in first
+        assert "<source3>" in second
+
+        manifest = Path.cwd() / ".unique" / "turn-refs.jsonl"
+        ids = [
+            json.loads(line)["id"]
+            for line in manifest.read_text(encoding="utf-8").splitlines()
+        ]
+        assert ids == ["cont_a", "cont_b", "cont_c"]
+
+    @patch("unique_sdk.Search.create")
+    def test_kb_does_not_dedupe_repeated_results(self, mock: MagicMock) -> None:
+        # NOTE: unique-cli web-search dedupes results by URL so the same URL
+        # keeps the same `websourceN`. KB search intentionally does NOT
+        # dedupe — each ContentChunk is its own citation target (page
+        # range, chunk_id differ in general). If a future change tries to
+        # add URL- or id-based dedup here, drop it: the runner relies on
+        # one manifest line per `<sourceN>` block emitted to the LLM.
+        same = _make_search_result(content_id="cont_dup", chunk_id="chunk_dup")
+        mock.return_value = [same, same]
+
+        out = cmd_search(_state(), "duplicate")
+
+        assert "<source1>" in out
+        assert "<source2>" in out
+        manifest = Path.cwd() / ".unique" / "turn-refs.jsonl"
+        assert len(manifest.read_text(encoding="utf-8").splitlines()) == 2
+
+    @patch("unique_sdk.Search.create")
+    def test_malformed_existing_manifest_lines_are_skipped(
+        self, mock: MagicMock
+    ) -> None:
+        manifest_dir = Path.cwd() / ".unique"
+        manifest_dir.mkdir()
+        manifest = manifest_dir / "turn-refs.jsonl"
+        manifest.write_text(
+            "\n".join(
+                [
+                    json.dumps({"id": "cont_pre", "text": "previous"}),
+                    "not-json",
+                    "{not even close}",
+                    "",
+                    json.dumps({"id": "cont_pre2", "text": "still here"}),
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        mock.return_value = [_make_search_result(content_id="cont_new")]
+        out = cmd_search(_state(), "query")
+
+        # 2 valid pre-existing entries + 1 new = the new block must be source3.
+        assert "<source3>" in out
+        ids = [
+            json.loads(line)["id"]
+            for line in manifest.read_text(encoding="utf-8").splitlines()
+            if line.strip().startswith("{") and "id" in line
+        ]
+        assert ids[-1] == "cont_new"
+
+    @patch("unique_sdk.Search.create")
+    def test_empty_results_no_manifest_write(self, mock: MagicMock) -> None:
+        mock.return_value = []
+        out = cmd_search(_state(), "no hits")
+        assert "No results found" in out
+        assert not (Path.cwd() / ".unique").exists()
+
+    @patch("unique_sdk.Search.create")
+    def test_api_error_returns_prefix_and_writes_nothing(self, mock: MagicMock) -> None:
+        mock.side_effect = ValueError("boom")
+        out = cmd_search(_state(), "fail")
+        assert out.startswith(SEARCH_ERROR_PREFIX)
+        assert "boom" in out
+        assert not (Path.cwd() / ".unique").exists()
+
+    @patch("unique_sdk.Search.create")
+    def test_symlinked_unique_dir_returns_error_and_skips_write(
+        self, mock: MagicMock, tmp_path: Path
+    ) -> None:
+        # Replace .unique with a symlink to a sibling dir to exercise the
+        # _assert_safe_refs_log_path guard. The command should refuse to
+        # write and surface a "search: ..." error string.
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+        unique_dir = Path.cwd() / ".unique"
+        os.symlink(elsewhere, unique_dir, target_is_directory=True)
+
+        mock.return_value = [_make_search_result()]
+        out = cmd_search(_state(), "query")
+
+        assert out.startswith(SEARCH_ERROR_PREFIX)
+        # No manifest in the real target dir either — the safety check
+        # fires before the write happens.
+        assert not (elsewhere / "turn-refs.jsonl").exists()
+
+
+class TestIsErrorOutput:
+    def test_error_string_is_error(self) -> None:
+        assert is_error_output(f"{SEARCH_ERROR_PREFIX} something failed") is True
+
+    def test_normal_output_is_not_error(self) -> None:
+        assert is_error_output("Found 1 result(s):\n<source1>...</source1>") is False
+
+
+class TestCitationManifestHelpers:
+    """Direct tests of the shared `_citation_manifest` module."""
+
+    def test_read_skips_blank_and_invalid_lines(self, tmp_path: Path) -> None:
+        manifest = tmp_path / ".unique" / "turn-refs.jsonl"
+        manifest.parent.mkdir()
+        manifest.write_text(
+            "\n".join(
+                [
+                    "",
+                    "not json",
+                    json.dumps({"id": "a"}),
+                    json.dumps(["array", "is", "skipped"]),
+                    json.dumps({"id": "b"}),
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        entries = _read_turn_refs_manifest(manifest)
+        assert [e["id"] for e in entries] == ["a", "b"]
+
+    def test_append_creates_parent_dir(self, tmp_path: Path) -> None:
+        manifest = tmp_path / ".unique" / "turn-refs.jsonl"
+        _append_turn_refs_manifest_entry(manifest, {"id": "first"})
+        _append_turn_refs_manifest_entry(manifest, {"id": "second"})
+        lines = manifest.read_text(encoding="utf-8").splitlines()
+        assert [json.loads(line)["id"] for line in lines] == ["first", "second"]
+
+    def test_assert_safe_rejects_symlinked_parent(self, tmp_path: Path) -> None:
+        real_dir = tmp_path / "real"
+        real_dir.mkdir()
+        link_dir = tmp_path / "link_to_real"
+        os.symlink(real_dir, link_dir, target_is_directory=True)
+        manifest = link_dir / "turn-refs.jsonl"
+
+        with pytest.raises(UnsafeRefsLogPathError):
+            _assert_safe_refs_log_path(manifest)
+
+    def test_locked_manifest_runs_critical_section(self, tmp_path: Path) -> None:
+        manifest = tmp_path / ".unique" / "turn-refs.jsonl"
+        with _locked_turn_refs_manifest(manifest, lock_filename="turn-refs.lock"):
+            _append_turn_refs_manifest_entry(manifest, {"id": "under-lock"})
+        lock_file = manifest.parent / "turn-refs.lock"
+        assert lock_file.exists()
+        assert json.loads(manifest.read_text(encoding="utf-8").splitlines()[0]) == {
+            "id": "under-lock"
+        }
+
+
+class TestContentChunkRoundTrip:
+    """Verify the manifest line shape rehydrates as a ``ContentChunk``.
+
+    Skipped when ``unique_toolkit`` is not installed in the test
+    environment — the SDK package on CI does not pull it in, so this
+    test depends on having the workspace toolkit available locally.
+    """
+
+    def test_manifest_line_rehydrates_as_content_chunk(self) -> None:
+        pytest.importorskip("unique_toolkit")
+        from unique_toolkit.content.schemas import ContentChunk
+
+        payload = _result_to_chunk_payload(
+            _make_search_result(
+                metadata={"key": "annual-report.pdf", "mimeType": "application/pdf"},
+            )
+        )
+        line = json.dumps(payload, default=str)
+        chunk = ContentChunk.model_validate(json.loads(line))
+
+        assert chunk.id == "cont_abc"
+        assert chunk.chunk_id == "chunk_xyz"
+        assert chunk.text.startswith("...the quarterly")
+        assert chunk.title == "annual-report.pdf"
+        assert chunk.start_page == 12
+        assert chunk.end_page == 13
+        assert chunk.metadata is not None
+        assert chunk.metadata.key == "annual-report.pdf"
+        assert chunk.metadata.mime_type == "application/pdf"
+
+
+class TestCmdSearchCallShapes:
+    """Existing happy-path call-shape coverage, kept here so the new module
+    is self-contained alongside test_commands.py (no extra surface)."""
+
+    @patch("unique_sdk.Search.create")
+    def test_scope_id_passed_through(self, mock: MagicMock) -> None:
+        mock.return_value = []
+        cmd_search(_state("/R", "scope_r"), "q")
+        assert mock.call_args[1]["scopeIds"] == ["scope_r"]
+
+    @patch("unique_sdk.Search.create")
+    def test_uses_workspace_scope_ids_when_no_folder(self, mock: MagicMock) -> None:
+        mock.return_value = []
+        s = _state()
+        s.workspace_scope_ids = ["scope_ws1", "scope_ws2"]
+        cmd_search(s, "q")
+        assert mock.call_args[1]["scopeIds"] == ["scope_ws1", "scope_ws2"]
+
+    @patch("unique_sdk.Search.create")
+    def test_api_error_includes_prefix(self, mock: MagicMock) -> None:
+        mock.side_effect = unique_sdk.APIError("oops")
+        out = cmd_search(_state(), "q")
+        assert out.startswith(SEARCH_ERROR_PREFIX)
+        assert "oops" in out

--- a/unique_sdk/unique_sdk/cli/commands/_citation_manifest.py
+++ b/unique_sdk/unique_sdk/cli/commands/_citation_manifest.py
@@ -1,0 +1,171 @@
+"""Shared helpers for the per-turn citation refs manifest under ``.unique/``.
+
+Both ``unique-cli search`` (KB) and ``unique-cli web-search`` (web) append
+to a small per-turn JSONL file inside the current workspace's ``.unique``
+directory so that the Swappable Intelligence runner can later substitute
+``[sourceN]`` / ``[websourceN]`` markers in the LLM answer with footnotes
+and reference chips.
+
+The handshake is symmetric across the two callers — the file name, lock
+file name, and on-disk layout differ, but the safety + locking +
+read/append semantics are identical. This module owns that machinery so
+neither caller has to maintain its own copy.
+
+Each caller passes its own ``refs_log_path`` (absolute path) and lock
+filename in. Nothing in this module is web- or KB-specific.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+
+class UnsafeRefsLogPathError(OSError):
+    """Raised when the internal refs log path would follow a symlink.
+
+    Callers should treat this as a hard failure for the current command —
+    refuse to render results, and surface the error via the caller's
+    usual ``<prefix>: <message>`` error string convention.
+    """
+
+
+def _assert_safe_refs_log_path(refs_log_path: Path) -> None:
+    """Reject symlinks for the parent dir, the manifest, or any file at
+    the same path that is not a regular file.
+
+    This is intentionally strict: the manifest path is a fixed,
+    well-known handoff path used by another process (the runner) running
+    in the same workspace. Following symlinks here would let a malicious
+    workspace redirect writes elsewhere.
+    """
+    refs_log_dir = refs_log_path.parent
+    if refs_log_dir.is_symlink() or (
+        refs_log_dir.exists() and not refs_log_dir.is_dir()
+    ):
+        raise UnsafeRefsLogPathError(
+            f"refusing unsafe refs log directory: {refs_log_dir}"
+        )
+    if refs_log_path.is_symlink():
+        raise UnsafeRefsLogPathError(f"refusing unsafe refs log file: {refs_log_path}")
+    if refs_log_path.exists() and not refs_log_path.is_file():
+        raise UnsafeRefsLogPathError(f"refusing unsafe refs log file: {refs_log_path}")
+
+
+def _read_turn_refs_manifest(refs_log_path: Path) -> list[dict[str, Any]]:
+    """Return all valid JSON object lines from the manifest, in order.
+
+    Blank lines and lines that fail to parse as a JSON object are
+    silently skipped — this matches the runner's tolerance for malformed
+    lines and keeps a stray partial write from breaking the next call.
+    """
+    _assert_safe_refs_log_path(refs_log_path)
+    if not refs_log_path.is_file():
+        return []
+    try:
+        raw_lines = refs_log_path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        raise UnsafeRefsLogPathError(
+            f"failed to read refs log: {refs_log_path}"
+        ) from exc
+
+    entries: list[dict[str, Any]] = []
+    for raw in raw_lines:
+        if not raw.strip():
+            continue
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            entries.append(payload)
+    return entries
+
+
+def _append_turn_refs_manifest_entry(
+    refs_log_path: Path,
+    payload: dict[str, Any],
+) -> None:
+    """Append one JSON object as a single line, creating parents if needed.
+
+    Uses ``O_NOFOLLOW`` and a 0o600 mode so a symlink swap between the
+    safety check and the open call still fails closed.
+    """
+    _assert_safe_refs_log_path(refs_log_path)
+    try:
+        refs_log_path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise UnsafeRefsLogPathError(
+            f"failed to create refs log directory: {refs_log_path.parent}"
+        ) from exc
+    _assert_safe_refs_log_path(refs_log_path)
+    flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    try:
+        fd = os.open(refs_log_path, flags, 0o600)
+    except OSError as exc:
+        raise UnsafeRefsLogPathError(
+            f"failed to open refs log safely: {refs_log_path}"
+        ) from exc
+    try:
+        with os.fdopen(fd, "a", encoding="utf-8") as fp:
+            fp.write(json.dumps(payload, default=str, ensure_ascii=False) + "\n")
+    except OSError as exc:
+        raise UnsafeRefsLogPathError(
+            f"failed to write refs log: {refs_log_path}"
+        ) from exc
+
+
+@contextmanager
+def _locked_turn_refs_manifest(
+    refs_log_path: Path,
+    *,
+    lock_filename: str,
+) -> Iterator[None]:
+    """Hold an ``fcntl.flock`` on a sibling lock file for the duration of
+    a read-existing → compute-next-number → append-new sequence.
+
+    The lock file lives in the same ``.unique`` directory as the manifest
+    so concurrent ``unique-cli`` invocations from the same workspace
+    serialise their appends and never race the source-number counter.
+    """
+    lock_path = refs_log_path.parent / lock_filename
+    _assert_safe_refs_log_path(lock_path)
+    try:
+        refs_log_path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise UnsafeRefsLogPathError(
+            f"failed to create refs log directory: {refs_log_path.parent}"
+        ) from exc
+    _assert_safe_refs_log_path(lock_path)
+
+    flags = os.O_RDWR | os.O_CREAT
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    try:
+        fd = os.open(lock_path, flags, 0o600)
+    except OSError as exc:
+        raise UnsafeRefsLogPathError(
+            f"failed to open refs lock safely: {lock_path}"
+        ) from exc
+
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+    except OSError as exc:
+        os.close(fd)
+        raise UnsafeRefsLogPathError(
+            f"failed to lock refs manifest: {lock_path}"
+        ) from exc
+
+    try:
+        yield
+    finally:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        except OSError:
+            pass
+        os.close(fd)

--- a/unique_sdk/unique_sdk/cli/commands/search.py
+++ b/unique_sdk/unique_sdk/cli/commands/search.py
@@ -1,15 +1,38 @@
-"""Search command: combined search with folder/metadata filters."""
+"""Search command: combined KB search with folder/metadata filters.
+
+Always emits results wrapped in ``<sourceN>...</sourceN>`` blocks and
+appends a per-turn ContentChunk-shaped manifest at
+``<cwd>/.unique/turn-refs.jsonl``. The Swappable Intelligence runner
+reads that manifest after the turn to convert ``[sourceN]`` markers in
+the LLM answer into ``<sup>N</sup>`` footnotes plus clickable reference
+chips on the Unique platform.
+
+The manifest format is identical to the legacy ``bundled_skills/kb-search``
+``search.py`` from the monorepo — that bundle is being retired in favor of
+this CLI command.
+"""
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 import unique_sdk
 from unique_sdk import UQLCombinator, UQLOperator
-from unique_sdk.cli.formatting import format_search_results
+from unique_sdk.cli.commands._citation_manifest import (
+    UnsafeRefsLogPathError,
+    _append_turn_refs_manifest_entry,
+    _locked_turn_refs_manifest,
+    _read_turn_refs_manifest,
+)
 from unique_sdk.cli.state import ShellState
 
 DEFAULT_LIMIT = 200
+
+SEARCH_ERROR_PREFIX = "search:"
+
+_REFS_LOG_RELATIVE_PATH = Path(".unique") / "turn-refs.jsonl"
+_LOCK_FILENAME = "turn-refs.lock"
 
 
 def _build_metadata_filter(
@@ -66,14 +89,125 @@ def _resolve_folder_to_scope_id(state: ShellState, folder: str) -> str:
     return scope_id
 
 
+def _format_source_block(source_number: int, result: Any) -> str:
+    """Render one search result as a ``<sourceN>...</sourceN>`` block.
+
+    Mirrors the legacy ``unique_ai`` source format that the Swappable
+    Intelligence runner's reference post-processor recognises — ``<sourceN>``
+    open/close tags with ``<|document|>``, ``<|page|>``, ``<|info|>``
+    sub-sections. The chunk-level metadata (startPage, endPage, url, etc.)
+    is captured in full in the JSONL manifest for the runner to consume;
+    only the human-relevant bits appear in the on-screen block.
+    """
+    title = (
+        getattr(result, "title", None)
+        or getattr(result, "key", None)
+        or f"content {getattr(result, 'id', '?')}"
+    )
+    content_id = getattr(result, "id", "") or ""
+    text = getattr(result, "text", "") or ""
+    start_page = getattr(result, "startPage", 0) or 0
+    end_page = getattr(result, "endPage", 0) or 0
+
+    sections: list[str] = []
+    sections.append(f"<|document|>{title}</|document|>")
+    if start_page and end_page and start_page > 0 and end_page > 0:
+        page_range = (
+            str(start_page) if start_page == end_page else f"{start_page}-{end_page}"
+        )
+        sections.append(f"<|page|>{page_range}</|page|>")
+    if content_id:
+        sections.append(f"<|info|>{content_id}</|info|>")
+    sections.append(text.strip())
+
+    body = "\n".join(sections)
+    return f"<source{source_number}>\n{body}\n</source{source_number}>"
+
+
+def _result_to_chunk_payload(result: Any) -> dict[str, Any]:
+    """Convert a ``unique_sdk.Search`` result into a ContentChunk-shaped dict.
+
+    Keys are camelCase aliases of ``unique_toolkit.content.ContentChunk``
+    fields so the runner can rehydrate them via
+    ``ContentChunk.model_validate(...)``. All keys are emitted (with
+    ``None`` when absent) to keep the per-line shape stable.
+    """
+
+    def _get(name: str, default: Any = None) -> Any:
+        return getattr(result, name, default)
+
+    metadata = _get("metadata")
+    return {
+        "id": _get("id", "") or "",
+        "chunkId": _get("chunkId"),
+        "text": _get("text", "") or "",
+        "order": _get("order", 0) or 0,
+        "key": _get("key"),
+        "url": _get("url"),
+        "title": _get("title"),
+        "startPage": _get("startPage"),
+        "endPage": _get("endPage"),
+        "metadata": metadata if isinstance(metadata, dict) else None,
+        "createdAt": _get("createdAt"),
+        "updatedAt": _get("updatedAt"),
+    }
+
+
+def _format_results_with_citations(
+    results: list[Any],
+    *,
+    refs_log_path: Path,
+) -> str:
+    """Number, format, and persist each result inside one locked critical section.
+
+    Reads the existing manifest under lock so ``sourceN`` numbering keeps
+    growing across multiple ``unique-cli search`` invocations within the
+    same turn — the runner truncates the manifest at turn start, so the
+    first call in a turn starts at 1.
+    """
+    if not results:
+        return "No results found."
+
+    with _locked_turn_refs_manifest(refs_log_path, lock_filename=_LOCK_FILENAME):
+        existing_entries = _read_turn_refs_manifest(refs_log_path)
+        starting_number = len(existing_entries) + 1
+
+        blocks: list[str] = []
+        for offset, result in enumerate(results):
+            source_number = starting_number + offset
+            blocks.append(_format_source_block(source_number, result))
+            _append_turn_refs_manifest_entry(
+                refs_log_path,
+                _result_to_chunk_payload(result),
+            )
+
+    return f"Found {len(results)} result(s):\n\n" + "\n\n".join(blocks)
+
+
 def cmd_search(
     state: ShellState,
     query: str,
     folder: str | None = None,
     metadata: list[tuple[str, str]] | None = None,
     limit: int = DEFAULT_LIMIT,
+    *,
+    refs_log_path: Path | None = None,
 ) -> str:
-    """Execute a combined search with optional folder and metadata filters."""
+    """Execute a combined search with optional folder and metadata filters.
+
+    Args:
+        state: Shell state carrying user/company credentials and cwd.
+        query: Search string.
+        folder: Optional folder path, name, or scope ID. Overrides
+            ``state.scope_id`` and ``state.workspace_scope_ids``.
+        metadata: Optional ``[(key, value), ...]`` metadata filters
+            combined with AND.
+        limit: Maximum number of results.
+        refs_log_path: Override the per-turn citation manifest path —
+            for tests; production callers leave this ``None`` so the
+            manifest lives at ``<cwd>/.unique/turn-refs.jsonl`` and the
+            Swappable Intelligence runner can find it.
+    """
     try:
         folder_scope_id: str | None = None
         if folder:
@@ -108,7 +242,21 @@ def cmd_search(
             **search_params,
         )
 
-        return format_search_results(results)
-
     except (ValueError, unique_sdk.APIError) as e:
-        return f"search: {e}"
+        return f"{SEARCH_ERROR_PREFIX} {e}"
+
+    log_path = refs_log_path or (Path.cwd() / _REFS_LOG_RELATIVE_PATH)
+    try:
+        return _format_results_with_citations(results, refs_log_path=log_path)
+    except UnsafeRefsLogPathError as exc:
+        return f"{SEARCH_ERROR_PREFIX} {exc}"
+
+
+def is_error_output(output: str) -> bool:
+    """Return ``True`` when ``output`` is a CLI error message.
+
+    Mirrors :func:`unique_sdk.cli.commands.web_search.is_error_output` so
+    the Click layer can translate a returned error string into a non-zero
+    exit code without changing the existing string-returning contract.
+    """
+    return output.startswith(SEARCH_ERROR_PREFIX)

--- a/unique_sdk/unique_sdk/cli/skills/unique-cli-search/SKILL.md
+++ b/unique_sdk/unique_sdk/cli/skills/unique-cli-search/SKILL.md
@@ -2,7 +2,9 @@
 name: unique-cli-search
 description: >-
   Search the Unique AI Platform knowledge base using the unique-cli search
-  command. Use when the user asks to find, search, or query documents
+  command, with automatic per-turn citation tracking so cited facts render
+  as clickable reference chips and `<sup>N</sup>` footnotes on the Unique
+  platform. Use whenever the user asks to find, search, or query documents
   or content on Unique, including filtering by folder or metadata.
   NOTE: This search uses combined vector + full-text indexing. Excel
   (.xlsx/.xls), CSV (.csv), and image files are NOT full-text indexed,
@@ -13,7 +15,7 @@ description: >-
 
 # Unique CLI -- Knowledge Base Search
 
-Search the Unique knowledge base using combined vector + full-text search via the `unique-cli search` command.
+Search the Unique knowledge base using combined vector + full-text search via the `unique-cli search` command. Every invocation wraps each result in a `<sourceN>...</sourceN>` block and records a per-turn citation manifest at `.unique/turn-refs.jsonl`, so any fact you cite as `[sourceN]` is rendered with a footnote and a clickable reference chip in the chat UI.
 
 > **Limitation:** Excel (`.xlsx`/`.xls`), CSV (`.csv`), and image files are **not** full-text indexed. They will not appear in search results. To find these files, use the `unique-cli-file-management` skill and browse folders with `unique-cli ls` to locate them by name.
 
@@ -76,16 +78,44 @@ unique-cli search <query> [--folder <path|scope_id>] [--metadata <key=value>]...
 
 ## Output Format
 
-```
-Found 15 result(s):
+Each result is rendered as a `<sourceN>...</sourceN>` block. `N` is **1-based**, unique within the current turn, and **continues across multiple `unique-cli search` calls in the same turn** — the first call in a turn starts at `<source1>`, a follow-up call that returns three more results emits `<source4>`, `<source5>`, `<source6>`, and so on.
 
-    1. annual-report.pdf (p.12-13)  [cont_abc123]
-       ...the quarterly revenue analysis shows a 15% increase...
-    2. Q1/financials.xlsx (p.1)  [cont_def456]
-       ...revenue breakdown by quarter indicates strong growth...
+```
+Found 2 result(s):
+
+<source1>
+<|document|>annual-report.pdf</|document|>
+<|page|>12-13</|page|>
+<|info|>cont_abc123</|info|>
+...the quarterly revenue analysis shows a 15% increase...
+</source1>
+
+<source2>
+<|document|>Q1/financials.xlsx</|document|>
+<|page|>1</|page|>
+<|info|>cont_def456</|info|>
+...revenue breakdown by quarter indicates strong growth...
+</source2>
 ```
 
-Each result shows: index, title, page range, content ID, and a text snippet.
+Each block carries the document title, page range (when known), content ID, and a text snippet. The full chunk metadata (`chunkId`, `url`, `startPage`, `endPage`, ...) is captured in the per-turn manifest and not duplicated on screen.
+
+## Citation Rules
+
+Cite a fact from `unique-cli search` results with `[sourceN]`, where `N` matches the number on the `<sourceN>` block you read it from. The Unique platform's Swappable Intelligence runner converts each `[sourceN]` marker in your final answer into a `<sup>N</sup>` footnote and a clickable reference chip; without `unique-cli search`, KB facts in your answer appear as plain text only, with no footnote and no chip — so this is the only way to make KB citations render correctly on the platform.
+
+```
+The company's quarterly revenue rose 15% year over year [source1],
+driven by strong growth in the EMEA segment [source2].
+```
+
+**Rules** (enforced by the platform's reference post-processor):
+
+1. **`[sourceN]` is for KB results only.** Web results from `unique-cli web-search` use `[websourceN]` instead — never mix the two namespaces.
+2. Only cite numbers you saw in the **current** turn's `unique-cli search` output. Numbers from previous turns are stale and will be silently dropped.
+3. Write `source` in singular form with the number in digits: `[source1]`, `[source2]` — not `[Source 1]` or `[source one]`.
+4. Prefer citing each fact with a single, most-relevant source.
+5. Do not invent source numbers for remembered or inferred facts.
 
 ## Scripting with Search
 


### PR DESCRIPTION
## Summary

- Wrap each result of `unique-cli search` in `<sourceN>…</sourceN>` blocks (legacy unique_ai source format that the Swappable Intelligence runner already knows how to stitch).
- Write a per-turn ContentChunk-shaped JSONL manifest to `<cwd>/.unique/turn-refs.jsonl` so the runner can convert `[sourceN]` markers in the LLM answer into `<sup>N</sup>` footnotes and clickable reference chips.
- Extract reusable safety + locking helpers into `_citation_manifest.py` so the symmetric `unique-cli web-search` manifest in #1733 can dedupe onto the same primitives.

This makes the monorepo `kb-search` bundled skill (added in monorepo #24355) redundant: it can switch to `unique-cli search` directly. Removal PR follows in the monorepo.

## Test plan

- `uv run --no-sync --with pytest pytest tests/cli/test_search.py -q`
- `uv run --no-sync --with pytest pytest tests/cli/test_web_search.py -q` (regression — manifest helpers were extracted)
- `uv run --no-sync --with ruff ruff format …` + `ruff check …`

Refs: UN-21086

Made with [Cursor](https://cursor.com)