### PR TITLE
feat(sdk): add scopeToAssignedRows for magic table sheet reads

### DIFF
--- a/unique_sdk/tests/test_async_fixes.py
+++ b/unique_sdk/tests/test_async_fixes.py
@@ -58,6 +58,37 @@ async def test_get_sheet_data_forwards_include_sheet_metadata_query_param():
 
 
 @pytest.mark.asyncio
+async def test_get_sheet_data_forwards_scope_to_assigned_rows_query_param():
+    with patch.object(
+        AgenticTable, "_static_request_async", new_callable=AsyncMock
+    ) as mock_req:
+        mock_req.return_value = {
+            "sheetId": "s1",
+            "name": "n",
+            "state": "IDLE",
+            "chatId": "ch1",
+            "createdBy": "u0",
+            "companyId": "c1",
+            "createdAt": "t0",
+            "magicTableRowCount": 0,
+        }
+
+        await AgenticTable.get_sheet_data(
+            user_id="u1",
+            company_id="c1",
+            tableId="t1",
+            includeRowCount=True,
+            scopeToAssignedRows=True,
+        )
+
+        mock_req.assert_awaited_once()
+        _method, _url, _uid, _cid, params = mock_req.await_args[0]
+        assert params["tableId"] == "t1"
+        assert params["includeRowCount"] is True
+        assert params["scopeToAssignedRows"] is True
+
+
+@pytest.mark.asyncio
 async def test_get_sheet_data_forwards_include_row_metadata_query_param():
     with patch.object(
         AgenticTable, "_static_request_async", new_callable=AsyncMock

--- a/unique_sdk/unique_sdk/api_resources/_agentic_table.py
+++ b/unique_sdk/unique_sdk/api_resources/_agentic_table.py
@@ -220,6 +220,7 @@ class AgenticTable(APIResource["AgenticTable"]):
         includeCellMetaData: NotRequired[bool]
         includeSheetMetadata: NotRequired[bool]
         includeRowMetadata: NotRequired[bool]
+        scopeToAssignedRows: NotRequired[bool]
         startRow: NotRequired[int]
         endRow: NotRequired[int]
 

--- a/unique_toolkit/tests/test_agentic_table_get_sheet_row_metadata.py
+++ b/unique_toolkit/tests/test_agentic_table_get_sheet_row_metadata.py
@@ -172,3 +172,43 @@ async def test_get_sheet_does_not_forward_include_row_metadata_when_disabled() -
     assert len(batch_kwargs) == 1
     assert "includeRowMetadata" not in batch_kwargs[0]
     get_cell.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_sheet_forwards_scope_to_assigned_rows_on_count_and_batch() -> None:
+    header = _minimal_sheet_header()
+    batch = {
+        **_minimal_sheet_header(),
+        "magicTableCells": [_cell(0, 0)],
+    }
+
+    async def fake_get_sheet_data(
+        *_args: object,
+        **kwargs: object,
+    ) -> dict:
+        if kwargs.get("includeCells") is False:
+            return header
+        return batch
+
+    svc = AgenticTableService("user-1", "company-1", "table-1")
+    with patch(
+        "unique_toolkit.agentic_table.service.AgenticTable.get_sheet_data",
+        new_callable=AsyncMock,
+        side_effect=fake_get_sheet_data,
+    ) as gsm:
+        await svc.get_sheet(
+            start_row=0,
+            end_row=1,
+            scope_to_assigned_rows=True,
+        )
+
+    count_kwargs = [
+        c.kwargs for c in gsm.await_args_list if c.kwargs.get("includeRowCount")
+    ]
+    batch_kwargs = [
+        c.kwargs for c in gsm.await_args_list if c.kwargs.get("includeCells")
+    ]
+    assert len(count_kwargs) == 1
+    assert count_kwargs[0].get("scopeToAssignedRows") is True
+    assert len(batch_kwargs) == 1
+    assert batch_kwargs[0].get("scopeToAssignedRows") is True

--- a/unique_toolkit/unique_toolkit/agentic_table/service.py
+++ b/unique_toolkit/unique_toolkit/agentic_table/service.py
@@ -322,6 +322,7 @@ class AgenticTableService:
         include_log_history: bool = False,
         include_cell_meta_data: bool = False,
         include_row_metadata: bool = False,
+        scope_to_assigned_rows: bool = False,
     ) -> MagicTableSheet:
         """
         Gets the sheet data from the Agentic Table paginated by batch_size.
@@ -333,6 +334,8 @@ class AgenticTableService:
             include_log_history (bool): Whether to include the log history.
             include_cell_meta_data (bool): Whether to include the cell metadata (renderer, selection, agreement status).
             include_row_metadata (bool): Whether to include the row metadata (key value pairs).
+            scope_to_assigned_rows (bool): When true, scope row count and cell batches to rows
+                assigned to the current user (Can Answer role).
         Returns:
             MagicTableSheet: The sheet data.
         """
@@ -345,6 +348,7 @@ class AgenticTableService:
             includeCells=False,
             includeLogHistory=False,
             includeCellMetaData=False,
+            scopeToAssignedRows=scope_to_assigned_rows,
         )
         total_rows = sheet_info.get("magicTableRowCount")
         if total_rows is None:
@@ -374,6 +378,7 @@ class AgenticTableService:
                     startRow=row,
                     endRow=end_row_batch - 1,
                     includeRowMetadata=True,
+                    scopeToAssignedRows=scope_to_assigned_rows,
                 )
             else:
                 sheet_partial = await AgenticTable.get_sheet_data(
@@ -386,6 +391,7 @@ class AgenticTableService:
                     includeCellMetaData=include_cell_meta_data,  # renderer, selection, agreement status
                     startRow=row,
                     endRow=end_row_batch - 1,
+                    scopeToAssignedRows=scope_to_assigned_rows,
                 )
             if "magicTableCells" in sheet_partial:
                 batch_cells = sheet_partial["magicTableCells"]


### PR DESCRIPTION

## What
- **unique-sdk**: optional `scopeToAssignedRows` on `AgenticTable.GetSheetData` (forwarded as query param to `GET /magic-table/{tableId}`).
- **unique-toolkit**: optional `scope_to_assigned_rows: bool = False` on `AgenticTableService.get_sheet`, passed through on the row-count and both cell-batch calls.

## Why
Server-side report export reads the whole sheet. For "Can Answer" users it must only include their assigned rows (matching the grid + Excel export). This flag lets the caller ask the platform to scope rows at the data boundary; the actual rule lives in node-chat. These packages just carry the flag through.

## Compatibility
Fully additive — both params default to off, so existing callers are unchanged.

## Note
The agentic-table bundle (uniquech) already calls `get_sheet(scope_to_assigned_rows=True)`; it takes effect once this toolkit build is published and the bundle bumps to it.

Refs: UN-21604