### PR TITLE
refactor(cli): dedupe web-search onto shared _citation_manifest + align SKILL.md

### DIFF
--- a/unique_sdk/unique_sdk/cli/commands/web_search.py
+++ b/unique_sdk/unique_sdk/cli/commands/web_search.py
@@ -17,14 +17,17 @@ Override precedence (highest first):
 
 from __future__ import annotations
 
-import fcntl
 import json
-import os
-from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, cast
 
 import unique_sdk
+from unique_sdk.cli.commands._citation_manifest import (
+    UnsafeRefsLogPathError,
+    _append_turn_refs_manifest_entry,
+    _locked_turn_refs_manifest,
+    _read_turn_refs_manifest,
+)
 from unique_sdk.cli.commands.web_search_config import (
     ConfigOverrides,
     WebSearchCLIConfigError,
@@ -40,54 +43,6 @@ _WEB_REFS_LOCK_FILENAME = "web-refs.lock"
 
 WEB_SEARCH_ERROR_PREFIX = "web-search:"
 WEB_CRAWL_ERROR_PREFIX = "web-crawl:"
-
-
-class UnsafeWebRefsLogPathError(OSError):
-    """Raised when the internal web refs log path would follow a symlink."""
-
-
-def _assert_safe_web_refs_log_path(refs_log_path: Path) -> None:
-    refs_log_dir = refs_log_path.parent
-    if refs_log_dir.is_symlink() or (
-        refs_log_dir.exists() and not refs_log_dir.is_dir()
-    ):
-        raise UnsafeWebRefsLogPathError(
-            f"refusing unsafe web refs log directory: {refs_log_dir}"
-        )
-    if refs_log_path.is_symlink():
-        raise UnsafeWebRefsLogPathError(
-            f"refusing unsafe web refs log file: {refs_log_path}"
-        )
-    if refs_log_path.exists() and not refs_log_path.is_file():
-        raise UnsafeWebRefsLogPathError(
-            f"refusing unsafe web refs log file: {refs_log_path}"
-        )
-
-
-def _read_web_refs_manifest(
-    refs_log_path: Path,
-) -> list[dict[str, Any]]:
-    _assert_safe_web_refs_log_path(refs_log_path)
-    if not refs_log_path.is_file():
-        return []
-    try:
-        raw_lines = refs_log_path.read_text(encoding="utf-8").splitlines()
-    except OSError as exc:
-        raise UnsafeWebRefsLogPathError(
-            f"failed to read web refs log: {refs_log_path}"
-        ) from exc
-
-    entries: list[dict[str, Any]] = []
-    for raw in raw_lines:
-        if not raw.strip():
-            continue
-        try:
-            payload = json.loads(raw)
-        except json.JSONDecodeError:
-            continue
-        if isinstance(payload, dict):
-            entries.append(payload)
-    return entries
 
 
 def _source_numbers_by_url(entries: list[dict[str, Any]]) -> dict[str, int]:
@@ -109,85 +64,23 @@ def _next_source_number(entries: list[dict[str, Any]]) -> int:
     return max(source_numbers, default=0) + 1
 
 
-def _append_web_refs_manifest_entry(
-    refs_log_path: Path,
-    payload: dict[str, Any],
-) -> None:
-    _assert_safe_web_refs_log_path(refs_log_path)
-    try:
-        refs_log_path.parent.mkdir(parents=True, exist_ok=True)
-    except OSError as exc:
-        raise UnsafeWebRefsLogPathError(
-            f"failed to create web refs log directory: {refs_log_path.parent}"
-        ) from exc
-    _assert_safe_web_refs_log_path(refs_log_path)
-    flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND
-    flags |= getattr(os, "O_NOFOLLOW", 0)
-    try:
-        fd = os.open(refs_log_path, flags, 0o600)
-    except OSError as exc:
-        raise UnsafeWebRefsLogPathError(
-            f"failed to open web refs log safely: {refs_log_path}"
-        ) from exc
-    try:
-        with os.fdopen(fd, "a", encoding="utf-8") as fp:
-            fp.write(json.dumps(payload, default=str, ensure_ascii=False) + "\n")
-    except OSError as exc:
-        raise UnsafeWebRefsLogPathError(
-            f"failed to write web refs log: {refs_log_path}"
-        ) from exc
-
-
-@contextmanager
-def _locked_web_refs_manifest(
-    refs_log_path: Path,
-) -> Any:
-    lock_path = refs_log_path.parent / _WEB_REFS_LOCK_FILENAME
-    _assert_safe_web_refs_log_path(lock_path)
-    try:
-        refs_log_path.parent.mkdir(parents=True, exist_ok=True)
-    except OSError as exc:
-        raise UnsafeWebRefsLogPathError(
-            f"failed to create web refs log directory: {refs_log_path.parent}"
-        ) from exc
-    _assert_safe_web_refs_log_path(lock_path)
-
-    flags = os.O_RDWR | os.O_CREAT
-    flags |= getattr(os, "O_NOFOLLOW", 0)
-    try:
-        fd = os.open(lock_path, flags, 0o600)
-    except OSError as exc:
-        raise UnsafeWebRefsLogPathError(
-            f"failed to open web refs lock safely: {lock_path}"
-        ) from exc
-
-    try:
-        fcntl.flock(fd, fcntl.LOCK_EX)
-    except OSError as exc:
-        os.close(fd)
-        raise UnsafeWebRefsLogPathError(
-            f"failed to lock web refs manifest: {lock_path}"
-        ) from exc
-
-    try:
-        yield
-    finally:
-        try:
-            fcntl.flock(fd, fcntl.LOCK_UN)
-        except OSError:
-            pass
-        os.close(fd)
-
-
 def _annotate_web_results_for_citations(
     payload: dict[str, Any],
     *,
     refs_log_path: Path | None = None,
 ) -> dict[str, Any]:
-    """Add per-turn web citation numbers and append the refs manifest."""
+    """Add per-turn web citation numbers and append the refs manifest.
+
+    Web results are deduped by URL: the same URL keeps the same
+    ``sourceNumber`` across consecutive ``search`` / ``crawl`` calls in
+    the same turn, so the crawled-content row carries the same citation
+    marker the search-snippet row already advertised.
+    """
     refs_log_path = refs_log_path or (Path.cwd() / _WEB_REFS_LOG_RELATIVE_PATH)
-    with _locked_web_refs_manifest(refs_log_path):
-        entries = _read_web_refs_manifest(refs_log_path)
+    with _locked_turn_refs_manifest(
+        refs_log_path, lock_filename=_WEB_REFS_LOCK_FILENAME
+    ):
+        entries = _read_turn_refs_manifest(refs_log_path)
         source_numbers_by_url = _source_numbers_by_url(entries)
         annotated = dict(payload)
         annotated_results: list[dict[str, Any]] = []
@@ -217,7 +110,7 @@ def _annotate_web_results_for_citations(
                 "content": result.get("content"),
                 "error": result.get("error"),
             }
-            _append_web_refs_manifest_entry(refs_log_path, manifest_entry)
+            _append_turn_refs_manifest_entry(refs_log_path, manifest_entry)
             annotated_results.append(result)
 
         annotated["results"] = annotated_results
@@ -448,7 +341,7 @@ def cmd_web_search(
 
     try:
         payload = _annotate_web_results_for_citations(_payload_from_resource(resource))
-    except UnsafeWebRefsLogPathError as exc:
+    except UnsafeRefsLogPathError as exc:
         return f"{WEB_SEARCH_ERROR_PREFIX} {exc}"
     if output_json:
         return _format_search_results_json(payload)
@@ -512,7 +405,7 @@ def cmd_web_crawl(
 
     try:
         payload = _annotate_web_results_for_citations(_payload_from_resource(resource))
-    except UnsafeWebRefsLogPathError as exc:
+    except UnsafeRefsLogPathError as exc:
         return f"{WEB_CRAWL_ERROR_PREFIX} {exc}"
     if output_json:
         return _format_crawl_results_json(payload)

--- a/unique_sdk/unique_sdk/cli/skills/unique-cli-web-search/SKILL.md
+++ b/unique_sdk/unique_sdk/cli/skills/unique-cli-web-search/SKILL.md
@@ -1,23 +1,27 @@
 ---
 name: unique-cli-web-search
 description: >-
-  ALWAYS use this skill when the user asks to search the public web,
-  research a topic online, look up news/articles/regulations, fetch the
-  contents of one or more URLs, or perform any "two-phase" web research
-  (search → review snippets → crawl selected URLs for full content).
-  Routes through the Unique AI Platform's `/web-search-api` endpoints
-  via `unique-cli web-search`, so the engine (Google, Brave, Tavily,
-  Jina, Firecrawl, …) and crawler are resolved server-side from the
-  current environment — you never need to manage engine API keys
-  yourself. Use this instead of fabricating answers from training data
-  whenever fresh / source-cited information is needed. Do NOT use this
-  skill for the internal knowledge base (`unique-cli search`) or for
-  arbitrary tool execution (`unique-cli mcp`).
+  Search the public web and crawl URLs via the Unique AI Platform's
+  `unique-cli web-search` command, with automatic per-turn citation
+  tracking so cited web facts render as clickable external reference
+  chips and `<sup>N</sup>` footnotes on the Unique platform. ALWAYS use
+  this skill when the user asks to search the public web, research a
+  topic online, look up news/articles/regulations, fetch the contents
+  of one or more URLs, or perform any "two-phase" web research (search
+  → review snippets → crawl selected URLs for full content). Routes
+  through the Unique AI Platform's `/web-search-api` endpoints, so the
+  engine (Google, Brave, Tavily, Jina, Firecrawl, …) and crawler are
+  resolved server-side from the current environment — you never need
+  to manage engine API keys yourself. Use this instead of fabricating
+  answers from training data whenever fresh / source-cited information
+  is needed. Do NOT use this skill for the internal knowledge base
+  (`unique-cli search`) or for arbitrary tool execution (`unique-cli
+  mcp`).
 ---
 
 # Unique CLI -- Web Search & Crawl
 
-Two-phase web research from the terminal, backed by the Unique AI Platform's public `/web-search-api`. Phase 1 (`search`) queries a search engine and returns URLs + snippets. Phase 2 (`crawl`) fetches the full page content for the URLs you actually want to read. The two-phase split lets you (or an LLM) review titles and snippets cheaply before paying the latency cost of full-page crawling.
+Two-phase web research from the terminal, backed by the Unique AI Platform's public `/web-search-api`. Phase 1 (`search`) queries a search engine and returns URLs + snippets. Phase 2 (`crawl`) fetches the full page content for the URLs you actually want to read. The two-phase split lets you (or an LLM) review titles and snippets cheaply before paying the latency cost of full-page crawling. Every invocation annotates each result with a `sourceNumber` / `citation: "websourceN"` and records a per-turn citation manifest at `.unique/web-refs.jsonl`, so any fact you cite as `[websourceN]` is rendered with a footnote and a clickable external reference chip in the chat UI.
 
 > **Server-side engine/crawler.** Unlike `unique-websearch`, this CLI does not instantiate engines locally — it just posts to the Unique platform, which resolves the engine and crawler from `ACTIVE_SEARCH_ENGINES` / `ACTIVE_INHOUSE_CRAWLERS` server-side. **You do not need any engine API keys** (Google, Brave, Tavily, etc.) on the client.
 
@@ -213,9 +217,6 @@ Found 3 result(s):
 >   | unique-cli web-search crawl --stdin
 > ```
 
-Use the `citation` value in final prose, wrapped in square brackets, e.g.
-`The regulation applies in phases [websource1].`
-
 ### `crawl` (text)
 
 ```
@@ -358,15 +359,20 @@ Both classes have `*_async` variants (`WebSearch.search_async`,
 
 ## Citation Rules
 
-- Use `[websourceN]` for public web citations, where `N` is the `sourceNumber`
-  returned by `unique-cli web-search`.
-- Do not use `[sourceN]` for web results; `[sourceN]` is reserved for internal
-  knowledge-base citations.
-- Only cite source numbers from the current turn's command output.
-- The same URL keeps the same `sourceNumber` across search and crawl calls in a
-  turn, so cite the crawled content with the same marker that the search result
-  used.
-- Never invent citation markers for remembered or inferred facts.
+Cite a fact from `unique-cli web-search` results with `[websourceN]`, where `N` matches the `sourceNumber` (also surfaced as the `citation: "websourceN"` field) the command emitted alongside the result. The Unique platform's Swappable Intelligence runner converts each `[websourceN]` marker in your final answer into a `<sup>N</sup>` footnote and a clickable external reference chip; without `unique-cli web-search`, web facts in your answer appear as plain text only, with no footnote and no chip — so this is the only way to make web citations render correctly on the platform.
+
+```
+The regulation enters into force in August 2026 [websource1],
+with phased obligations through 2028 [websource2].
+```
+
+**Rules** (enforced by the platform's reference post-processor, which reads `.unique/web-refs.jsonl` rather than your prose):
+
+1. **`[websourceN]` is for public web citations only.** Knowledge-base results from `unique-cli search` use `[sourceN]` instead — never mix the two namespaces, and never use `[sourceN]` for web results.
+2. Only cite numbers you saw in the **current** turn's `unique-cli web-search` output. Numbers from previous turns are stale and will be silently dropped.
+3. Write `websource` in singular form with the number in digits: `[websource1]`, `[websource2]` — not `[Websource 1]` or `[websource one]`.
+4. The same URL keeps the same `[websourceN]` across `search` and `crawl` calls in a turn, so cite a fact from the crawled page with the marker the search snippet already advertised.
+5. Do not invent source numbers for remembered or inferred facts.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary

Follow-up commits to PR #1733 to keep `unique-cli web-search` in lockstep with `unique-cli search` (added in #1738):

- **Dedupe.** Replace the local `_assert_safe_web_refs_log_path`, `_read_web_refs_manifest`, `_append_web_refs_manifest_entry`, `_locked_web_refs_manifest`, and `UnsafeWebRefsLogPathError` in `web_search.py` with imports from `_citation_manifest.py` (introduced by #1738). Web-specific logic — `.unique/web-refs.jsonl` path, URL-based dedup (`_source_numbers_by_url`, `_next_source_number`), and `_annotate_web_results_for_citations` — stays local.
- **Docs alignment.** Reorganize the `Citation Rules` section in `unique-cli-web-search/SKILL.md` to mirror the structure of the sibling section in `unique-cli-search/SKILL.md`: same opening pattern, same numbered-rule layout, parallel "never mix [sourceN] / [websourceN]" prose. Frontmatter description now also briefly notes citation tracking.
- **Minor doc tidy.** Removed a one-liner inline citation hint at the end of the JSON-output section because the new Citation Rules section covers it more thoroughly.

No semantic changes — the URL dedup, manifest line shape, output formatting, and error prefixes are all preserved. All existing tests in `tests/cli/test_web_search.py` still pass when validated against PR #1738's shared module.

## ⚠️ Blocked by #1738

This branch references `unique_sdk.cli.commands._citation_manifest`, which is introduced by [#1738](https://github.com/Unique-AG/ai/pull/1738) and not yet on `main` (or on this branch's base). Tests will fail in isolation here. To validate, locally cherry-pick `6fe3771b` (the #1738 commit) onto this branch — that's how the test results below were produced.

**Merge order:** wait for #1738 → main → rebase #1733 (this PR's base) onto main → this PR can then merge cleanly.

## Test plan

Validated locally with `6fe3771b` cherry-picked onto this branch:

- `pytest tests/cli/test_web_search.py -q` → **86 passed**
- `pytest tests/cli/test_search.py -q`     → **27 passed, 1 skipped**
- `ruff check + format` clean on `web_search.py` and `tests/cli/test_web_search.py`.

## How to integrate

Targets benhaj's branch (`benhaj/UN-21086-web-search-citations`). Merge order described above; once merged, the consolidated PR (#1733) will carry both benhaj's web-citation work and the consistency pass.

Refs: UN-21086

Made with [Cursor](https://cursor.com)