### PR TITLE
fix(search-proxy): strip workspace editable paths from cd requirements.txt

### DIFF
--- a/.github/workflows/cd-containerize.yaml
+++ b/.github/workflows/cd-containerize.yaml
@@ -44,11 +44,15 @@ jobs:
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Export hash-pinned requirements
-        run: >
-          uv export --frozen
-          --package ${{ inputs.pypi_name }}
-          --no-dev --no-emit-project
-          -o ${{ inputs.package_dir }}/deploy/requirements.txt
+        run: |
+          uv export --frozen \
+            --package ${{ inputs.pypi_name }} \
+            --no-dev --no-emit-project \
+            -o ${{ inputs.package_dir }}/deploy/requirements.txt
+          # Workspace members export as local editable paths (-e ./...) which pip
+          # cannot resolve inside a Docker build context. Strip them here; the main
+          # package install below will pull them from PyPI as regular dependencies.
+          sed -i '/^-e /d' "${{ inputs.package_dir }}/deploy/requirements.txt"
 
       - name: Wait for PyPI to publish package
         run: |

--- a/.github/workflows/cd-containerize.yaml
+++ b/.github/workflows/cd-containerize.yaml
@@ -44,15 +44,12 @@ jobs:
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Export hash-pinned requirements
-        run: |
-          uv export --frozen \
-            --package ${{ inputs.pypi_name }} \
-            --no-dev --no-emit-project \
-            -o ${{ inputs.package_dir }}/deploy/requirements.txt
-          # Workspace members export as local editable paths (-e ./...) which pip
-          # cannot resolve inside a Docker build context. Strip them here; the main
-          # package install below will pull them from PyPI as regular dependencies.
-          sed -i '/^-e /d' "${{ inputs.package_dir }}/deploy/requirements.txt"
+        run: >
+          uv export --frozen
+          --package ${{ inputs.pypi_name }}
+          --no-dev --no-emit-project
+          --no-sources
+          -o ${{ inputs.package_dir }}/deploy/requirements.txt
 
       - name: Wait for PyPI to publish package
         run: |

--- a/connectors/unique_search_proxy/unique_search_proxy_client/deploy/Dockerfile
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/deploy/Dockerfile
@@ -35,7 +35,7 @@ RUN if [ -n "$LOCAL_WHEEL_CLIENT" ]; then \
       pip install --no-cache-dir "./$LOCAL_WHEEL" && rm -f "./$LOCAL_WHEEL"; \
     elif [ -n "$PACKAGE_VERSION" ]; then \
       pip install --no-cache-dir --require-hashes -r ./requirements.txt \
-        && pip install --no-cache-dir "unique-search-proxy==${PACKAGE_VERSION}" \
+        && pip install --no-cache-dir --no-deps "unique-search-proxy==${PACKAGE_VERSION}" \
         && rm -f ./requirements.txt; \
     else \
       echo "ERROR: set PACKAGE_VERSION, LOCAL_WHEEL, or LOCAL_WHEEL_CORE+LOCAL_WHEEL_CLIENT" >&2; exit 1; \

--- a/connectors/unique_search_proxy/unique_search_proxy_client/deploy/Dockerfile
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/deploy/Dockerfile
@@ -35,7 +35,7 @@ RUN if [ -n "$LOCAL_WHEEL_CLIENT" ]; then \
       pip install --no-cache-dir "./$LOCAL_WHEEL" && rm -f "./$LOCAL_WHEEL"; \
     elif [ -n "$PACKAGE_VERSION" ]; then \
       pip install --no-cache-dir --require-hashes -r ./requirements.txt \
-        && pip install --no-cache-dir --no-deps "unique-search-proxy==${PACKAGE_VERSION}" \
+        && pip install --no-cache-dir "unique-search-proxy==${PACKAGE_VERSION}" \
         && rm -f ./requirements.txt; \
     else \
       echo "ERROR: set PACKAGE_VERSION, LOCAL_WHEEL, or LOCAL_WHEEL_CORE+LOCAL_WHEEL_CLIENT" >&2; exit 1; \


### PR DESCRIPTION
> AI Assist: **Heavy** 🤖

## Summary

- `uv export` emits workspace members as local editable paths (`-e ./path`) in `requirements.txt`
- Those paths don't exist inside the Docker build context, so `pip --require-hashes` fails with *"not a valid editable requirement"*
- Strip `-e` lines from `requirements.txt` after `uv export` in `cd-containerize.yaml`
- Drop `--no-deps` from the main package `pip install` so pip resolves those workspace packages from PyPI instead

## Test plan

- [ ] Verify `cd-containerize` job passes on next release for `unique-search-proxy-client`
- [ ] Confirm Docker image builds without `not a valid editable requirement` error

Refs: UN-21384

Made with [Cursor](https://cursor.com)