### PR TITLE
feat(toolkit): preserve requestedByUserId on generate-artifact payload

### DIFF
--- a/unique_toolkit/tests/agentic_table/test_schemas.py
+++ b/unique_toolkit/tests/agentic_table/test_schemas.py
@@ -141,6 +141,22 @@ class TestMagicTableGenerateArtifactPayload:
         )
         assert payload.data.artifact_type == ArtifactType.FULL_REPORT
 
+    def test_generate_artifact_payload_requested_by_user_id_from_camel_case(self):
+        payload = MagicTableGenerateArtifactPayload.model_validate(
+            {
+                "name": "test_module",
+                "sheetName": "test_sheet",
+                "action": MagicTableAction.GENERATE_ARTIFACT,
+                "chatId": "chat_123",
+                "assistantId": "assistant_123",
+                "tableId": "table_123",
+                "metadata": {},
+                "data": {"artifactType": ArtifactType.AGENTIC_REPORT},
+                "requestedByUserId": "answer-360",
+            }
+        )
+        assert payload.requested_by_user_id == "answer-360"
+
     def test_generate_artifact_payload_serialization_agentic_report(self):
         """Test payload serialization with AGENTIC_REPORT maintains type."""
         payload = MagicTableGenerateArtifactPayload(

--- a/unique_toolkit/unique_toolkit/agentic_table/schemas.py
+++ b/unique_toolkit/unique_toolkit/agentic_table/schemas.py
@@ -164,6 +164,13 @@ class MagicTableGenerateArtifactPayload(
     MagicTableBasePayload[Literal[MagicTableAction.GENERATE_ARTIFACT], BaseMetadata]
 ):
     data: ArtifactData
+    requested_by_user_id: str | None = Field(
+        default=None,
+        description=(
+            "User who initiated the export when the event top-level user_id is the "
+            "sheet owner (set by node-chat as requestedByUserId)."
+        ),
+    )
 
 
 ########## Sheet Completed Payload ##########


### PR DESCRIPTION
## Summary
- Add optional `requested_by_user_id` to `MagicTableGenerateArtifactPayload` so node-chat's `requestedByUserId` survives Pydantic validation
- Add a test verifying camelCase wire input maps to the field

When node sends a generate-artifact event, the top-level `user_id` is the sheet owner (so the agent can write to the shared chat). The real export initiator is carried in `requestedByUserId`; without this field, toolkit's `extra="ignore"` config dropped it and the agent bundle could not scope export reads to the Can Answer user.

Pairs with the agent-bundle `export_identity` helper and complements #1808 (`scopeToAssignedRows` on sheet reads).

## Test plan
- [x] `uv run --package unique-toolkit pytest tests/agentic_table/test_schemas.py::TestMagicTableGenerateArtifactPayload::test_generate_artifact_payload_requested_by_user_id_from_camel_case`
- [x] CI green on PR


Made with [Cursor](https://cursor.com)