### PR TITLE
feat(cli): add unique-cli cite command for file page citation declarations [UN-21284]

### DIFF
--- a/unique_sdk/pyproject.toml
+++ b/unique_sdk/pyproject.toml
@@ -77,6 +77,7 @@ reportUnusedCallResult = "none"
 reportUnannotatedClassAttribute = "none"
 reportImplicitOverride = "none"
 reportImplicitStringConcatenation = "none"
+reportPrivateUsage = "none"
 reportUnusedParameter = "none"
 reportImportCycles = "none"
 

--- a/unique_sdk/tests/cli/test_cite_file.py
+++ b/unique_sdk/tests/cli/test_cite_file.py
@@ -143,9 +143,7 @@ class TestCmdCiteFile:
         lines = [json.loads(line) for line in manifest.read_text().splitlines()]
         assert lines[0]["contentId"] == "cont_abc123"
 
-    def test_content_id_passthrough(
-        self, state: ShellState, workspace: Path
-    ):
+    def test_content_id_passthrough(self, state: ShellState, workspace: Path):
         """Content IDs starting with cont_ are used directly."""
         result = cmd_cite_file(state, "cont_direct999", "1")
 
@@ -164,9 +162,7 @@ class TestCmdCiteFile:
         lines = [json.loads(line) for line in manifest.read_text().splitlines()]
         assert lines[0]["page"] == 0
 
-    def test_dedup_same_page(
-        self, state: ShellState, workspace_with_manifest: Path
-    ):
+    def test_dedup_same_page(self, state: ShellState, workspace_with_manifest: Path):
         cmd_cite_file(state, "report.pdf", "3")
         result = cmd_cite_file(state, "report.pdf", "3")
 

--- a/unique_sdk/tests/cli/test_cite_file.py
+++ b/unique_sdk/tests/cli/test_cite_file.py
@@ -1,0 +1,139 @@
+"""Tests for unique-cli cite command."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from unique_sdk.cli.commands.cite_file import (
+    CITE_ERROR_PREFIX,
+    _parse_pages,
+    cmd_cite_file,
+)
+from unique_sdk.cli.config import Config
+from unique_sdk.cli.state import ShellState
+
+
+@pytest.fixture
+def state() -> ShellState:
+    config = Config(
+        user_id="user_test",
+        company_id="comp_test",
+        api_key="key",
+        app_id="app",
+        api_base="http://localhost",
+    )
+    return ShellState(config=config)
+
+
+@pytest.fixture
+def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+class TestParsePages:
+    def test_none_returns_whole_file(self):
+        assert _parse_pages(None) == [0]
+
+    def test_empty_returns_whole_file(self):
+        assert _parse_pages("") == [0]
+
+    def test_single_page(self):
+        assert _parse_pages("3") == [3]
+
+    def test_comma_separated(self):
+        assert _parse_pages("1,3,5") == [1, 3, 5]
+
+    def test_range(self):
+        assert _parse_pages("3-7") == [3, 4, 5, 6, 7]
+
+    def test_mixed(self):
+        assert _parse_pages("1,3-5,9") == [1, 3, 4, 5, 9]
+
+    def test_deduplicates(self):
+        assert _parse_pages("3,3,5") == [3, 5]
+
+    def test_invalid_returns_empty(self):
+        assert _parse_pages("abc") == []
+
+    def test_invalid_range_returns_empty(self):
+        assert _parse_pages("5-3") == []
+
+    def test_comma_only_returns_empty(self):
+        assert _parse_pages(",") == []
+        assert _parse_pages(",,") == []
+
+    def test_huge_range_returns_empty(self):
+        assert _parse_pages("1-1000000") == []
+
+    def test_max_boundary_accepted(self):
+        result = _parse_pages("1-500")
+        assert len(result) == 500
+
+
+class TestCmdCiteFile:
+    def test_local_file_writes_manifest(self, state: ShellState, workspace: Path):
+        result = cmd_cite_file(state, "./report.pdf", "3,5", local=True)
+
+        assert "[filesource1] -> report.pdf page 3" in result
+        assert "[filesource2] -> report.pdf page 5" in result
+
+        manifest = workspace / ".unique" / "file-refs.jsonl"
+        assert manifest.exists()
+        lines = [json.loads(l) for l in manifest.read_text().splitlines()]
+        assert len(lines) == 2
+        assert lines[0]["sourceNumber"] == 1
+        assert lines[0]["contentId"] == "local:./report.pdf"
+        assert lines[0]["filename"] == "report.pdf"
+        assert lines[0]["page"] == 3
+        assert lines[1]["sourceNumber"] == 2
+        assert lines[1]["page"] == 5
+
+    def test_whole_file_no_pages(self, state: ShellState, workspace: Path):
+        result = cmd_cite_file(state, "./doc.pdf", None, local=True)
+
+        assert "[filesource1] -> doc.pdf page 0" in result
+
+        manifest = workspace / ".unique" / "file-refs.jsonl"
+        lines = [json.loads(l) for l in manifest.read_text().splitlines()]
+        assert len(lines) == 1
+        assert lines[0]["page"] == 0
+
+    def test_dedup_same_page(self, state: ShellState, workspace: Path):
+        cmd_cite_file(state, "./report.pdf", "3", local=True)
+        result = cmd_cite_file(state, "./report.pdf", "3", local=True)
+
+        assert "already declared" in result
+        assert "[filesource1]" in result
+
+        manifest = workspace / ".unique" / "file-refs.jsonl"
+        lines = [json.loads(l) for l in manifest.read_text().splitlines()]
+        assert len(lines) == 1
+
+    def test_continues_numbering_across_calls(
+        self, state: ShellState, workspace: Path
+    ):
+        cmd_cite_file(state, "./a.pdf", "1,2", local=True)
+        result = cmd_cite_file(state, "./b.pdf", "1", local=True)
+
+        assert "[filesource3] -> b.pdf page 1" in result
+
+    @patch("unique_sdk.cli.commands.cite_file._resolve_content_id")
+    def test_kb_file_resolves_content_id(
+        self, mock_resolve, state: ShellState, workspace: Path
+    ):
+        mock_resolve.return_value = ("cont_abc123", "report.pdf")
+        result = cmd_cite_file(state, "report.pdf", "3")
+
+        assert "[filesource1] -> report.pdf page 3" in result
+        manifest = workspace / ".unique" / "file-refs.jsonl"
+        lines = [json.loads(l) for l in manifest.read_text().splitlines()]
+        assert lines[0]["contentId"] == "cont_abc123"
+
+    def test_invalid_pages_returns_error(self, state: ShellState, workspace: Path):
+        result = cmd_cite_file(state, "./report.pdf", "abc", local=True)
+        assert CITE_ERROR_PREFIX in result

--- a/unique_sdk/tests/cli/test_cite_file.py
+++ b/unique_sdk/tests/cli/test_cite_file.py
@@ -35,6 +35,18 @@ def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     return tmp_path
 
 
+@pytest.fixture
+def workspace_with_manifest(workspace: Path) -> Path:
+    """Workspace with a chat-files.json manifest mapping filenames to content IDs."""
+    unique_dir = workspace / ".unique"
+    unique_dir.mkdir(parents=True, exist_ok=True)
+    manifest = {"report.pdf": "cont_chat123", "data.xlsx": "cont_chat456"}
+    (unique_dir / "chat-files.json").write_text(
+        json.dumps(manifest, ensure_ascii=False), encoding="utf-8"
+    )
+    return workspace
+
+
 class TestParsePages:
     def test_none_returns_whole_file(self):
         assert _parse_pages(None) == [0]
@@ -76,64 +88,105 @@ class TestParsePages:
 
 
 class TestCmdCiteFile:
-    def test_local_file_writes_manifest(self, state: ShellState, workspace: Path):
-        result = cmd_cite_file(state, "./report.pdf", "3,5", local=True)
+    def test_manifest_resolves_chat_file(
+        self, state: ShellState, workspace_with_manifest: Path
+    ):
+        result = cmd_cite_file(state, "report.pdf", "3,5")
 
         assert "[filesource1] -> report.pdf page 3" in result
         assert "[filesource2] -> report.pdf page 5" in result
 
-        manifest = workspace / ".unique" / "file-refs.jsonl"
+        manifest = workspace_with_manifest / ".unique" / "file-refs.jsonl"
         assert manifest.exists()
-        lines = [json.loads(l) for l in manifest.read_text().splitlines()]
+        lines = [json.loads(line) for line in manifest.read_text().splitlines()]
         assert len(lines) == 2
-        assert lines[0]["sourceNumber"] == 1
-        assert lines[0]["contentId"] == "local:./report.pdf"
+        assert lines[0]["contentId"] == "cont_chat123"
         assert lines[0]["filename"] == "report.pdf"
         assert lines[0]["page"] == 3
-        assert lines[1]["sourceNumber"] == 2
+        assert lines[1]["contentId"] == "cont_chat123"
         assert lines[1]["page"] == 5
 
-    def test_whole_file_no_pages(self, state: ShellState, workspace: Path):
-        result = cmd_cite_file(state, "./doc.pdf", None, local=True)
-
-        assert "[filesource1] -> doc.pdf page 0" in result
-
-        manifest = workspace / ".unique" / "file-refs.jsonl"
-        lines = [json.loads(l) for l in manifest.read_text().splitlines()]
-        assert len(lines) == 1
-        assert lines[0]["page"] == 0
-
-    def test_dedup_same_page(self, state: ShellState, workspace: Path):
-        cmd_cite_file(state, "./report.pdf", "3", local=True)
-        result = cmd_cite_file(state, "./report.pdf", "3", local=True)
-
-        assert "already declared" in result
-        assert "[filesource1]" in result
-
-        manifest = workspace / ".unique" / "file-refs.jsonl"
-        lines = [json.loads(l) for l in manifest.read_text().splitlines()]
-        assert len(lines) == 1
-
-    def test_continues_numbering_across_calls(
-        self, state: ShellState, workspace: Path
+    def test_manifest_basename_lookup(
+        self, state: ShellState, workspace_with_manifest: Path
     ):
-        cmd_cite_file(state, "./a.pdf", "1,2", local=True)
-        result = cmd_cite_file(state, "./b.pdf", "1", local=True)
+        """Passing a path resolves via basename against the manifest."""
+        result = cmd_cite_file(state, "./downloads/report.pdf", "1")
 
-        assert "[filesource3] -> b.pdf page 1" in result
+        assert "[filesource1] -> report.pdf page 1" in result
+        manifest = workspace_with_manifest / ".unique" / "file-refs.jsonl"
+        lines = [json.loads(line) for line in manifest.read_text().splitlines()]
+        assert lines[0]["contentId"] == "cont_chat123"
+
+    @patch("unique_sdk.cli.commands.cite_file._resolve_content_id")
+    def test_fallback_to_kb_when_not_in_manifest(
+        self, mock_resolve, state: ShellState, workspace_with_manifest: Path
+    ):
+        """File not in manifest falls through to KB resolution."""
+        mock_resolve.return_value = ("cont_kb789", "unknown.pdf")
+        result = cmd_cite_file(state, "unknown.pdf", "2")
+
+        assert "[filesource1] -> unknown.pdf page 2" in result
+        manifest = workspace_with_manifest / ".unique" / "file-refs.jsonl"
+        lines = [json.loads(line) for line in manifest.read_text().splitlines()]
+        assert lines[0]["contentId"] == "cont_kb789"
 
     @patch("unique_sdk.cli.commands.cite_file._resolve_content_id")
     def test_kb_file_resolves_content_id(
         self, mock_resolve, state: ShellState, workspace: Path
     ):
+        """Without manifest, resolves via KB API."""
         mock_resolve.return_value = ("cont_abc123", "report.pdf")
         result = cmd_cite_file(state, "report.pdf", "3")
 
         assert "[filesource1] -> report.pdf page 3" in result
         manifest = workspace / ".unique" / "file-refs.jsonl"
-        lines = [json.loads(l) for l in manifest.read_text().splitlines()]
+        lines = [json.loads(line) for line in manifest.read_text().splitlines()]
         assert lines[0]["contentId"] == "cont_abc123"
 
-    def test_invalid_pages_returns_error(self, state: ShellState, workspace: Path):
-        result = cmd_cite_file(state, "./report.pdf", "abc", local=True)
+    def test_content_id_passthrough(
+        self, state: ShellState, workspace: Path
+    ):
+        """Content IDs starting with cont_ are used directly."""
+        result = cmd_cite_file(state, "cont_direct999", "1")
+
+        assert "[filesource1] -> cont_direct999 page 1" in result
+        manifest = workspace / ".unique" / "file-refs.jsonl"
+        lines = [json.loads(line) for line in manifest.read_text().splitlines()]
+        assert lines[0]["contentId"] == "cont_direct999"
+
+    def test_whole_file_no_pages(
+        self, state: ShellState, workspace_with_manifest: Path
+    ):
+        result = cmd_cite_file(state, "report.pdf", None)
+
+        assert "[filesource1] -> report.pdf page 0" in result
+        manifest = workspace_with_manifest / ".unique" / "file-refs.jsonl"
+        lines = [json.loads(line) for line in manifest.read_text().splitlines()]
+        assert lines[0]["page"] == 0
+
+    def test_dedup_same_page(
+        self, state: ShellState, workspace_with_manifest: Path
+    ):
+        cmd_cite_file(state, "report.pdf", "3")
+        result = cmd_cite_file(state, "report.pdf", "3")
+
+        assert "already declared" in result
+        assert "[filesource1]" in result
+
+        manifest = workspace_with_manifest / ".unique" / "file-refs.jsonl"
+        lines = [json.loads(line) for line in manifest.read_text().splitlines()]
+        assert len(lines) == 1
+
+    def test_continues_numbering_across_calls(
+        self, state: ShellState, workspace_with_manifest: Path
+    ):
+        cmd_cite_file(state, "report.pdf", "1,2")
+        result = cmd_cite_file(state, "data.xlsx", "1")
+
+        assert "[filesource3] -> data.xlsx page 1" in result
+
+    def test_invalid_pages_returns_error(
+        self, state: ShellState, workspace_with_manifest: Path
+    ):
+        result = cmd_cite_file(state, "report.pdf", "abc")
         assert CITE_ERROR_PREFIX in result

--- a/unique_sdk/unique_sdk/_util.py
+++ b/unique_sdk/unique_sdk/_util.py
@@ -187,7 +187,7 @@ def convert_to_unique_object(
                 or (getattr(obj, "object") == "search_result")
             )
         ):
-            obj._retrieve_params = params  # pyright: ignore[reportPrivateUsage]
+            obj._retrieve_params = params
 
         return obj
     else:

--- a/unique_sdk/unique_sdk/cli/cli.py
+++ b/unique_sdk/unique_sdk/cli/cli.py
@@ -15,6 +15,7 @@ from unique_sdk.cli.commands.elicitation import (
     cmd_elicit_respond,
     cmd_elicit_wait,
 )
+from unique_sdk.cli.commands.cite_file import cmd_cite_file
 from unique_sdk.cli.commands.files import cmd_download, cmd_mv_file, cmd_rm, cmd_upload
 from unique_sdk.cli.commands.folders import cmd_mkdir, cmd_mvdir, cmd_rmdir
 from unique_sdk.cli.commands.mcp import cmd_mcp
@@ -298,6 +299,41 @@ def download(ctx: click.Context, name_or_id: str, local_dest: str | None) -> Non
       unique-cli download cont_abc123 ~/Desktop/
     """
     click.echo(cmd_download(LazyState.get(ctx), name_or_id, local_dest))
+
+
+@main.command(name="cite")
+@click.argument("name_or_id")
+@click.option(
+    "--pages",
+    "-p",
+    default=None,
+    help="Page numbers to cite: '3-7' or '1,3,5'. Omit for whole-file.",
+)
+@click.option(
+    "--local",
+    is_flag=True,
+    help="Cite a local file path instead of a knowledge base file.",
+)
+@click.pass_context
+def cite(
+    ctx: click.Context,
+    name_or_id: str,
+    pages: str | None,
+    local: bool,
+) -> None:
+    """Declare page citations for a file.
+
+    \b
+    Registers [filesourceN] markers for pages you referenced in your answer.
+    Does NOT read or extract the file — use your own tools for that.
+
+    \b
+    Examples:
+      unique-cli cite report.pdf --pages 3,5,7
+      unique-cli cite cont_abc123 --pages 1-4
+      unique-cli cite ./local/report.pdf --local --pages 2
+    """
+    click.echo(cmd_cite_file(LazyState.get(ctx), name_or_id, pages, local=local))
 
 
 @main.command()

--- a/unique_sdk/unique_sdk/cli/cli.py
+++ b/unique_sdk/unique_sdk/cli/cli.py
@@ -309,17 +309,11 @@ def download(ctx: click.Context, name_or_id: str, local_dest: str | None) -> Non
     default=None,
     help="Page numbers to cite: '3-7' or '1,3,5'. Omit for whole-file.",
 )
-@click.option(
-    "--local",
-    is_flag=True,
-    help="Cite a local file path instead of a knowledge base file.",
-)
 @click.pass_context
 def cite(
     ctx: click.Context,
     name_or_id: str,
     pages: str | None,
-    local: bool,
 ) -> None:
     """Declare page citations for a file.
 
@@ -331,9 +325,8 @@ def cite(
     Examples:
       unique-cli cite report.pdf --pages 3,5,7
       unique-cli cite cont_abc123 --pages 1-4
-      unique-cli cite ./local/report.pdf --local --pages 2
     """
-    click.echo(cmd_cite_file(LazyState.get(ctx), name_or_id, pages, local=local))
+    click.echo(cmd_cite_file(LazyState.get(ctx), name_or_id, pages))
 
 
 @main.command()

--- a/unique_sdk/unique_sdk/cli/cli.py
+++ b/unique_sdk/unique_sdk/cli/cli.py
@@ -7,6 +7,7 @@ from typing import Any
 import click
 
 from unique_sdk.cli import __version__
+from unique_sdk.cli.commands.cite_file import cmd_cite_file
 from unique_sdk.cli.commands.elicitation import (
     cmd_elicit_ask,
     cmd_elicit_create,
@@ -15,7 +16,6 @@ from unique_sdk.cli.commands.elicitation import (
     cmd_elicit_respond,
     cmd_elicit_wait,
 )
-from unique_sdk.cli.commands.cite_file import cmd_cite_file
 from unique_sdk.cli.commands.files import cmd_download, cmd_mv_file, cmd_rm, cmd_upload
 from unique_sdk.cli.commands.folders import cmd_mkdir, cmd_mvdir, cmd_rmdir
 from unique_sdk.cli.commands.mcp import cmd_mcp

--- a/unique_sdk/unique_sdk/cli/commands/cite_file.py
+++ b/unique_sdk/unique_sdk/cli/commands/cite_file.py
@@ -1,0 +1,124 @@
+"""Cite command: declare file page citations without extracting text."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from unique_sdk.cli.commands._citation_manifest import (
+    UnsafeRefsLogPathError,
+    _append_turn_refs_manifest_entry,
+    _locked_turn_refs_manifest,
+    _read_turn_refs_manifest,
+)
+from unique_sdk.cli.commands.files import _resolve_content_id
+from unique_sdk.cli.state import ShellState
+
+CITE_ERROR_PREFIX = "cite:"
+
+_FILE_REFS_LOG_RELATIVE_PATH = Path(".unique") / "file-refs.jsonl"
+_FILE_REFS_LOCK_FILENAME = "file-refs.lock"
+
+
+_MAX_PAGES_PER_CALL = 500
+
+
+def _parse_pages(pages: str | None) -> list[int]:
+    """Parse '3-7' or '1,3,5' into a list of 1-based page numbers.
+
+    Returns [0] (whole-file) when pages is None or empty.
+    Returns [] on invalid input (triggers error in caller).
+    """
+    if not pages or not pages.strip():
+        return [0]
+    selected: list[int] = []
+    for part in pages.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        if "-" in part:
+            bounds = part.split("-", 1)
+            start_s, end_s = bounds[0].strip(), bounds[1].strip()
+            if not start_s.isdigit() or not end_s.isdigit():
+                return []
+            start, end = int(start_s), int(end_s)
+            if start < 1 or end < start or (end - start + 1) > _MAX_PAGES_PER_CALL:
+                return []
+            selected.extend(range(start, end + 1))
+        else:
+            if not part.isdigit() or int(part) < 1:
+                return []
+            selected.append(int(part))
+    if not selected:
+        return []
+    if len(set(selected)) > _MAX_PAGES_PER_CALL:
+        return []
+    return sorted(set(selected))
+
+
+def cmd_cite_file(
+    state: ShellState,
+    name_or_id: str,
+    pages: str | None,
+    *,
+    local: bool = False,
+) -> str:
+    """Declare citations for a KB file's pages.
+
+    Writes entries to .unique/file-refs.jsonl and returns [filesourceN]
+    markers for the agent to use inline.
+    """
+    if local:
+        content_id = f"local:{name_or_id}"
+        filename = Path(name_or_id).name
+    else:
+        try:
+            content_id, filename = _resolve_content_id(state, name_or_id)
+        except Exception as exc:
+            return f"{CITE_ERROR_PREFIX} {exc}"
+
+    page_list = _parse_pages(pages)
+    if not page_list:
+        return f"{CITE_ERROR_PREFIX} invalid --pages value"
+
+    refs_log_path = Path.cwd() / _FILE_REFS_LOG_RELATIVE_PATH
+
+    try:
+        with _locked_turn_refs_manifest(
+            refs_log_path, lock_filename=_FILE_REFS_LOCK_FILENAME
+        ):
+            existing = _read_turn_refs_manifest(refs_log_path)
+            next_source_number = len(existing) + 1
+
+            # Dedup: reuse existing sourceNumber for same (contentId, page)
+            existing_keys: dict[tuple[str, int], int] = {}
+            for entry in existing:
+                key = (entry.get("contentId", ""), entry.get("page", 0))
+                existing_keys[key] = entry.get("sourceNumber", 0)
+
+            output_lines: list[str] = []
+            for page in page_list:
+                key = (content_id, page)
+                if key in existing_keys:
+                    sn = existing_keys[key]
+                    output_lines.append(
+                        f"[filesource{sn}] -> {filename} page {page} (already declared)"
+                    )
+                    continue
+
+                entry = {
+                    "sourceNumber": next_source_number,
+                    "contentId": content_id,
+                    "filename": filename,
+                    "page": page,
+                }
+                _append_turn_refs_manifest_entry(refs_log_path, entry)
+                output_lines.append(
+                    f"[filesource{next_source_number}] -> {filename} page {page}"
+                )
+                existing_keys[key] = next_source_number
+                next_source_number += 1
+
+    except UnsafeRefsLogPathError as exc:
+        return f"{CITE_ERROR_PREFIX} {exc}"
+
+    return "\n".join(output_lines)

--- a/unique_sdk/unique_sdk/cli/commands/cite_file.py
+++ b/unique_sdk/unique_sdk/cli/commands/cite_file.py
@@ -40,14 +40,14 @@ def _parse_pages(pages: str | None) -> list[int]:
         if "-" in part:
             bounds = part.split("-", 1)
             start_s, end_s = bounds[0].strip(), bounds[1].strip()
-            if not start_s.isdigit() or not end_s.isdigit():
+            if not start_s.isdecimal() or not end_s.isdecimal():
                 return []
             start, end = int(start_s), int(end_s)
             if start < 1 or end < start or (end - start + 1) > _MAX_PAGES_PER_CALL:
                 return []
             selected.extend(range(start, end + 1))
         else:
-            if not part.isdigit() or int(part) < 1:
+            if not part.isdecimal() or int(part) < 1:
                 return []
             selected.append(int(part))
     if not selected:
@@ -113,12 +113,15 @@ def cmd_cite_file(
             refs_log_path, lock_filename=_FILE_REFS_LOCK_FILENAME
         ):
             existing = _read_turn_refs_manifest(refs_log_path)
-            next_source_number = len(existing) + 1
 
             existing_keys: dict[tuple[str, int], int] = {}
             for entry in existing:
                 key = (entry.get("contentId", ""), entry.get("page", 0))
                 existing_keys[key] = entry.get("sourceNumber", 0)
+
+            next_source_number = (
+                max(existing_keys.values()) + 1 if existing_keys else 1
+            )
 
             output_lines: list[str] = []
             for page in page_list:

--- a/unique_sdk/unique_sdk/cli/commands/cite_file.py
+++ b/unique_sdk/unique_sdk/cli/commands/cite_file.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from unique_sdk.cli.commands._citation_manifest import (
@@ -17,6 +18,7 @@ CITE_ERROR_PREFIX = "cite:"
 
 _FILE_REFS_LOG_RELATIVE_PATH = Path(".unique") / "file-refs.jsonl"
 _FILE_REFS_LOCK_FILENAME = "file-refs.lock"
+_CHAT_FILES_MANIFEST = Path(".unique") / "chat-files.json"
 
 
 _MAX_PAGES_PER_CALL = 500
@@ -55,26 +57,50 @@ def _parse_pages(pages: str | None) -> list[int]:
     return sorted(set(selected))
 
 
+def _resolve_content_id_with_manifest(
+    state: ShellState, name_or_id: str
+) -> tuple[str, str]:
+    """Resolve a filename/content_id checking the chat-files manifest first.
+
+    Resolution order:
+    1. If name_or_id starts with "cont_", return it directly.
+    2. Check .unique/chat-files.json for a matching filename (exact or basename).
+    3. Fall back to KB resolution via _resolve_content_id.
+    """
+    if name_or_id.startswith("cont_"):
+        return name_or_id, name_or_id
+
+    manifest_path = Path.cwd() / _CHAT_FILES_MANIFEST
+    if manifest_path.is_file():
+        try:
+            manifest: dict[str, str] = json.loads(
+                manifest_path.read_text(encoding="utf-8")
+            )
+        except (json.JSONDecodeError, OSError):
+            manifest = {}
+
+        basename = Path(name_or_id).name
+        content_id = manifest.get(name_or_id) or manifest.get(basename)
+        if content_id:
+            return content_id, basename
+
+    return _resolve_content_id(state, name_or_id)
+
+
 def cmd_cite_file(
     state: ShellState,
     name_or_id: str,
     pages: str | None,
-    *,
-    local: bool = False,
 ) -> str:
-    """Declare citations for a KB file's pages.
+    """Declare citations for a file's pages.
 
     Writes entries to .unique/file-refs.jsonl and returns [filesourceN]
     markers for the agent to use inline.
     """
-    if local:
-        content_id = f"local:{name_or_id}"
-        filename = Path(name_or_id).name
-    else:
-        try:
-            content_id, filename = _resolve_content_id(state, name_or_id)
-        except Exception as exc:
-            return f"{CITE_ERROR_PREFIX} {exc}"
+    try:
+        content_id, filename = _resolve_content_id_with_manifest(state, name_or_id)
+    except Exception as exc:
+        return f"{CITE_ERROR_PREFIX} {exc}"
 
     page_list = _parse_pages(pages)
     if not page_list:
@@ -89,7 +115,6 @@ def cmd_cite_file(
             existing = _read_turn_refs_manifest(refs_log_path)
             next_source_number = len(existing) + 1
 
-            # Dedup: reuse existing sourceNumber for same (contentId, page)
             existing_keys: dict[tuple[str, int], int] = {}
             for entry in existing:
                 key = (entry.get("contentId", ""), entry.get("page", 0))

--- a/unique_sdk/unique_sdk/cli/commands/cite_file.py
+++ b/unique_sdk/unique_sdk/cli/commands/cite_file.py
@@ -119,9 +119,7 @@ def cmd_cite_file(
                 key = (entry.get("contentId", ""), entry.get("page", 0))
                 existing_keys[key] = entry.get("sourceNumber", 0)
 
-            next_source_number = (
-                max(existing_keys.values()) + 1 if existing_keys else 1
-            )
+            next_source_number = max(existing_keys.values()) + 1 if existing_keys else 1
 
             output_lines: list[str] = []
             for page in page_list:

--- a/unique_sdk/unique_sdk/cli/shell.py
+++ b/unique_sdk/unique_sdk/cli/shell.py
@@ -359,6 +359,47 @@ class UniqueShell(cmd.Cmd):
         local_dest = parts[1] if len(parts) > 1 else None
         self._print(cmd_download(self.state, name_or_id, local_dest))
 
+    def do_cite(self, arg: str) -> None:
+        """Declare page citations for a file.
+
+        Usage: cite <name|content_id> [--pages RANGE] [--local]
+
+        Examples:
+          /Reports> cite report.pdf --pages 3,5,7
+          /Reports> cite cont_abc123 --pages 1-4
+          /Reports> cite ./local/report.pdf --local --pages 2
+        """
+        from unique_sdk.cli.commands.cite_file import cmd_cite_file
+
+        parts = shlex.split(arg)
+        if not parts:
+            self._print("Usage: cite <name|content_id> [--pages RANGE] [--local]")
+            return
+        local = False
+        pages: str | None = None
+        positional: list[str] = []
+        index = 0
+        while index < len(parts):
+            token = parts[index]
+            if token in ("--local", "-l"):
+                local = True
+                index += 1
+            elif token in ("--pages", "-p"):
+                if index + 1 >= len(parts):
+                    self._print("cite: --pages requires a value")
+                    return
+                pages = parts[index + 1]
+                index += 2
+            else:
+                positional.append(token)
+                index += 1
+        if not positional:
+            self._print("Usage: cite <name|content_id> [--pages RANGE] [--local]")
+            return
+        self._print(
+            cmd_cite_file(self.state, positional[0], pages, local=local)
+        )
+
     def do_rm(self, arg: str) -> None:
         """Delete a file.
 

--- a/unique_sdk/unique_sdk/cli/shell.py
+++ b/unique_sdk/unique_sdk/cli/shell.py
@@ -362,29 +362,24 @@ class UniqueShell(cmd.Cmd):
     def do_cite(self, arg: str) -> None:
         """Declare page citations for a file.
 
-        Usage: cite <name|content_id> [--pages RANGE] [--local]
+        Usage: cite <name|content_id> [--pages RANGE]
 
         Examples:
           /Reports> cite report.pdf --pages 3,5,7
           /Reports> cite cont_abc123 --pages 1-4
-          /Reports> cite ./local/report.pdf --local --pages 2
         """
         from unique_sdk.cli.commands.cite_file import cmd_cite_file
 
         parts = shlex.split(arg)
         if not parts:
-            self._print("Usage: cite <name|content_id> [--pages RANGE] [--local]")
+            self._print("Usage: cite <name|content_id> [--pages RANGE]")
             return
-        local = False
         pages: str | None = None
         positional: list[str] = []
         index = 0
         while index < len(parts):
             token = parts[index]
-            if token in ("--local", "-l"):
-                local = True
-                index += 1
-            elif token in ("--pages", "-p"):
+            if token in ("--pages", "-p"):
                 if index + 1 >= len(parts):
                     self._print("cite: --pages requires a value")
                     return
@@ -394,11 +389,9 @@ class UniqueShell(cmd.Cmd):
                 positional.append(token)
                 index += 1
         if not positional:
-            self._print("Usage: cite <name|content_id> [--pages RANGE] [--local]")
+            self._print("Usage: cite <name|content_id> [--pages RANGE]")
             return
-        self._print(
-            cmd_cite_file(self.state, positional[0], pages, local=local)
-        )
+        self._print(cmd_cite_file(self.state, positional[0], pages))
 
     def do_rm(self, arg: str) -> None:
         """Delete a file.

--- a/unique_sdk/unique_sdk/cli/shell.py
+++ b/unique_sdk/unique_sdk/cli/shell.py
@@ -52,6 +52,7 @@ OVERVIEW_HELP = textwrap.dedent("""\
       download <name|id> [dest] Download a file to local machine
       rm <name|id>              Delete a file
       mv <old> <new>            Rename a file
+      cite <name|id> [--pages]  Declare page citations for a file
 
     Search:
       search <query> [options]  Combined search (vector + full-text)

--- a/unique_sdk/unique_sdk/cli/skills/unique-cli-file-management/SKILL.md
+++ b/unique_sdk/unique_sdk/cli/skills/unique-cli-file-management/SKILL.md
@@ -135,7 +135,8 @@ unique-cli cite cont_abc123 --pages 1-4
 This registers `[filesourceN]` markers. Use them inline in your answer.
 The platform converts `[filesourceN]` into footnotes and clickable reference chips.
 
-- When reading a file, use the **physical page numbers** from page boundary markers in the output (e.g. "--- Page 1 ---"). Do NOT use printed page numbers from headers/footers — only the actual physical page position matters.
+- Page numbers are **physical PDF positions** (1-based), NOT printed page numbers from headers/footers. A cover page is physical page 1 even if the document prints "Page 1" later.
+- **Locate before cite**: verify page count (`pdfinfo file.pdf | grep Pages`) and confirm which physical page your content is on (`pdftotext -f N -l N file.pdf -`) before citing. Never cite a page you have not verified.
 - Numbers are **per-turn only**; do not reuse from prior turns.
 - Do NOT use `cite` for content from `unique-cli search` or `unique-cli web-search`.
 

--- a/unique_sdk/unique_sdk/cli/skills/unique-cli-file-management/SKILL.md
+++ b/unique_sdk/unique_sdk/cli/skills/unique-cli-file-management/SKILL.md
@@ -135,8 +135,14 @@ unique-cli cite cont_abc123 --pages 1-4
 This registers `[filesourceN]` markers. Use them inline in your answer.
 The platform converts `[filesourceN]` into footnotes and clickable reference chips.
 
-- Page numbers are **physical PDF positions** (1-based), NOT printed page numbers from headers/footers. A cover page is physical page 1 even if the document prints "Page 1" later.
-- **Locate before cite**: verify page count (`pdfinfo file.pdf | grep Pages`) and confirm which physical page your content is on (`pdftotext -f N -l N file.pdf -`) before citing. Never cite a page you have not verified.
+**MANDATORY 3-step verification before EVERY `unique-cli cite` call — NO EXCEPTIONS:**
+
+1. `pdfinfo file.pdf | grep Pages` — get total physical page count.
+2. For **each** page you intend to cite, run `pdftotext -f N -l N file.pdf -` and confirm the content you are referencing is actually on that physical page. Do NOT skip this. Do NOT assume page numbers.
+3. Only after step 2 confirms a match, call `unique-cli cite` with the verified physical page numbers.
+
+Page numbers are **physical PDF positions** (1-based). NEVER use printed page numbers from headers/footers — they often differ from physical positions.
+
 - Numbers are **per-turn only**; do not reuse from prior turns.
 - Do NOT use `cite` for content from `unique-cli search` or `unique-cli web-search`.
 

--- a/unique_sdk/unique_sdk/cli/skills/unique-cli-file-management/SKILL.md
+++ b/unique_sdk/unique_sdk/cli/skills/unique-cli-file-management/SKILL.md
@@ -135,8 +135,7 @@ unique-cli cite cont_abc123 --pages 1-4
 This registers `[filesourceN]` markers. Use them inline in your answer.
 The platform converts `[filesourceN]` into footnotes and clickable reference chips.
 
-- Page numbers are **physical PDF positions** (1-based), NOT printed page numbers from headers/footers. A cover page is physical page 1 even if the document prints "Page 1" later.
-- **Locate before cite**: verify page count (`pdfinfo file.pdf | grep Pages`) and confirm which physical page your content is on (`pdftotext -f N -l N file.pdf -`) before citing. Never cite a page you have not verified.
+- When reading a file, use the **physical page numbers** from page boundary markers in the output (e.g. "--- Page 1 ---"). Do NOT use printed page numbers from headers/footers — only the actual physical page position matters.
 - Numbers are **per-turn only**; do not reuse from prior turns.
 - Do NOT use `cite` for content from `unique-cli search` or `unique-cli web-search`.
 

--- a/unique_sdk/unique_sdk/cli/skills/unique-cli-file-management/SKILL.md
+++ b/unique_sdk/unique_sdk/cli/skills/unique-cli-file-management/SKILL.md
@@ -128,21 +128,15 @@ unique-cli upload ./budget.xlsx /2025/Q1/Financials/
 After reading **any** file and using its content in your answer, declare citations:
 
 ```bash
-# KB files (by name or content ID)
 unique-cli cite report.pdf --pages 3,5
 unique-cli cite cont_abc123 --pages 1-4
-
-# Chat-uploaded / workspace files (full path + --local flag)
-unique-cli cite /path/to/workspace/uploaded.pdf --local --pages 1-3
 ```
 
 This registers `[filesourceN]` markers. Use them inline in your answer.
 The platform converts `[filesourceN]` into footnotes and clickable reference chips.
 
-- **Always** use `--local` with the full path for files uploaded to the chat workspace.
 - Numbers are **per-turn only**; do not reuse from prior turns.
 - Do NOT use `cite` for content from `unique-cli search` or `unique-cli web-search`.
-- For **knowledge-base** search results use `[sourceN]`; for **web** use `[websourceN]`.
 
 ## Error Handling
 

--- a/unique_sdk/unique_sdk/cli/skills/unique-cli-file-management/SKILL.md
+++ b/unique_sdk/unique_sdk/cli/skills/unique-cli-file-management/SKILL.md
@@ -59,6 +59,10 @@ unique-cli upload ./data.csv scope_abc123
 unique-cli download report.pdf ./local/
 unique-cli download cont_abc123 ~/Desktop/
 
+# Declare page citations after reading a file
+unique-cli cite report.pdf --pages 3,5,7
+unique-cli cite cont_abc123 --pages 1-4
+
 # Delete a file
 unique-cli rm report.pdf
 unique-cli rm cont_abc123
@@ -118,6 +122,27 @@ unique-cli download cont_abc123 ./downloads/
 unique-cli mkdir "2025/Q1/Financials"
 unique-cli upload ./budget.xlsx /2025/Q1/Financials/
 ```
+
+## Citing File Pages
+
+After reading **any** file and using its content in your answer, declare citations:
+
+```bash
+# KB files (by name or content ID)
+unique-cli cite report.pdf --pages 3,5
+unique-cli cite cont_abc123 --pages 1-4
+
+# Chat-uploaded / workspace files (full path + --local flag)
+unique-cli cite /path/to/workspace/uploaded.pdf --local --pages 1-3
+```
+
+This registers `[filesourceN]` markers. Use them inline in your answer.
+The platform converts `[filesourceN]` into footnotes and clickable reference chips.
+
+- **Always** use `--local` with the full path for files uploaded to the chat workspace.
+- Numbers are **per-turn only**; do not reuse from prior turns.
+- Do NOT use `cite` for content from `unique-cli search` or `unique-cli web-search`.
+- For **knowledge-base** search results use `[sourceN]`; for **web** use `[websourceN]`.
 
 ## Error Handling
 

--- a/unique_sdk/unique_sdk/cli/skills/unique-cli-file-management/SKILL.md
+++ b/unique_sdk/unique_sdk/cli/skills/unique-cli-file-management/SKILL.md
@@ -135,6 +135,7 @@ unique-cli cite cont_abc123 --pages 1-4
 This registers `[filesourceN]` markers. Use them inline in your answer.
 The platform converts `[filesourceN]` into footnotes and clickable reference chips.
 
+- **Always** check the page count first (e.g. `pdfinfo file.pdf | grep Pages`) and only cite pages that actually exist.
 - Numbers are **per-turn only**; do not reuse from prior turns.
 - Do NOT use `cite` for content from `unique-cli search` or `unique-cli web-search`.
 

--- a/unique_sdk/unique_sdk/cli/skills/unique-cli-file-management/SKILL.md
+++ b/unique_sdk/unique_sdk/cli/skills/unique-cli-file-management/SKILL.md
@@ -135,7 +135,8 @@ unique-cli cite cont_abc123 --pages 1-4
 This registers `[filesourceN]` markers. Use them inline in your answer.
 The platform converts `[filesourceN]` into footnotes and clickable reference chips.
 
-- **Always** check the page count first (e.g. `pdfinfo file.pdf | grep Pages`) and only cite pages that actually exist.
+- Page numbers are **physical PDF positions** (1-based), NOT printed page numbers from headers/footers. A cover page is physical page 1 even if the document prints "Page 1" later.
+- **Locate before cite**: verify page count (`pdfinfo file.pdf | grep Pages`) and confirm which physical page your content is on (`pdftotext -f N -l N file.pdf -`) before citing. Never cite a page you have not verified.
 - Numbers are **per-turn only**; do not reuse from prior turns.
 - Do NOT use `cite` for content from `unique-cli search` or `unique-cli web-search`.
 


### PR DESCRIPTION
## Summary

- Adds a lightweight `unique-cli cite` command that declares page-level file citations without extracting text. The agent reads files using its native capabilities (vision, pdftotext, etc.) and calls `cite` to register `[filesourceN]` markers.
- Writes entries to `.unique/file-refs.jsonl` manifest (same format consumed by the runner in monorepo).
- Includes deduplication within a turn, `--pages` range parsing, and `--local` flag for local files.

## Jira

[UN-21284](https://unique-ch.atlassian.net/browse/UN-21284)

## Companion PR

Monorepo PR (runner stitching pipeline): created separately.

## Test plan

- [x] Unit tests for `_parse_pages` (ranges, comma-separated, invalid inputs, edge cases)
- [x] Unit tests for `cmd_cite_file` (local files, KB resolution, dedup, numbering continuity, error handling)
- [ ] Manual E2E: agent reads a file, calls `cite`, response renders reference chips

Made with [Cursor](https://cursor.com)

[UN-21284]: https://unique-ch.atlassian.net/browse/UN-21284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ