### PR TITLE
feat(unique-sdk-cli): support versioned file uploads

### DIFF
--- a/unique_sdk/tests/cli/test_commands.py
+++ b/unique_sdk/tests/cli/test_commands.py
@@ -366,6 +366,23 @@ class TestFiles:
         assert mock_folder.call_args.kwargs["folderPath"] == "/Reports/Q1"
 
     @patch("unique_sdk.Content.get_infos")
+    @patch("unique_sdk.Folder.get_info")
+    def test_resolve_content_id_normalizes_dot_path(
+        self,
+        mock_folder: MagicMock,
+        mock_content: MagicMock,
+    ) -> None:
+        mock_folder.return_value = {"id": "scope_q1"}
+        mock_content.return_value = {"contentInfos": [_content_info()]}
+        cid, name = _resolve_content_id(
+            _state("/Reports", "scope_r"),
+            "./Q1/report.pdf",
+        )
+        assert cid == "cont_123"
+        assert name == "report.pdf"
+        assert mock_folder.call_args.kwargs["folderPath"] == "/Reports/Q1"
+
+    @patch("unique_sdk.Content.get_infos")
     def test_resolve_content_id_not_found(self, mock: MagicMock) -> None:
         mock.return_value = {"contentInfos": []}
         with pytest.raises(ValueError, match="File not found"):

--- a/unique_sdk/tests/cli/test_commands.py
+++ b/unique_sdk/tests/cli/test_commands.py
@@ -403,8 +403,10 @@ class TestFiles:
 
     @patch("unique_sdk.Content.get_infos")
     def test_resolve_content_id_scans_paginated_files(self, mock: MagicMock) -> None:
+        other = _content_info(title="other.pdf")
+        other["key"] = "other.pdf"
         mock.side_effect = [
-            {"contentInfos": [_content_info(title="other.pdf")], "totalCount": 2},
+            {"contentInfos": [other], "totalCount": 2},
             {"contentInfos": [_content_info()], "totalCount": 2},
         ]
         cid, name = _resolve_content_id(_state("/Reports", "scope_r"), "report.pdf")
@@ -412,6 +414,16 @@ class TestFiles:
         assert name == "report.pdf"
         assert mock.call_args_list[0].kwargs["skip"] == 0
         assert mock.call_args_list[1].kwargs["skip"] == 1
+
+    @patch("unique_sdk.Content.get_infos")
+    def test_resolve_content_id_matches_storage_key(self, mock: MagicMock) -> None:
+        mock.return_value = {
+            "contentInfos": [_content_info(title="Display Name.pdf")],
+            "totalCount": 1,
+        }
+        cid, name = _resolve_content_id(_state("/Reports", "scope_r"), "report.pdf")
+        assert cid == "cont_123"
+        assert name == "Display Name.pdf"
 
     @patch("unique_sdk.Content.get_infos")
     def test_resolve_content_id_not_found(self, mock: MagicMock) -> None:

--- a/unique_sdk/tests/cli/test_commands.py
+++ b/unique_sdk/tests/cli/test_commands.py
@@ -13,8 +13,10 @@ from unique_sdk.cli.commands.files import (
     _resolve_upload_destination,
     cmd_download,
     cmd_mv_file,
+    cmd_restore_version,
     cmd_rm,
     cmd_upload,
+    cmd_versions,
 )
 from unique_sdk.cli.commands.folders import cmd_mkdir, cmd_mvdir, cmd_rmdir
 from unique_sdk.cli.commands.mcp import _parse_and_validate, _read_payload, cmd_mcp
@@ -329,6 +331,41 @@ class TestFiles:
         assert name == "report.pdf"
 
     @patch("unique_sdk.Content.get_infos")
+    @patch("unique_sdk.Folder.get_info")
+    def test_resolve_content_id_by_absolute_path(
+        self,
+        mock_folder: MagicMock,
+        mock_content: MagicMock,
+    ) -> None:
+        mock_folder.return_value = {"id": "scope_q1"}
+        mock_content.return_value = {"contentInfos": [_content_info()]}
+        cid, name = _resolve_content_id(
+            _state("/Reports", "scope_r"),
+            "/Reports/Q1/report.pdf",
+        )
+        assert cid == "cont_123"
+        assert name == "report.pdf"
+        assert mock_folder.call_args.kwargs["folderPath"] == "/Reports/Q1"
+        assert mock_content.call_args.kwargs["parentId"] == "scope_q1"
+
+    @patch("unique_sdk.Content.get_infos")
+    @patch("unique_sdk.Folder.get_info")
+    def test_resolve_content_id_by_relative_path(
+        self,
+        mock_folder: MagicMock,
+        mock_content: MagicMock,
+    ) -> None:
+        mock_folder.return_value = {"id": "scope_q1"}
+        mock_content.return_value = {"contentInfos": [_content_info()]}
+        cid, name = _resolve_content_id(
+            _state("/Reports", "scope_r"),
+            "Q1/report.pdf",
+        )
+        assert cid == "cont_123"
+        assert name == "report.pdf"
+        assert mock_folder.call_args.kwargs["folderPath"] == "/Reports/Q1"
+
+    @patch("unique_sdk.Content.get_infos")
     def test_resolve_content_id_not_found(self, mock: MagicMock) -> None:
         mock.return_value = {"contentInfos": []}
         with pytest.raises(ValueError, match="File not found"):
@@ -545,6 +582,56 @@ class TestFiles:
         result = cmd_upload(_state("/Reports", "scope_r"), str(f))
         assert "Uploaded" in result
         assert "cont_new" in result
+        assert mock_upload.call_args.kwargs["versioning_enabled"] is True
+
+    @patch("unique_sdk.Content.versions")
+    @patch("unique_sdk.Content.get_infos")
+    def test_versions_by_name(
+        self,
+        mock_infos: MagicMock,
+        mock_versions: MagicMock,
+    ) -> None:
+        mock_infos.return_value = {"contentInfos": [_content_info()]}
+        mock_versions.return_value = {
+            "data": [
+                {
+                    "id": "cver_1",
+                    "versionNumber": 1,
+                    "archivedAt": "2026-06-06T12:00:00Z",
+                    "reason": "REPLACED",
+                    "title": "report.pdf",
+                }
+            ]
+        }
+        result = cmd_versions(_state("/R", "scope_r"), "report.pdf", take=10)
+        assert "Versions for report.pdf" in result
+        assert "cver_1" in result
+        assert mock_versions.call_args.kwargs["contentId"] == "cont_123"
+        assert mock_versions.call_args.kwargs["take"] == 10
+
+    @patch("unique_sdk.Content.versions")
+    @patch("unique_sdk.Content.get_infos")
+    @patch("unique_sdk.Folder.get_info")
+    def test_versions_by_path(
+        self,
+        mock_folder: MagicMock,
+        mock_infos: MagicMock,
+        mock_versions: MagicMock,
+    ) -> None:
+        mock_folder.return_value = {"id": "scope_q1"}
+        mock_infos.return_value = {"contentInfos": [_content_info()]}
+        mock_versions.return_value = {"data": []}
+        result = cmd_versions(_state("/Reports", "scope_r"), "/Reports/Q1/report.pdf")
+        assert "Versions for report.pdf" in result
+        assert mock_versions.call_args.kwargs["contentId"] == "cont_123"
+
+    @patch("unique_sdk.Content.restore_version")
+    def test_restore_version(self, mock_restore: MagicMock) -> None:
+        mock_restore.return_value = _content_info(title="report.pdf")
+        result = cmd_restore_version(_state(), "cver_1")
+        assert "Restored" in result
+        assert "cver_1" in result
+        assert mock_restore.call_args.kwargs["contentVersionId"] == "cver_1"
 
     @patch("unique_sdk.cli.commands.files.shutil.move")
     @patch("unique_sdk.cli.commands.files.download_content")

--- a/unique_sdk/tests/cli/test_commands.py
+++ b/unique_sdk/tests/cli/test_commands.py
@@ -710,6 +710,30 @@ class TestFiles:
         assert "Versions for report.pdf" in result
         assert mock_versions.call_args.kwargs["contentId"] == "cont_123"
 
+    @patch("unique_sdk.Folder.get_info")
+    def test_versions_path_outside_workspace_blocked(
+        self,
+        mock_folder: MagicMock,
+    ) -> None:
+        state = _state("/Workspace", "scope_ws")
+        state.workspace_scope_ids = ["scope_ws"]
+        state._workspace_scope_paths = ["/Workspace"]
+        result = cmd_versions(state, "/Outside/report.pdf")
+        assert "permission denied" in result
+        mock_folder.assert_not_called()
+
+    @patch("unique_sdk.Content.get_info")
+    def test_versions_content_id_outside_workspace_blocked(
+        self,
+        mock_info: MagicMock,
+    ) -> None:
+        mock_info.return_value = {"contentInfo": [{"ownerId": "scope_other"}]}
+        state = _state("/Workspace", "scope_ws")
+        state.workspace_scope_ids = ["scope_ws"]
+        state._workspace_scope_paths = ["/Workspace"]
+        result = cmd_versions(state, "cont_outside")
+        assert "permission denied" in result
+
     @patch("unique_sdk.Content.restore_version")
     def test_restore_version(self, mock_restore: MagicMock) -> None:
         mock_restore.return_value = _content_info(title="report.pdf")
@@ -717,6 +741,18 @@ class TestFiles:
         assert "Restored" in result
         assert "cver_1" in result
         assert mock_restore.call_args.kwargs["contentVersionId"] == "cver_1"
+
+    @patch("unique_sdk.Content.restore_version")
+    def test_restore_version_workspace_restricted_blocked(
+        self,
+        mock_restore: MagicMock,
+    ) -> None:
+        state = _state("/Workspace", "scope_ws")
+        state.workspace_scope_ids = ["scope_ws"]
+        state._workspace_scope_paths = ["/Workspace"]
+        result = cmd_restore_version(state, "cver_1")
+        assert "permission denied" in result
+        mock_restore.assert_not_called()
 
     @patch("unique_sdk.cli.commands.files.shutil.move")
     @patch("unique_sdk.cli.commands.files.download_content")
@@ -729,6 +765,18 @@ class TestFiles:
         mock_dl.return_value = tmp_path / "downloaded"
         result = cmd_download(_state(), "cont_abc")
         assert "Downloaded" in result
+
+    @patch("unique_sdk.Content.get_info")
+    def test_download_content_id_outside_workspace_blocked(
+        self,
+        mock_info: MagicMock,
+    ) -> None:
+        mock_info.return_value = {"contentInfo": [{"ownerId": "scope_other"}]}
+        state = _state("/Workspace", "scope_ws")
+        state.workspace_scope_ids = ["scope_ws"]
+        state._workspace_scope_paths = ["/Workspace"]
+        result = cmd_download(state, "cont_outside")
+        assert "permission denied" in result
 
     @patch("unique_sdk.cli.commands.files.shutil.move")
     @patch("unique_sdk.cli.commands.files.download_content")

--- a/unique_sdk/tests/cli/test_commands.py
+++ b/unique_sdk/tests/cli/test_commands.py
@@ -401,6 +401,15 @@ class TestFiles:
         assert name == "report.pdf"
         assert mock_folder.call_args.kwargs["folderPath"] == "/Reports/Q1"
 
+    @patch("unique_sdk.Folder.get_info")
+    def test_resolve_content_id_rejects_paths_above_root(
+        self,
+        mock_folder: MagicMock,
+    ) -> None:
+        with pytest.raises(ValueError, match="escapes root"):
+            _resolve_content_id(_state("/Reports", "scope_r"), "../../secret.pdf")
+        mock_folder.assert_not_called()
+
     @patch("unique_sdk.Content.get_infos")
     def test_resolve_content_id_scans_paginated_files(self, mock: MagicMock) -> None:
         other = _content_info(title="other.pdf")

--- a/unique_sdk/tests/cli/test_commands.py
+++ b/unique_sdk/tests/cli/test_commands.py
@@ -743,11 +743,24 @@ class TestFiles:
         assert mock_restore.call_args.kwargs["contentVersionId"] == "cver_1"
 
     @patch("unique_sdk.Content.restore_version")
-    def test_restore_version_workspace_restricted_blocked(
+    def test_restore_version_workspace_restricted_inside_allowed(
         self,
         mock_restore: MagicMock,
     ) -> None:
+        mock_restore.return_value = _content_info(title="report.pdf")
         state = _state("/Workspace", "scope_ws")
+        state.workspace_scope_ids = ["scope_ws"]
+        state._workspace_scope_paths = ["/Workspace"]
+        result = cmd_restore_version(state, "cver_1")
+        assert "Restored" in result
+        assert mock_restore.call_args.kwargs["contentVersionId"] == "cver_1"
+
+    @patch("unique_sdk.Content.restore_version")
+    def test_restore_version_workspace_restricted_outside_blocked(
+        self,
+        mock_restore: MagicMock,
+    ) -> None:
+        state = _state("/Outside", "scope_other")
         state.workspace_scope_ids = ["scope_ws"]
         state._workspace_scope_paths = ["/Workspace"]
         result = cmd_restore_version(state, "cver_1")

--- a/unique_sdk/tests/cli/test_commands.py
+++ b/unique_sdk/tests/cli/test_commands.py
@@ -347,6 +347,8 @@ class TestFiles:
         assert name == "report.pdf"
         assert mock_folder.call_args.kwargs["folderPath"] == "/Reports/Q1"
         assert mock_content.call_args.kwargs["parentId"] == "scope_q1"
+        assert mock_content.call_args.kwargs["skip"] == 0
+        assert mock_content.call_args.kwargs["take"] == 100
 
     @patch("unique_sdk.Content.get_infos")
     @patch("unique_sdk.Folder.get_info")
@@ -381,6 +383,35 @@ class TestFiles:
         assert cid == "cont_123"
         assert name == "report.pdf"
         assert mock_folder.call_args.kwargs["folderPath"] == "/Reports/Q1"
+
+    @patch("unique_sdk.Content.get_infos")
+    @patch("unique_sdk.Folder.get_info")
+    def test_resolve_content_id_normalizes_dot_dot_path(
+        self,
+        mock_folder: MagicMock,
+        mock_content: MagicMock,
+    ) -> None:
+        mock_folder.return_value = {"id": "scope_q1"}
+        mock_content.return_value = {"contentInfos": [_content_info()]}
+        cid, name = _resolve_content_id(
+            _state("/Reports/Q2", "scope_q2"),
+            "../Q1/report.pdf",
+        )
+        assert cid == "cont_123"
+        assert name == "report.pdf"
+        assert mock_folder.call_args.kwargs["folderPath"] == "/Reports/Q1"
+
+    @patch("unique_sdk.Content.get_infos")
+    def test_resolve_content_id_scans_paginated_files(self, mock: MagicMock) -> None:
+        mock.side_effect = [
+            {"contentInfos": [_content_info(title="other.pdf")], "totalCount": 2},
+            {"contentInfos": [_content_info()], "totalCount": 2},
+        ]
+        cid, name = _resolve_content_id(_state("/Reports", "scope_r"), "report.pdf")
+        assert cid == "cont_123"
+        assert name == "report.pdf"
+        assert mock.call_args_list[0].kwargs["skip"] == 0
+        assert mock.call_args_list[1].kwargs["skip"] == 1
 
     @patch("unique_sdk.Content.get_infos")
     def test_resolve_content_id_not_found(self, mock: MagicMock) -> None:
@@ -683,18 +714,17 @@ class TestFiles:
 
     @patch("unique_sdk.cli.commands.files.shutil.move")
     @patch("unique_sdk.cli.commands.files.download_content")
-    @patch("unique_sdk.Content.get_infos")
+    @patch("unique_sdk.cli.commands.files._resolve_content_id")
     def test_download_sanitizes_path_traversal(
         self,
-        mock_infos: MagicMock,
+        mock_resolve: MagicMock,
         mock_dl: MagicMock,
         mock_move: MagicMock,
         tmp_path,  # type: ignore[no-untyped-def]
     ) -> None:
-        malicious = _content_info(title="../../.bashrc")
-        mock_infos.return_value = {"contentInfos": [malicious]}
+        mock_resolve.return_value = ("cont_123", "../../.bashrc")
         mock_dl.return_value = tmp_path / "downloaded"
-        cmd_download(_state("/R", "scope_r"), "../../.bashrc", str(tmp_path))
+        cmd_download(_state("/R", "scope_r"), "cont_123", str(tmp_path))
         move_dest = mock_move.call_args[0][1]
         assert ".." not in move_dest
 

--- a/unique_sdk/tests/cli/test_commands.py
+++ b/unique_sdk/tests/cli/test_commands.py
@@ -416,6 +416,22 @@ class TestFiles:
         assert mock.call_args_list[1].kwargs["skip"] == 1
 
     @patch("unique_sdk.Content.get_infos")
+    def test_resolve_content_id_ignores_total_count_for_pagination(
+        self,
+        mock: MagicMock,
+    ) -> None:
+        other = _content_info(title="other.pdf")
+        other["key"] = "other.pdf"
+        mock.side_effect = [
+            {"contentInfos": [other], "totalCount": 1},
+            {"contentInfos": [], "totalCount": 1},
+        ]
+        with pytest.raises(ValueError, match="File not found"):
+            _resolve_content_id(_state("/Reports", "scope_r"), "report.pdf")
+        assert mock.call_args_list[0].kwargs["skip"] == 0
+        assert mock.call_args_list[1].kwargs["skip"] == 1
+
+    @patch("unique_sdk.Content.get_infos")
     def test_resolve_content_id_matches_storage_key(self, mock: MagicMock) -> None:
         mock.return_value = {
             "contentInfos": [_content_info(title="Display Name.pdf")],

--- a/unique_sdk/unique_sdk/api_resources/_content.py
+++ b/unique_sdk/unique_sdk/api_resources/_content.py
@@ -170,6 +170,50 @@ class Content(APIResource["Content"]):
         # a SAS URL the caller PUTs the PDF bytes to. ``file_io.upload_file``
         # exposes this as ``preview_pdf_path`` for a one-call flow.
         previewPdfFileName: NotRequired[str | None]
+        # When true, the platform archives previous blobs for this
+        # content and makes them restorable through the version APIs.
+        versioningEnabled: NotRequired[bool | None]
+
+    class VersionsParams(RequestOptions):
+        contentId: str
+        skip: NotRequired[int | None]
+        take: NotRequired[int | None]
+
+    class ContentVersion(TypedDict):
+        id: str
+        contentId: str
+        versionNumber: int
+        reason: str
+        blobObjectKey: str
+        key: str
+        title: str | None
+        description: str | None
+        url: str | None
+        byteSize: int
+        mimeType: str
+        ownerType: str
+        ownerId: str
+        contentHash: str | None
+        archivedAt: str
+        archivedBy: str | None
+        originalCreatedAt: str
+        originalCreatedBy: str | None
+        createdBy: str | None
+
+    class PaginatedContentVersions(TypedDict):
+        data: list["Content.ContentVersion"]
+        object: str
+
+    class VersionDownloadUrlParams(RequestOptions):
+        contentVersionId: str
+
+    class ContentVersionDownloadUrl(TypedDict):
+        id: str
+        object: str
+        url: str
+
+    class RestoreVersionParams(RequestOptions):
+        contentVersionId: str
 
     class UpdateParams(RequestOptions):
         contentId: NotRequired[str]
@@ -461,6 +505,120 @@ class Content(APIResource["Content"]):
             await cls._static_request_async(
                 "post",
                 "/content/upsert",
+                user_id,
+                company_id,
+                params=params,
+            ),
+        )
+
+    @classmethod
+    def versions(
+        cls,
+        user_id: str,
+        company_id: str,
+        **params: Unpack["Content.VersionsParams"],
+    ) -> "Content.PaginatedContentVersions":
+        content_id = params.pop("contentId")
+        return cast(
+            Content.PaginatedContentVersions,
+            cls._static_request(
+                "get",
+                f"/content/{content_id}/versions",
+                user_id,
+                company_id,
+                params=params,
+            ),
+        )
+
+    @classmethod
+    async def versions_async(
+        cls,
+        user_id: str,
+        company_id: str,
+        **params: Unpack["Content.VersionsParams"],
+    ) -> "Content.PaginatedContentVersions":
+        content_id = params.pop("contentId")
+        return cast(
+            Content.PaginatedContentVersions,
+            await cls._static_request_async(
+                "get",
+                f"/content/{content_id}/versions",
+                user_id,
+                company_id,
+                params=params,
+            ),
+        )
+
+    @classmethod
+    def version_download_url(
+        cls,
+        user_id: str,
+        company_id: str,
+        **params: Unpack["Content.VersionDownloadUrlParams"],
+    ) -> "Content.ContentVersionDownloadUrl":
+        content_version_id = params.pop("contentVersionId")
+        return cast(
+            Content.ContentVersionDownloadUrl,
+            cls._static_request(
+                "get",
+                f"/content/versions/{content_version_id}/download-url",
+                user_id,
+                company_id,
+                params=params,
+            ),
+        )
+
+    @classmethod
+    async def version_download_url_async(
+        cls,
+        user_id: str,
+        company_id: str,
+        **params: Unpack["Content.VersionDownloadUrlParams"],
+    ) -> "Content.ContentVersionDownloadUrl":
+        content_version_id = params.pop("contentVersionId")
+        return cast(
+            Content.ContentVersionDownloadUrl,
+            await cls._static_request_async(
+                "get",
+                f"/content/versions/{content_version_id}/download-url",
+                user_id,
+                company_id,
+                params=params,
+            ),
+        )
+
+    @classmethod
+    def restore_version(
+        cls,
+        user_id: str,
+        company_id: str,
+        **params: Unpack["Content.RestoreVersionParams"],
+    ) -> "Content.ContentInfo":
+        content_version_id = params.pop("contentVersionId")
+        return cast(
+            Content.ContentInfo,
+            cls._static_request(
+                "post",
+                f"/content/versions/{content_version_id}/restore",
+                user_id,
+                company_id,
+                params=params,
+            ),
+        )
+
+    @classmethod
+    async def restore_version_async(
+        cls,
+        user_id: str,
+        company_id: str,
+        **params: Unpack["Content.RestoreVersionParams"],
+    ) -> "Content.ContentInfo":
+        content_version_id = params.pop("contentVersionId")
+        return cast(
+            Content.ContentInfo,
+            await cls._static_request_async(
+                "post",
+                f"/content/versions/{content_version_id}/restore",
                 user_id,
                 company_id,
                 params=params,

--- a/unique_sdk/unique_sdk/cli/cli.py
+++ b/unique_sdk/unique_sdk/cli/cli.py
@@ -110,7 +110,7 @@ Examples:
   unique-cli upload ./file.pdf      Upload versioned to current folder
   unique-cli download cont_abc123   Download by content ID
   unique-cli versions cont_abc123   List archived file versions
-  unique-cli restore-version ver_1  Restore a file from a version
+  unique-cli restore-version cver_1 Restore a file from a version
   unique-cli elicit ask "Which?"    Ask the user a question synchronously
   unique-cli subagent Legal "Review" Invoke a connected space/subagent
   unique-cli web-search search "x"  Search the web via the public API

--- a/unique_sdk/unique_sdk/cli/cli.py
+++ b/unique_sdk/unique_sdk/cli/cli.py
@@ -349,8 +349,8 @@ def download(ctx: click.Context, name_or_id: str, local_dest: str | None) -> Non
     """Download a file to your local machine.
 
     \b
-    NAME_OR_ID is a file name (matched in the current directory) or
-    a content ID (cont_...) which is resolved directly.
+    NAME_OR_ID is a file path, a file name matched in the current
+    directory, or a content ID (cont_...) which is resolved directly.
 
     \b
     LOCAL_DEST is an optional path (directory or file) to save to.
@@ -359,6 +359,7 @@ def download(ctx: click.Context, name_or_id: str, local_dest: str | None) -> Non
     \b
     Examples:
       unique-cli download annual.pdf
+      unique-cli download /Reports/Q1/annual.pdf
       unique-cli download annual.pdf ./downloads/
       unique-cli download cont_abc123 ~/Desktop/
     """

--- a/unique_sdk/unique_sdk/cli/cli.py
+++ b/unique_sdk/unique_sdk/cli/cli.py
@@ -385,10 +385,12 @@ def cite(
     \b
     Registers [filesourceN] markers for pages you referenced in your answer.
     Does NOT read or extract the file — use your own tools for that.
+    NAME_OR_ID can be a file path, current-directory file name, or content ID.
 
     \b
     Examples:
       unique-cli cite report.pdf --pages 3,5,7
+      unique-cli cite /Reports/Q1/report.pdf --pages 3,5,7
       unique-cli cite cont_abc123 --pages 1-4
     """
     click.echo(cmd_cite_file(LazyState.get(ctx), name_or_id, pages))
@@ -496,15 +498,16 @@ def dynamic_frontend_list(ctx: click.Context, output_json: bool) -> None:
 @click.argument("name_or_id")
 @click.pass_context
 def rm(ctx: click.Context, name_or_id: str) -> None:
-    """Delete a file by name or content ID.
+    """Delete a file by path, name, or content ID.
 
     \b
-    NAME_OR_ID is a file name (matched in the current directory) or
-    a content ID (cont_...).
+    NAME_OR_ID is a file path, a file name matched in the current
+    directory, or a content ID (cont_...).
 
     \b
     Examples:
       unique-cli rm report.pdf
+      unique-cli rm /Reports/Q1/report.pdf
       unique-cli rm cont_abc123
     """
     click.echo(cmd_rm(LazyState.get(ctx), name_or_id))
@@ -519,11 +522,12 @@ def mv(ctx: click.Context, old_name: str, new_name: str) -> None:
 
     \b
     Changes the file's display title without changing its content ID
-    or location. OLD_NAME can be a file name or content ID.
+    or location. OLD_NAME can be a file path, file name, or content ID.
 
     \b
     Examples:
       unique-cli mv annual.pdf annual-2025.pdf
+      unique-cli mv /Reports/Q1/annual.pdf annual-2025.pdf
       unique-cli mv cont_abc123 "New Title.pdf"
     """
     click.echo(cmd_mv_file(LazyState.get(ctx), old_name, new_name))

--- a/unique_sdk/unique_sdk/cli/cli.py
+++ b/unique_sdk/unique_sdk/cli/cli.py
@@ -20,7 +20,14 @@ from unique_sdk.cli.commands.elicitation import (
     cmd_elicit_respond,
     cmd_elicit_wait,
 )
-from unique_sdk.cli.commands.files import cmd_download, cmd_mv_file, cmd_rm, cmd_upload
+from unique_sdk.cli.commands.files import (
+    cmd_download,
+    cmd_mv_file,
+    cmd_restore_version,
+    cmd_rm,
+    cmd_upload,
+    cmd_versions,
+)
 from unique_sdk.cli.commands.folders import cmd_mkdir, cmd_mvdir, cmd_rmdir
 from unique_sdk.cli.commands.mcp import cmd_mcp
 from unique_sdk.cli.commands.navigation import cmd_cd, cmd_ls, cmd_pwd
@@ -91,6 +98,7 @@ Path formats accepted by all commands:
 \b
 File identifiers:
   report.pdf          File name (matched in current directory)
+  /Reports/report.pdf File path (absolute or relative)
   cont_abc123         Content ID (used directly)
 
 \b
@@ -99,8 +107,10 @@ Examples:
   unique-cli ls                     List root folders
   unique-cli ls /Reports            List a specific folder
   unique-cli search "revenue" -l 50 Search with custom limit
-  unique-cli upload ./file.pdf      Upload to current folder
+  unique-cli upload ./file.pdf      Upload versioned to current folder
   unique-cli download cont_abc123   Download by content ID
+  unique-cli versions cont_abc123   List archived file versions
+  unique-cli restore-version ver_1  Restore a file from a version
   unique-cli elicit ask "Which?"    Ask the user a question synchronously
   unique-cli subagent Legal "Review" Invoke a connected space/subagent
   unique-cli web-search search "x"  Search the web via the public API
@@ -261,12 +271,13 @@ def mvdir(ctx: click.Context, old_name: str, new_name: str) -> None:
 @click.argument("destination", required=False, default=None)
 @click.pass_context
 def upload(ctx: click.Context, local_path: str, destination: str | None) -> None:
-    """Upload a local file (works like Linux cp).
+    """Upload a local file with versioning enabled (works like Linux cp).
 
     \b
-    Uploads LOCAL_PATH to the Unique platform. DESTINATION works like
-    the target in cp -- it can be a folder path, a new filename, or
-    a combination of both. MIME type is auto-detected.
+    Uploads LOCAL_PATH to the Unique platform with immutable versioning
+    enabled. DESTINATION works like the target in cp -- it can be a
+    folder path, a new filename, or a combination of both. MIME type is
+    auto-detected.
 
     \b
     Destination formats:
@@ -286,6 +297,48 @@ def upload(ctx: click.Context, local_path: str, destination: str | None) -> None
       unique-cli upload ./report.pdf /Archive/2025/
     """
     click.echo(cmd_upload(LazyState.get(ctx), local_path, destination))
+
+
+@main.command()
+@click.argument("name_or_id")
+@click.option("--skip", type=int, default=None, help="Number of versions to skip.")
+@click.option("--take", type=int, default=None, help="Number of versions to return.")
+@click.pass_context
+def versions(
+    ctx: click.Context,
+    name_or_id: str,
+    skip: int | None,
+    take: int | None,
+) -> None:
+    """List archived versions for a file.
+
+    \b
+    NAME_OR_ID is a file path, a file name matched in the current
+    directory, or a content ID (cont_...) which is resolved directly.
+
+    \b
+    Examples:
+      unique-cli versions report.pdf
+      unique-cli versions /Reports/Q1/report.pdf
+      unique-cli versions cont_abc123 --take 10
+    """
+    click.echo(cmd_versions(LazyState.get(ctx), name_or_id, skip=skip, take=take))
+
+
+@main.command(name="restore-version")
+@click.argument("content_version_id")
+@click.pass_context
+def restore_version(ctx: click.Context, content_version_id: str) -> None:
+    """Restore a file from a content version ID.
+
+    \b
+    CONTENT_VERSION_ID is returned by `unique-cli versions`.
+
+    \b
+    Examples:
+      unique-cli restore-version cver_abc123
+    """
+    click.echo(cmd_restore_version(LazyState.get(ctx), content_version_id))
 
 
 @main.command()

--- a/unique_sdk/unique_sdk/cli/commands/files.py
+++ b/unique_sdk/unique_sdk/cli/commands/files.py
@@ -269,7 +269,7 @@ def cmd_versions(
 
 def cmd_restore_version(state: ShellState, content_version_id: str) -> str:
     """Restore a file from an archived content version ID."""
-    if state.workspace_restricted:
+    if not state.is_within_workspace():
         return "restore-version: permission denied (outside workspace scope)"
     try:
         result = unique_sdk.Content.restore_version(

--- a/unique_sdk/unique_sdk/cli/commands/files.py
+++ b/unique_sdk/unique_sdk/cli/commands/files.py
@@ -63,9 +63,10 @@ def _resolve_content_id(state: ShellState, name_or_id: str) -> tuple[str, str]:
         )
         content_infos = result.get("contentInfos", [])
         for info in content_infos:
-            title = info.get("title") or info.get("key") or ""
-            if title == lookup_name:
-                return info["id"], title
+            title = info.get("title") or ""
+            key = info.get("key") or ""
+            if lookup_name in {title, key}:
+                return info["id"], title or key
 
         total_count = result.get("totalCount")
         skip += len(content_infos)

--- a/unique_sdk/unique_sdk/cli/commands/files.py
+++ b/unique_sdk/unique_sdk/cli/commands/files.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import mimetypes
+import posixpath
 import shutil
 from pathlib import Path
 from typing import Any
@@ -35,6 +36,7 @@ def _resolve_content_id(state: ShellState, name_or_id: str) -> tuple[str, str]:
             folder_path = "/"
         elif not folder_path.startswith("/"):
             folder_path = f"{state.cwd.rstrip('/')}/{folder_path}"
+        folder_path = posixpath.normpath(folder_path)
 
         info = unique_sdk.Folder.get_info(
             user_id=state.config.user_id,

--- a/unique_sdk/unique_sdk/cli/commands/files.py
+++ b/unique_sdk/unique_sdk/cli/commands/files.py
@@ -16,12 +16,35 @@ from unique_sdk.utils.file_io import download_content, upload_file
 def _resolve_content_id(state: ShellState, name_or_id: str) -> tuple[str, str]:
     """Resolve a file name or content ID to (content_id, display_name).
 
-    Accepts either a content ID (cont_...) or a file name/path.
+    Accepts a content ID (cont_...), a file name in the current folder,
+    or an absolute/relative Unique file path.
     """
     if name_or_id.startswith("cont_"):
         return name_or_id, name_or_id
 
+    lookup_name = name_or_id
     scope_id = state.scope_id
+    # Preserve support for unusual literal filenames like "../../.bashrc".
+    # Only resolve slash-containing values as Unique paths when they are not
+    # path traversal shaped names.
+    if "/" in name_or_id and ".." not in name_or_id.split("/"):
+        folder_path, lookup_name = name_or_id.rsplit("/", 1)
+        if not lookup_name:
+            raise ValueError(f"File path must include a file name: {name_or_id}")
+        if not folder_path:
+            folder_path = "/"
+        elif not folder_path.startswith("/"):
+            folder_path = f"{state.cwd.rstrip('/')}/{folder_path}"
+
+        info = unique_sdk.Folder.get_info(
+            user_id=state.config.user_id,
+            company_id=state.config.company_id,
+            folderPath=folder_path,
+        )
+        scope_id = info.get("id")
+        if not scope_id:
+            raise ValueError(f"folder not found: {folder_path}")
+
     params: dict[str, Any] = {}
     if scope_id:
         params["parentId"] = scope_id
@@ -33,10 +56,36 @@ def _resolve_content_id(state: ShellState, name_or_id: str) -> tuple[str, str]:
     )
     for info in result.get("contentInfos", []):
         title = info.get("title") or info.get("key") or ""
-        if title == name_or_id:
+        if title == lookup_name:
             return info["id"], title
 
     raise ValueError(f"File not found: {name_or_id}")
+
+
+def _format_version_value(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value)
+
+
+def _format_content_versions(versions: list[dict[str, Any]]) -> str:
+    if not versions:
+        return "No versions found."
+
+    lines = ["VERSION  VERSION_ID  ARCHIVED_AT  REASON  TITLE"]
+    for version in versions:
+        lines.append(
+            "  ".join(
+                [
+                    _format_version_value(version.get("versionNumber")),
+                    _format_version_value(version.get("id")),
+                    _format_version_value(version.get("archivedAt")),
+                    _format_version_value(version.get("reason")),
+                    _format_version_value(version.get("title") or version.get("key")),
+                ]
+            )
+        )
+    return "\n".join(lines)
 
 
 def _resolve_upload_destination(
@@ -144,6 +193,7 @@ def cmd_upload(
             displayed_filename=display_name,
             mime_type=mime_type,
             scope_or_unique_path=scope_id,
+            versioning_enabled=True,
         )
 
         content_id = result.id if hasattr(result, "id") else "?"
@@ -156,6 +206,47 @@ def cmd_upload(
 
     except (ValueError, unique_sdk.APIError, OSError) as e:
         return f"upload: {e}"
+
+
+def cmd_versions(
+    state: ShellState,
+    name_or_id: str,
+    skip: int | None = None,
+    take: int | None = None,
+) -> str:
+    """List archived versions for a file by name or content ID."""
+    try:
+        content_id, display_name = _resolve_content_id(state, name_or_id)
+        params: dict[str, Any] = {"contentId": content_id}
+        if skip is not None:
+            params["skip"] = skip
+        if take is not None:
+            params["take"] = take
+
+        result = unique_sdk.Content.versions(
+            user_id=state.config.user_id,
+            company_id=state.config.company_id,
+            **params,
+        )
+        data = result.get("data", [])
+        return f"Versions for {display_name} ({content_id}):\n{_format_content_versions(data)}"
+    except (ValueError, unique_sdk.APIError) as e:
+        return f"versions: {e}"
+
+
+def cmd_restore_version(state: ShellState, content_version_id: str) -> str:
+    """Restore a file from an archived content version ID."""
+    try:
+        result = unique_sdk.Content.restore_version(
+            user_id=state.config.user_id,
+            company_id=state.config.company_id,
+            contentVersionId=content_version_id,
+        )
+        title = result.get("title") or result.get("key") or result.get("id", "?")
+        content_id = result.get("id", "?")
+        return f"Restored: {title} ({content_id}) from version {content_version_id}"
+    except (ValueError, unique_sdk.APIError) as e:
+        return f"restore-version: {e}"
 
 
 def cmd_download(

--- a/unique_sdk/unique_sdk/cli/commands/files.py
+++ b/unique_sdk/unique_sdk/cli/commands/files.py
@@ -25,18 +25,18 @@ def _resolve_content_id(state: ShellState, name_or_id: str) -> tuple[str, str]:
 
     lookup_name = name_or_id
     scope_id = state.scope_id
-    # Preserve support for unusual literal filenames like "../../.bashrc".
-    # Only resolve slash-containing values as Unique paths when they are not
-    # path traversal shaped names.
-    if "/" in name_or_id and ".." not in name_or_id.split("/"):
-        folder_path, lookup_name = name_or_id.rsplit("/", 1)
+    if "/" in name_or_id:
+        unique_path = (
+            name_or_id
+            if name_or_id.startswith("/")
+            else f"{state.cwd.rstrip('/')}/{name_or_id}"
+        )
+        unique_path = posixpath.normpath(unique_path)
+        folder_path, lookup_name = unique_path.rsplit("/", 1)
         if not lookup_name:
             raise ValueError(f"File path must include a file name: {name_or_id}")
         if not folder_path:
             folder_path = "/"
-        elif not folder_path.startswith("/"):
-            folder_path = f"{state.cwd.rstrip('/')}/{folder_path}"
-        folder_path = posixpath.normpath(folder_path)
 
         info = unique_sdk.Folder.get_info(
             user_id=state.config.user_id,
@@ -51,15 +51,26 @@ def _resolve_content_id(state: ShellState, name_or_id: str) -> tuple[str, str]:
     if scope_id:
         params["parentId"] = scope_id
 
-    result = unique_sdk.Content.get_infos(
-        user_id=state.config.user_id,
-        company_id=state.config.company_id,
-        **params,
-    )
-    for info in result.get("contentInfos", []):
-        title = info.get("title") or info.get("key") or ""
-        if title == lookup_name:
-            return info["id"], title
+    take = 100
+    skip = 0
+    while True:
+        result = unique_sdk.Content.get_infos(
+            user_id=state.config.user_id,
+            company_id=state.config.company_id,
+            skip=skip,
+            take=take,
+            **params,
+        )
+        content_infos = result.get("contentInfos", [])
+        for info in content_infos:
+            title = info.get("title") or info.get("key") or ""
+            if title == lookup_name:
+                return info["id"], title
+
+        total_count = result.get("totalCount")
+        skip += len(content_infos)
+        if not content_infos or (total_count is not None and skip >= total_count):
+            break
 
     raise ValueError(f"File not found: {name_or_id}")
 

--- a/unique_sdk/unique_sdk/cli/commands/files.py
+++ b/unique_sdk/unique_sdk/cli/commands/files.py
@@ -39,6 +39,8 @@ def _resolve_content_id(state: ShellState, name_or_id: str) -> tuple[str, str]:
     or an absolute/relative Unique file path.
     """
     if name_or_id.startswith("cont_"):
+        if not state.is_content_within_workspace(name_or_id):
+            raise ValueError("permission denied (outside workspace scope)")
         return name_or_id, name_or_id
 
     lookup_name = name_or_id
@@ -50,6 +52,8 @@ def _resolve_content_id(state: ShellState, name_or_id: str) -> tuple[str, str]:
             raise ValueError(f"File path must include a file name: {name_or_id}")
         if not folder_path:
             folder_path = "/"
+        if not state.is_folder_target_within_workspace(folder_path):
+            raise ValueError("permission denied (outside workspace scope)")
 
         info = unique_sdk.Folder.get_info(
             user_id=state.config.user_id,
@@ -59,6 +63,8 @@ def _resolve_content_id(state: ShellState, name_or_id: str) -> tuple[str, str]:
         scope_id = info.get("id")
         if not scope_id:
             raise ValueError(f"folder not found: {folder_path}")
+    elif not state.is_within_workspace():
+        raise ValueError("permission denied (outside workspace scope)")
 
     params: dict[str, Any] = {}
     if scope_id:
@@ -263,6 +269,8 @@ def cmd_versions(
 
 def cmd_restore_version(state: ShellState, content_version_id: str) -> str:
     """Restore a file from an archived content version ID."""
+    if state.workspace_restricted:
+        return "restore-version: permission denied (outside workspace scope)"
     try:
         result = unique_sdk.Content.restore_version(
             user_id=state.config.user_id,

--- a/unique_sdk/unique_sdk/cli/commands/files.py
+++ b/unique_sdk/unique_sdk/cli/commands/files.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import mimetypes
-import posixpath
 import shutil
 from collections.abc import Mapping, Sequence
 from pathlib import Path
@@ -13,6 +12,24 @@ import unique_sdk
 from unique_sdk.cli.formatting import format_content_info
 from unique_sdk.cli.state import ShellState
 from unique_sdk.utils.file_io import download_content, upload_file
+
+
+def _normalize_unique_file_path(cwd: str, path: str) -> str:
+    """Normalize a Unique file path without allowing traversal above root."""
+    raw_parts = (
+        path.split("/") if path.startswith("/") else [*cwd.split("/"), *path.split("/")]
+    )
+    parts: list[str] = []
+    for part in raw_parts:
+        if part in ("", "."):
+            continue
+        if part == "..":
+            if not parts:
+                raise ValueError(f"File path escapes root: {path}")
+            parts.pop()
+            continue
+        parts.append(part)
+    return "/" + "/".join(parts)
 
 
 def _resolve_content_id(state: ShellState, name_or_id: str) -> tuple[str, str]:
@@ -27,12 +44,7 @@ def _resolve_content_id(state: ShellState, name_or_id: str) -> tuple[str, str]:
     lookup_name = name_or_id
     scope_id = state.scope_id
     if "/" in name_or_id:
-        unique_path = (
-            name_or_id
-            if name_or_id.startswith("/")
-            else f"{state.cwd.rstrip('/')}/{name_or_id}"
-        )
-        unique_path = posixpath.normpath(unique_path)
+        unique_path = _normalize_unique_file_path(state.cwd, name_or_id)
         folder_path, lookup_name = unique_path.rsplit("/", 1)
         if not lookup_name:
             raise ValueError(f"File path must include a file name: {name_or_id}")

--- a/unique_sdk/unique_sdk/cli/commands/files.py
+++ b/unique_sdk/unique_sdk/cli/commands/files.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import mimetypes
 import posixpath
 import shutil
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
@@ -62,16 +63,16 @@ def _resolve_content_id(state: ShellState, name_or_id: str) -> tuple[str, str]:
             **params,
         )
         content_infos = result.get("contentInfos", [])
+        if not content_infos:
+            break
+
         for info in content_infos:
             title = info.get("title") or ""
             key = info.get("key") or ""
             if lookup_name in {title, key}:
                 return info["id"], title or key
 
-        total_count = result.get("totalCount")
         skip += len(content_infos)
-        if not content_infos or (total_count is not None and skip >= total_count):
-            break
 
     raise ValueError(f"File not found: {name_or_id}")
 
@@ -82,7 +83,7 @@ def _format_version_value(value: Any) -> str:
     return str(value)
 
 
-def _format_content_versions(versions: list[dict[str, Any]]) -> str:
+def _format_content_versions(versions: Sequence[Mapping[str, Any]]) -> str:
     if not versions:
         return "No versions found."
 

--- a/unique_sdk/unique_sdk/cli/shell.py
+++ b/unique_sdk/unique_sdk/cli/shell.py
@@ -59,9 +59,9 @@ OVERVIEW_HELP = textwrap.dedent("""\
       versions <name|path|id>   List archived file versions
       restore-version <ver_id>  Restore a file from a version
       download <name|path|id> [dest] Download a file to local machine
-      rm <name|id>              Delete a file
-      mv <old> <new>            Rename a file
-      cite <name|id> [--pages]  Declare page citations for a file
+      rm <name|path|id>         Delete a file
+      mv <old|path|id> <new>    Rename a file
+      cite <name|path|id> [--pages] Declare page citations for a file
 
     Search:
       search <query> [options]  Combined search (vector + full-text)

--- a/unique_sdk/unique_sdk/cli/shell.py
+++ b/unique_sdk/unique_sdk/cli/shell.py
@@ -58,7 +58,7 @@ OVERVIEW_HELP = textwrap.dedent("""\
       upload <local> [name]     Upload a local file with versioning
       versions <name|path|id>   List archived file versions
       restore-version <ver_id>  Restore a file from a version
-      download <name|id> [dest] Download a file to local machine
+      download <name|path|id> [dest] Download a file to local machine
       rm <name|id>              Delete a file
       mv <old> <new>            Rename a file
       cite <name|id> [--pages]  Declare page citations for a file
@@ -404,14 +404,14 @@ class UniqueShell(cmd.Cmd):
     def do_download(self, arg: str) -> None:
         """Download a file from the platform to your local machine.
 
-        Usage: download <name|content_id> [local_path]
+        Usage: download <name|path|content_id> [local_path]
 
-        Downloads a file identified by its name (matched in the current
-        directory) or content ID (cont_...). Saves to the specified local
-        path, or the current working directory if omitted.
+        Downloads a file identified by its Unique path, name (matched in
+        the current directory), or content ID (cont_...). Saves to the
+        specified local path, or the current working directory if omitted.
 
         Arguments:
-          name_or_id    File name or content ID (cont_...)
+          name_or_id    File path, file name, or content ID (cont_...)
           local_path    Optional local directory or file path
 
         Examples:
@@ -421,12 +421,15 @@ class UniqueShell(cmd.Cmd):
           /Reports> download annual.pdf ./downloads/
           Downloaded: annual.pdf -> ./downloads/annual.pdf
 
+          /Reports> download /Reports/Q1/annual.pdf ./downloads/
+          Downloaded: annual.pdf -> ./downloads/annual.pdf
+
           /Reports> download cont_mno345 ~/Desktop/
           Downloaded: cont_mno345 -> ~/Desktop/cont_mno345
         """
         parts = shlex.split(arg)
         if not parts:
-            self._print("Usage: download <name|content_id> [local_path]")
+            self._print("Usage: download <name|path|content_id> [local_path]")
             return
         name_or_id = parts[0]
         local_dest = parts[1] if len(parts) > 1 else None

--- a/unique_sdk/unique_sdk/cli/shell.py
+++ b/unique_sdk/unique_sdk/cli/shell.py
@@ -16,7 +16,14 @@ from unique_sdk.cli.commands.elicitation import (
     cmd_elicit_respond,
     cmd_elicit_wait,
 )
-from unique_sdk.cli.commands.files import cmd_download, cmd_mv_file, cmd_rm, cmd_upload
+from unique_sdk.cli.commands.files import (
+    cmd_download,
+    cmd_mv_file,
+    cmd_restore_version,
+    cmd_rm,
+    cmd_upload,
+    cmd_versions,
+)
 from unique_sdk.cli.commands.folders import cmd_mkdir, cmd_mvdir, cmd_rmdir
 from unique_sdk.cli.commands.mcp import cmd_mcp
 from unique_sdk.cli.commands.navigation import cmd_cd, cmd_ls, cmd_pwd
@@ -35,7 +42,7 @@ OVERVIEW_HELP = textwrap.dedent("""\
 
     Navigate the knowledge base like a Linux filesystem. Folders are
     identified by name, path, or scope ID. Files are identified by
-    name or content ID.
+    name, path, or content ID.
 
     Navigation:
       pwd                       Print current working directory
@@ -48,7 +55,9 @@ OVERVIEW_HELP = textwrap.dedent("""\
       mvdir <old> <new>         Rename a folder
 
     File operations:
-      upload <local> [name]     Upload a local file
+      upload <local> [name]     Upload a local file with versioning
+      versions <name|path|id>   List archived file versions
+      restore-version <ver_id>  Restore a file from a version
       download <name|id> [dest] Download a file to local machine
       rm <name|id>              Delete a file
       mv <old> <new>            Rename a file
@@ -292,13 +301,14 @@ class UniqueShell(cmd.Cmd):
     # -- File operations --
 
     def do_upload(self, arg: str) -> None:
-        """Upload a local file (works like Linux cp).
+        """Upload a local file with versioning enabled (works like Linux cp).
 
         Usage: upload <local_path> [destination]
 
-        Uploads a file from your local machine. The destination argument
-        works like cp -- it can be a folder, a new filename, or both.
-        MIME type is auto-detected from the file extension.
+        Uploads a file from your local machine with immutable versioning
+        enabled. The destination argument works like cp -- it can be a
+        folder, a new filename, or both. MIME type is auto-detected from
+        the file extension.
 
         Destination formats:
           (omitted)       Upload to current dir, keep original name
@@ -329,6 +339,67 @@ class UniqueShell(cmd.Cmd):
         local_path = parts[0]
         destination = parts[1] if len(parts) > 1 else None
         self._print(cmd_upload(self.state, local_path, destination))
+
+    def do_versions(self, arg: str) -> None:
+        """List archived versions for a file.
+
+        Usage: versions <name|path|content_id> [--skip N] [--take N]
+
+        Lists immutable versions for a file identified by its Unique
+        path, name (matched in the current directory), or content ID
+        (cont_...). Use the VERSION_ID column with restore-version.
+
+        Examples:
+          /Reports> versions annual.pdf
+          /Reports> versions /Reports/Q1/annual.pdf
+          /Reports> versions cont_mno345 --take 10
+        """
+        parts = shlex.split(arg)
+        if not parts:
+            self._print("Usage: versions <name|path|content_id> [--skip N] [--take N]")
+            return
+
+        name_or_id = parts[0]
+        skip: int | None = None
+        take: int | None = None
+        i = 1
+        while i < len(parts):
+            if parts[i] == "--skip" and i + 1 < len(parts):
+                try:
+                    skip = int(parts[i + 1])
+                except ValueError:
+                    self._print(f"Invalid --skip: {parts[i + 1]}")
+                    return
+                i += 2
+            elif parts[i] == "--take" and i + 1 < len(parts):
+                try:
+                    take = int(parts[i + 1])
+                except ValueError:
+                    self._print(f"Invalid --take: {parts[i + 1]}")
+                    return
+                i += 2
+            else:
+                self._print(f"Unknown option: {parts[i]}")
+                return
+
+        self._print(cmd_versions(self.state, name_or_id, skip=skip, take=take))
+
+    def do_restore_version(self, arg: str) -> None:
+        """Restore a file from a content version ID.
+
+        Usage: restore-version <content_version_id>
+
+        The content version ID is shown by the versions command.
+
+        Example:
+          /Reports> restore-version cver_abc123
+          Restored: annual.pdf (cont_mno345) from version cver_abc123
+        """
+        content_version_id = arg.strip()
+        if not content_version_id:
+            self._print("Usage: restore-version <content_version_id>")
+            return
+        self._print(cmd_restore_version(self.state, content_version_id))
 
     def do_download(self, arg: str) -> None:
         """Download a file from the platform to your local machine.
@@ -1103,6 +1174,9 @@ class UniqueShell(cmd.Cmd):
         return False
 
     def default(self, line: str) -> None:
+        if line.startswith("restore-version"):
+            self.do_restore_version(line[len("restore-version") :].strip())
+            return
         self._print(
             f"Unknown command: {line.split()[0]}. Type 'help' for available commands."
         )

--- a/unique_sdk/unique_sdk/cli/shell.py
+++ b/unique_sdk/unique_sdk/cli/shell.py
@@ -438,17 +438,18 @@ class UniqueShell(cmd.Cmd):
     def do_cite(self, arg: str) -> None:
         """Declare page citations for a file.
 
-        Usage: cite <name|content_id> [--pages RANGE]
+        Usage: cite <name|path|content_id> [--pages RANGE]
 
         Examples:
           /Reports> cite report.pdf --pages 3,5,7
+          /Reports> cite /Reports/Q1/report.pdf --pages 3,5,7
           /Reports> cite cont_abc123 --pages 1-4
         """
         from unique_sdk.cli.commands.cite_file import cmd_cite_file
 
         parts = shlex.split(arg)
         if not parts:
-            self._print("Usage: cite <name|content_id> [--pages RANGE]")
+            self._print("Usage: cite <name|path|content_id> [--pages RANGE]")
             return
         pages: str | None = None
         positional: list[str] = []
@@ -465,7 +466,7 @@ class UniqueShell(cmd.Cmd):
                 positional.append(token)
                 index += 1
         if not positional:
-            self._print("Usage: cite <name|content_id> [--pages RANGE]")
+            self._print("Usage: cite <name|path|content_id> [--pages RANGE]")
             return
         self._print(cmd_cite_file(self.state, positional[0], pages))
 
@@ -494,13 +495,16 @@ class UniqueShell(cmd.Cmd):
     def do_rm(self, arg: str) -> None:
         """Delete a file.
 
-        Usage: rm <name|content_id>
+        Usage: rm <name|path|content_id>
 
-        Permanently deletes a file by its name (matched in the current
-        directory) or content ID.
+        Permanently deletes a file by its Unique path, name (matched in
+        the current directory), or content ID.
 
         Examples:
           /Reports> rm annual.pdf
+          Deleted: annual.pdf (cont_mno345)
+
+          /Reports> rm /Reports/Q1/annual.pdf
           Deleted: annual.pdf (cont_mno345)
 
           /Reports> rm cont_xyz789
@@ -508,14 +512,14 @@ class UniqueShell(cmd.Cmd):
         """
         name_or_id = arg.strip()
         if not name_or_id:
-            self._print("Usage: rm <name|content_id>")
+            self._print("Usage: rm <name|path|content_id>")
             return
         self._print(cmd_rm(self.state, name_or_id))
 
     def do_mv(self, arg: str) -> None:
         """Rename a file.
 
-        Usage: mv <old_name|content_id> <new_name>
+        Usage: mv <old_name|path|content_id> <new_name>
 
         Changes the file's display title. The content ID and location
         remain the same.
@@ -524,12 +528,15 @@ class UniqueShell(cmd.Cmd):
           /Reports> mv annual.pdf annual-2025.pdf
           Renamed: annual.pdf -> annual-2025.pdf
 
+          /Reports> mv /Reports/Q1/annual.pdf annual-2025.pdf
+          Renamed: annual.pdf -> annual-2025.pdf
+
           /Reports> mv cont_abc123 "New Title.pdf"
           Renamed: cont_abc123 -> New Title.pdf
         """
         parts = shlex.split(arg)
         if len(parts) != 2:
-            self._print("Usage: mv <old_name|content_id> <new_name>")
+            self._print("Usage: mv <old_name|path|content_id> <new_name>")
             return
         self._print(cmd_mv_file(self.state, parts[0], parts[1]))
 

--- a/unique_sdk/unique_sdk/cli/skills/unique-cli-file-management/SKILL.md
+++ b/unique_sdk/unique_sdk/cli/skills/unique-cli-file-management/SKILL.md
@@ -3,7 +3,7 @@ name: unique-cli-file-management
 description: >-
   Manage files and folders on the Unique AI Platform using the unique-cli
   command-line tool. Use when the user asks to upload, download, delete,
-  rename, list, find, look for, or organize files and folders on Unique,
+  rename, list, find, restore versions, list versions, look for, or organize files and folders on Unique,
   or when working with scope IDs (scope_*) or content IDs (cont_*).
   IMPORTANT: When a user says they are "looking for a file" or wants to
   "find a file", they typically mean locating it within the Unique AI
@@ -50,10 +50,15 @@ unique-cli rmdir scope_abc123 -r
 # Rename a folder
 unique-cli mvdir Q1 "Q1-2025"
 
-# Upload a file (to current scope -- cd first or specify destination)
+# Upload a file with versioning enabled (to current scope -- cd first or specify destination)
 unique-cli upload ./report.pdf
 unique-cli upload ./report.pdf /Reports/Q1/
 unique-cli upload ./data.csv scope_abc123
+
+# List and restore file versions
+unique-cli versions /Reports/Q1/report.pdf
+unique-cli versions cont_abc123 --take 10
+unique-cli restore-version cver_abc123
 
 # Download a file
 unique-cli download report.pdf ./local/
@@ -81,10 +86,11 @@ unique-cli mv report.pdf "Annual Report 2025.pdf"
 | `..` | `..` | Parent directory |
 | `/` | `/` | Root |
 | Content ID | `cont_abc123` | File directly by ID |
+| File path | `/Reports/Q1/report.pdf` | File in a folder |
 
 ## Upload Destination Resolution
 
-The `upload` destination works like Linux `cp`:
+The `upload` command always enables immutable content versioning. It does not expose an unversioned upload mode. Its destination works like Linux `cp`:
 
 | Destination | Behavior |
 |-------------|----------|
@@ -114,6 +120,18 @@ unique-cli ls /Reports/Q1
 # Download specific files
 unique-cli download "annual.pdf" ./downloads/
 unique-cli download cont_abc123 ./downloads/
+```
+
+### Restore a previous file version
+
+```bash
+# List versions for a file path, file name in the current folder, or content ID.
+unique-cli versions /Reports/Q1/annual.pdf
+unique-cli versions "annual.pdf"
+unique-cli versions cont_abc123 --take 20
+
+# Restore using the VERSION_ID shown by `versions`.
+unique-cli restore-version cver_abc123
 ```
 
 ### Create folder hierarchy and upload

--- a/unique_sdk/unique_sdk/utils/file_io.py
+++ b/unique_sdk/unique_sdk/utils/file_io.py
@@ -106,6 +106,7 @@ def upload_file(
     ingestion_config: Content.IngestionConfig | None = None,
     metadata: dict[str, Any] | None = None,
     preview_pdf_path: str | None = None,
+    versioning_enabled: bool | None = None,
 ):
     """Upload *path_to_file* as a Unique :class:`Content`.
 
@@ -148,6 +149,9 @@ def upload_file(
             responsibility — there is no override kwarg, by design,
             so all callers land on the same ``${content.id}_pdfPreview``
             convention as the ingestion worker.
+        versioning_enabled: When ``True``, ask the platform to archive
+            previous blobs for the same content so they can be listed
+            and restored through the content version endpoints.
     """
     if not chat_id and not scope_or_unique_path:
         raise ValueError("chat_id or scope_or_unique_path must be provided")
@@ -177,6 +181,7 @@ def upload_file(
         },
         scopeId=scope_or_unique_path,
         chatId=chat_id,
+        versioningEnabled=versioning_enabled,
     )
 
     # Step 2 — PUT the original bytes to the SAS URL minted by Step 1.
@@ -229,6 +234,7 @@ def upload_file(
             },
             fileUrl=createdContent.readUrl,
             chatId=chat_id,
+            versioningEnabled=versioning_enabled,
             **preview_kwargs,
         )
     else:
@@ -246,6 +252,7 @@ def upload_file(
             },
             fileUrl=createdContent.readUrl,
             scopeId=scope_or_unique_path,
+            versioningEnabled=versioning_enabled,
             **preview_kwargs,
         )
 


### PR DESCRIPTION
## Summary
- Add SDK support for versioned content uploads plus content version listing, download-url lookup, and restore APIs.
- Make `unique-cli upload` always enable immutable versioning, with no unversioned CLI mode.
- Add `unique-cli versions` and `unique-cli restore-version`, including path-based file resolution and updated CLI skill guidance.

## Changes
- `unique_sdk.Content` now exposes `versions`, `version_download_url`, and `restore_version` methods with async variants.
- `upload_file` accepts `versioning_enabled`, and the CLI always passes `True`.
- File commands can resolve content by content ID, current-folder filename, storage key, or Unique file path such as `/Reports/Q1/report.pdf`.

## Test plan
- [x] `poetry run pytest tests/cli/test_commands.py -q`
- [x] `poetry run ruff check unique_sdk/cli/cli.py unique_sdk/cli/commands/files.py unique_sdk/api_resources/_content.py unique_sdk/utils/file_io.py tests/cli/test_commands.py`
- [x] `poetry run ruff format --check unique_sdk/cli/cli.py unique_sdk/cli/commands/files.py unique_sdk/api_resources/_content.py unique_sdk/utils/file_io.py tests/cli/test_commands.py`
- [x] `poetry run basedpyright unique_sdk/cli/cli.py unique_sdk/cli/commands/files.py tests/cli/test_commands.py`

## Risk / rollout
- CLI upload behavior changes intentionally: uploads from `unique-cli upload` are versioned-only.
- Existing SDK callers remain opt-in through `upload_file(..., versioning_enabled=True)` or `Content.upsert(..., versioningEnabled=True)`.

Supersedes the file-versioning part of the closed mixed PR #1839.

Made with [Cursor](https://cursor.com)