### PR TITLE
feat(unique_sdk): add dynamic frontend CLI support

### DIFF
--- a/unique_sdk/tests/cli/test_dynamic_frontend.py
+++ b/unique_sdk/tests/cli/test_dynamic_frontend.py
@@ -7,9 +7,11 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from click.testing import CliRunner
 
 import unique_sdk
 from unique_sdk.api_resources._dynamic_frontend import DynamicFrontend
+from unique_sdk.cli.cli import main
 from unique_sdk.cli.commands.dynamic_frontend import (
     _format_space,
     cmd_dynamic_frontend_deploy,
@@ -147,16 +149,16 @@ def test_dynamic_frontend_list__returns_response_data(
 
 
 @patch.object(DynamicFrontend, "_static_request", autospec=True)
-def test_dynamic_frontend_list__non_dict_response_returns_empty(
+def test_dynamic_frontend_list__top_level_array_response_returns_spaces(
     mock_request: MagicMock,
 ) -> None:
-    """Purpose: Verify malformed list responses degrade to an empty list.
-    Why this matters: The command formatter can handle no spaces without crashing.
-    Setup summary: Mock a non-dict response, call list, and assert an empty list.
+    """Purpose: Verify top-level list responses are preserved.
+    Why this matters: Some list endpoints return arrays directly after object conversion.
+    Setup summary: Mock a list response, call list, and assert the spaces are returned.
     """
-    mock_request.return_value = object()
+    mock_request.return_value = [_space()]
 
-    assert DynamicFrontend.list(user_id="user_1", company_id="company_1") == []
+    assert DynamicFrontend.list(user_id="user_1", company_id="company_1") == [_space()]
 
 
 @patch("unique_sdk.cli.commands.dynamic_frontend.upload_file")
@@ -223,6 +225,30 @@ def test_cmd_dynamic_frontend_deploy__updates_existing_space(
         company_id="company_1",
         contentId="cont_2",
         name="Revenue Dashboard v2",
+    )
+
+
+@patch("unique_sdk.DynamicFrontend.modify")
+def test_cmd_dynamic_frontend_deploy__omits_name_when_updating_without_rename(
+    mock_modify: MagicMock,
+) -> None:
+    """Purpose: Verify update deploys do not send name=None.
+    Why this matters: Sending a JSON null name could clear the existing display name.
+    Setup summary: Mock modify, update by content id without name, and assert payload.
+    """
+    mock_modify.return_value = _space(content_id="cont_2")
+
+    cmd_dynamic_frontend_deploy(
+        _state(),
+        content_id="cont_2",
+        space_id="space_1",
+    )
+
+    mock_modify.assert_called_once_with(
+        "space_1",
+        user_id="user_1",
+        company_id="company_1",
+        contentId="cont_2",
     )
 
 
@@ -361,3 +387,43 @@ def test_cmd_dynamic_frontend_list__api_error_is_returned(mock_list: MagicMock) 
     output = cmd_dynamic_frontend_list(_state())
 
     assert "dynamic-frontend list: upstream boom" in output
+
+
+@patch("unique_sdk.cli.cli.LazyState.get")
+@patch("unique_sdk.cli.cli.cmd_dynamic_frontend_deploy")
+def test_dynamic_frontend_deploy_cli__errors_exit_nonzero(
+    mock_deploy: MagicMock,
+    mock_get_state: MagicMock,
+) -> None:
+    """Purpose: Verify deploy command errors return a non-zero process status.
+    Why this matters: Automation must be able to fail fast when deploy validation fails.
+    Setup summary: Mock the command helper to return an error string and assert exit code 1.
+    """
+    mock_get_state.return_value = _state()
+    mock_deploy.return_value = "dynamic-frontend deploy: upstream boom"
+
+    result = CliRunner().invoke(
+        main, ["dynamic-frontend", "deploy", "--content-id", "cont_1"]
+    )
+
+    assert result.exit_code == 1
+    assert "dynamic-frontend deploy: upstream boom" in result.output
+
+
+@patch("unique_sdk.cli.cli.LazyState.get")
+@patch("unique_sdk.cli.cli.cmd_dynamic_frontend_list")
+def test_dynamic_frontend_list_cli__errors_exit_nonzero(
+    mock_list: MagicMock,
+    mock_get_state: MagicMock,
+) -> None:
+    """Purpose: Verify list command errors return a non-zero process status.
+    Why this matters: Scripts should not treat failed list requests as successful commands.
+    Setup summary: Mock the command helper to return an error string and assert exit code 1.
+    """
+    mock_get_state.return_value = _state()
+    mock_list.return_value = "dynamic-frontend list: upstream boom"
+
+    result = CliRunner().invoke(main, ["dynamic-frontend", "list"])
+
+    assert result.exit_code == 1
+    assert "dynamic-frontend list: upstream boom" in result.output

--- a/unique_sdk/tests/cli/test_dynamic_frontend.py
+++ b/unique_sdk/tests/cli/test_dynamic_frontend.py
@@ -1,0 +1,363 @@
+"""Tests for Dynamic Frontend SDK and CLI helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import unique_sdk
+from unique_sdk.api_resources._dynamic_frontend import DynamicFrontend
+from unique_sdk.cli.commands.dynamic_frontend import (
+    _format_space,
+    cmd_dynamic_frontend_deploy,
+    cmd_dynamic_frontend_list,
+)
+from unique_sdk.cli.config import Config
+from unique_sdk.cli.state import ShellState
+
+pytestmark = pytest.mark.ai
+
+
+class _FakeSpace(dict[str, object]):
+    def __getattr__(self, name: str) -> object:
+        try:
+            return self[name]
+        except KeyError as exc:
+            raise AttributeError(name) from exc
+
+
+def _state(path: str = "/Apps", scope_id: str | None = "scope_apps") -> ShellState:
+    state = ShellState(
+        Config(
+            user_id="user_1",
+            company_id="company_1",
+            api_key="key",
+            app_id="app",
+            api_base="https://example.com",
+        )
+    )
+    state._path = path
+    state._scope_id = scope_id
+    return state
+
+
+def _space(
+    *,
+    space_id: str = "space_1",
+    name: str = "Revenue Dashboard",
+    content_id: str = "cont_1",
+    status: dict[str, object] | None = None,
+) -> _FakeSpace:
+    return _FakeSpace(
+        {
+            "id": space_id,
+            "spaceId": space_id,
+            "name": name,
+            "contentId": content_id,
+            "status": status,
+        }
+    )
+
+
+def test_dynamic_frontend_object_name__returns_api_resource_name() -> None:
+    """Purpose: Verify the SDK resource object name is stable.
+    Why this matters: The base SDK resource machinery depends on each resource's object name.
+    Setup summary: Read the class property and assert it matches the API resource name.
+    """
+    assert DynamicFrontend.OBJECT_NAME == "dynamic-frontend"
+
+
+@patch.object(DynamicFrontend, "_static_request", autospec=True)
+def test_dynamic_frontend_create__calls_expected_endpoint(
+    mock_request: MagicMock,
+) -> None:
+    """Purpose: Verify creating a Dynamic Frontend space sends the expected request.
+    Why this matters: Incorrect method, path, or payload would create a broken SDK wrapper.
+    Setup summary: Mock _static_request, call create, and assert the request shape.
+    """
+    mock_request.return_value = _space()
+
+    result = DynamicFrontend.create(
+        user_id="user_1",
+        company_id="company_1",
+        name="Revenue Dashboard",
+        contentId="cont_1",
+    )
+
+    assert result["spaceId"] == "space_1"
+    mock_request.assert_called_once_with(
+        "post",
+        "/dynamic-frontend",
+        "user_1",
+        "company_1",
+        params={"name": "Revenue Dashboard", "contentId": "cont_1"},
+    )
+
+
+@patch.object(DynamicFrontend, "_static_request", autospec=True)
+def test_dynamic_frontend_modify__calls_expected_endpoint(
+    mock_request: MagicMock,
+) -> None:
+    """Purpose: Verify updating a Dynamic Frontend space sends the expected request.
+    Why this matters: Update calls must target the existing space by id.
+    Setup summary: Mock _static_request, call modify, and assert PATCH path and payload.
+    """
+    mock_request.return_value = _space(content_id="cont_2")
+
+    result = DynamicFrontend.modify(
+        "space_1",
+        user_id="user_1",
+        company_id="company_1",
+        contentId="cont_2",
+        name=None,
+    )
+
+    assert result["contentId"] == "cont_2"
+    mock_request.assert_called_once_with(
+        "patch",
+        "/dynamic-frontend/space_1",
+        "user_1",
+        "company_1",
+        params={"contentId": "cont_2", "name": None},
+    )
+
+
+@patch.object(DynamicFrontend, "_static_request", autospec=True)
+def test_dynamic_frontend_list__returns_response_data(
+    mock_request: MagicMock,
+) -> None:
+    """Purpose: Verify listing spaces unwraps the API data collection.
+    Why this matters: CLI callers expect a plain list of manageable Dynamic Frontend spaces.
+    Setup summary: Mock a data response, call list, and assert the returned collection.
+    """
+    mock_request.return_value = {"data": [_space()]}
+
+    spaces = DynamicFrontend.list(user_id="user_1", company_id="company_1")
+
+    assert spaces == [_space()]
+    mock_request.assert_called_once_with(
+        "get",
+        "/dynamic-frontend",
+        "user_1",
+        "company_1",
+    )
+
+
+@patch.object(DynamicFrontend, "_static_request", autospec=True)
+def test_dynamic_frontend_list__non_dict_response_returns_empty(
+    mock_request: MagicMock,
+) -> None:
+    """Purpose: Verify malformed list responses degrade to an empty list.
+    Why this matters: The command formatter can handle no spaces without crashing.
+    Setup summary: Mock a non-dict response, call list, and assert an empty list.
+    """
+    mock_request.return_value = object()
+
+    assert DynamicFrontend.list(user_id="user_1", company_id="company_1") == []
+
+
+@patch("unique_sdk.cli.commands.dynamic_frontend.upload_file")
+@patch("unique_sdk.DynamicFrontend.create")
+def test_cmd_dynamic_frontend_deploy__uploads_file_and_creates_space(
+    mock_create: MagicMock,
+    mock_upload_file: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """Purpose: Verify deploy uploads a ZIP bundle and creates a new space.
+    Why this matters: This is the main CLI path for publishing a Dynamic Frontend app.
+    Setup summary: Create a local bundle, mock upload/create, and assert output plus API args.
+    """
+    bundle = tmp_path / "app.zip"
+    bundle.write_bytes(b"zip")
+    mock_upload_file.return_value = MagicMock(id="cont_1")
+    mock_create.return_value = _space()
+
+    output = cmd_dynamic_frontend_deploy(
+        _state(),
+        file=str(bundle),
+        name="Revenue Dashboard",
+    )
+
+    assert 'Created Dynamic Frontend space "Revenue Dashboard" (space_1)' in output
+    assert "Content: cont_1" in output
+    mock_upload_file.assert_called_once_with(
+        userId="user_1",
+        companyId="company_1",
+        path_to_file=str(bundle.resolve()),
+        displayed_filename="app.zip",
+        mime_type="application/zip",
+        scope_or_unique_path="scope_apps",
+    )
+    mock_create.assert_called_once_with(
+        user_id="user_1",
+        company_id="company_1",
+        name="Revenue Dashboard",
+        contentId="cont_1",
+    )
+
+
+@patch("unique_sdk.DynamicFrontend.modify")
+def test_cmd_dynamic_frontend_deploy__updates_existing_space(
+    mock_modify: MagicMock,
+) -> None:
+    """Purpose: Verify deploy can update an existing Dynamic Frontend space.
+    Why this matters: Iterating on an app should not require creating a new space each time.
+    Setup summary: Mock modify, deploy by content id and space id, then assert payload.
+    """
+    mock_modify.return_value = _space(content_id="cont_2")
+
+    output = cmd_dynamic_frontend_deploy(
+        _state(),
+        content_id="cont_2",
+        space_id="space_1",
+        name="Revenue Dashboard v2",
+    )
+
+    assert 'Updated Dynamic Frontend space "Revenue Dashboard" (space_1)' in output
+    mock_modify.assert_called_once_with(
+        "space_1",
+        user_id="user_1",
+        company_id="company_1",
+        contentId="cont_2",
+        name="Revenue Dashboard v2",
+    )
+
+
+def test_cmd_dynamic_frontend_deploy__validates_input() -> None:
+    """Purpose: Verify deploy rejects missing or conflicting input before API calls.
+    Why this matters: Clear CLI errors prevent confusing partial deployments.
+    Setup summary: Call deploy without required input and assert the validation message.
+    """
+    assert "provide either --file or --content-id" in cmd_dynamic_frontend_deploy(
+        _state(),
+        name="Revenue Dashboard",
+    )
+
+
+def test_cmd_dynamic_frontend_deploy__requires_folder_for_upload(
+    tmp_path: Path,
+) -> None:
+    """Purpose: Verify file upload refuses the root folder.
+    Why this matters: Uploaded bundles need a concrete KB scope to store content.
+    Setup summary: Create a bundle, use root state, and assert a helpful error.
+    """
+    bundle = tmp_path / "app.zip"
+    bundle.write_bytes(b"zip")
+
+    output = cmd_dynamic_frontend_deploy(
+        _state(path="/", scope_id=None),
+        file=str(bundle),
+        name="Revenue Dashboard",
+    )
+
+    assert "cannot upload bundle to root" in output
+
+
+@patch("unique_sdk.DynamicFrontend.create")
+def test_cmd_dynamic_frontend_deploy__json_output(
+    mock_create: MagicMock,
+) -> None:
+    """Purpose: Verify deploy can emit raw JSON for scripting.
+    Why this matters: CI and automation consumers need machine-readable output.
+    Setup summary: Mock create, deploy by content id with JSON output, and parse the result.
+    """
+    mock_create.return_value = _space()
+
+    output = cmd_dynamic_frontend_deploy(
+        _state(),
+        content_id="cont_1",
+        name="Revenue Dashboard",
+        output_json=True,
+    )
+
+    assert json.loads(output)["spaceId"] == "space_1"
+
+
+@patch("unique_sdk.DynamicFrontend.create")
+def test_cmd_dynamic_frontend_deploy__api_error_is_returned(
+    mock_create: MagicMock,
+) -> None:
+    """Purpose: Verify deploy reports SDK API errors as CLI output.
+    Why this matters: CLI callers should receive actionable errors instead of tracebacks.
+    Setup summary: Make create raise APIError and assert the returned message.
+    """
+    mock_create.side_effect = unique_sdk.APIError("upstream boom")
+
+    output = cmd_dynamic_frontend_deploy(
+        _state(),
+        content_id="cont_1",
+        name="Revenue Dashboard",
+    )
+
+    assert "dynamic-frontend deploy: upstream boom" in output
+
+
+def test_format_space__includes_status_fields() -> None:
+    """Purpose: Verify list formatting includes status phase and URL when present.
+    Why this matters: Operators need deployment status and URL from list output.
+    Setup summary: Format a fake space with status metadata and assert tabular fields.
+    """
+    output = _format_space(
+        _space(status={"phase": "READY", "url": "https://app.example.com"})
+    )
+
+    assert (
+        output == "space_1\tRevenue Dashboard\tcont_1\tREADY\thttps://app.example.com"
+    )
+
+
+@patch("unique_sdk.DynamicFrontend.list")
+def test_cmd_dynamic_frontend_list__formats_spaces(mock_list: MagicMock) -> None:
+    """Purpose: Verify list renders manageable Dynamic Frontend spaces.
+    Why this matters: The default CLI output should be readable without JSON parsing.
+    Setup summary: Mock one space, call list, and assert formatted content.
+    """
+    mock_list.return_value = [_space()]
+
+    output = cmd_dynamic_frontend_list(_state())
+
+    assert output == "space_1\tRevenue Dashboard\tcont_1"
+    mock_list.assert_called_once_with(user_id="user_1", company_id="company_1")
+
+
+@patch("unique_sdk.DynamicFrontend.list")
+def test_cmd_dynamic_frontend_list__empty_result(mock_list: MagicMock) -> None:
+    """Purpose: Verify list handles no manageable spaces.
+    Why this matters: Empty accounts should get a clear message rather than blank output.
+    Setup summary: Mock an empty list and assert the user-facing message.
+    """
+    mock_list.return_value = []
+
+    assert (
+        cmd_dynamic_frontend_list(_state())
+        == "No manageable Dynamic Frontend spaces found."
+    )
+
+
+@patch("unique_sdk.DynamicFrontend.list")
+def test_cmd_dynamic_frontend_list__json_output(mock_list: MagicMock) -> None:
+    """Purpose: Verify list can emit raw JSON for scripting.
+    Why this matters: Automation can consume full API fields without parsing table output.
+    Setup summary: Mock one dict-like space, request JSON output, and parse it.
+    """
+    mock_list.return_value = [_space()]
+
+    output = cmd_dynamic_frontend_list(_state(), output_json=True)
+
+    assert json.loads(output)[0]["spaceId"] == "space_1"
+
+
+@patch("unique_sdk.DynamicFrontend.list")
+def test_cmd_dynamic_frontend_list__api_error_is_returned(mock_list: MagicMock) -> None:
+    """Purpose: Verify list reports SDK API errors as CLI output.
+    Why this matters: CLI users need an error string instead of an unhandled traceback.
+    Setup summary: Make list raise APIError and assert the returned message.
+    """
+    mock_list.side_effect = unique_sdk.APIError("upstream boom")
+
+    output = cmd_dynamic_frontend_list(_state())
+
+    assert "dynamic-frontend list: upstream boom" in output

--- a/unique_sdk/unique_sdk/__init__.py
+++ b/unique_sdk/unique_sdk/__init__.py
@@ -77,6 +77,9 @@ from unique_sdk.api_resources._message import Message as Message
 from unique_sdk.api_resources._integrated import Integrated as Integrated
 from unique_sdk.api_resources._search import Search as Search
 from unique_sdk.api_resources._content import Content as Content
+from unique_sdk.api_resources._dynamic_frontend import (
+    DynamicFrontend as DynamicFrontend,
+)
 from unique_sdk.api_resources._search_string import SearchString as SearchString
 from unique_sdk.api_resources._short_term_memory import (
     ShortTermMemory as ShortTermMemory,

--- a/unique_sdk/unique_sdk/api_resources/_dynamic_frontend.py
+++ b/unique_sdk/unique_sdk/api_resources/_dynamic_frontend.py
@@ -75,5 +75,7 @@ class DynamicFrontend(APIResource["DynamicFrontend"]):
             user_id,
             company_id,
         )
+        if isinstance(response, list):
+            return cast(list[DynamicFrontend], response)
         data = response.get("data", []) if isinstance(response, dict) else []
         return cast(list[DynamicFrontend], data)

--- a/unique_sdk/unique_sdk/api_resources/_dynamic_frontend.py
+++ b/unique_sdk/unique_sdk/api_resources/_dynamic_frontend.py
@@ -1,0 +1,79 @@
+from typing import Literal, cast
+
+from typing_extensions import NotRequired, Unpack
+
+from unique_sdk._api_resource import APIResource
+from unique_sdk._request_options import RequestOptions
+from unique_sdk._util import classproperty
+
+
+class DynamicFrontend(APIResource["DynamicFrontend"]):
+    @classproperty
+    def OBJECT_NAME(cls) -> Literal["dynamic-frontend"]:
+        return "dynamic-frontend"
+
+    id: str
+    spaceId: str
+    name: str
+    contentId: str
+    status: dict[str, object] | None
+
+    class CreateParams(RequestOptions):
+        name: str
+        contentId: str
+
+    class UpdateParams(RequestOptions):
+        contentId: str
+        name: NotRequired[str | None]
+
+    @classmethod
+    def create(
+        cls,
+        user_id: str,
+        company_id: str,
+        **params: Unpack["DynamicFrontend.CreateParams"],
+    ) -> "DynamicFrontend":
+        return cast(
+            DynamicFrontend,
+            cls._static_request(
+                "post",
+                "/dynamic-frontend",
+                user_id,
+                company_id,
+                params=params,
+            ),
+        )
+
+    @classmethod
+    def modify(
+        cls,
+        space_id: str,
+        user_id: str,
+        company_id: str,
+        **params: Unpack["DynamicFrontend.UpdateParams"],
+    ) -> "DynamicFrontend":
+        return cast(
+            DynamicFrontend,
+            cls._static_request(
+                "patch",
+                f"/dynamic-frontend/{space_id}",
+                user_id,
+                company_id,
+                params=params,
+            ),
+        )
+
+    @classmethod
+    def list(
+        cls,
+        user_id: str,
+        company_id: str,
+    ) -> list["DynamicFrontend"]:
+        response = cls._static_request(
+            "get",
+            "/dynamic-frontend",
+            user_id,
+            company_id,
+        )
+        data = response.get("data", []) if isinstance(response, dict) else []
+        return cast(list[DynamicFrontend], data)

--- a/unique_sdk/unique_sdk/cli/cli.py
+++ b/unique_sdk/unique_sdk/cli/cli.py
@@ -57,6 +57,8 @@ from unique_sdk.cli.config import load_config
 from unique_sdk.cli.shell import UniqueShell
 from unique_sdk.cli.state import ShellState
 
+_DYNAMIC_FRONTEND_ERROR_PREFIX = "dynamic-frontend "
+
 MAIN_HELP = """\
 Unique CLI -- Linux-like file explorer for the Unique AI Platform.
 
@@ -410,16 +412,17 @@ def dynamic_frontend_deploy(
       unique-cli dynamic-frontend deploy --content-id content_123 --name "Revenue Dashboard"
       unique-cli dynamic-frontend deploy --space-id assistant_123 --file ./app.zip
     """
-    click.echo(
-        cmd_dynamic_frontend_deploy(
-            LazyState.get(ctx),
-            file=file_path,
-            content_id=content_id,
-            name=name,
-            space_id=space_id,
-            output_json=output_json,
-        )
+    output = cmd_dynamic_frontend_deploy(
+        LazyState.get(ctx),
+        file=file_path,
+        content_id=content_id,
+        name=name,
+        space_id=space_id,
+        output_json=output_json,
     )
+    click.echo(output)
+    if output.startswith(_DYNAMIC_FRONTEND_ERROR_PREFIX):
+        ctx.exit(1)
 
 
 @dynamic_frontend.command(name="list")
@@ -429,7 +432,10 @@ def dynamic_frontend_deploy(
 @click.pass_context
 def dynamic_frontend_list(ctx: click.Context, output_json: bool) -> None:
     """List Dynamic Frontend spaces the current user can manage."""
-    click.echo(cmd_dynamic_frontend_list(LazyState.get(ctx), output_json=output_json))
+    output = cmd_dynamic_frontend_list(LazyState.get(ctx), output_json=output_json)
+    click.echo(output)
+    if output.startswith(_DYNAMIC_FRONTEND_ERROR_PREFIX):
+        ctx.exit(1)
 
 
 @main.command()

--- a/unique_sdk/unique_sdk/cli/cli.py
+++ b/unique_sdk/unique_sdk/cli/cli.py
@@ -8,6 +8,10 @@ import click
 
 from unique_sdk.cli import __version__
 from unique_sdk.cli.commands.cite_file import cmd_cite_file
+from unique_sdk.cli.commands.dynamic_frontend import (
+    cmd_dynamic_frontend_deploy,
+    cmd_dynamic_frontend_list,
+)
 from unique_sdk.cli.commands.elicitation import (
     cmd_elicit_ask,
     cmd_elicit_create,
@@ -99,6 +103,7 @@ Examples:
   unique-cli subagent Legal "Review" Invoke a connected space/subagent
   unique-cli web-search search "x"  Search the web via the public API
   unique-cli web-search crawl URL   Crawl a URL via the public API
+  unique-cli dynamic-frontend list  List manageable Dynamic Frontend spaces
 """
 
 
@@ -357,6 +362,74 @@ def read_cmd(ctx: click.Context, cont_id: str) -> None:
         click.echo(output, err=True)
         raise SystemExit(1)
     click.echo(output)
+
+
+@main.group(name="dynamic-frontend")
+def dynamic_frontend() -> None:
+    """Deploy and list Dynamic Frontend spaces."""
+
+
+@dynamic_frontend.command(name="deploy")
+@click.option(
+    "--file",
+    "file_path",
+    default=None,
+    type=click.Path(exists=True),
+    help="Path to an upload-ready Dynamic Frontend ZIP bundle.",
+)
+@click.option(
+    "--content-id",
+    default=None,
+    help="Existing Knowledge Base content id for the ZIP bundle.",
+)
+@click.option(
+    "--name",
+    default=None,
+    help="Space display name. Required when creating; optional rename when updating.",
+)
+@click.option(
+    "--space-id", default=None, help="Existing Dynamic Frontend space id to update."
+)
+@click.option(
+    "--json", "output_json", is_flag=True, default=False, help="Print raw JSON."
+)
+@click.pass_context
+def dynamic_frontend_deploy(
+    ctx: click.Context,
+    file_path: str | None,
+    content_id: str | None,
+    name: str | None,
+    space_id: str | None,
+    output_json: bool,
+) -> None:
+    """Create or update a Dynamic Frontend space.
+
+    \b
+    Examples:
+      unique-cli dynamic-frontend deploy --file ./app.zip --name "Revenue Dashboard"
+      unique-cli dynamic-frontend deploy --content-id content_123 --name "Revenue Dashboard"
+      unique-cli dynamic-frontend deploy --space-id assistant_123 --file ./app.zip
+    """
+    click.echo(
+        cmd_dynamic_frontend_deploy(
+            LazyState.get(ctx),
+            file=file_path,
+            content_id=content_id,
+            name=name,
+            space_id=space_id,
+            output_json=output_json,
+        )
+    )
+
+
+@dynamic_frontend.command(name="list")
+@click.option(
+    "--json", "output_json", is_flag=True, default=False, help="Print raw JSON."
+)
+@click.pass_context
+def dynamic_frontend_list(ctx: click.Context, output_json: bool) -> None:
+    """List Dynamic Frontend spaces the current user can manage."""
+    click.echo(cmd_dynamic_frontend_list(LazyState.get(ctx), output_json=output_json))
 
 
 @main.command()

--- a/unique_sdk/unique_sdk/cli/commands/dynamic_frontend.py
+++ b/unique_sdk/unique_sdk/cli/commands/dynamic_frontend.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import unique_sdk
+from unique_sdk.cli.state import ShellState
+from unique_sdk.utils.file_io import upload_file
+
+
+def _upload_bundle(state: ShellState, file_path: str) -> str:
+    path = Path(file_path).expanduser().resolve()
+    if not path.is_file():
+        raise ValueError(f"local file not found: {file_path}")
+
+    if not state.scope_id:
+        raise ValueError("cannot upload bundle to root. cd into a folder first.")
+
+    result = upload_file(
+        userId=state.config.user_id,
+        companyId=state.config.company_id,
+        path_to_file=str(path),
+        displayed_filename=path.name,
+        mime_type="application/zip",
+        scope_or_unique_path=state.scope_id,
+    )
+    content_id = getattr(result, "id", None)
+    if not isinstance(content_id, str) or not content_id:
+        raise ValueError("upload did not return a content id")
+    return content_id
+
+
+def _format_space(space: object) -> str:
+    space_id = getattr(space, "spaceId", None) or getattr(space, "id", "")
+    name = getattr(space, "name", "")
+    content_id = getattr(space, "contentId", "")
+    status = getattr(space, "status", None)
+    phase = ""
+    url = ""
+    if isinstance(status, dict):
+        phase = str(status.get("phase") or "")
+        url = str(status.get("url") or "")
+    return "\t".join(
+        part for part in [str(space_id), str(name), str(content_id), phase, url] if part
+    )
+
+
+def cmd_dynamic_frontend_deploy(
+    state: ShellState,
+    *,
+    file: str | None = None,
+    content_id: str | None = None,
+    name: str | None = None,
+    space_id: str | None = None,
+    output_json: bool = False,
+) -> str:
+    try:
+        if not file and not content_id:
+            return "dynamic-frontend deploy: provide either --file or --content-id."
+        if file and content_id:
+            return "dynamic-frontend deploy: --file and --content-id are mutually exclusive."
+        if not space_id and not name:
+            return "dynamic-frontend deploy: provide --name when creating a Dynamic Frontend space."
+
+        resolved_content_id = _upload_bundle(state, file) if file else content_id
+        if not resolved_content_id:
+            return "dynamic-frontend deploy: expected a content id after resolving deploy input."
+
+        if space_id:
+            space = unique_sdk.DynamicFrontend.modify(
+                space_id,
+                user_id=state.config.user_id,
+                company_id=state.config.company_id,
+                contentId=resolved_content_id,
+                name=name,
+            )
+            action = "Updated"
+        else:
+            space = unique_sdk.DynamicFrontend.create(
+                user_id=state.config.user_id,
+                company_id=state.config.company_id,
+                name=name or "",
+                contentId=resolved_content_id,
+            )
+            action = "Created"
+
+        if output_json:
+            return json.dumps(dict(space), indent=2, default=str)
+
+        space_id_value = getattr(space, "spaceId", None) or getattr(space, "id", "")
+        name_value = getattr(space, "name", name or "")
+        return (
+            f'{action} Dynamic Frontend space "{name_value}" ({space_id_value})\n'
+            f"Content: {resolved_content_id}"
+        )
+    except (ValueError, unique_sdk.APIError, OSError) as e:
+        return f"dynamic-frontend deploy: {e}"
+
+
+def cmd_dynamic_frontend_list(state: ShellState, *, output_json: bool = False) -> str:
+    try:
+        spaces = unique_sdk.DynamicFrontend.list(
+            user_id=state.config.user_id,
+            company_id=state.config.company_id,
+        )
+        if output_json:
+            return json.dumps(spaces, indent=2, default=str)
+        if not spaces:
+            return "No manageable Dynamic Frontend spaces found."
+        return "\n".join(_format_space(space) for space in spaces)
+    except unique_sdk.APIError as e:
+        return f"dynamic-frontend list: {e}"

--- a/unique_sdk/unique_sdk/cli/commands/dynamic_frontend.py
+++ b/unique_sdk/unique_sdk/cli/commands/dynamic_frontend.py
@@ -67,12 +67,16 @@ def cmd_dynamic_frontend_deploy(
             return "dynamic-frontend deploy: expected a content id after resolving deploy input."
 
         if space_id:
+            update_params: unique_sdk.DynamicFrontend.UpdateParams = {
+                "contentId": resolved_content_id,
+            }
+            if name is not None:
+                update_params["name"] = name
             space = unique_sdk.DynamicFrontend.modify(
                 space_id,
                 user_id=state.config.user_id,
                 company_id=state.config.company_id,
-                contentId=resolved_content_id,
-                name=name,
+                **update_params,
             )
             action = "Updated"
         else:


### PR DESCRIPTION
## Summary
- Add a `DynamicFrontend` SDK resource for create, update, and list operations.
- Expose `unique-cli dynamic-frontend deploy` and `unique-cli dynamic-frontend list` for managing Dynamic Frontend spaces.
- Register the resource on the public `unique_sdk` import surface.

## Changes
- `unique_sdk`: adds the `/dynamic-frontend` API resource wrapper.
- `unique-cli`: adds deploy/list command handlers, upload support for ZIP bundles, and top-level Click command registration.

## Test plan
- [x] `PYENV_VERSION=3.12.10 ruff format .`
- [x] `PYENV_VERSION=3.12.10 ruff check .`
- [x] `PYENV_VERSION=3.12.10 PYTHONPATH=. python -c "from unique_sdk.cli.cli import main; main(['dynamic-frontend', '--help'])"`
- [ ] `uv run poe format && uv run poe lint` (blocked locally: current `uv` fails parsing root `pyproject.toml` / `uv.lock` settings in this worktree)

## Risk / rollout
- Low-risk SDK/CLI addition; existing commands and resources are unchanged.

Made with [Cursor](https://cursor.com)