### PR TITLE
fix(ci): UN-21527 export container requirements with --frozen

### DIFF
--- a/.github/workflows/cd-containerize.yaml
+++ b/.github/workflows/cd-containerize.yaml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Export hash-pinned requirements
         run: >
-          uv export --locked
+          uv export --frozen
           --package ${{ inputs.pypi_name }}
           --no-dev --no-emit-project
           -o ${{ inputs.package_dir }}/deploy/requirements.txt


### PR DESCRIPTION
## Summary

The `containerize-search_proxy` build (via `cd-containerize.yaml`) fails at the `uv export` step on `main`:

```
Resolving despite existing lockfile due to change of exclude newer timestamp
  from `2026-05-16T22:00:00Z` to `2026-05-17T00:00:00Z` for package `litellm`
error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.
```

`exclude-newer` is a *relative* window, so it drifts day-to-day. `uv export --locked` re-resolves and refuses to proceed unless `uv.lock` is perfectly fresh — meaning the container build breaks on any day the window rolls over, independent of any actual dependency change.

This swaps `--locked` for `--frozen`, which exports `requirements.txt` straight from the existing `uv.lock` without re-resolution. That is the intended behaviour for a container build that must match the already-published, locked dependency set.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, next `[CD] Publish dev builds to PyPI` run on `main` that includes a containerizable package builds + pushes `search-proxy` successfully

Refs: UN-21527

Made with [Cursor](https://cursor.com)