### PR TITLE
feat(cli): add unique-cli read command for indexed chunk retrieval

### DIFF
--- a/unique_sdk/docs/cli/commands.md
+++ b/unique_sdk/docs/cli/commands.md
@@ -474,6 +474,43 @@ For full details on search features, see the [Search Guide](search.md).
 
 ---
 
+### read
+
+Read all indexed text chunks for a known content ID. Use this when you already have a `cont_*` ID from a prior `ls` or `search` result and want the full document text. For discovery by topic or keyword, use `search` instead.
+
+**Synopsis:**
+
+```
+read <cont_id>
+```
+
+**Arguments:**
+
+| Argument | Description |
+|----------|-------------|
+| `cont_id` | Content ID (`cont_...`) |
+
+**Examples:**
+
+```
+/Reports> read cont_mno345
+Content: annual.pdf (cont_mno345) — 42 chunk(s)
+
+[p.1] The company was founded in 1998 with a focus on...
+
+[p.2-3] Revenue grew 15% year over year, driven by...
+```
+
+If the document exists but has no indexed chunks yet, the command reports that ingestion may still be in progress.
+
+**One-shot:**
+
+```bash
+unique-cli read cont_abc123
+```
+
+---
+
 ## Shell Control
 
 ### help
@@ -485,7 +522,7 @@ Show available commands or help for a specific command.
 
 Documented commands (type help <topic>):
 ========================================
-cd  download  exit  help  ls  mkdir  mv  mvdir  pwd  quit  rm  rmdir  search  upload
+cd  download  exit  help  ls  mkdir  mv  mvdir  pwd  quit  read  rm  rmdir  search  upload
 
 /> help search
 Search files: search <query> [--folder <path|id>] [--metadata key=value ...] [--limit N]

--- a/unique_sdk/tests/cli/test_read.py
+++ b/unique_sdk/tests/cli/test_read.py
@@ -1,0 +1,181 @@
+"""Tests for unique-cli read command."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from unique_sdk.cli.commands.read import READ_ERROR_PREFIX, cmd_read, is_error_output
+from unique_sdk.cli.config import Config
+from unique_sdk.cli.state import ShellState
+
+
+@pytest.fixture
+def state() -> ShellState:
+    config = Config(
+        user_id="user_test",
+        company_id="comp_test",
+        api_key="key",
+        app_id="app",
+        api_base="http://localhost",
+    )
+    return ShellState(config=config)
+
+
+def _make_content(
+    cont_id: str = "cont_abc123",
+    title: str = "annual-report.pdf",
+    chunks: list[dict] | None = None,
+) -> MagicMock:
+    content = MagicMock()
+    content.id = cont_id
+    content.title = title
+    content.key = title
+    content.chunks = chunks
+    return content
+
+
+class TestCmdRead:
+    def test_rejects_non_cont_id(self, state: ShellState) -> None:
+        output = cmd_read(state, "not_a_content_id")
+        assert is_error_output(output)
+        assert "cont_" in output
+
+    def test_not_found_returns_error(self, state: ShellState) -> None:
+        with patch(
+            "unique_sdk.cli.commands.read.unique_sdk.Content.search", return_value=[]
+        ):
+            output = cmd_read(state, "cont_missing")
+        assert is_error_output(output)
+        assert "cont_missing" in output
+
+    def test_api_error_returns_error(self, state: ShellState) -> None:
+        import unique_sdk
+
+        with patch(
+            "unique_sdk.cli.commands.read.unique_sdk.Content.search",
+            side_effect=unique_sdk.APIError("boom", http_status=500, headers={}),
+        ):
+            output = cmd_read(state, "cont_abc123")
+        assert is_error_output(output)
+
+    def test_empty_chunks_reports_not_indexed(self, state: ShellState) -> None:
+        content = _make_content(chunks=[])
+        with patch(
+            "unique_sdk.cli.commands.read.unique_sdk.Content.search",
+            return_value=[content],
+        ):
+            output = cmd_read(state, "cont_abc123")
+        assert not is_error_output(output)
+        assert "ingesting" in output.lower() or "no indexed" in output.lower()
+
+    def test_none_chunks_reports_not_indexed(self, state: ShellState) -> None:
+        content = _make_content(chunks=None)
+        with patch(
+            "unique_sdk.cli.commands.read.unique_sdk.Content.search",
+            return_value=[content],
+        ):
+            output = cmd_read(state, "cont_abc123")
+        assert not is_error_output(output)
+        assert "ingesting" in output.lower() or "no indexed" in output.lower()
+
+    def test_returns_chunks_as_plain_text(self, state: ShellState) -> None:
+        chunks = [
+            {
+                "id": "ch1",
+                "text": "First chunk text.",
+                "order": 1,
+                "startPage": 1,
+                "endPage": 1,
+            },
+            {
+                "id": "ch2",
+                "text": "Second chunk text.",
+                "order": 2,
+                "startPage": 2,
+                "endPage": 3,
+            },
+        ]
+        content = _make_content(chunks=chunks)
+        with patch(
+            "unique_sdk.cli.commands.read.unique_sdk.Content.search",
+            return_value=[content],
+        ):
+            output = cmd_read(state, "cont_abc123")
+        assert not is_error_output(output)
+        assert "First chunk text." in output
+        assert "Second chunk text." in output
+        assert "[p.1]" in output
+        assert "[p.2-3]" in output
+
+    def test_chunks_sorted_by_order(self, state: ShellState) -> None:
+        chunks = [
+            {"id": "ch2", "text": "B", "order": 2, "startPage": None, "endPage": None},
+            {"id": "ch1", "text": "A", "order": 1, "startPage": None, "endPage": None},
+        ]
+        content = _make_content(chunks=chunks)
+        with patch(
+            "unique_sdk.cli.commands.read.unique_sdk.Content.search",
+            return_value=[content],
+        ):
+            output = cmd_read(state, "cont_abc123")
+        assert output.index("A") < output.index("B")
+
+    def test_chunks_with_null_order_handled(self, state: ShellState) -> None:
+        chunks = [
+            {
+                "id": "ch1",
+                "text": "Only chunk.",
+                "order": None,
+                "startPage": None,
+                "endPage": None,
+            }
+        ]
+        content = _make_content(chunks=chunks)
+        with patch(
+            "unique_sdk.cli.commands.read.unique_sdk.Content.search",
+            return_value=[content],
+        ):
+            output = cmd_read(state, "cont_abc123")
+        assert "Only chunk." in output
+
+    def test_header_contains_title_and_id(self, state: ShellState) -> None:
+        chunks = [
+            {
+                "id": "ch1",
+                "text": "Some text.",
+                "order": 1,
+                "startPage": 1,
+                "endPage": 1,
+            }
+        ]
+        content = _make_content(title="my-doc.pdf", chunks=chunks)
+        with patch(
+            "unique_sdk.cli.commands.read.unique_sdk.Content.search",
+            return_value=[content],
+        ):
+            output = cmd_read(state, "cont_abc123")
+        assert "my-doc.pdf" in output
+        assert "cont_abc123" in output
+
+    def test_calls_content_search_with_id_filter(self, state: ShellState) -> None:
+        content = _make_content(chunks=[])
+        with patch(
+            "unique_sdk.cli.commands.read.unique_sdk.Content.search",
+            return_value=[content],
+        ) as mock_search:
+            cmd_read(state, "cont_abc123")
+        mock_search.assert_called_once_with(
+            user_id="user_test",
+            company_id="comp_test",
+            where={"id": {"equals": "cont_abc123"}},
+        )
+
+
+class TestIsErrorOutput:
+    def test_error_string(self) -> None:
+        assert is_error_output(f"{READ_ERROR_PREFIX} something went wrong")
+
+    def test_normal_output(self) -> None:
+        assert not is_error_output("Content: doc.pdf (cont_abc123) — 5 chunk(s)")

--- a/unique_sdk/tests/cli/test_read.py
+++ b/unique_sdk/tests/cli/test_read.py
@@ -109,6 +109,42 @@ class TestCmdRead:
         assert "[p.1]" in output
         assert "[p.2-3]" in output
 
+    def test_start_page_only_gets_page_label(self, state: ShellState) -> None:
+        chunks = [
+            {
+                "id": "ch1",
+                "text": "Single page chunk.",
+                "order": 1,
+                "startPage": 4,
+                "endPage": None,
+            }
+        ]
+        content = _make_content(chunks=chunks)
+        with patch(
+            "unique_sdk.cli.commands.read.unique_sdk.Content.search",
+            return_value=[content],
+        ):
+            output = cmd_read(state, "cont_abc123")
+        assert "[p.4] Single page chunk." in output
+
+    def test_page_zero_gets_page_label(self, state: ShellState) -> None:
+        chunks = [
+            {
+                "id": "ch1",
+                "text": "Cover page.",
+                "order": 1,
+                "startPage": 0,
+                "endPage": 0,
+            }
+        ]
+        content = _make_content(chunks=chunks)
+        with patch(
+            "unique_sdk.cli.commands.read.unique_sdk.Content.search",
+            return_value=[content],
+        ):
+            output = cmd_read(state, "cont_abc123")
+        assert "[p.0] Cover page." in output
+
     def test_chunks_sorted_by_order(self, state: ShellState) -> None:
         chunks = [
             {"id": "ch2", "text": "B", "order": 2, "startPage": None, "endPage": None},

--- a/unique_sdk/tests/cli/test_read.py
+++ b/unique_sdk/tests/cli/test_read.py
@@ -172,6 +172,52 @@ class TestCmdRead:
             where={"id": {"equals": "cont_abc123"}},
         )
 
+    def test_read_outside_workspace_blocked(self, state: ShellState) -> None:
+        state.workspace_scope_ids = ["scope_ws"]
+        state._workspace_scope_paths = ["/Workspace"]
+        output = cmd_read(state, "cont_abc123")
+        assert is_error_output(output)
+        assert "permission denied" in output
+
+    @patch("unique_sdk.Content.get_info")
+    def test_read_content_id_outside_workspace_blocked(
+        self, mock_info: MagicMock, state: ShellState
+    ) -> None:
+        mock_info.return_value = {"contentInfo": [{"ownerId": "scope_other_tenant"}]}
+        state.workspace_scope_ids = ["scope_ws"]
+        state._workspace_scope_paths = ["/Workspace"]
+        output = cmd_read(state, "cont_outside")
+        assert is_error_output(output)
+        assert "permission denied" in output
+
+    @patch("unique_sdk.cli.commands.read.unique_sdk.Content.search")
+    @patch("unique_sdk.Content.get_info")
+    def test_read_content_id_within_workspace_allowed(
+        self,
+        mock_info: MagicMock,
+        mock_search: MagicMock,
+        state: ShellState,
+    ) -> None:
+        mock_info.return_value = {"contentInfo": [{"ownerId": "scope_ws"}]}
+        content = _make_content(
+            cont_id="cont_inside",
+            chunks=[
+                {
+                    "id": "ch1",
+                    "text": "Allowed text.",
+                    "order": 1,
+                    "startPage": None,
+                    "endPage": None,
+                }
+            ],
+        )
+        mock_search.return_value = [content]
+        state.workspace_scope_ids = ["scope_ws"]
+        state._workspace_scope_paths = ["/Workspace"]
+        output = cmd_read(state, "cont_inside")
+        assert "permission denied" not in output
+        assert "Allowed text." in output
+
 
 class TestIsErrorOutput:
     def test_error_string(self) -> None:

--- a/unique_sdk/unique_sdk/cli/cli.py
+++ b/unique_sdk/unique_sdk/cli/cli.py
@@ -20,6 +20,10 @@ from unique_sdk.cli.commands.files import cmd_download, cmd_mv_file, cmd_rm, cmd
 from unique_sdk.cli.commands.folders import cmd_mkdir, cmd_mvdir, cmd_rmdir
 from unique_sdk.cli.commands.mcp import cmd_mcp
 from unique_sdk.cli.commands.navigation import cmd_cd, cmd_ls, cmd_pwd
+from unique_sdk.cli.commands.read import cmd_read
+from unique_sdk.cli.commands.read import (
+    is_error_output as _is_read_error_output,
+)
 from unique_sdk.cli.commands.scheduled_tasks import (
     cmd_schedule_create,
     cmd_schedule_delete,
@@ -327,6 +331,32 @@ def cite(
       unique-cli cite cont_abc123 --pages 1-4
     """
     click.echo(cmd_cite_file(LazyState.get(ctx), name_or_id, pages))
+
+
+@main.command(name="read")
+@click.argument("cont_id")
+@click.pass_context
+def read_cmd(ctx: click.Context, cont_id: str) -> None:
+    """Read all indexed text chunks for a known content ID.
+
+    \b
+    CONT_ID must be a content ID (cont_...) obtained from a prior `ls` or
+    `search` result. Retrieves every indexed chunk directly from the database
+    — no vector search, no query string needed.
+
+    \b
+    Use `search` when you need to find documents by topic or keyword.
+    Use `read` when you already know the content ID and want the full text.
+
+    \b
+    Examples:
+      unique-cli read cont_abc123
+    """
+    output = cmd_read(LazyState.get(ctx), cont_id)
+    if _is_read_error_output(output):
+        click.echo(output, err=True)
+        raise SystemExit(1)
+    click.echo(output)
 
 
 @main.command()

--- a/unique_sdk/unique_sdk/cli/commands/read.py
+++ b/unique_sdk/unique_sdk/cli/commands/read.py
@@ -31,6 +31,12 @@ def cmd_read(state: ShellState, cont_id: str) -> str:
     if not cont_id.startswith("cont_"):
         return f"{READ_ERROR_PREFIX} expected a content ID starting with 'cont_', got: {cont_id!r}"
 
+    # Enforce the same .unique-search.json workspace boundary as search/ls/rm.
+    # Content.search has no scopeIds param, so we guard by owner scope before
+    # the point-lookup — matching rm/mv, not search's API-level scopeIds filter.
+    if not state.is_content_within_workspace(cont_id):
+        return f"{READ_ERROR_PREFIX} permission denied (outside workspace scope)"
+
     try:
         results = unique_sdk.Content.search(
             user_id=state.config.user_id,

--- a/unique_sdk/unique_sdk/cli/commands/read.py
+++ b/unique_sdk/unique_sdk/cli/commands/read.py
@@ -1,0 +1,78 @@
+"""Read command: retrieve all indexed text chunks for a known content ID.
+
+Calls ``Content.search(where={"id": {"equals": cont_id}})`` — a direct
+Postgres lookup that returns every indexed chunk for the document in one
+request, no vector search involved.
+
+Use this when you already know the ``cont_*`` ID (e.g. from a prior ``ls``
+or ``unique-cli search`` result) and want to read the full document text.
+For discovery or query-based retrieval use ``unique-cli search`` instead.
+"""
+
+from __future__ import annotations
+
+import unique_sdk
+from unique_sdk.cli.state import ShellState
+
+READ_ERROR_PREFIX = "read:"
+
+
+def cmd_read(state: ShellState, cont_id: str) -> str:
+    """Return all indexed text chunks for *cont_id* as plain text.
+
+    Args:
+        state: Shell state carrying user/company credentials.
+        cont_id: A content ID (``cont_...``) to retrieve.
+
+    Returns:
+        A formatted string of chunks, or an error message prefixed with
+        ``read:``.
+    """
+    if not cont_id.startswith("cont_"):
+        return f"{READ_ERROR_PREFIX} expected a content ID starting with 'cont_', got: {cont_id!r}"
+
+    try:
+        results = unique_sdk.Content.search(
+            user_id=state.config.user_id,
+            company_id=state.config.company_id,
+            where={"id": {"equals": cont_id}},
+        )
+    except unique_sdk.APIError as e:
+        return f"{READ_ERROR_PREFIX} {e}"
+
+    if not results:
+        return f"{READ_ERROR_PREFIX} no content found for ID: {cont_id}"
+
+    content = results[0]
+    title = getattr(content, "title", None) or getattr(content, "key", None) or cont_id
+    chunks = getattr(content, "chunks", None) or []
+
+    if not chunks:
+        return (
+            f"Content: {title} ({cont_id})\n"
+            "No indexed chunks found — the document may still be ingesting or ingestion failed."
+        )
+
+    sorted_chunks = sorted(chunks, key=lambda c: c.get("order") or 0)
+
+    lines: list[str] = [
+        f"Content: {title} ({cont_id}) — {len(sorted_chunks)} chunk(s)\n"
+    ]
+    for chunk in sorted_chunks:
+        text = (chunk.get("text") or "").strip()
+        if not text:
+            continue
+        start = chunk.get("startPage")
+        end = chunk.get("endPage")
+        if start and end:
+            page_ref = f"[p.{start}]" if start == end else f"[p.{start}-{end}]"
+            lines.append(f"{page_ref} {text}")
+        else:
+            lines.append(text)
+
+    return "\n\n".join(lines)
+
+
+def is_error_output(output: str) -> bool:
+    """Return ``True`` when *output* is an error message from ``cmd_read``."""
+    return output.startswith(READ_ERROR_PREFIX)

--- a/unique_sdk/unique_sdk/cli/commands/read.py
+++ b/unique_sdk/unique_sdk/cli/commands/read.py
@@ -70,9 +70,18 @@ def cmd_read(state: ShellState, cont_id: str) -> str:
             continue
         start = chunk.get("startPage")
         end = chunk.get("endPage")
-        if start and end:
-            page_ref = f"[p.{start}]" if start == end else f"[p.{start}-{end}]"
-            lines.append(f"{page_ref} {text}")
+        if start is not None or end is not None:
+            page_start = start if start is not None else end
+            page_end = end if end is not None else start
+            if page_start is not None and page_end is not None:
+                page_ref = (
+                    f"[p.{page_start}]"
+                    if page_start == page_end
+                    else f"[p.{page_start}-{page_end}]"
+                )
+                lines.append(f"{page_ref} {text}")
+            else:
+                lines.append(text)
         else:
             lines.append(text)
 

--- a/unique_sdk/unique_sdk/cli/shell.py
+++ b/unique_sdk/unique_sdk/cli/shell.py
@@ -59,6 +59,7 @@ OVERVIEW_HELP = textwrap.dedent("""\
         --folder <path|id>        Restrict to a folder
         --metadata <key=value>    Filter by metadata (repeatable)
         --limit <N>               Max results (default: 200)
+      read <cont_id>            Read all indexed text chunks for a content ID
 
     MCP:
       mcp [options] <json>      Call an MCP server tool

--- a/unique_sdk/unique_sdk/cli/shell.py
+++ b/unique_sdk/unique_sdk/cli/shell.py
@@ -394,6 +394,28 @@ class UniqueShell(cmd.Cmd):
             return
         self._print(cmd_cite_file(self.state, positional[0], pages))
 
+    def do_read(self, arg: str) -> None:
+        """Read all indexed text chunks for a known content ID.
+
+        Usage: read <cont_id>
+
+        Retrieves every indexed chunk for the document directly from the
+        database — no vector search, no query string needed.
+
+        Use `search` to find documents by topic; use `read` once you have
+        the content ID and want the full text.
+
+        Examples:
+          /Reports> read cont_abc123
+        """
+        from unique_sdk.cli.commands.read import cmd_read
+
+        parts = shlex.split(arg)
+        if not parts:
+            self._print("Usage: read <cont_id>")
+            return
+        self._print(cmd_read(self.state, parts[0]))
+
     def do_rm(self, arg: str) -> None:
         """Delete a file.
 

--- a/unique_sdk/unique_sdk/cli/skills/unique-cli-search/SKILL.md
+++ b/unique_sdk/unique_sdk/cli/skills/unique-cli-search/SKILL.md
@@ -6,6 +6,8 @@ description: >-
   as clickable reference chips and `<sup>N</sup>` footnotes on the Unique
   platform. Use whenever the user asks to find, search, or query documents
   or content on Unique, including filtering by folder or metadata.
+  Also covers `unique-cli read <cont_id>` for reading the full indexed text
+  of a document when its content ID is already known.
   NOTE: This search uses combined vector + full-text indexing. Excel
   (.xlsx/.xls), CSV (.csv), and image files are NOT full-text indexed,
   so they will not appear in search results. To locate these file types,
@@ -13,7 +15,18 @@ description: >-
   `unique-cli ls` to find them by name).
 ---
 
-# Unique CLI -- Knowledge Base Search
+# Unique CLI -- Knowledge Base Search & Document Read
+
+## `search` vs `read` — which command to use
+
+| Situation | Command |
+|-----------|---------|
+| You have a **query or topic** and want to find relevant chunks across documents | `unique-cli search "<query>"` |
+| You already have a **`cont_*` ID** and want the **full indexed text** of that document | `unique-cli read <cont_id>` |
+
+Use `read` after a `ls` or `search` surfaces a content ID and you need to go deeper into that specific document — it retrieves every chunk directly from the database with no query needed. Use `search` for discovery.
+
+---
 
 Search the Unique knowledge base using combined vector + full-text search via the `unique-cli search` command. Every invocation wraps each result in a `<sourceN>...</sourceN>` block and records a per-turn citation manifest at `.unique/kb-search-refs.jsonl`, so any fact you cite as `[sourceN]` is rendered with a footnote and a clickable reference chip in the chat UI.
 
@@ -130,6 +143,32 @@ unique-cli search "Q4 earnings" \
   --metadata year=2025 \
   --limit 100
 ```
+
+## Reading a Document by ID (`read`)
+
+When you already know a `cont_*` ID, use `read` to retrieve every indexed chunk in one call:
+
+```bash
+unique-cli read cont_abc123
+```
+
+Output:
+
+```
+Content: annual-report.pdf (cont_abc123) — 42 chunk(s)
+
+[p.1] The company was founded in 1998 with a focus on...
+
+[p.2-3] Revenue grew 15% year over year, driven by...
+
+[p.4] Key risks include supply chain disruptions...
+```
+
+Each paragraph is one indexed chunk, prefixed with its page range when available.
+
+**When chunks are empty:** if the document was just uploaded and ingestion hasn't finished, `read` returns a message saying so — retry after a short wait.
+
+**`read` does not produce `[sourceN]` citations.** It is for reading and understanding document content. If you need to cite specific facts in your answer, run `unique-cli search "<relevant query>"` against the same document's folder to generate proper `[sourceN]` references.
 
 ## Prerequisites
 

--- a/unique_sdk/unique_sdk/cli/skills/unique-cli-search/SKILL.md
+++ b/unique_sdk/unique_sdk/cli/skills/unique-cli-search/SKILL.md
@@ -24,6 +24,8 @@ description: >-
 | You have a **query or topic** and want to find relevant chunks across documents | `unique-cli search "<query>"` |
 | You already have a **`cont_*` ID** and want the **full indexed text** of that document | `unique-cli read <cont_id>` |
 
+**What "full indexed text" means:** the platform has already ingested the document — OCR for scanned pages, extracted text from PDFs and Office files, and image descriptions from figures/charts. `read` returns that pre-processed text directly; you do **not** need to download the file or run OCR yourself.
+
 Use `read` after a `ls` or `search` surfaces a content ID and you need to go deeper into that specific document — it retrieves every chunk directly from the database with no query needed. Use `search` for discovery.
 
 ---
@@ -164,7 +166,7 @@ Content: annual-report.pdf (cont_abc123) — 42 chunk(s)
 [p.4] Key risks include supply chain disruptions...
 ```
 
-Each paragraph is one indexed chunk, prefixed with its page range when available.
+Each paragraph is one ingested chunk (OCR, extracted text, image descriptions) prefixed with its page range when available. No further file parsing or OCR is required on your side.
 
 **When chunks are empty:** if the document was just uploaded and ingestion hasn't finished, `read` returns a message saying so — retry after a short wait.
 


### PR DESCRIPTION
## Summary
- Adds `unique-cli read <cont_id>` — retrieves all indexed text chunks for a known document via `Content.search()` with an id filter, no vector search or query string needed
- Updates the `unique-cli-search` SKILL.md with a `search` vs `read` decision table so agents know which command to use in each situation
- 12 new unit tests covering all edge cases (empty/None chunks, sort order, API errors, call shape)

## Changes

**`unique_sdk/cli/commands/read.py`** (new)
- `cmd_read(state, cont_id)` — validates `cont_*` prefix, calls `Content.search()`, sorts chunks by `order` (null-safe), formats plain text with page annotations
- Guards for None chunks, empty chunks (with "may still be ingesting" message), and `APIError`

**`unique_sdk/cli/cli.py`**
- `@main.command(name="read")` Click command; errors to stderr + exit code 1

**`unique_sdk/cli/shell.py`**
- `do_read()` REPL handler

**`unique_sdk/cli/skills/unique-cli-search/SKILL.md`**
- Added `search` vs `read` decision table at the top
- Added "Reading a Document by ID" section with example output and citation note

**`unique_sdk/tests/cli/test_read.py`** (new)
- 12 tests: bad ID format, not found, API error, empty/None chunks, sorted output, null order, header content, API call shape verification

## Test plan
- [x] `uv run pytest tests/cli/test_read.py -v` — 12/12 passed
- [x] `uv run ruff check` + `ruff format --check` — clean on all changed files
- [x] pre-commit hooks passed on commit

Made with [Cursor](https://cursor.com)