### PR TITLE
chore(ci): UN-19550 use environment-scoped PYPI_PUBLISH_TOKEN

### DIFF
--- a/.github/workflows/cd-publish-dev.yaml
+++ b/.github/workflows/cd-publish-dev.yaml
@@ -202,7 +202,7 @@ jobs:
 
   publish:
     needs: resolve
-    if: ${{ fromJson(needs.resolve.outputs.matrix).include[0] != null }}
+    if: fromJson(needs.resolve.outputs.matrix).include[0] != null
     runs-on: ubuntu-latest
     environment: pypi-publish
     strategy:

--- a/.github/workflows/cd-publish-dev.yaml
+++ b/.github/workflows/cd-publish-dev.yaml
@@ -202,8 +202,9 @@ jobs:
 
   publish:
     needs: resolve
-    if: fromJson(needs.resolve.outputs.matrix).include[0] != null
+    if: ${{ fromJson(needs.resolve.outputs.matrix).include[0] != null }}
     runs-on: ubuntu-latest
+    environment: pypi-publish
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.resolve.outputs.matrix) }}
@@ -269,7 +270,7 @@ jobs:
 
       - name: Publish to PyPI
         working-directory: ${{ matrix.dir }}
-        run: uv publish --username __token__ --password "${{ secrets.PYPI_TOKEN }}"
+        run: uv publish --username __token__ --password "${{ secrets.PYPI_PUBLISH_TOKEN }}"
 
   tag-cut:
     # Tag every successful dev publish so it can later be promoted to an

--- a/.github/workflows/cd-publish-rc.yaml
+++ b/.github/workflows/cd-publish-rc.yaml
@@ -243,6 +243,7 @@ jobs:
   publish:
     needs: resolve
     runs-on: ubuntu-latest
+    environment: pypi-publish
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.resolve.outputs.matrix) }}
@@ -312,7 +313,7 @@ jobs:
 
       - name: Publish to PyPI
         working-directory: ${{ matrix.dir }}
-        run: uv publish --username __token__ --password "${{ secrets.PYPI_TOKEN }}"
+        run: uv publish --username __token__ --password "${{ secrets.PYPI_PUBLISH_TOKEN }}"
 
   tag-release:
     # After every package in the cut publishes successfully, tag the

--- a/.github/workflows/cd-publish.yaml
+++ b/.github/workflows/cd-publish.yaml
@@ -94,6 +94,7 @@ jobs:
     needs: resolve-package
     if: ${{ fromJson(needs.resolve-package.outputs.matrix).include[0] != null }}
     runs-on: ubuntu-latest
+    environment: pypi-publish
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.resolve-package.outputs.matrix) }}
@@ -110,4 +111,4 @@ jobs:
           package_name: ${{ matrix.pypi_name }}
           python_version: ${{ matrix.python }}
           check_version: "false"
-          pypi_token: ${{ secrets.PYPI_TOKEN }}
+          pypi_token: ${{ secrets.PYPI_PUBLISH_TOKEN }}

--- a/.github/workflows/unique_search_proxy-publish.yaml
+++ b/.github/workflows/unique_search_proxy-publish.yaml
@@ -49,6 +49,7 @@ jobs:
   publish-package:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    environment: pypi-publish
     timeout-minutes: 10
     outputs:
       version: ${{ steps.version.outputs.version }}
@@ -70,7 +71,7 @@ jobs:
           package_name: unique-search-proxy
           python_version: '3.12'
           check_version: 'true'
-          pypi_token: ${{ secrets.PYPI_TOKEN }}
+          pypi_token: ${{ secrets.PYPI_PUBLISH_TOKEN }}
 
   containerize:
     needs: publish-package


### PR DESCRIPTION
## Summary

Updates PyPI publish workflows to use the Terraform-managed environment secret introduced in UN-19550.

- Sets `environment: pypi-publish` on all publish jobs
- Replaces `secrets.PYPI_TOKEN` with `secrets.PYPI_PUBLISH_TOKEN`

Affected workflows:
- `cd-publish.yaml`
- `cd-publish-dev.yaml`
- `cd-publish-rc.yaml`
- `unique_search_proxy-publish.yaml`

## Dependency

**Merge after** https://github.com/Unique-AG/infrastructure/pull/2807 is applied and `pypi-publish` / `PYPI_PUBLISH_TOKEN` exist in GitHub.

Immediately after merging this PR, delete the repo-level `PYPI_TOKEN` secret in GitHub settings (within a few minutes of step 2 in the infra PR rollout).

## Test plan

- [ ] After infra rollout, run a publish workflow (dev or RC) and confirm PyPI upload succeeds
- [ ] Confirm publish jobs resolve `pypi-publish` environment and new secret

Refs: UN-19550