### PR TITLE
fix(unique-toolkit): env-var fallback when configuration-backend is unset

### DIFF
--- a/unique_toolkit/tests/experimental/resources/feature_flags/test_feature_flags.py
+++ b/unique_toolkit/tests/experimental/resources/feature_flags/test_feature_flags.py
@@ -48,7 +48,12 @@ def _make_client(url: str = _URL, ttl_ms: int = 5_000) -> FeatureFlagClient:
 @pytest.fixture(autouse=True)
 def reset_singleton() -> None:
     """Reset the from_settings() singleton between tests so monkeypatch env changes take effect."""
+    from unique_toolkit.experimental.resources.feature_flags.client import (
+        _EnvOnlyFeatureFlagClient,
+    )
+
     FeatureFlagClient._instance = None
+    _EnvOnlyFeatureFlagClient._env_instance = None
 
 
 def _gql_response(value: bool) -> dict:
@@ -654,3 +659,68 @@ async def test_is_flag_enabled__enabled__no_log(
 
     assert result is True
     assert not any(_FLAG in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Env-only fallback when configuration-backend is not configured
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.ai
+def test_get_feature_flag_client__no_backend__returns_env_only_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without CONFIGURATION_BACKEND_URL, the client degrades to env-only instead of raising."""
+    from unique_toolkit.experimental.resources.feature_flags.client import (
+        _EnvOnlyFeatureFlagClient,
+    )
+
+    monkeypatch.delenv("CONFIGURATION_BACKEND_URL", raising=False)
+    monkeypatch.delenv("FEATURE_FLAG_SERVICE_ID", raising=False)
+
+    client = get_feature_flag_client()
+
+    assert isinstance(client, _EnvOnlyFeatureFlagClient)
+    # Repeated calls reuse the same env-only instance.
+    assert get_feature_flag_client() is client
+
+
+@pytest.mark.ai
+async def test_is_flag_enabled__no_backend__reads_env_var(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The convenience wrapper never raises on missing config; it honours the env var."""
+    monkeypatch.delenv("CONFIGURATION_BACKEND_URL", raising=False)
+    monkeypatch.delenv("FEATURE_FLAG_SERVICE_ID", raising=False)
+    monkeypatch.setenv(_FLAG, "true")
+
+    assert await is_flag_enabled(_FLAG, company_id=_COMPANY_ID) is True
+
+    monkeypatch.setenv(_FLAG, "false")
+    assert await is_flag_enabled(_FLAG, company_id=_COMPANY_ID) is False
+
+
+@pytest.mark.ai
+async def test_env_only_client__allowlist__company_in_list(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Comma-separated company allowlist is honoured in env-only mode."""
+    monkeypatch.delenv("CONFIGURATION_BACKEND_URL", raising=False)
+    monkeypatch.delenv("FEATURE_FLAG_SERVICE_ID", raising=False)
+    monkeypatch.setenv(_FLAG, f"other-co,{_COMPANY_ID}")
+
+    result = await get_feature_flag_client().evaluate(_FLAG, company_id=_COMPANY_ID)
+
+    assert result == FlagEvaluation(value=True, reason="fallback")
+
+
+@pytest.mark.ai
+async def test_env_only_client__empty_company_id__raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Empty company_id still raises, matching FeatureFlagClient.evaluate semantics."""
+    monkeypatch.delenv("CONFIGURATION_BACKEND_URL", raising=False)
+    monkeypatch.delenv("FEATURE_FLAG_SERVICE_ID", raising=False)
+
+    with pytest.raises(ValueError, match="company_id"):
+        await get_feature_flag_client().evaluate(_FLAG, company_id="   ")

--- a/unique_toolkit/unique_toolkit/experimental/resources/feature_flags/README.md
+++ b/unique_toolkit/unique_toolkit/experimental/resources/feature_flags/README.md
@@ -14,8 +14,8 @@ directly to avoid SDK overhead.
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
-| `CONFIGURATION_BACKEND_URL` | **Yes** | — | Base URL of your configuration-backend instance. |
-| `FEATURE_FLAG_SERVICE_ID` | **Yes** | — | Service identifier sent as `x-service-id`. Must match a registered value in configuration-backend's `Service` enum. |
+| `CONFIGURATION_BACKEND_URL` | No | — | Base URL of your configuration-backend instance. If unset, `get_feature_flag_client()` returns an env-var-only client (see [Init-time fallback](#init-time-fallback)). |
+| `FEATURE_FLAG_SERVICE_ID` | No | — | Service identifier sent as `x-service-id`. Must match a registered value in configuration-backend's `Service` enum. Required when `CONFIGURATION_BACKEND_URL` is set. |
 | `FEATURE_FLAG_CACHE_TTL_MS` | No | `5000` | In-process cache TTL in milliseconds. |
 
 ---
@@ -43,6 +43,39 @@ class MyServiceFlags:
     ENABLE_MY_FEATURE = "FEATURE_FLAG_ENABLE_MY_FEATURE"
     ENABLE_OTHER_FEATURE = "FEATURE_FLAG_ENABLE_OTHER_FEATURE_UN_12345"
 ```
+
+---
+
+## Init-time fallback
+
+Use `get_feature_flag_client()` instead of `FeatureFlagClient.from_settings()` when
+`CONFIGURATION_BACKEND_URL` / `FEATURE_FLAG_SERVICE_ID` may not be set (e.g. local
+dev, testing, or services that haven't wired up configuration-backend yet).
+
+```python
+from unique_toolkit.experimental.resources.feature_flags import get_feature_flag_client
+
+client = get_feature_flag_client()
+# Returns a full FeatureFlagClient (remote + cache) when the backend is configured,
+# or an env-var-only client when it isn't — no ValueError, no extra error handling needed.
+```
+
+```mermaid
+flowchart TD
+    A(["get_feature_flag_client()"]) --> B{CONFIGURATION_BACKEND_URL\nand FEATURE_FLAG_SERVICE_ID set?}
+
+    B -- yes --> C[FeatureFlagClient.from_settings\nsingleton with TTL cache]
+    C --> D([remote evaluation\nwith env-var fallback on error])
+
+    B -- no --> E[_EnvOnlyFeatureFlagClient\nsingleton]
+    E --> F([env-var evaluation only\nreason=fallback])
+
+    style D fill:#22c55e,color:#fff
+    style F fill:#ef4444,color:#fff
+```
+
+When the env-var-only client is active every `evaluate()` call goes straight to
+the env-var fallback — same logic as step 4 of the full evaluation order below.
 
 ---
 

--- a/unique_toolkit/unique_toolkit/experimental/resources/feature_flags/__init__.py
+++ b/unique_toolkit/unique_toolkit/experimental/resources/feature_flags/__init__.py
@@ -5,7 +5,7 @@ transport errors, and env-var fallback when no prior value exists.
 Env-var values support both plain booleans and comma-separated company-ID
 allowlists, consistent with ``unique_toolkit.agentic.feature_flags``.
 
-Required env vars::
+Optional env vars (when unset, flags are evaluated from env vars only)::
 
     CONFIGURATION_BACKEND_URL=https://<your-configuration-backend>
     FEATURE_FLAG_SERVICE_ID=your-service-name

--- a/unique_toolkit/unique_toolkit/experimental/resources/feature_flags/client.py
+++ b/unique_toolkit/unique_toolkit/experimental/resources/feature_flags/client.py
@@ -215,14 +215,60 @@ class BoundFeatureFlagClient:
         return (await self.evaluate(flag)).value
 
 
+class _EnvOnlyFeatureFlagClient(FeatureFlagClient):
+    """Env-var-only flag client used when configuration-backend is not configured.
+
+    Returned by :func:`get_feature_flag_client` when ``CONFIGURATION_BACKEND_URL``
+    / ``FEATURE_FLAG_SERVICE_ID`` are unset, so callers degrade gracefully to
+    environment-variable evaluation instead of hitting the ``ValueError`` raised
+    by :meth:`FeatureFlagClient.from_settings`. Uses the same env-var semantics as
+    :meth:`FeatureFlagClient._env_fallback` (plain booleans or comma-separated
+    company-ID allowlists). Subclasses :class:`FeatureFlagClient` so that
+    ``bind_settings`` / ``is_enabled`` and type checks keep working unchanged.
+    """
+
+    _env_instance: ClassVar[_EnvOnlyFeatureFlagClient | None] = None
+
+    def __init__(self) -> None:  # no URL / HTTP client / cache needed
+        pass
+
+    async def evaluate(
+        self,
+        flag: str,
+        *,
+        company_id: str,
+        user_id: str | None = None,
+    ) -> FlagEvaluation:
+        company_id = company_id.strip()
+        if not company_id:
+            raise ValueError("company_id must be a non-empty string")
+        return FlagEvaluation(
+            value=self._env_fallback(flag, company_id), reason="fallback"
+        )
+
+
 def get_feature_flag_client() -> FeatureFlagClient:
     """Return the process-level :class:`FeatureFlagClient` singleton.
 
     Built lazily via :meth:`FeatureFlagClient.from_settings` which reads
     ``CONFIGURATION_BACKEND_URL`` and ``FEATURE_FLAG_SERVICE_ID`` from env.
-    Falls back to env-var defaults on missing config or transport errors.
+
+    When those settings are absent, configuration-backend cannot be reached, so
+    this returns an env-var-only client instead of raising — callers always get
+    a usable client and flags are read from ``FEATURE_FLAG_*`` env vars. Once the
+    settings are present a real remote-backed client is built and returned.
     """
-    return FeatureFlagClient.from_settings()
+    try:
+        return FeatureFlagClient.from_settings()
+    except ValueError:
+        if _EnvOnlyFeatureFlagClient._env_instance is None:
+            logger.warning(
+                "configuration-backend not configured "
+                "(CONFIGURATION_BACKEND_URL / FEATURE_FLAG_SERVICE_ID unset) — "
+                "feature flags will be evaluated from env vars only."
+            )
+            _EnvOnlyFeatureFlagClient._env_instance = _EnvOnlyFeatureFlagClient()
+        return _EnvOnlyFeatureFlagClient._env_instance
 
 
 async def is_flag_enabled(

--- a/unique_toolkit/unique_toolkit/experimental/resources/feature_flags/client.py
+++ b/unique_toolkit/unique_toolkit/experimental/resources/feature_flags/client.py
@@ -5,6 +5,7 @@ import os
 from typing import ClassVar
 
 import httpx
+from pydantic import ValidationError
 from tenacity import retry, retry_if_exception, stop_after_attempt
 
 from unique_toolkit.app.unique_settings import AuthContextProtocol, UniqueSettings
@@ -57,8 +58,12 @@ class FeatureFlagClient:
     def __init__(self, *, url: str, service_id: str, ttl_ms: int = 5_000) -> None:
         self._url = url
         self._service_id = service_id
-        self._cache = AsyncTTLCache(ttl_ms=ttl_ms)
-        self._http = httpx.AsyncClient(timeout=httpx.Timeout(2.0, connect=1.0))
+        self._cache: AsyncTTLCache | None = (
+            AsyncTTLCache(ttl_ms=ttl_ms) if url else None
+        )
+        self._http: httpx.AsyncClient | None = (
+            httpx.AsyncClient(timeout=httpx.Timeout(2.0, connect=1.0)) if url else None
+        )
 
     @classmethod
     def from_settings(cls) -> FeatureFlagClient:
@@ -260,10 +265,11 @@ def get_feature_flag_client() -> FeatureFlagClient:
     """
     if _EnvOnlyFeatureFlagClient._env_instance is not None:
         return _EnvOnlyFeatureFlagClient._env_instance
-    if (
-        not (os.getenv("CONFIGURATION_BACKEND_URL") or "").strip()
-        or not (os.getenv("FEATURE_FLAG_SERVICE_ID") or "").strip()
-    ):
+    try:
+        return FeatureFlagClient.from_settings()
+    except ValidationError:
+        raise
+    except ValueError:
         logger.warning(
             "configuration-backend not configured "
             "(CONFIGURATION_BACKEND_URL / FEATURE_FLAG_SERVICE_ID unset) — "
@@ -271,7 +277,6 @@ def get_feature_flag_client() -> FeatureFlagClient:
         )
         _EnvOnlyFeatureFlagClient._env_instance = _EnvOnlyFeatureFlagClient()
         return _EnvOnlyFeatureFlagClient._env_instance
-    return FeatureFlagClient.from_settings()
 
 
 async def is_flag_enabled(

--- a/unique_toolkit/unique_toolkit/experimental/resources/feature_flags/client.py
+++ b/unique_toolkit/unique_toolkit/experimental/resources/feature_flags/client.py
@@ -58,12 +58,8 @@ class FeatureFlagClient:
     def __init__(self, *, url: str, service_id: str, ttl_ms: int = 5_000) -> None:
         self._url = url
         self._service_id = service_id
-        self._cache: AsyncTTLCache = (
-            AsyncTTLCache(ttl_ms=ttl_ms) if url else None  # type: ignore[assignment]
-        )
-        self._http: httpx.AsyncClient = (
-            httpx.AsyncClient(timeout=httpx.Timeout(2.0, connect=1.0)) if url else None  # type: ignore[assignment]
-        )
+        self._cache = AsyncTTLCache(ttl_ms=ttl_ms)
+        self._http = httpx.AsyncClient(timeout=httpx.Timeout(2.0, connect=1.0))
 
     @classmethod
     def from_settings(cls) -> FeatureFlagClient:

--- a/unique_toolkit/unique_toolkit/experimental/resources/feature_flags/client.py
+++ b/unique_toolkit/unique_toolkit/experimental/resources/feature_flags/client.py
@@ -58,11 +58,11 @@ class FeatureFlagClient:
     def __init__(self, *, url: str, service_id: str, ttl_ms: int = 5_000) -> None:
         self._url = url
         self._service_id = service_id
-        self._cache: AsyncTTLCache | None = (
-            AsyncTTLCache(ttl_ms=ttl_ms) if url else None
+        self._cache: AsyncTTLCache = (
+            AsyncTTLCache(ttl_ms=ttl_ms) if url else None  # type: ignore[assignment]
         )
-        self._http: httpx.AsyncClient | None = (
-            httpx.AsyncClient(timeout=httpx.Timeout(2.0, connect=1.0)) if url else None
+        self._http: httpx.AsyncClient = (
+            httpx.AsyncClient(timeout=httpx.Timeout(2.0, connect=1.0)) if url else None  # type: ignore[assignment]
         )
 
     @classmethod

--- a/unique_toolkit/unique_toolkit/experimental/resources/feature_flags/client.py
+++ b/unique_toolkit/unique_toolkit/experimental/resources/feature_flags/client.py
@@ -258,16 +258,17 @@ def get_feature_flag_client() -> FeatureFlagClient:
     a usable client and flags are read from ``FEATURE_FLAG_*`` env vars. Once the
     settings are present a real remote-backed client is built and returned.
     """
+    if _EnvOnlyFeatureFlagClient._env_instance is not None:
+        return _EnvOnlyFeatureFlagClient._env_instance
     try:
         return FeatureFlagClient.from_settings()
     except ValueError:
-        if _EnvOnlyFeatureFlagClient._env_instance is None:
-            logger.warning(
-                "configuration-backend not configured "
-                "(CONFIGURATION_BACKEND_URL / FEATURE_FLAG_SERVICE_ID unset) — "
-                "feature flags will be evaluated from env vars only."
-            )
-            _EnvOnlyFeatureFlagClient._env_instance = _EnvOnlyFeatureFlagClient()
+        logger.warning(
+            "configuration-backend not configured "
+            "(CONFIGURATION_BACKEND_URL / FEATURE_FLAG_SERVICE_ID unset) — "
+            "feature flags will be evaluated from env vars only."
+        )
+        _EnvOnlyFeatureFlagClient._env_instance = _EnvOnlyFeatureFlagClient()
         return _EnvOnlyFeatureFlagClient._env_instance
 
 

--- a/unique_toolkit/unique_toolkit/experimental/resources/feature_flags/client.py
+++ b/unique_toolkit/unique_toolkit/experimental/resources/feature_flags/client.py
@@ -260,9 +260,9 @@ def get_feature_flag_client() -> FeatureFlagClient:
     """
     if _EnvOnlyFeatureFlagClient._env_instance is not None:
         return _EnvOnlyFeatureFlagClient._env_instance
-    try:
-        return FeatureFlagClient.from_settings()
-    except ValueError:
+    if not os.getenv("CONFIGURATION_BACKEND_URL") or not os.getenv(
+        "FEATURE_FLAG_SERVICE_ID"
+    ):
         logger.warning(
             "configuration-backend not configured "
             "(CONFIGURATION_BACKEND_URL / FEATURE_FLAG_SERVICE_ID unset) — "
@@ -270,6 +270,7 @@ def get_feature_flag_client() -> FeatureFlagClient:
         )
         _EnvOnlyFeatureFlagClient._env_instance = _EnvOnlyFeatureFlagClient()
         return _EnvOnlyFeatureFlagClient._env_instance
+    return FeatureFlagClient.from_settings()
 
 
 async def is_flag_enabled(

--- a/unique_toolkit/unique_toolkit/experimental/resources/feature_flags/client.py
+++ b/unique_toolkit/unique_toolkit/experimental/resources/feature_flags/client.py
@@ -260,8 +260,9 @@ def get_feature_flag_client() -> FeatureFlagClient:
     """
     if _EnvOnlyFeatureFlagClient._env_instance is not None:
         return _EnvOnlyFeatureFlagClient._env_instance
-    if not os.getenv("CONFIGURATION_BACKEND_URL") or not os.getenv(
-        "FEATURE_FLAG_SERVICE_ID"
+    if (
+        not (os.getenv("CONFIGURATION_BACKEND_URL") or "").strip()
+        or not (os.getenv("FEATURE_FLAG_SERVICE_ID") or "").strip()
     ):
         logger.warning(
             "configuration-backend not configured "

--- a/unique_toolkit/unique_toolkit/experimental/resources/feature_flags/client.py
+++ b/unique_toolkit/unique_toolkit/experimental/resources/feature_flags/client.py
@@ -230,7 +230,7 @@ class _EnvOnlyFeatureFlagClient(FeatureFlagClient):
     _env_instance: ClassVar[_EnvOnlyFeatureFlagClient | None] = None
 
     def __init__(self) -> None:  # no URL / HTTP client / cache needed
-        pass
+        super().__init__(url="", service_id="")
 
     async def evaluate(
         self,


### PR DESCRIPTION
## Summary

`get_feature_flag_client()` / `is_flag_enabled()` previously **raised `ValueError`** whenever `CONFIGURATION_BACKEND_URL` or `FEATURE_FLAG_SERVICE_ID` were unset — because `FeatureFlagClient.from_settings()` raises in that case, and the documented env-var fallback only kicks in *inside* `evaluate()` (i.e. after a client is already constructed). The `get_feature_flag_client` docstring claimed it "falls back to env-var defaults on missing config", which was not actually true.

This makes the contract true:

- New `_EnvOnlyFeatureFlagClient` — subclasses `FeatureFlagClient` (so `bind_settings` / `is_enabled` / type checks keep working), no URL/HTTP/cache, and `evaluate()` resolves purely via the existing `_env_fallback` (booleans **and** comma-separated company-ID allowlists). Reused as a process singleton.
- `get_feature_flag_client()` catches the `ValueError` from `from_settings()` and returns the env-only client (one-time WARNING log) instead of propagating. Once the settings are present, the real remote-backed client is built as before.
- `from_settings()` is left **unchanged** (still raises) — it has an explicit test asserting that contract and direct callers may rely on it.

## Why

Consumers wiring per-tenant flags into runtime hot paths (e.g. assistants-core's `start_proxies()`, see [monorepo#24834](https://github.com/Unique-AG/monorepo/pull/24834)) would otherwise crash every turn in any environment without configuration-backend configured — local dev, helm-chart base, untouched overlays. Pre-existing `os.getenv`-based flag checks never raised; this restores that behavior and lets consumers drop bespoke try/except guards.

## Tests

Added to `tests/experimental/resources/feature_flags/test_feature_flags.py`:
- env-only client returned on missing config (+ singleton reuse)
- `is_flag_enabled` honors the env var without raising
- comma-separated company allowlist match in env-only mode
- empty `company_id` still raises (parity with `FeatureFlagClient.evaluate`)

`reset_singleton` autouse fixture now also resets the env-only singleton.

Refs: UN-21295