### PR TITLE
feat(toolkit): make RetrieveSearchScope content IDs optional

### DIFF
--- a/unique_toolkit/tests/agentic/tools/test_retrieve_search_scope_tool.py
+++ b/unique_toolkit/tests/agentic/tools/test_retrieve_search_scope_tool.py
@@ -124,6 +124,7 @@ class TestRetrieveSearchScopeToolRun:
         mock_tool_call: LanguageModelFunction,
         mocker: MockerFixture,
     ):
+        tool.config.show_content_id = True
         content_infos = [
             _make_content_info("report.pdf", id="id_1"),
             _make_content_info("report.pdf", id="id_2"),
@@ -161,6 +162,7 @@ class TestRetrieveSearchScopeToolRun:
         mock_tool_call: LanguageModelFunction,
         mocker: MockerFixture,
     ):
+        tool.config.show_content_id = True
         content_infos = [
             _make_content_info("report.pdf", id="cont_1"),
             _make_content_info("report.pdf", id="cont_1"),
@@ -171,7 +173,7 @@ class TestRetrieveSearchScopeToolRun:
         assert response.content.count("report.pdf (cont_1)") == 1
         assert "Listing 1 of 2" in response.content
 
-    async def test_non_openable_same_name_deduplicated(
+    async def test_same_name_deduplicated_when_content_ids_hidden(
         self,
         tool: RetrieveSearchScopeTool,
         mock_tool_call: LanguageModelFunction,
@@ -187,6 +189,24 @@ class TestRetrieveSearchScopeToolRun:
         assert response.content.count("page.html") == 1
         assert "Listing 1 of 2" in response.content
 
+    async def test_same_name_listed_separately_when_content_ids_shown(
+        self,
+        tool: RetrieveSearchScopeTool,
+        mock_tool_call: LanguageModelFunction,
+        mocker: MockerFixture,
+    ):
+        tool.config.show_content_id = True
+        content_infos = [
+            _make_content_info("page.html", mime_type="text/html", id="cont_3"),
+            _make_content_info("page.html", mime_type="text/html", id="cont_4"),
+        ]
+        _stub_kb(mocker, content_infos)
+        response = await tool.run(mock_tool_call)
+
+        assert "page.html (cont_3)" in response.content
+        assert "page.html (cont_4)" in response.content
+        assert "2 of 2 files" in response.content
+
     async def test_returns_error_on_kb_failure(
         self,
         tool: RetrieveSearchScopeTool,
@@ -201,46 +221,15 @@ class TestRetrieveSearchScopeToolRun:
 
 
 @pytest.mark.unit
-class TestContentIdForOpenableFiles:
-    @pytest.mark.parametrize(
-        "filename, mime_type",
-        [
-            ("doc.pdf", "application/pdf"),
-            (
-                "doc.docx",
-                "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-            ),
-            ("doc.doc", "application/msword"),
-            (
-                "slides.pptx",
-                "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-            ),
-            ("slides.ppt", "application/vnd.ms-powerpoint"),
-        ],
-    )
-    async def test_openable_mime_types_include_content_id(
-        self,
-        tool: RetrieveSearchScopeTool,
-        mock_tool_call: LanguageModelFunction,
-        mocker: MockerFixture,
-        filename: str,
-        mime_type: str,
-    ):
-        content_infos = [
-            _make_content_info(filename, mime_type=mime_type, id="cont_123")
-        ]
-        _stub_kb(mocker, content_infos)
-        response = await tool.run(mock_tool_call)
-        assert f"{filename} (cont_123)" in response.content
-
-    async def test_openable_file_without_id_does_not_append_content_id(
+class TestShowContentId:
+    async def test_default_excludes_content_id(
         self,
         tool: RetrieveSearchScopeTool,
         mock_tool_call: LanguageModelFunction,
         mocker: MockerFixture,
     ):
         content_infos = [
-            _make_content_info("doc.pdf", mime_type="application/pdf", id="")
+            _make_content_info("doc.pdf", mime_type="application/pdf", id="cont_123")
         ]
         _stub_kb(mocker, content_infos)
         response = await tool.run(mock_tool_call)
@@ -250,6 +239,7 @@ class TestContentIdForOpenableFiles:
     @pytest.mark.parametrize(
         "filename, mime_type",
         [
+            ("doc.pdf", "application/pdf"),
             (
                 "data.xlsx",
                 "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
@@ -257,7 +247,7 @@ class TestContentIdForOpenableFiles:
             ("notes.txt", "text/plain"),
         ],
     )
-    async def test_non_openable_mime_types_exclude_content_id(
+    async def test_when_enabled_includes_content_id_regardless_of_mime_type(
         self,
         tool: RetrieveSearchScopeTool,
         mock_tool_call: LanguageModelFunction,
@@ -265,15 +255,28 @@ class TestContentIdForOpenableFiles:
         filename: str,
         mime_type: str,
     ):
+        tool.config.show_content_id = True
         content_infos = [
-            _make_content_info(
-                filename, mime_type=mime_type, id="cont_should_not_appear"
-            )
+            _make_content_info(filename, mime_type=mime_type, id="cont_123")
+        ]
+        _stub_kb(mocker, content_infos)
+        response = await tool.run(mock_tool_call)
+        assert f"{filename} (cont_123)" in response.content
+
+    async def test_when_enabled_empty_id_does_not_append_content_id(
+        self,
+        tool: RetrieveSearchScopeTool,
+        mock_tool_call: LanguageModelFunction,
+        mocker: MockerFixture,
+    ):
+        tool.config.show_content_id = True
+        content_infos = [
+            _make_content_info("doc.pdf", mime_type="application/pdf", id="")
         ]
         _stub_kb(mocker, content_infos)
         response = await tool.run(mock_tool_call)
         file_section = response.content.split("\n\n", 1)[1]
-        assert file_section.strip() == filename
+        assert file_section.strip() == "doc.pdf"
 
 
 @pytest.mark.unit
@@ -436,6 +439,7 @@ class TestTreeMode:
         mocker: MockerFixture,
     ):
         tool.config.display_mode = DisplayMode.tree
+        tool.config.show_content_id = True
         ci = _make_content_info("report.pdf", id="cont_1")
         _stub_kb(mocker, resolved_paths=[(ci, ["Documents", "Reports", "report.pdf"])])
         response = await tool.run(mock_tool_call)
@@ -457,13 +461,14 @@ class TestTreeMode:
         assert file_section.strip() == "orphan.txt"
         assert "_no_folder_path" not in response.content
 
-    async def test_openable_file_with_folder_path_includes_content_id(
+    async def test_file_with_folder_path_includes_content_id_when_enabled(
         self,
         tool: RetrieveSearchScopeTool,
         mock_tool_call: LanguageModelFunction,
         mocker: MockerFixture,
     ):
         tool.config.display_mode = DisplayMode.tree
+        tool.config.show_content_id = True
         ci = _make_content_info("doc.pdf", id="cont_123")
         _stub_kb(mocker, resolved_paths=[(ci, ["Folder", "doc.pdf"])])
         response = await tool.run(mock_tool_call)
@@ -492,6 +497,7 @@ class TestTreeMode:
         mocker: MockerFixture,
     ):
         tool.config.display_mode = DisplayMode.tree
+        tool.config.show_content_id = True
         ci_1 = _make_content_info("report.pdf", id="cont_1")
         ci_2 = _make_content_info("report.pdf", id="cont_2")
         _stub_kb(

--- a/unique_toolkit/unique_toolkit/agentic/tools/experimental/retrieve_search_scope_tool/config.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/experimental/retrieve_search_scope_tool/config.py
@@ -52,7 +52,6 @@ _TOOL_SYSTEM_PROMPT_TEMPLATE = (
     "2. Craft more targeted search queries using the actual file names "
     "(a file name in the query promotes chunks from that file).\n"
     "3. Inform the user about available sources when relevant.\n"
-    "4. Files that come with a content id can be opened with a file opener tool."
 )
 
 DEFAULT_TOOL_SYSTEM_PROMPT = _TOOL_SYSTEM_PROMPT_TEMPLATE.format(
@@ -74,6 +73,24 @@ class RetrieveSearchScopeConfig(BaseToolConfig):
     ] = Field(
         default=False,
         description="Enable the RetrieveSearchScope tool.",
+    )
+
+    show_content_id: Annotated[
+        bool,
+        RJSFMetaTag.BooleanWidget.checkbox(
+            help=(
+                "When enabled, files in the RetrieveSearchScope result "
+                "include their content_id next to the file name "
+                "(e.g. report.pdf (cont_abc123)). When disabled, only file names "
+                "are returned."
+            ),
+        ),
+    ] = Field(
+        default=False,
+        description=(
+            "Include content IDs alongside file names for files "
+            "in the search scope listing."
+        ),
     )
 
     display_mode: DisplayMode = Field(

--- a/unique_toolkit/unique_toolkit/agentic/tools/experimental/retrieve_search_scope_tool/tool.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/experimental/retrieve_search_scope_tool/tool.py
@@ -22,15 +22,6 @@ from unique_toolkit.services.knowledge_base import KnowledgeBaseService
 
 _LOGGER = getLogger(__name__)
 
-_OPENABLE_MIME_PREFIXES = (
-    "application/pdf",
-    "application/msword",
-    "application/vnd.ms-word",
-    "application/vnd.ms-powerpoint",
-    "application/vnd.openxmlformats-officedocument.wordprocessingml",
-    "application/vnd.openxmlformats-officedocument.presentationml",
-)
-
 
 class RetrieveSearchScopeTool(Tool[RetrieveSearchScopeConfig]):
     name = "RetrieveSearchScope"
@@ -79,9 +70,8 @@ class RetrieveSearchScopeTool(Tool[RetrieveSearchScopeConfig]):
             )
         return False
 
-    @staticmethod
-    def _format_entry(ci: ContentInfo, prefix: str = "") -> str:
-        if ci.mime_type.startswith(_OPENABLE_MIME_PREFIXES) and ci.id:
+    def _format_entry(self, ci: ContentInfo, prefix: str = "") -> str:
+        if self.config.show_content_id and ci.id:
             name_part = f"{ci.key} ({ci.id})"
         else:
             name_part = ci.key


### PR DESCRIPTION
## Summary

- Adds `show_content_id` config to RetrieveSearchScope (default `false`) so file listings return file names only unless enabled.
- Removes openable-mime-type gating; content IDs are included for all files when the flag is on and `ci.id` is set.
- Drops the system-prompt bullet about opening files via content id (IDs are now optional).

## Changes

- **config.py**: New `show_content_id` checkbox; removed outdated system-prompt line about file opener.
- **tool.py**: `_format_entry` respects `show_content_id` instead of mime-type prefixes.
- **tests**: Replaced mime-based tests with `TestShowContentId`; updated tree/run tests to set the flag where needed.

## Test plan

- [x] `uv run pytest tests/agentic/tools/test_retrieve_search_scope_tool.py` (30 passed)

## Notes

- **Breaking default**: Existing deployments that relied on automatic content IDs for PDF/Office files must set `show_content_id: true` in assistant config.