### PR TITLE
fix(ci): use getunique-github-oidc environment for helm publish

### DIFF
--- a/.github/workflows/cd-helm-publish.yaml
+++ b/.github/workflows/cd-helm-publish.yaml
@@ -38,6 +38,7 @@ permissions:
 jobs:
   helm-publish:
     runs-on: ubuntu-latest
+    environment: ${{ contains(inputs.registries, 'getunique.azurecr.io') && 'getunique-github-oidc' || '' }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -55,9 +56,9 @@ jobs:
         if: contains(inputs.registries, 'getunique.azurecr.io')
         uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
         with:
-          client-id: daa88f8d-0943-459c-890a-17b1a018d11e # acr_oidc getunique_push
-          tenant-id: 99330c76-81d2-460e-861e-35af8e2a4266
-          subscription-id: fb8bce09-908a-459f-b200-a578005bfeb2
+          client-id: ${{ vars.CLIENT_ID }}
+          tenant-id: ${{ vars.TENANT_ID }}
+          subscription-id: ${{ vars.SUBSCRIPTION_ID }}
 
       - name: Login to getunique ACR
         if: contains(inputs.registries, 'getunique.azurecr.io')


### PR DESCRIPTION
## 🚀 Summary
Refs: UN-21527

Stable helm publish to getunique runs on release tag refs. Branch-only OIDC credentials fail Azure login with `AADSTS7002131`. Use the `getunique-github-oidc` GitHub environment when pushing to getunique so the OIDC subject matches the federated credential.

## ✅ Changes

- [x] Fixed bug / updated CI
- [ ] Refactored code / cleaned up

- Set job `environment: getunique-github-oidc` when `getunique.azurecr.io` is in `registries`
- Replace hardcoded Azure login IDs with `${{ vars.* }}` from the environment

## 🧪 Testing

Depends on infrastructure PR merging and Atlantis apply first (creates the GitHub environment + federated credential).

After both land:
- [ ] Re-run stable helm publish workflow for `unique-search-proxy-v2026.24.1`
- [ ] Confirm getunique ACR login succeeds on tag-triggered release workflow

Infrastructure PR: https://github.com/Unique-AG/infrastructure/pull/2895