### PR TITLE
fix(search-proxy): strip workspace editable paths from cd requirements.txt

### DIFF
--- a/.github/workflows/cd-containerize.yaml
+++ b/.github/workflows/cd-containerize.yaml
@@ -48,6 +48,7 @@ jobs:
           uv export --frozen
           --package ${{ inputs.pypi_name }}
           --no-dev --no-emit-project
+          --no-sources
           -o ${{ inputs.package_dir }}/deploy/requirements.txt
 
       - name: Wait for PyPI to publish package


### PR DESCRIPTION
## Summary

Backport of #1807 to `release/2026.24`.

Cherry-pick of `fb30683dfa2201405a6e4cedba9adb32acd30acf`.

## Changes

- [x] Backport: strip workspace editable paths from cd requirements.txt

## Testing

Cherry-pick applied cleanly with no conflicts. CI on this PR validates.

Made with [Cursor](https://cursor.com)