### PR TITLE
feat(unique_orchestrator): RJSF textarea tags for agent prompt config

### DIFF
--- a/postprocessors/unique_follow_up_questions/unique_follow_up_questions/config.py
+++ b/postprocessors/unique_follow_up_questions/unique_follow_up_questions/config.py
@@ -1,6 +1,8 @@
 from logging import getLogger
+from typing import Annotated
 
 from pydantic import AliasChoices, BaseModel, Field, field_validator
+from unique_toolkit._common.pydantic.rjsf_tags import RJSFMetaTag
 from unique_toolkit._common.utils.jinja.utils import validate_template_placeholders
 from unique_toolkit._common.validators import LMI
 from unique_toolkit.agentic.tools.config import get_configuration_dict
@@ -26,15 +28,24 @@ class FollowUpQuestionsConfig(BaseModel):
         description="The language model to be used for the follow-up question.",
     )
 
-    user_prompt: str = Field(
+    user_prompt: Annotated[
+        str,
+        RJSFMetaTag.StringWidget.textarea(rows=10),
+    ] = Field(
         default=FOLLOW_UP_QUESTION_USER_PROMPT_TEMPLATE,
         description="The user prompt to be used for the follow-up question.",
     )
-    system_prompt: str = Field(
+    system_prompt: Annotated[
+        str,
+        RJSFMetaTag.StringWidget.textarea(rows=15),
+    ] = Field(
         default=FOLLOW_UP_QUESTION_SYSTEM_PROMPT_TEMPLATE,
         description="The system prompt to be used for the follow-up question.",
     )
-    suggestions_format: str = Field(
+    suggestions_format: Annotated[
+        str,
+        RJSFMetaTag.StringWidget.textarea(rows=8),
+    ] = Field(
         default=SUGGESTION_FORMAT_TEMPLATE,
         description="The suggestion format to be used for displaying the suggestions of follow-up questions.",
     )

--- a/unique_orchestrator/unique_orchestrator/config.py
+++ b/unique_orchestrator/unique_orchestrator/config.py
@@ -14,6 +14,7 @@ from unique_internal_search.uploaded_search.config import (
 )
 from unique_stock_ticker.config import StockTickerConfig
 from unique_swot import SwotAnalysisTool, SwotAnalysisToolConfig
+from unique_toolkit._common.pydantic.rjsf_tags import RJSFMetaTag
 from unique_toolkit._common.validators import (
     LMI,
     ClipInt,
@@ -236,14 +237,20 @@ class EvaluationConfig(BaseToolConfig):
 
 
 class UniqueAIPromptConfig(BaseToolConfig):
-    system_prompt_template: str = Field(
+    system_prompt_template: Annotated[
+        str,
+        RJSFMetaTag.StringWidget.textarea(rows=25),
+    ] = Field(
         default_factory=lambda: (
             Path(__file__).parent / "prompts" / "system_prompt.jinja2"
         ).read_text(),
         description="The system prompt template as a Jinja2 template string.",
     )
 
-    user_message_prompt_template: str = Field(
+    user_message_prompt_template: Annotated[
+        str,
+        RJSFMetaTag.StringWidget.textarea(rows=4),
+    ] = Field(
         default_factory=lambda: (
             Path(__file__).parent / "prompts" / "user_message_prompt.jinja2"
         ).read_text(),

--- a/unique_orchestrator/unique_orchestrator/tests/test_agent_config_rjsf_ui_schema.py
+++ b/unique_orchestrator/unique_orchestrator/tests/test_agent_config_rjsf_ui_schema.py
@@ -1,0 +1,53 @@
+from humps import camelize
+from unique_toolkit._common.pydantic.rjsf_tags import ui_schema_for_model
+
+from unique_orchestrator.config import UniqueAIAgentConfig
+
+
+def _nested_get(data: dict, path: str) -> object:
+    current: object = data
+    for part in path.split("."):
+        assert isinstance(current, dict)
+        current = current[part]
+    return current
+
+
+def test_unique_ai_agent_config__prompt_fields__textarea_widgets() -> None:
+    ui_schema = ui_schema_for_model(UniqueAIAgentConfig, key_transform=camelize)
+    assert _nested_get(ui_schema, "promptConfig.systemPromptTemplate") == {
+        "ui:widget": "textarea",
+        "ui:disabled": False,
+        "ui:readonly": False,
+        "ui:options": {"rows": 25},
+        "ui:emptyValue": "",
+    }
+    assert _nested_get(ui_schema, "promptConfig.userMessagePromptTemplate") == {
+        "ui:widget": "textarea",
+        "ui:disabled": False,
+        "ui:readonly": False,
+        "ui:options": {"rows": 4},
+        "ui:emptyValue": "",
+    }
+    assert _nested_get(ui_schema, "services.followUpQuestionsConfig.userPrompt") == {
+        "ui:widget": "textarea",
+        "ui:disabled": False,
+        "ui:readonly": False,
+        "ui:options": {"rows": 10},
+        "ui:emptyValue": "",
+    }
+    assert _nested_get(ui_schema, "services.followUpQuestionsConfig.systemPrompt") == {
+        "ui:widget": "textarea",
+        "ui:disabled": False,
+        "ui:readonly": False,
+        "ui:options": {"rows": 15},
+        "ui:emptyValue": "",
+    }
+    assert _nested_get(
+        ui_schema, "services.followUpQuestionsConfig.suggestionsFormat"
+    ) == {
+        "ui:widget": "textarea",
+        "ui:disabled": False,
+        "ui:readonly": False,
+        "ui:options": {"rows": 8},
+        "ui:emptyValue": "",
+    }


### PR DESCRIPTION
## Summary

- Add `RJSFMetaTag.StringWidget.textarea` on `UniqueAIPromptConfig` (`system_prompt_template`, `user_message_prompt_template`).
- Add textarea tags on `FollowUpQuestionsConfig` (`user_prompt`, `system_prompt`, `suggestions_format`).
- Unit test asserts full generated uiSchema for loop agent prompt paths (camelCase).

## Why

Admin loop-agent configuration uses `ui_schema_for_model(UniqueAIAgentConfig)`. Without field-level RJSF tags, prompt fields render as single-line inputs. Open File already had tags in toolkit; this completes the remaining prompt fields.

## Test plan

- [x] `uv run pytest unique_orchestrator/tests/test_agent_config_rjsf_ui_schema.py`

## Follow-up

Merge this first. Monorepo PR unique-ag/monorepo#24831 removes interim manual uiSchema overrides and depends on the next dev PyPI publish of `unique-orchestrator` and `unique-follow-up-questions`.


Made with [Cursor](https://cursor.com)