### PR TITLE
feat(toolkit): preserve requestedByUserId on generate-artifact payload

### DIFF
--- a/unique_toolkit/tests/agentic_table/test_schemas.py
+++ b/unique_toolkit/tests/agentic_table/test_schemas.py
@@ -141,6 +141,22 @@ class TestMagicTableGenerateArtifactPayload:
         )
         assert payload.data.artifact_type == ArtifactType.FULL_REPORT
 
+    def test_generate_artifact_payload_requested_by_user_id_from_camel_case(self):
+        payload = MagicTableGenerateArtifactPayload.model_validate(
+            {
+                "name": "test_module",
+                "sheetName": "test_sheet",
+                "action": MagicTableAction.GENERATE_ARTIFACT,
+                "chatId": "chat_123",
+                "assistantId": "assistant_123",
+                "tableId": "table_123",
+                "metadata": {},
+                "data": {"artifactType": ArtifactType.AGENTIC_REPORT},
+                "requestedByUserId": "answer-360",
+            }
+        )
+        assert payload.requested_by_user_id == "answer-360"
+
     def test_generate_artifact_payload_serialization_agentic_report(self):
         """Test payload serialization with AGENTIC_REPORT maintains type."""
         payload = MagicTableGenerateArtifactPayload(

--- a/unique_toolkit/unique_toolkit/agentic_table/schemas.py
+++ b/unique_toolkit/unique_toolkit/agentic_table/schemas.py
@@ -164,6 +164,13 @@ class MagicTableGenerateArtifactPayload(
     MagicTableBasePayload[Literal[MagicTableAction.GENERATE_ARTIFACT], BaseMetadata]
 ):
     data: ArtifactData
+    requested_by_user_id: str | None = Field(
+        default=None,
+        description=(
+            "User who initiated the export when the event top-level user_id is the "
+            "sheet owner (set by node-chat as requestedByUserId)."
+        ),
+    )
 
 
 ########## Sheet Completed Payload ##########


### PR DESCRIPTION
## Summary

Backport of #1818 to `release/2026.24`. Final commit in the post-release backport set.

Cherry-pick of `68ac537d3c20f9bf7e3e063056e745dc4453597f`.

## Changes

- [x] Backport: preserve requestedByUserId on generate-artifact payload

## Testing

Cherry-pick applied cleanly with no conflicts. CI on this PR validates.

Made with [Cursor](https://cursor.com)