### PR TITLE
fix(search-proxy): UN-21527 make helm extra-files paths package-relative

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -61,8 +61,8 @@
     "connectors/unique_search_proxy": {
       "component": "unique-search-proxy",
       "extra-files": [
-        { "type": "generic", "path": "connectors/unique_search_proxy/deploy/helm-chart/Chart.yaml" },
-        { "type": "generic", "path": "connectors/unique_search_proxy/deploy/helm-chart/values.yaml" }
+        { "type": "generic", "path": "deploy/helm-chart/Chart.yaml" },
+        { "type": "generic", "path": "deploy/helm-chart/values.yaml" }
       ]
     },
     "tool_packages/unique_skill_tool": {


### PR DESCRIPTION
## What

Make the `unique-search-proxy` `extra-files` paths in `release-please-config.json` **package-relative** instead of repo-root-relative.

```diff
-        { "type": "generic", "path": "connectors/unique_search_proxy/deploy/helm-chart/Chart.yaml" },
-        { "type": "generic", "path": "connectors/unique_search_proxy/deploy/helm-chart/values.yaml" }
+        { "type": "generic", "path": "deploy/helm-chart/Chart.yaml" },
+        { "type": "generic", "path": "deploy/helm-chart/values.yaml" }
```

## Why

release-please resolves `extra-files` paths relative to the package directory (`connectors/unique_search_proxy`), not the repo root. The previous repo-root-relative paths resolved to a doubled, non-existent path and were silently skipped:

```
⚠ file connectors/unique_search_proxy/connectors/unique_search_proxy/deploy/helm-chart/Chart.yaml did not exist
⚠ file connectors/unique_search_proxy/connectors/unique_search_proxy/deploy/helm-chart/values.yaml did not exist
```

As a result the standing stable Release PR only bumped `pyproject.toml` / `CHANGELOG.md`, never the chart's `# x-release-please-version` markers. With this fix release-please will stamp `Chart.yaml` (`version`/`appVersion`) and `values.yaml` (`image.tag`) on stable releases, which the new Helm publish flow relies on.

## AI assist

light

Refs: UN-21527

Made with [Cursor](https://cursor.com)