### PR TITLE
fix(web-search): bug fixes + prompt improvements (alternative to #1732, no SERP scoring agent)

### DIFF
--- a/tool_packages/unique_web_search/src/unique_web_search/services/content_processing/cleaning/character_sanitize.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/content_processing/cleaning/character_sanitize.py
@@ -1,17 +1,21 @@
-import re
-
-_CONTROL_CHAR_RE = re.compile(
-    r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f\x80-\x9f\ufffe\uffff\ufffd]"
-)
+from unique_web_search.services.text_sanitize import strip_controls
 
 
 class CharacterSanitize:
+    """Drop ASCII control characters from page content.
+
+    Thin wrapper around :func:`strip_controls` so the content-processing
+    pipeline shares the same regex / character class as the boundary
+    sanitization on :class:`WebSearchResult`. See ``services/text_sanitize.py``
+    for the rationale (Postgres NUL-byte rejection, etc.).
+    """
+
     def __init__(self, enabled: bool = True):
         self.enabled = enabled
 
     def __call__(self, content: str) -> str:
         if self.enabled:
-            return _CONTROL_CHAR_RE.sub("", content)
+            return strip_controls(content)
         return content
 
     @property

--- a/tool_packages/unique_web_search/src/unique_web_search/services/content_processing/cleaning/config.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/content_processing/cleaning/config.py
@@ -1,8 +1,17 @@
 from pydantic import BaseModel, Field
 from unique_toolkit._common.pydantic_helpers import get_configuration_dict
 
-# Patterns that remove entire lines
+# Patterns that remove entire lines.
+#
+# NOTE on ordering: these patterns run *after* MarkdownTransform, so by the time
+# they execute, ``[text](url)`` has already been collapsed to ``[text]`` and bare
+# URLs are gone. That's what lets the "link-only / image-only / multi-bracket
+# nav row" patterns below recognise the boilerplate Tavily ships back from
+# directory-style sites (Hipflat, propertyhub, livinginsider, ddproperty…) —
+# whole pages of currency dropdowns, BTS-station lists, and district-filter
+# checkboxes that the agent never needs to see.
 REGEX_LINE_REMOVAL_PATTERNS = [
+    # ── Generic web boilerplate ─────────────────────────────────────────────
     # Skip navigation elements only (not content navigation)
     r"^[\*\+\-]?\s*(Skip to|Skip Navigation|Jump to|Accessibility help).*$",
     # Standalone authentication links (not part of content)
@@ -13,6 +22,25 @@ REGEX_LINE_REMOVAL_PATTERNS = [
     r"^.*(Cookie Policy|Privacy Policy|Terms of Service|Cookie Settings|Accept Cookies|Cookie Notice).*$",
     # Accessibility labels
     r"^\s*\[.*accessibility.*\].*$",
+    # ── Structural nav (link/image-only lines, post-MarkdownTransform) ──────
+    # One or more bracketed link tokens on a line, optionally prefixed by a
+    # bullet/list marker. Catches ``* [Bangkok Home]``,
+    # ``[Condo for Sale][Home for Sale][Townhome for Sale]`` (inline nav row),
+    # and similar.
+    r"^\s*[\*\+\-]?\s*(\[[^\]\n]+\]\s*){1,}$",
+    # Pure image line: ``![alt]`` (after URL strip) with optional bullet.
+    r"^\s*[\*\+\-]?\s*!\[[^\]\n]*\]\s*$",
+    # Wrapped image-link form left over after MarkdownTransform: ``[![alt]]``.
+    r"^\s*[\*\+\-]?\s*\[\s*!\[[^\]\n]*\]\s*\]\s*$",
+    # Checkbox-style filter row with a short label (≤ 3 whitespace-separated
+    # tokens). Targets the ``- [x] กรุงเทพฯ`` / ``- [x] BTS`` UI lists. The
+    # short-label cap keeps real prose like ``- [x] this is a long sentence
+    # about something important`` from getting eaten.
+    r"^\s*[\*\+\-]\s*\[\s*[xX ]?\s*\]\s*\S+(\s+\S+){0,2}\s*$",
+    # Currency / code dropdown row: short prose followed by a 3-letter code,
+    # a dash, and a short symbol. Catches ``* Thai Baht THB - ฿``,
+    # ``Swiss Franc CHF - CHF``, ``THB - ฿``, etc.
+    r"^\s*\*?\s*[\w\s\-]{0,40}\b[A-Z]{3}\s+-\s+\S{1,5}\s*$",
 ]
 
 
@@ -32,8 +60,18 @@ class LineRemovalPatternsConfig(BaseModel):
 
 # Pattern/replacement pairs for content transformation
 LINK_AND_URL_CLEANUP_PATTERNS = [
-    # Transform markdown links: [text](url) → [text]
-    (r"\[([^\]]+)\]\([^)]+\)", r"[\1]"),
+    # Transform markdown links: ``[text](url) → [text]``. Both groups allow
+    # one level of nesting so the regex handles two common real-world forms
+    # the previous ``[^\]]+/[^)]+`` pattern silently bailed on:
+    #   1. wrapped image links ``[![alt](img-url)](page-url)``, where the
+    #      bracket text itself contains ``[alt]``;
+    #   2. ``javascript:void(0)``-style URLs with parens inside.
+    # Either one left behind unmatched residue (``[![alt]](url)`` or
+    # ``[text])``) that LineRemoval's bracket-only patterns couldn't see.
+    (
+        r"\[((?:[^\[\]]|\[[^\[\]]*\])*)\]\((?:[^()]|\([^()]*\))*\)",
+        r"[\1]",
+    ),
     # Remove standalone URLs
     (r"https?://[^\s\])]+ ?", r""),
     # Normalize whitespace

--- a/tool_packages/unique_web_search/src/unique_web_search/services/content_processing/processing_strategies/llm_guard_judge.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/content_processing/processing_strategies/llm_guard_judge.py
@@ -42,6 +42,9 @@ class LLMGuardResponse(BaseModel):
             "except any that constitute GDPR Art. 9 sensitive data, which must be replaced inline with the appropriate "
             "typed redaction tag (e.g. [RedactHealth], [RedactReligiousBelief], [RedactPoliticalOpinion], "
             "[RedactSexualOrientation], [RedactRacialOrEthnic], [RedactTradeUnion], [RedactGeneticData], [RedactBiometricData]). "
+            "Always include labeled data fields and structured key-value pairs — preserve the field label and "
+            "non-sensitive values verbatim; if a field value is GDPR Art. 9 sensitive, replace only the value with "
+            "the appropriate redaction tag rather than omitting the entire field. "
             "Applies to all individuals mentioned on the page. "
             "A less complete summary that is fully sanitized is always preferred over a complete summary containing sensitive data."
         ),
@@ -103,6 +106,9 @@ class JudgeAndSanitizeResponse(BaseModel):
             "except any that constitute GDPR Art. 9 sensitive data, which must be replaced inline with the appropriate "
             "typed redaction tag (e.g. [RedactHealth], [RedactReligiousBelief], [RedactPoliticalOpinion], "
             "[RedactSexualOrientation], [RedactRacialOrEthnic], [RedactTradeUnion], [RedactGeneticData], [RedactBiometricData]). "
+            "Always include labeled data fields and structured key-value pairs — preserve the field label and "
+            "non-sensitive values verbatim; if a field value is GDPR Art. 9 sensitive, replace only the value with "
+            "the appropriate redaction tag rather than omitting the entire field. "
             "Set to null if needs_sanitization is false."
         ),
     )

--- a/tool_packages/unique_web_search/src/unique_web_search/services/content_processing/processing_strategies/prompts/judge_and_sanitize_prompt.j2
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/content_processing/processing_strategies/prompts/judge_and_sanitize_prompt.j2
@@ -16,6 +16,7 @@ GDPR Art. 9 compliance is your **primary constraint** — it overrides everythin
 - Extract and preserve all key facts, findings, data points, and conclusions — except any that are GDPR Art. 9 sensitive, which must be redacted.
 - Maintain factual accuracy — do not infer or add information not present in the original.
 - Remove redundancy, boilerplate text, navigation elements, advertisements, and filler content.
+- Never drop labeled data fields. When the page contains structured key–value pairs or attribute tables, always preserve the field labels and non-sensitive values — they are factual data, not boilerplate, and are frequently the direct answer to the query. If a field's value is GDPR Art. 9 sensitive, apply the appropriate redaction tag to the value rather than omitting the entire field.
 - Retain important numbers, statistics, dates, and proper nouns.
 - Use clear, professional language.
 - The output should be self-contained and understandable without access to the original content.

--- a/tool_packages/unique_web_search/src/unique_web_search/services/content_processing/processing_strategies/prompts/system_prompt.j2
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/content_processing/processing_strategies/prompts/system_prompt.j2
@@ -15,6 +15,7 @@ Your secondary task is to produce a sanitized_content summary of the web page co
 - Extract and preserve all key facts, findings, data points, and conclusions — except any that are GDPR Art. 9 sensitive, which must be redacted.
 - Maintain factual accuracy — do not infer or add information not present in the original.
 - Remove redundancy, boilerplate text, navigation elements, advertisements, and filler content.
+- Never drop labeled data fields. When the page contains structured key–value pairs or attribute tables, always preserve the field labels and non-sensitive values — they are factual data, not boilerplate, and are frequently the direct answer to the query. If a field's value is GDPR Art. 9 sensitive, apply the appropriate redaction tag to the value rather than omitting the entire field.
 - Retain important numbers, statistics, dates, and proper nouns.
 - Use clear, professional language.
 - Structure the summary logically, preserving the information hierarchy of the original.
@@ -51,6 +52,7 @@ You are an expert content summarizer. Your task is to produce a concise, accurat
 - Extract and preserve all key facts, findings, data points, and conclusions.
 - Maintain factual accuracy — do not infer or add information not present in the original.
 - Remove redundancy, boilerplate text, navigation elements, advertisements, and filler content.
+- Never drop labeled data fields. When the page contains structured key–value pairs or attribute tables, always include them verbatim — they are factual data, not boilerplate, and are frequently the direct answer to the query.
 - Retain important numbers, statistics, dates, and proper nouns.
 - Use clear, professional language.
 - Structure the summary logically, preserving the information hierarchy of the original.

--- a/tool_packages/unique_web_search/src/unique_web_search/services/content_processing/processing_strategies/prompts/user_prompt.j2
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/content_processing/processing_strategies/prompts/user_prompt.j2
@@ -1,4 +1,5 @@
 Analyze the following web page and produce a summary in relation to the search query.
+Focus on the portion of the page most relevant to the search query. Always include labeled data fields and structured key–value tables, even if they appear outside the most relevant section{% if sanitize %} — apply the appropriate redaction tag to any GDPR Art. 9 sensitive values rather than omitting entire fields{% endif %}.
 {% if sanitize %}
 
 REMINDER: You MUST apply all sanitization rules to the sanitized_content. Replace every piece of GDPR Art. 9 sensitive data with the appropriate typed redaction tag (e.g., [RedactHealth], [RedactPoliticalOpinion]). This applies to ALL individuals mentioned on the page, not only the subject of the search query. Read the content below with this constraint active.

--- a/tool_packages/unique_web_search/src/unique_web_search/services/content_processing/processing_strategies/schema.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/content_processing/processing_strategies/schema.py
@@ -11,7 +11,12 @@ class LLMProcessorResponse(BaseModel):
         description="A short, self-contained excerpt (2-3 sentences) capturing the most relevant finding from the page in relation to the search query.",
     )
     summary: str = Field(
-        description="A comprehensive summary of the page content focused on information relevant to the search query. Preserves key facts, data points, and conclusions.",
+        description=(
+            "A comprehensive summary of the page content focused on information relevant to the search query. "
+            "Preserves key facts, data points, dates, statistics, and conclusions. "
+            "Always include labeled data fields and structured key-value pairs — "
+            "they are factual data, not boilerplate, and are frequently the direct answer to the query."
+        ),
     )
 
     def apply_to_page(self, page: WebSearchResult) -> WebSearchResult:

--- a/tool_packages/unique_web_search/src/unique_web_search/services/content_processing/service.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/content_processing/service.py
@@ -54,15 +54,22 @@ class ContentProcessor:
         self._encoder = encoder
         self._decoder = decoder
 
+        # Order matters: MarkdownTransform runs *before* LineRemoval so that
+        # ``[text](url)`` is collapsed to ``[text]`` and bare URLs are stripped
+        # *first*. LineRemoval then sees normalised content and its
+        # link-only / image-only / multi-bracket patterns can spot whole rows
+        # of nav boilerplate that would otherwise survive untouched (currency
+        # dropdowns, BTS-station lists, district-filter checkboxes from
+        # directory-style sites like Hipflat/livinginsider/propertyhub).
         self._cleaning_strategies: list[CleaningStrategy] = [
             CharacterSanitize(
                 enabled=self.config.cleaning.enable_character_sanitize,
             ),
-            LineRemoval(
-                config=self.config.cleaning.line_removal,
-            ),
             MarkdownTransform(
                 enabled=self.config.cleaning.enable_markdown_cleaning,
+            ),
+            LineRemoval(
+                config=self.config.cleaning.line_removal,
             ),
         ]
 

--- a/tool_packages/unique_web_search/src/unique_web_search/services/executors/v3/executor.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/executors/v3/executor.py
@@ -31,8 +31,19 @@ from unique_web_search.services.executors.v3.schema import (
     WebSearchV3ToolParameters,
 )
 from unique_web_search.services.search_engine.schema import WebSearchResult
+from unique_web_search.services.text_sanitize import sanitize_single_line
 
 _LOGGER = logging.getLogger(__name__)
+
+# Agent-supplied strings (objective / query / urls) do not pass through the
+# ``WebSearchResult`` boundary — that model sanitizes engine + crawler output,
+# not what the LLM emits. Real models occasionally emit strings containing
+# ASCII control characters (most commonly NUL ``\x00``), which Postgres TEXT
+# columns reject with error ``22P05`` and which crash every downstream
+# ``modify_message`` / ``stream-responses`` call once they land in a tool
+# result. ``sanitize_single_line`` is a no-op on clean text, so wrapping every
+# agent-supplied string at the run() boundary is cheap and removes a class of
+# 500 errors that otherwise poisons the whole chat once it appears.
 
 
 class WebSearchV3Executor(BaseWebSearchExecutor[WebSearchV3ToolParameters]):
@@ -56,13 +67,18 @@ class WebSearchV3Executor(BaseWebSearchExecutor[WebSearchV3ToolParameters]):
 
     async def run(self) -> list[ContentChunk]:
         p = self.tool_parameters
+        objective = sanitize_single_line(p.objective)
         if isinstance(p.payload, SearchPayload):
             await self._message_log_callback.log_progress("_Executing Search_")
-            return await self._run_search(query=p.payload.query, objective=p.objective)
+            return await self._run_search(
+                query=sanitize_single_line(p.payload.query),
+                objective=objective,
+            )
         if isinstance(p.payload, FetchUrlsPayload):
             await self._message_log_callback.log_progress("_Reading Web Pages_")
             return await self._run_fetch_urls(
-                urls=p.payload.urls, objective=p.objective
+                urls=[sanitize_single_line(u) for u in p.payload.urls],
+                objective=objective,
             )
 
         msg = "WebSearchV3ToolParameters requires exactly one of 'query' or 'urls'."
@@ -80,7 +96,10 @@ class WebSearchV3Executor(BaseWebSearchExecutor[WebSearchV3ToolParameters]):
         await self.notify_callback()
 
         elicited = await self.query_elicitation([query])
-        query = elicited[0]
+        # ``query_elicitation`` is an LLM call that can re-introduce control
+        # chars (observed: elicitation form forwards the model's raw output).
+        # Re-sanitize defensively. No-op for clean queries.
+        query = sanitize_single_line(elicited[0])
 
         self.debug_info.steps.append(
             StepDebugInfo(

--- a/tool_packages/unique_web_search/src/unique_web_search/services/executors/v3/prompts/tool_description.j2
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/executors/v3/prompts/tool_description.j2
@@ -1,14 +1,14 @@
 The WebSearch tool returns up-to-date information from the web. It exposes two capabilities, picked per call via `command`:
 
 - **Search** (`command: "search"`) — runs the configured search engine and returns SERP rows (URL, domain, title, snippet). Gives a high-level read of what relevant pages contain without crawling them. Useful for **exploration** and quick lookups when a snippet is enough to answer.
-- **Fetch** (`command: "read_urls"`) — crawls one or more URLs and returns full-page text. Useful for **deep dives** when the task is complex and needs exact figures, quotes, regulatory text, or specs, and when the user provides a URL directly.
+- **Fetch** (`command: "read_urls"`) — crawls one or more URLs and returns page text. Use it surgically when snippets are insufficient and precision is needed. You may also construct a page URL by deriving its slug from an entity name when you have already seen the domain's URL pattern in prior SERP results.
 
-Each call performs **one** operation. Drive multi-part tasks by chaining calls.
+Each call performs **one** operation. Drive multi-part tasks by chaining calls. Stop as soon as you have enough information — but for field-level questions (ownership, status, specifications, counts), a snippet confirming an entity exists is not sufficient; fetch before stopping.
 
 ### Fields
 
 {{ tool_parameters_schema }}
 
-Never invent URLs.
+Never invent domain names.
 
 For a deeper playbook on when to search vs fetch (snippet hedging, canonical-source topics, sub-question decomposition, URL-selection rules, anti-patterns), activate the `web-search-v3` skill before/while using this tool.

--- a/tool_packages/unique_web_search/src/unique_web_search/services/executors/v3/prompts/tool_description_for_system_prompt.j2
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/executors/v3/prompts/tool_description_for_system_prompt.j2
@@ -40,6 +40,26 @@ Use it when:
 - **User-provided URLs go straight to fetch.** If the user pasted URL(s), the first call should be `command: "read_urls"`. Do not "search" for a URL the user already supplied.
 - **Latency is a fair trade.** `read_urls` takes longer than `search`. That latency is acceptable on complex queries where the user expects depth — give them the answer that's actually grounded. Don't fetch when a snippet already answers the question; don't refuse to fetch when the snippet doesn't.
 
+### When to say "I could not find a reliable source"
+
+Web search is not omniscient. Some questions have no answer in the public, crawlable web — the data is not published, sits behind a paywall the crawler cannot reach, or the entity / timeframe does not match anything indexed. **Fabricating a number, or paraphrasing one from a weak snippet, is worse than admitting the gap.** A clean "no" with a concrete reformulation suggestion is the correct answer in that case.
+
+Answer with "I could not find a reliable source" when **all** of these hold:
+
+- You have run **at least two** `search` calls for the same gap, ideally with different keywords, languages, or timeframes.
+- The most promising URLs from those SERPs have been fetched and either returned a dead / off-topic / blocked page, or returned a page whose scope (entity, geography, timeframe, field) did not actually match the gap.
+- One more refined query is unlikely to surface anything stronger — you have already tried the obvious reformulations (entity name in local language, alternative source classes, broader time window).
+
+When that condition is met, answer plainly. Do **not** present a guess as a fact:
+
+> "I could not find a reliable source for **\<the specific field\>**. The data may not be publicly available, may sit behind a paywall, or the entity / timeframe may not match what is indexed. You could try: **\<one concrete reformulation — different time window, broader geography, specific source name, primary-source database\>**."
+
+Anti-patterns this rule blocks:
+- **Quoting a number from a weak / hedged snippet** as if it were sourced. If the snippet only paraphrases or qualifies the value, the answer must hedge in the same way — or, better, the answer is "I could not find a reliable source."
+- **Synthesising from adjacent data points** the user did not ask for. The fetched page may match on topic but sit in the **wrong scope** — a broader or narrower geographic level than the gap names, a different named entity in the same category, a neighbouring timeframe on a field whose value changes between periods, or a different field entirely. Same topic, wrong scope is not an answer. Once you have the page you must check that its scope (entity, geography, timeframe, field) actually matches the gap's scope; if it does not, treat the page as not containing the answer, regardless of how relevant the snippet looked. **Scope mismatch is the dominant cause of hallucinated answers in this tool — you must catch it yourself after fetching.**
+- **Padding a fabricated number with caveats** ("varies", "depends on context", "subject to negotiation") to make a guess look defensible. Caveats do not turn a guess into a source.
+- **Giving up after one bad fetch.** A single 404 / blocked / off-topic page is not a stop signal — it is a signal to try the next-most-relevant URL from the same SERP, or to reformulate. Only after at least two searches plus the failed fetches is "I could not find it" the right answer.
+
 For the deeper explore-then-exploit playbook (snippet hedging triggers, canonical-source topics, sub-question decomposition, URL-selection rules, anti-patterns, worked examples), activate the `web-search-v3` skill before/while using this tool.
 
 Tool arguments are defined by the tool schema; the live JSON schema comes from the tool definition.

--- a/tool_packages/unique_web_search/src/unique_web_search/services/executors/v3/prompts/tool_description_for_system_prompt.j2
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/executors/v3/prompts/tool_description_for_system_prompt.j2
@@ -7,14 +7,14 @@ Runs the configured search engine and returns SERP rows (URL, domain, title, sni
 Use it when:
 
 - You need to **discover sources**: you don't yet have URLs and need the engine to surface candidates for a topic.
-- The user's question can be answered from **snippets alone** — a definition, a status, a current value, a short factual lookup.
+- The user's question can be answered from **snippets alone** — a definition, a simple yes/no, or a direct fact like a date, name, or headline. Not for database fields, registry values, or any structured data that requires the full page body.
 - You're at the **start of a complex task** and need to map out what's out there before deciding which pages are worth a deeper read.
 - You want to **scope or sanity-check** a topic cheaply (does this entity / event / product even exist? how recent is the latest coverage?).
 - You need to **cover a new gap / sub-question** in a multi-step task — issue another search rather than blindly fetching.
 
-#### `command: "read_urls"` — fetch full page content
+#### `command: "read_urls"` — fetch specific page content
 
-Crawls one or more URLs and returns the full-page text. It is **slower** than search but gives the **complete content** of the chosen pages, not just a snippet.
+Crawls one or more URLs and returns the full-page text or relevant portions. It is **slower** than search but gives the **complete content** of the chosen pages, not just a snippet.
 
 Use it when:
 
@@ -24,14 +24,19 @@ Use it when:
 - The topic is **canonical-source-driven** — financial filings (10-K, 10-Q, earnings releases), regulator publications, official product docs, peer-reviewed papers, primary press releases — where the page itself is the source of truth.
 - You found a **highly relevant** SERP hit but the title/snippet alone doesn't support the claim you want to make.
 - The snippets from the previous "search" commands are relevant but do not fully answer the question or fill the gap and fetching the full page is necessary.
+- The question asks for a **specific structured data field** (ownership type, transaction records, legal status, unit count, floor count, specifications, registration numbers) and the SERP contains database or registry pages (property portals, company registries, official catalogs) — snippets from these sources show only brief summaries; the field-level data is embedded in the page body. Never treat a snippet from a database/registry page as sufficient for a field-level question.
+- A SERP result revealed a **domain whose URL pattern is predictable** (e.g. `site.com/en/buildings/{slug}/`) and you can derive the slug for the specific entity from its name — construct the URL and fetch it directly rather than issuing another search. You may construct page-level URLs from patterns you have already seen on a domain; never invent domain names.
 
 **Current date:** {{ date_string }}
 
-### Balance exploration and exploitation
+### Efficiency & Latency Optimization
 
 - **Explore first.** Start with `command: "search"` to get a cheap, high-level read of candidate pages. Cover one `gap` per call.
 - **Refine, don't escalate prematurely.** If the first search did not fill the `gap`, issue another `command: "search"` with a refined query (different keywords, narrower entity, different timeframe) before reaching for `read_urls`.
-- **Exploit when snippets aren't enough.** Switch to `command: "read_urls"` when snippets paraphrase / hedge, or the task needs exact figures, quotes, regulatory text, specs, or canonical-source content. Pick **1-3 high-signal URLs** from the most recent SERP — complementary domains preferred.
+- **Exploit surgically.** Switch to `command: "read_urls"` when snippets are insufficient. Pick high-signal URLs from the most recent SERP. Prefer complementary domains.
+- **Escalate on search failure.** After **one or two search tool calls** return no usable result for a gap, stop issuing more searches — do not keep batching more queries hoping for a different outcome. Instead, fetch the most relevant URL already in your SERP results (even if the snippet looks only partially relevant).
+- **Construct URLs from domain patterns.** If SERP reveals a domain whose URL structure is predictable (e.g. `site.com/en/buildings/{slug}/`), derive the slug from the entity name and fetch that URL directly — do not issue another search to rediscover it. You may construct page-level URLs from patterns you have already seen on a domain; never invent domain names.
+- **Stop early — but not prematurely.** If you have enough information to answer with high confidence, stop and answer. A SERP snippet that confirms an entity exists (address, name, date) is **not** sufficient when the question asks for a specific data field (ownership type, status, count, spec). In that case, fetch before stopping.
 - **User-provided URLs go straight to fetch.** If the user pasted URL(s), the first call should be `command: "read_urls"`. Do not "search" for a URL the user already supplied.
 - **Latency is a fair trade.** `read_urls` takes longer than `search`. That latency is acceptable on complex queries where the user expects depth — give them the answer that's actually grounded. Don't fetch when a snippet already answers the question; don't refuse to fetch when the snippet doesn't.
 

--- a/tool_packages/unique_web_search/src/unique_web_search/services/executors/v3/schema.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/executors/v3/schema.py
@@ -16,13 +16,13 @@ class SearchPayload(BaseModel):
         description="A brief description of the gap that the query is meant to fill"
     )
     query: str = Field(
-        description="Search query for the configured search engine. Query must be fixed for the entire rounds."
+        description="Search query for the configured search engine. May be refined across calls — issue a new search with different keywords or narrower scope if the previous call did not fill the gap."
     )
 
 
 class FetchUrlsPayload(BaseModel):
     urls: list[str] = Field(
-        description="HTTP(S) URLs to crawl for full-page text. Use only URLs returned by a prior search or pasted by the user."
+        description="HTTP(S) URLs to crawl. Use URLs returned by a prior search, pasted by the user, or constructed from a domain URL pattern already observed in SERP results. Prefer a small number of high-signal URLs to reduce latency."
     )
 
 

--- a/tool_packages/unique_web_search/src/unique_web_search/services/search_engine/schema.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/search_engine/schema.py
@@ -1,10 +1,29 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from unique_toolkit.content import ContentReference
 
 from unique_web_search.services.helpers import extract_root_domain
+from unique_web_search.services.text_sanitize import (
+    sanitize_single_line,
+    strip_controls,
+)
 
 
 class WebSearchResult(BaseModel):
+    """The single ingress point for external text into the web-search pipeline.
+
+    Every search engine adapter and the ``read_urls`` crawler path constructs
+    a ``WebSearchResult`` before any downstream consumer (chunker, content
+    processor, debug payload, tool result) sees the data. The field validators
+    below strip ASCII control characters at this boundary — most importantly
+    the NUL byte (``\\u0000``), which Postgres TEXT columns reject with error
+    ``22P05`` and which would otherwise poison every subsequent message write
+    once the dirty string lands in a tool result.
+
+    Sanitizing here rather than at every downstream call site means no consumer
+    needs to defensively re-sanitize: by the time a ``WebSearchResult``
+    exists, it is safe to embed in JSON, SQL, or chunk metadata.
+    """
+
     url: str = Field(
         ...,
         description="The URL of the website",
@@ -21,6 +40,28 @@ class WebSearchResult(BaseModel):
         default="",
         description="The content of the website",
     )
+
+    # Short, strictly-single-line fields — replace controls with space and
+    # collapse whitespace. URLs cannot legitimately span lines; titles in
+    # practice are one-line. Empty string is fine (``read_urls`` passes
+    # ``title=""``).
+    @field_validator("url", "title", mode="before")
+    @classmethod
+    def _sanitize_short_field(cls, v: object) -> object:
+        if isinstance(v, str):
+            return sanitize_single_line(v)
+        return v
+
+    # ``snippet`` and ``content`` may legitimately carry newlines — some
+    # engines (Brave, Bing grounding) join multiple sub-snippets with ``\n``,
+    # and crawled page bodies preserve paragraph structure. Strip controls
+    # only; keep TAB/LF/CR.
+    @field_validator("snippet", "content", mode="before")
+    @classmethod
+    def _sanitize_long_field(cls, v: object) -> object:
+        if isinstance(v, str):
+            return strip_controls(v)
+        return v
 
     @property
     def display_link(self):

--- a/tool_packages/unique_web_search/src/unique_web_search/services/text_sanitize.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/text_sanitize.py
@@ -1,0 +1,64 @@
+"""Shared text-sanitization helpers — single source of truth for NUL-byte hygiene.
+
+The web-search pipeline ingests strings from three external sources: the search
+engine API (titles / snippets / URLs / cached content), the crawler (full page
+bodies extracted from PDFs / HTML), and the agent itself (objective / query /
+gap / supplied URLs). All three occasionally surface ASCII control characters
+— most often the NUL byte (``\\u0000``), which Postgres TEXT columns reject
+with error ``22P05`` ("``\\u0000`` cannot be converted to text") and which
+crashes every downstream ``modify_message`` / ``stream-responses`` call once
+the dirty text lands in a tool result.
+
+Two sanitization shapes are needed:
+
+- ``sanitize_single_line`` — for short fields (URLs, titles, snippets, queries,
+  objectives, gaps) where whitespace structure does not matter and adjacent
+  words must not silently merge when a stripped control char sat between them.
+  Replaces control characters with SPACE and then collapses whitespace runs.
+
+- ``strip_controls`` — for long-form text (page bodies / crawler output) where
+  paragraph and list structure must survive. Strips control characters (TAB /
+  LF / CR are *not* in the class, so they pass through unchanged), leaving the
+  rest of the document intact.
+
+Both functions are no-ops on clean text, so wrapping is cheap and safe to call
+defensively.
+"""
+
+from __future__ import annotations
+
+import re
+
+# C0 controls (except TAB/LF/CR), C1 controls, DEL, BOM, noncharacters, and the
+# replacement char (``�``). TAB ``\x09``, LF ``\x0a``, CR ``\x0d`` are
+# deliberately excluded so ``strip_controls`` preserves line structure in
+# long-form text; ``sanitize_single_line`` then collapses them along with any
+# spacing the control-→-space substitution introduced.
+CONTROL_CHAR_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f\x80-\x9f￾￿�]")
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+def strip_controls(text: str) -> str:
+    """Strip C0/C1/DEL/BOM/noncharacters; preserve TAB/LF/CR.
+
+    For long-form text (page bodies) where paragraph / list structure must
+    survive. NUL-byte safe: removes ``\\u0000`` which Postgres TEXT columns
+    reject (error ``22P05``).
+    """
+    return CONTROL_CHAR_RE.sub("", text)
+
+
+def sanitize_single_line(text: str) -> str:
+    """Replace controls with space, collapse whitespace runs, trim.
+
+    For short, single-line fields (URLs, titles, snippets, queries, objectives,
+    gaps) where whitespace structure does not matter. Replacing with SPACE
+    instead of stripping preserves word boundaries — observed regression
+    otherwise: ``a\\x0eb`` would strip to ``ab`` and the engine matched a
+    nonsense token, returning an empty SERP. With SPACE substitution the same
+    input becomes ``a b`` and the engine tokenizes both words.
+
+    Safe to call on any short externally-supplied string. No-op for clean text.
+    """
+    spaced = CONTROL_CHAR_RE.sub(" ", text)
+    return _WHITESPACE_RE.sub(" ", spaced).strip()

--- a/tool_packages/unique_web_search/src/unique_web_search/skills/web-search-v3.md
+++ b/tool_packages/unique_web_search/src/unique_web_search/skills/web-search-v3.md
@@ -34,7 +34,9 @@ flowchart TD
     HasUrl -- no --> Search["command: search<br/>payload.gap + payload.query"]
     Search --> Check{Snippets fill the gap?}
     Check -- "yes, more gaps remain" --> Search
-    Check -- "yes, all covered" --> Answer[Answer]
+    Check -- "yes, all covered" --> FieldCheck{"Field-level question\n+ registry/DB in SERP?"}
+    FieldCheck -- "no" --> Answer[Answer]
+    FieldCheck -- "yes" --> Fetch
     Check -- "no (hedged / exact text / canonical source)" --> Fetch
     Fetch --> Answer
 ```
@@ -52,9 +54,11 @@ flowchart TD
       allowed). For time-sensitive topics you may incorporate the current
       year or month to improve recall.
   - For `"read_urls"`:
-    - **`urls`** — HTTP(S) URLs to crawl for full-page text. Use only URLs
-      returned by a prior `search` call or pasted by the user — **never
-      invent URLs**.
+    - **`urls`** — HTTP(S) URLs to crawl for full-page text. Use URLs
+      returned by a prior `search` call, pasted by the user, or constructed
+      from a domain URL pattern already observed in SERP results (e.g. derive
+      a slug from the entity name when the domain's URL structure is
+      predictable). **Never invent or guess domain names.**
 
 ## Step 1 — Decide complexity (in your head, not in the tool args)
 
@@ -90,8 +94,9 @@ For complex tasks, decompose into 2-5 self-contained sub-questions and run
 - Use **`command: "read_urls"`** when the URL(s) to read are already known:
   the user pasted them, asked you to read a specific page, **or** a
   previous `search` call returned them and snippets are not enough. Pass
-  the URL(s) from the `url` fields of those snippet chunks — do not invent
-  or paraphrase URLs.
+  URLs from the `url` fields of SERP results, or construct a page-level URL
+  by deriving its slug from the entity name when you have already seen that
+  domain's URL pattern in SERP results. Never invent or guess domain names.
 
 If the user pasted URL(s) at the start of the task, your **first** call
 should use `command: "read_urls"`. Do not run a search to "find" a URL the
@@ -115,13 +120,17 @@ Decide:
 - **Snippets sufficient** + still uncovered sub-questions ⇒ next call is
   another `command: "search"` for the next sub-question.
 - **Snippets sufficient** + all sub-questions covered (or task was simple)
-  ⇒ stop calling and answer.
+  ⇒ stop calling and answer — **except** when the question asks for a
+  specific structured data field (ownership type, legal status, counts,
+  specs, registration numbers) and the SERP contains database or registry
+  pages. A snippet that confirms an entity exists is not sufficient for a
+  field-level question; fetch before stopping.
 - **Snippets insufficient** ⇒ go to Step 4.
 
 ### Triggers that mean snippets are not sufficient
 
-Follow up with `command: "read_urls"` (1-3 high-signal URLs from the SERP
-just returned) whenever any of these holds:
+Follow up with `command: "read_urls"` on high-signal URLs from the SERP
+just returned whenever any of these holds:
 
 - Snippets **paraphrase** or **hedge** ("reportedly", "around",
   "approximately", "is expected to") and the task wants exact figures,
@@ -134,6 +143,12 @@ just returned) whenever any of these holds:
   releases. Snippets summarize these; the page is the source of truth.
 - A hit is **highly relevant** but the title/snippet alone cannot support
   the claim you want to make.
+- The question asks for a **specific structured data field** (ownership type,
+  transaction records, legal status, unit count, floor count, specifications,
+  registration numbers) and SERP results include database or registry pages
+  (property portals, company registries, official catalogs). Snippets from
+  these sources show only brief summaries; the field-level data is embedded
+  in the page body.
 
 Fetching takes longer than searching. That latency is a fair trade on
 complex queries where the user expects depth — don't refuse to fetch when
@@ -147,9 +162,9 @@ Issue a follow-up call with:
 - `command: "read_urls"`.
 - An `objective` like "Read full article X to extract <missing detail> for
   <sub-question Y>".
-- `payload.urls` set to a **small, high-signal** subset (typically 1-3
-  URLs; pick complementary domains) of URLs from the `url` fields of the
-  SERP JSON you already received.
+- `payload.urls` set to a **small, high-signal** subset of URLs from the
+  `url` fields of the SERP JSON you already received. Pick complementary
+  domains.
 
 Once the page text comes back, do another sufficiency check. If the task is
 complex and more sub-questions remain, continue with the next
@@ -157,11 +172,13 @@ complex and more sub-questions remain, continue with the next
 
 ### URL-selection rules
 
-- Pick URLs from the **`url` fields of recent SERP chunks** only — never
-  type, paraphrase, or guess a URL.
-- Prefer the **smallest set** that fills the gap (1-3 URLs is usually
-  enough). If you need many pages, issue **additional**
-  `command: "read_urls"` calls rather than one giant list.
+- Pick URLs from the **`url` fields of recent SERP chunks**, or construct a
+  page-level URL by deriving its slug from the entity name when you have
+  already seen that domain's URL pattern in SERP results. **Never invent or
+  guess domain names.**
+- Prefer the **smallest set** that fills the gap. If you need many pages,
+  issue **additional** `command: "read_urls"` calls rather than one giant
+  list.
 - Prefer **complementary domains** (e.g. one official source + one
   independent corroborator) over multiple URLs from the same domain.
 - For canonical-source topics, prioritize the **issuer's own page** (the
@@ -173,8 +190,10 @@ complex and more sub-questions remain, continue with the next
   calls instead, one `gap` per call.
 - Running `command: "search"` "just in case" before reading a URL the user
   already provided.
-- Calling `command: "read_urls"` with paraphrased or invented URLs — only
-  URLs surfaced by a prior search (or pasted by the user) are valid.
+- Calling `command: "read_urls"` with invented or guessed URLs. Valid
+  sources: SERP `url` fields from a prior search, URLs pasted by the user,
+  and page-level URLs constructed from a domain URL pattern already observed
+  in SERP results. Never invent domain names.
 - Refetching pages already crawled in this task.
 - Re-deciding mid-task whether the task is simple or complex — keep the
   plan stable for the whole task.

--- a/tool_packages/unique_web_search/tests/test_cleaning.py
+++ b/tool_packages/unique_web_search/tests/test_cleaning.py
@@ -1,0 +1,254 @@
+"""Tests for the content_processing cleaning pipeline.
+
+Focus: the LineRemoval + MarkdownTransform ordering and the new boilerplate
+patterns that strip navigation-only chunks (currency dropdowns, BTS-station
+lists, district-filter checkboxes) before they reach the agent. Driven by the
+Hipflat/livinginsider/propertyhub traces from the BNPP test set, where the
+first 4-5 chunks per page were pure nav junk and the actual listings only
+appeared at chunk 5+.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+
+from unique_web_search.services.content_processing.cleaning import (
+    LineRemoval,
+    LineRemovalPatternsConfig,
+    MarkdownTransform,
+)
+from unique_web_search.services.content_processing.config import (
+    ContentProcessorConfig,
+)
+from unique_web_search.services.content_processing.service import (
+    ContentProcessor,
+)
+
+
+def _line_removal() -> LineRemoval:
+    """Default LineRemoval with the production pattern list."""
+    return LineRemoval(config=LineRemovalPatternsConfig())
+
+
+def _markdown_transform() -> MarkdownTransform:
+    return MarkdownTransform(enabled=True)
+
+
+def _clean_end_to_end(content: str) -> str:
+    """Run MarkdownTransform + LineRemoval in production order on a string."""
+    return _line_removal()(_markdown_transform()(content))
+
+
+class TestLineRemovalDropsLinkOnlyBoilerplate:
+    """The largest class of nav chatter: bullet/markdown link-only lines."""
+
+    @pytest.mark.ai
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "* [Bangkok Home]",
+            "* [Apartment building for rent Bangkok]",
+            "- [Sukhumvit Condo for rent]",
+            "+ [Condo near Chula]",
+            "[Edit]",
+            "[ลงทะเบียนนายหน้า]",
+        ],
+    )
+    def test_drops_single_bracketed_link_line(self, line: str) -> None:
+        assert _line_removal()(line) == ""
+
+    @pytest.mark.ai
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "[Condo for Sale][Home for Sale][Townhome for Sale][Land for Sale]",
+            "[Bangkok Home][Chiangmai Home][Phuket Home][Pattaya Home]",
+            "[ลงทะเบียนนายหน้า][ลงประกาศ]",
+        ],
+    )
+    def test_drops_multi_bracket_inline_nav_row(self, line: str) -> None:
+        assert _line_removal()(line) == ""
+
+    @pytest.mark.ai
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "* « First",  # plain text with no brackets — keep
+            "* Item description with content",
+            "Hello world [link] inside a sentence",
+            "Section A: real content here",
+            "[Reference 1]: see footnote at bottom of page",
+        ],
+    )
+    def test_keeps_real_prose_with_optional_links(self, line: str) -> None:
+        assert _line_removal()(line) == line
+
+
+class TestLineRemovalDropsImageOnlyLines:
+    @pytest.mark.ai
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "![Image 1: Hipflat]",
+            "* ![Image 4]",
+            "![logo]",
+            "- ![banner]",
+        ],
+    )
+    def test_drops_image_only_line(self, line: str) -> None:
+        assert _line_removal()(line) == ""
+
+    @pytest.mark.ai
+    def test_keeps_image_line_with_trailing_text(self) -> None:
+        # The real ad row: ``* ![Image 4]Advertise here`` — has content after
+        # the image so we *must* keep it (the agent can decide whether the ad
+        # text matters; we're not in the business of filtering content).
+        line = "* ![Image 4]Advertise here"
+        assert _line_removal()(line) == line
+
+
+class TestLineRemovalDropsCheckboxFilters:
+    """Drop short-label checkbox UI; preserve real lists with longer entries."""
+
+    @pytest.mark.ai
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "- [x] กรุงเทพฯ",
+            "- [x] BTS",
+            "- [ ] Bangkok",
+            "- [x] Phuket Island",  # two tokens, still short
+        ],
+    )
+    def test_drops_short_checkbox_label(self, line: str) -> None:
+        assert _line_removal()(line) == ""
+
+    @pytest.mark.ai
+    def test_keeps_long_checkbox_label(self) -> None:
+        # Looks like a checkbox but the label is a real sentence — keep it,
+        # could be a real to-do or content snippet from a Markdown article.
+        line = "- [x] this is a long sentence about something important"
+        assert _line_removal()(line) == line
+
+
+class TestLineRemovalDropsCurrencyDropdowns:
+    @pytest.mark.ai
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "* Thai Baht THB - ฿",
+            "* Swiss Franc CHF - CHF",
+            "* Vietnamese Dong VND - ₫",
+            "* New Zealand Dollar NZD - $",
+            "Thai Baht THB - ฿",
+            "THB - ฿",
+            "* USD - $",
+        ],
+    )
+    def test_drops_currency_dropdown_row(self, line: str) -> None:
+        assert _line_removal()(line) == ""
+
+    @pytest.mark.ai
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "The BIS published a report on FX markets in Q3.",  # has 3-letter code but no "- $" pattern
+            "Section A.B.C describes the methodology.",
+            "Page 1 of 12 - next",  # not a currency code
+        ],
+    )
+    def test_keeps_unrelated_prose_with_abbreviations(self, line: str) -> None:
+        assert _line_removal()(line) == line
+
+
+class TestMarkdownTransformThenLineRemoval:
+    """End-to-end on the *exact* boilerplate shapes from the Hipflat trace.
+
+    The whole point of reordering MarkdownTransform before LineRemoval is so
+    that ``[text](url)`` collapses to ``[text]`` *first*, and LineRemoval's
+    bracket-only patterns can then strip them out. Verify the integration.
+    """
+
+    @pytest.mark.ai
+    def test_markdown_link_line_dropped_after_url_collapse(self) -> None:
+        # Raw form from Tavily: a markdown link line.
+        raw = "* [English - EN](javascript:void(0))"
+        # MarkdownTransform → ``* [English - EN]`` → LineRemoval drops it.
+        assert _clean_end_to_end(raw) == ""
+
+    @pytest.mark.ai
+    def test_wrapped_image_link_dropped(self) -> None:
+        # The Hipflat header logo: ``[![Image 1: Hipflat]](/some/url)`` →
+        # MarkdownTransform → ``[![Image 1: Hipflat]]`` → LineRemoval drops.
+        raw = "[![Image 1: Hipflat]](/HIPFLAT)"
+        assert _clean_end_to_end(raw) == ""
+
+    @pytest.mark.ai
+    def test_real_listing_content_survives(self) -> None:
+        # The kind of line we actually want the agent to see — a real Hipflat
+        # listing with size and price. Must survive cleaning.
+        raw = (
+            "ให้เช่า โกดัง 800 ตรม คลองเตย กรุงเทพมหานคร ฿ 152,000 / month "
+            "พื้นที่ใช้สอย 800 ตร.ม."
+        )
+        assert _clean_end_to_end(raw) == raw
+
+    @pytest.mark.ai
+    def test_full_hipflat_header_collapses_to_almost_nothing(self) -> None:
+        """The first chunk of a Hipflat page is ~80% nav. Verify cleaning."""
+        raw = "\n".join(
+            [
+                "[![Image 1: Hipflat]](/HIPFLAT)",
+                "* [English - EN](javascript:void(0))",
+                "* [ภาษาไทย - TH](javascript:void(0))",
+                "* Thai Baht THB - ฿",
+                "* Euro EUR - €",
+                "* United States Dollar USD - $",
+                "- [x] กรุงเทพฯ",
+                "- [x] ภูเก็ต",
+                "[Condo for Sale][Home for Sale][Land for Sale]",
+                "",
+                "Khlong Toei warehouse 800 sqm available for ฿ 152,000/month.",
+            ]
+        )
+        cleaned = _clean_end_to_end(raw)
+        # Real content must survive.
+        assert "152,000" in cleaned
+        assert "Khlong Toei" in cleaned
+        # None of the nav lines should survive.
+        assert "Thai Baht" not in cleaned
+        assert "Image 1" not in cleaned
+        assert "Condo for Sale" not in cleaned
+        assert "[ภาษาไทย" not in cleaned
+        assert "กรุงเทพฯ" not in cleaned
+
+
+class TestContentProcessorPipelineOrder:
+    """Regression test for the cleaning_strategies ordering itself.
+
+    If someone reorders the list back to the old form, MarkdownTransform won't
+    run before LineRemoval and the new bracket-only patterns will see raw
+    ``[text](url)`` markdown — which they don't match. Bake the ordering into
+    a test so the regression is visible.
+    """
+
+    def _simple_encoder(self, text: str) -> list[int]:
+        return list(range(len(text.split())))
+
+    def _simple_decoder(self, tokens: list[int]) -> str:
+        return " ".join(["word"] * len(tokens))
+
+    @pytest.mark.ai
+    def test_cleaning_strategies_order__markdown_before_line_removal(
+        self,
+    ) -> None:
+        processor = ContentProcessor(
+            language_model_service=Mock(),
+            config=ContentProcessorConfig(),
+            encoder=self._simple_encoder,
+            decoder=self._simple_decoder,
+        )
+        names = [s.__class__.__name__ for s in processor._cleaning_strategies]
+        # CharacterSanitize must remain first (NUL byte safety), then
+        # MarkdownTransform must come *before* LineRemoval.
+        assert names == ["CharacterSanitize", "MarkdownTransform", "LineRemoval"]

--- a/tool_packages/unique_web_search/tests/test_search_engines.py
+++ b/tool_packages/unique_web_search/tests/test_search_engines.py
@@ -1256,5 +1256,93 @@ class TestCustomAPISearch:
         assert call_kwargs["max_redirects"] == 10
 
 
+class TestWebSearchResultControlCharSanitization:
+    """``WebSearchResult`` strips ASCII control characters at construction.
+
+    This is the single ingress point for external text into the web-search
+    pipeline (every engine adapter + the ``read_urls`` crawler wraps its
+    output here), so sanitizing in the model's field validators guarantees
+    every downstream consumer — chunker, content processor, debug payload,
+    tool result — sees data that Postgres TEXT columns can store.
+
+    The Postgres failure mode is ``22P05`` ("``\\u0000`` cannot be converted
+    to text") on any single embedded NUL byte; the dirty string poisons every
+    subsequent ``stream-responses`` / ``modify_message`` write once it lands
+    in a tool result, and the chat is then stuck because every retry resends
+    the same dirty history.
+    """
+
+    def test_url_and_title_control_chars_replaced_with_space_and_collapsed(self):
+        """Short single-line fields: controls → space, whitespace collapsed."""
+        nul = chr(0)
+        so = chr(0x0E)
+        result = WebSearchResult(
+            url=f"https://example.com/path{nul}with{so}controls",
+            title=f"A{nul}Title{so}With Controls",
+            snippet="",
+            content="",
+        )
+        # No control chars survive.
+        for forbidden in (nul, so, chr(0x1F), chr(0x7F)):
+            assert forbidden not in result.url
+            assert forbidden not in result.title
+        # Word boundaries preserved (no silent merging).
+        assert "path with controls" in result.url
+        assert result.title == "A Title With Controls"
+
+    def test_snippet_preserves_newlines_but_strips_nul(self):
+        """Engines (Brave, Bing grounding) join multiple sub-snippets with
+        ``\\n``; that structure must survive while NUL bytes are removed."""
+        nul = chr(0)
+        result = WebSearchResult(
+            url="https://example.com",
+            title="t",
+            snippet=f"line one{nul}\nline two\nline{nul} three",
+            content="",
+        )
+        assert nul not in result.snippet
+        # Newlines kept — list structure survives.
+        assert result.snippet == "line one\nline two\nline three"
+
+    def test_content_preserves_newlines_and_tabs(self):
+        """Long-form crawled bodies keep paragraph structure (TAB/LF/CR)."""
+        nul = chr(0)
+        result = WebSearchResult(
+            url="https://example.com",
+            title="t",
+            snippet="",
+            content=f"para 1{nul}\n\npara 2\twith tab\nlast{nul} line",
+        )
+        assert nul not in result.content
+        assert "\n\n" in result.content  # paragraph break preserved
+        assert "\t" in result.content  # tab preserved
+
+    def test_clean_input_is_noop(self):
+        """Sanitization must not mutate already-clean input."""
+        result = WebSearchResult(
+            url="https://example.com/clean/path",
+            title="Clean Title",
+            snippet="line one\nline two",
+            content="para 1\n\npara 2",
+        )
+        assert result.url == "https://example.com/clean/path"
+        assert result.title == "Clean Title"
+        assert result.snippet == "line one\nline two"
+        assert result.content == "para 1\n\npara 2"
+
+    def test_display_link_is_clean_because_url_is_sanitized_first(self):
+        """``display_link`` is derived from ``url``; sanitizing ``url`` at
+        construction means consumers reading ``display_link`` never see a
+        control char either, without a separate validator."""
+        nul = chr(0)
+        result = WebSearchResult(
+            url=f"https://exam{nul}ple.com/page",
+            title="t",
+            snippet="",
+            content="",
+        )
+        assert nul not in result.display_link
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## 🚀 Summary

Refs: alternative formulation of #1732

This PR is a **lighter alternative** to #1732. It keeps every change from that PR **except the LLM-based SERP relevance filter** (the scoring agent introduced in `feat(web-search): LLM-based SERP relevance filter for V3`). The intent is to give us a clean A/B comparison: how much of the observed quality and latency improvement comes from the bug fixes + prompt + cleaning work alone, vs. how much depends on the extra LLM judge.

Branched from the same base as #1732 (`2b3ff5d2`) so the two PRs are directly comparable. Against `dev` this shows up as a **partial revert** of the SERP-filter commit on top of the other four changes.

## ✅ Changes

- [x] Fixed bug — strip ASCII control characters at the `WebSearchResult` boundary (Postgres `22P05` / chat-poisoning fix). Shared `services/text_sanitize.py` powers both the per-field validators and the existing `CharacterSanitize` cleaning strategy. Agent-supplied strings (`objective` / `query` / `urls`) are wrapped at the V3 executor's `run()` boundary.
- [x] Performance — cut nav-boilerplate from page chunks. Reorder `_cleaning_strategies` to `CharacterSanitize → MarkdownTransform → LineRemoval`, fix the markdown-link regex to handle nested groups, add line-removal patterns targeting directory-style sites (currency dropdowns, multi-bracket nav rows, image-only lines, checkbox filters).
- [x] Updated prompts — V3 tool description rebalanced for exploration / exploitation, GDPR carve-out added, and a new \"I could not find a reliable source\" branch that gives the agent an explicit refuse template plus scope-mismatch anti-pattern.
- [x] **Dropped vs #1732** — the SERP scoring agent (`SerpFilterConfig`, `_filter_serp_results`, judge wiring in V3, score-driven decision rule in the tool description, `kept_scores` debug step, `llm_duration{purpose=\"serp_filter\"}` metric). No `relevance_score` is exposed to the agent.

## 🧪 Testing

- `tests/test_search_engines.py::TestWebSearchResultControlCharSanitization` — pins boundary sanitization (URL/title controls → space + collapse, snippet/content keep TAB/LF/CR, `display_link` clean, no-op on clean input).
- `tests/test_cleaning.py` (added by the nav-boilerplate commit) — pins cleaning-strategy ordering and the new line-removal patterns.
- All 44 sanitization + cleaning tests pass locally:
  ```
  uv run --frozen pytest tests/test_search_engines.py::TestWebSearchResultControlCharSanitization tests/test_cleaning.py -q
  44 passed in 0.08s
  ```

## 📊 Footprint comparison vs #1732

|  | #1732 | This PR |
|---|---|---|
| Lines changed | +3094 / -158 (36 files) | **+621 / -47 (17 files)** |
| New LLM calls per `search` | 1 judge call | 0 |
| New behavioural surface | SERP filter pipeline, score-driven decision rule, `kept_scores` debug, Prometheus metric | None — pure data hygiene + prompt wording |

## Commits

- `790d24f1` — fix(web-search): rebalance V3 prompts — exploration/exploitation + GDPR carve-out
- `3fccf418` — perf(web-search): cut nav-boilerplate from page chunks
- `50d0b6e3` — fix(web-search): strip control chars at WebSearchResult boundary
- `8431c2bb` — improve(web-search): teach V3 to refuse cleanly when no reliable source exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)