### PR TITLE
fix: Remove experimental from entrypoint

### DIFF
--- a/connectors/unique_search_proxy/unique_search_proxy_client/deploy/entrypoint.sh
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/deploy/entrypoint.sh
@@ -17,7 +17,6 @@ if [ "${WORKERS}" -gt 1 ]; then
 fi
 
 echo "=========================================="
-echo "            🧪 EXPERIMENTAL 🧪            "
 echo "    Search Proxy - Starting Application   "
 echo "=========================================="
 echo "Host: ${HOST}"


### PR DESCRIPTION
## Summary

Backport of #1810 to `release/2026.24`.

Cherry-pick of `7045696677adf1e0f256a4424890dd10f1a23730`.

## Changes

- [x] Backport: Remove experimental from entrypoint

## Testing

Cherry-pick applied cleanly with no conflicts. CI on this PR validates.

Made with [Cursor](https://cursor.com)