### PR TITLE
fix(ci): UN-21527 grant packages:write through containerize batch chain

### DIFF
--- a/.github/workflows/cd-containerize-batch.yaml
+++ b/.github/workflows/cd-containerize-batch.yaml
@@ -29,6 +29,10 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   prepare:
     runs-on: ubuntu-latest

--- a/.github/workflows/cd-publish-dev.yaml
+++ b/.github/workflows/cd-publish-dev.yaml
@@ -273,6 +273,9 @@ jobs:
   containerize:
     needs: [resolve, publish]
     if: needs.publish.result == 'success'
+    permissions:
+      contents: read
+      packages: write
     uses: ./.github/workflows/cd-containerize-batch.yaml
     secrets: inherit
     with:

--- a/.github/workflows/cd-publish-rc.yaml
+++ b/.github/workflows/cd-publish-rc.yaml
@@ -317,6 +317,9 @@ jobs:
   containerize:
     needs: [resolve, publish]
     if: needs.publish.result == 'success'
+    permissions:
+      contents: read
+      packages: write
     uses: ./.github/workflows/cd-containerize-batch.yaml
     secrets: inherit
     with:

--- a/.github/workflows/cd-publish.yaml
+++ b/.github/workflows/cd-publish.yaml
@@ -118,6 +118,9 @@ jobs:
     # release-only: a manual workflow_dispatch has no release tag to derive the
     # image version from, so containerization runs solely on release events.
     if: needs.publish.result == 'success' && github.event_name == 'release'
+    permissions:
+      contents: read
+      packages: write
     uses: ./.github/workflows/cd-containerize-batch.yaml
     secrets: inherit
     with:


### PR DESCRIPTION
## Summary

Post-merge, the `[CD] Publish dev builds to PyPI` workflow on `main` hit a `startup_failure` ([run 26887352369](https://github.com/Unique-AG/ai/actions/runs/26887352369)):

> Error calling workflow `.../cd-containerize.yaml`. The workflow is requesting `packages: write`, but is only allowed `packages: none`.

**Root cause:** the refactor that introduced `cd-containerize-batch.yaml` (#1785) dropped the `packages: write` grant. The batch reusable workflow declared no `permissions` block, so its nested call to `cd-containerize.yaml` (which requests `packages: write` to push to GHCR) failed static validation. The publish workflows also call the batch without granting the scope.

## Changes

- `cd-containerize-batch.yaml`: add workflow-level `permissions: { contents: read, packages: write }` so the nested `cd-containerize.yaml` call is valid.
- `cd-publish-dev.yaml`, `cd-publish-rc.yaml`, `cd-publish.yaml`: add job-level `permissions: { contents: read, packages: write }` on the `containerize` job that calls the batch, so the token actually carries the scope (top-level workflow permissions are `contents: read` only).

## Test plan

- [x] YAML validates for all four workflows
- [ ] Next dev publish on `main` runs the `containerize` job without `startup_failure` and pushes the image to GHCR

Refs: UN-21527

Made with [Cursor](https://cursor.com)