### PR TITLE
chore: Mount tmp volume for search proxy container

### DIFF
--- a/connectors/unique_search_proxy/unique_search_proxy_client/deploy/helm-chart/values.yaml
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/deploy/helm-chart/values.yaml
@@ -103,6 +103,17 @@ pdb:
 networkPolicy:
   enabled: false
 
+# ── Volumes ───────────────────────────────────────────────────────────────────
+volumeMounts:
+  - mountPath: /tmp
+    name: tmp-volume
+
+volumes:
+  - emptyDir:
+      sizeLimit: 5Gi
+    name: tmp-volume
+
+
 # ── WorkloadIdentity (GCP, Vertex AI) ─────────────────────────────────────────
 # Vertex AI backend authenticates via GCP Workload Identity Federation; base
 # sets GOOGLE_APPLICATION_CREDENTIALS for the SDK. Enable and fill the
@@ -118,4 +129,4 @@ workloadIdentity:
 
 # ── Prometheus ────────────────────────────────────────────────────────────────
 prometheus:
-  enabled: false
+  enabled: true


### PR DESCRIPTION
## Summary

Backport of #1824 to `release/2026.24`.

Cherry-pick of `f88e88417f53bd9db9211de755e5e5eaa50652b6`.

## Changes

- [x] Backport: mount tmp volume for search proxy container

## Testing

Cherry-pick applied cleanly with no conflicts. CI on this PR validates.

Made with [Cursor](https://cursor.com)