### PR TITLE
fix(search-proxy): UN-21527 make hotfix extra-files paths package-relative

### DIFF
--- a/release-please-config.release.json
+++ b/release-please-config.release.json
@@ -62,8 +62,8 @@
     "connectors/unique_search_proxy": {
       "component": "unique-search-proxy",
       "extra-files": [
-        { "type": "generic", "path": "connectors/unique_search_proxy/deploy/helm-chart/Chart.yaml" },
-        { "type": "generic", "path": "connectors/unique_search_proxy/deploy/helm-chart/values.yaml" }
+        { "type": "generic", "path": "deploy/helm-chart/Chart.yaml" },
+        { "type": "generic", "path": "deploy/helm-chart/values.yaml" }
       ]
     },
     "tool_packages/unique_skill_tool": {


### PR DESCRIPTION
## Summary

- Fix `release-please-config.release.json` extra-files paths for `unique_search_proxy` to be package-relative (`deploy/helm-chart/...`), matching the stable config fix in #1797
- Ensures release-please on `release/*` branches bumps `Chart.yaml` and `values.yaml` during hotfix PRs instead of silently skipping missing doubled paths

## Context

release-please resolves `extra-files` paths relative to the package directory (`connectors/unique_search_proxy`), not the repo root. The previous repo-root-relative paths produced warnings like:

```
file connectors/unique_search_proxy/connectors/unique_search_proxy/deploy/helm-chart/Chart.yaml did not exist
```

## Test plan

- [ ] Merge and cut a hotfix on a `release/*` branch; verify the release-please PR includes `Chart.yaml` / `values.yaml` version bumps
- [ ] Confirm stable flow on `main` remains unchanged (already fixed in #1797)

Refs: UN-21527

<!-- AI assist: medium -->

Made with [Cursor](https://cursor.com)