### PR TITLE
feat(cli): add page-range filtering to unique-cli read

### DIFF
--- a/unique_sdk/docs/cli/commands.md
+++ b/unique_sdk/docs/cli/commands.md
@@ -476,12 +476,14 @@ For full details on search features, see the [Search Guide](search.md).
 
 ### read
 
-Read all indexed text chunks for a known content ID. Use this when you already have a `cont_*` ID from a prior `ls` or `search` result and want the full document text. For discovery by topic or keyword, use `search` instead.
+Read indexed text chunks for a known content ID. Use this when you already have a `cont_*` ID from a prior `ls` or `search` result and want the full document text. For discovery by topic or keyword, use `search` instead.
+
+Restrict the output to specific pages with `--page` (single page) or `--from-page`/`--to-page` (inclusive range). Page filtering is applied to the `startPage`/`endPage` the platform already returns for each chunk, so a chunk spanning pages 2-4 is returned for any request that overlaps those pages. Content without page numbers (e.g. plain text/markdown) is only returned when no page range is given.
 
 **Synopsis:**
 
 ```
-read <cont_id>
+read <cont_id> [--page N | --from-page N --to-page M] [--max-chars N]
 ```
 
 **Arguments:**
@@ -489,6 +491,17 @@ read <cont_id>
 | Argument | Description |
 |----------|-------------|
 | `cont_id` | Content ID (`cont_...`) |
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--page`, `-p` | Read a single page (shorthand for `--from-page N --to-page N`) | None |
+| `--from-page` | First page to include (inclusive) | None |
+| `--to-page` | Last page to include (inclusive) | None |
+| `--max-chars` | Truncate the printed text to at most N characters | None |
+
+`--page` cannot be combined with `--from-page`/`--to-page`.
 
 **Examples:**
 
@@ -501,12 +514,21 @@ Content: annual.pdf (cont_mno345) — 42 chunk(s)
 [p.2-3] Revenue grew 15% year over year, driven by...
 ```
 
-If the document exists but has no indexed chunks yet, the command reports that ingestion may still be in progress.
+```
+/Reports> read cont_mno345 --from-page 2 --to-page 3
+Content: annual.pdf (cont_mno345) — 1 chunk(s)
+
+[p.2-3] Revenue grew 15% year over year, driven by...
+```
+
+If the document exists but has no indexed chunks yet, the command reports that ingestion may still be in progress. If a page range matches no chunks, the command says so and suggests reading without a range.
 
 **One-shot:**
 
 ```bash
 unique-cli read cont_abc123
+unique-cli read cont_abc123 --page 12
+unique-cli read cont_abc123 --from-page 5 --to-page 9 --max-chars 8000
 ```
 
 ---

--- a/unique_sdk/tests/cli/test_cli.py
+++ b/unique_sdk/tests/cli/test_cli.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 from click.testing import CliRunner
 
@@ -149,6 +149,65 @@ class TestClickCLI:
         result = runner.invoke(main, ["search", "query"])
         assert result.exit_code == 1
         assert "search:" in result.output
+
+    @patch("unique_sdk.cli.cli.cmd_read")
+    def test_read(self, mock_read: MagicMock) -> None:
+        mock_read.return_value = "Content: doc (cont_abc) — 1 chunk(s)\n\ntext"
+        runner = CliRunner()
+        result = runner.invoke(main, ["read", "cont_abc"])
+        assert result.exit_code == 0
+        mock_read.assert_called_once_with(
+            ANY, "cont_abc", from_page=None, to_page=None, max_chars=None
+        )
+
+    @patch("unique_sdk.cli.cli.cmd_read")
+    def test_read_single_page(self, mock_read: MagicMock) -> None:
+        mock_read.return_value = "ok"
+        runner = CliRunner()
+        result = runner.invoke(main, ["read", "cont_abc", "--page", "12"])
+        assert result.exit_code == 0
+        _, kwargs = mock_read.call_args
+        assert kwargs["from_page"] == 12
+        assert kwargs["to_page"] == 12
+
+    @patch("unique_sdk.cli.cli.cmd_read")
+    def test_read_range_and_max_chars(self, mock_read: MagicMock) -> None:
+        mock_read.return_value = "ok"
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "read",
+                "cont_abc",
+                "--from-page",
+                "5",
+                "--to-page",
+                "9",
+                "--max-chars",
+                "100",
+            ],
+        )
+        assert result.exit_code == 0
+        _, kwargs = mock_read.call_args
+        assert kwargs["from_page"] == 5
+        assert kwargs["to_page"] == 9
+        assert kwargs["max_chars"] == 100
+
+    def test_read_page_conflict_exits_nonzero(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            main, ["read", "cont_abc", "--page", "3", "--from-page", "1"]
+        )
+        assert result.exit_code == 1
+        assert "use either" in result.output
+
+    @patch("unique_sdk.cli.cli.cmd_read")
+    def test_read_error_exits_nonzero(self, mock_read: MagicMock) -> None:
+        mock_read.return_value = "read: no content found for ID: cont_abc"
+        runner = CliRunner()
+        result = runner.invoke(main, ["read", "cont_abc"])
+        assert result.exit_code == 1
+        assert "read:" in result.output
 
     def test_upload_nonexistent(self) -> None:
         runner = CliRunner()

--- a/unique_sdk/tests/cli/test_read.py
+++ b/unique_sdk/tests/cli/test_read.py
@@ -344,6 +344,11 @@ class TestCmdReadPageRange:
         assert is_error_output(output)
         assert "invalid page range" in output
 
+    def test_negative_max_chars_rejected(self, state: ShellState) -> None:
+        output = cmd_read(state, "cont_abc123", max_chars=-5)
+        assert is_error_output(output)
+        assert "invalid --max-chars" in output
+
     def test_excludes_unpaged_chunks_when_filtering(self, state: ShellState) -> None:
         content = _make_content(
             chunks=[

--- a/unique_sdk/tests/cli/test_read.py
+++ b/unique_sdk/tests/cli/test_read.py
@@ -6,7 +6,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from unique_sdk.cli.commands.read import READ_ERROR_PREFIX, cmd_read, is_error_output
+from unique_sdk.cli.commands.read import (
+    READ_ERROR_PREFIX,
+    _chunk_in_page_range,
+    cmd_read,
+    is_error_output,
+)
 from unique_sdk.cli.config import Config
 from unique_sdk.cli.state import ShellState
 
@@ -253,6 +258,108 @@ class TestCmdRead:
         output = cmd_read(state, "cont_inside")
         assert "permission denied" not in output
         assert "Allowed text." in output
+
+
+class TestChunkInPageRange:
+    def test_single_page_overlap(self) -> None:
+        spanning = {"startPage": 2, "endPage": 4}
+        assert _chunk_in_page_range(spanning, 3, 3)
+        assert _chunk_in_page_range(spanning, 2, 2)
+        assert _chunk_in_page_range(spanning, 4, 4)
+        assert not _chunk_in_page_range(spanning, 5, 5)
+        assert not _chunk_in_page_range(spanning, 1, 1)
+
+    def test_open_ended_ranges(self) -> None:
+        chunk = {"startPage": 5, "endPage": 5}
+        assert _chunk_in_page_range(chunk, 5, None)
+        assert _chunk_in_page_range(chunk, None, 5)
+        assert not _chunk_in_page_range(chunk, 6, None)
+        assert not _chunk_in_page_range(chunk, None, 4)
+
+    def test_chunk_without_pages_excluded(self) -> None:
+        assert not _chunk_in_page_range({"startPage": None, "endPage": None}, 1, 3)
+
+    def test_start_only_chunk(self) -> None:
+        assert _chunk_in_page_range({"startPage": 4, "endPage": None}, 4, 4)
+        assert not _chunk_in_page_range({"startPage": 4, "endPage": None}, 5, 5)
+
+
+def _read(state: ShellState, content: MagicMock, *args, **kwargs) -> str:
+    with patch(
+        "unique_sdk.cli.commands.read.unique_sdk.Content.search",
+        return_value=[content],
+    ):
+        return cmd_read(state, "cont_abc123", *args, **kwargs)
+
+
+class TestCmdReadPageRange:
+    def _content(self) -> MagicMock:
+        return _make_content(
+            chunks=[
+                {"id": "c1", "text": "first", "order": 0, "startPage": 1, "endPage": 1},
+                {
+                    "id": "c2",
+                    "text": "second",
+                    "order": 1,
+                    "startPage": 5,
+                    "endPage": 5,
+                },
+                {"id": "c3", "text": "third", "order": 2, "startPage": 9, "endPage": 9},
+            ]
+        )
+
+    def test_filters_to_range(self, state: ShellState) -> None:
+        output = _read(state, self._content(), from_page=4, to_page=6)
+        assert "second" in output
+        assert "first" not in output
+        assert "third" not in output
+
+    def test_single_page(self, state: ShellState) -> None:
+        output = _read(state, self._content(), from_page=1, to_page=1)
+        assert "first" in output
+        assert "second" not in output
+
+    def test_no_match_in_range(self, state: ShellState) -> None:
+        output = _read(state, self._content(), from_page=50, to_page=60)
+        assert not is_error_output(output)
+        assert "No indexed chunks found in page range" in output
+
+    def test_invalid_range(self, state: ShellState) -> None:
+        output = cmd_read(state, "cont_abc123", from_page=9, to_page=3)
+        assert is_error_output(output)
+        assert "invalid page range" in output
+
+    def test_excludes_unpaged_chunks_when_filtering(self, state: ShellState) -> None:
+        content = _make_content(
+            chunks=[
+                {"id": "c1", "text": "paged", "order": 0, "startPage": 2, "endPage": 2},
+                {
+                    "id": "c2",
+                    "text": "unpaged",
+                    "order": 1,
+                    "startPage": None,
+                    "endPage": None,
+                },
+            ]
+        )
+        output = _read(state, content, from_page=2, to_page=2)
+        assert "paged" in output
+        assert "unpaged" not in output
+
+    def test_max_chars_truncates(self, state: ShellState) -> None:
+        content = _make_content(
+            chunks=[
+                {
+                    "id": "c1",
+                    "text": "x" * 500,
+                    "order": 0,
+                    "startPage": 1,
+                    "endPage": 1,
+                }
+            ]
+        )
+        output = _read(state, content, max_chars=50)
+        assert "truncated at 50 chars" in output
 
 
 class TestIsErrorOutput:

--- a/unique_sdk/tests/cli/test_read.py
+++ b/unique_sdk/tests/cli/test_read.py
@@ -9,6 +9,7 @@ import pytest
 from unique_sdk.cli.commands.read import (
     READ_ERROR_PREFIX,
     _chunk_in_page_range,
+    _format_requested_range,
     cmd_read,
     is_error_output,
 )
@@ -282,6 +283,20 @@ class TestChunkInPageRange:
     def test_start_only_chunk(self) -> None:
         assert _chunk_in_page_range({"startPage": 4, "endPage": None}, 4, 4)
         assert not _chunk_in_page_range({"startPage": 4, "endPage": None}, 5, 5)
+
+
+class TestFormatRequestedRange:
+    def test_both_bounds(self) -> None:
+        assert _format_requested_range(2, 5) == "2-5"
+
+    def test_single_page(self) -> None:
+        assert _format_requested_range(3, 3) == "3"
+
+    def test_from_only(self) -> None:
+        assert _format_requested_range(4, None) == "4+"
+
+    def test_to_only(self) -> None:
+        assert _format_requested_range(None, 7) == "up to 7"
 
 
 def _read(state: ShellState, content: MagicMock, *args, **kwargs) -> str:

--- a/unique_sdk/tests/cli/test_read.py
+++ b/unique_sdk/tests/cli/test_read.py
@@ -361,7 +361,7 @@ class TestCmdReadPageRange:
         assert "paged" in output
         assert "unpaged" not in output
 
-    def test_max_chars_truncates(self, state: ShellState) -> None:
+    def test_max_chars_truncates_without_range(self, state: ShellState) -> None:
         content = _make_content(
             chunks=[
                 {
@@ -375,6 +375,25 @@ class TestCmdReadPageRange:
         )
         output = _read(state, content, max_chars=50)
         assert "truncated at 50 chars" in output
+        # No page range was given, so the hint must not say to narrow one.
+        assert "use a page range" in output
+        assert "narrow the page range" not in output
+
+    def test_max_chars_truncates_with_range(self, state: ShellState) -> None:
+        content = _make_content(
+            chunks=[
+                {
+                    "id": "c1",
+                    "text": "x" * 500,
+                    "order": 0,
+                    "startPage": 2,
+                    "endPage": 2,
+                }
+            ]
+        )
+        output = _read(state, content, from_page=2, to_page=2, max_chars=50)
+        assert "truncated at 50 chars" in output
+        assert "narrow the page range" in output
 
 
 class TestIsErrorOutput:

--- a/unique_sdk/tests/cli/test_shell.py
+++ b/unique_sdk/tests/cli/test_shell.py
@@ -366,6 +366,14 @@ class TestShellRead:
         out = _capture(_shell(), "read cont_abc --page abc")
         assert "Invalid" in out
 
+    def test_read_bare_flag_missing_value(self) -> None:
+        out = _capture(_shell(), "read cont_abc --page")
+        assert "Missing value for --page" in out
+
+    def test_read_bare_flag_without_id(self) -> None:
+        out = _capture(_shell(), "read --from-page")
+        assert "Missing value for --from-page" in out
+
     def test_read_page_range_conflict(self) -> None:
         out = _capture(_shell(), "read cont_abc --page 3 --from-page 1")
         assert "use either" in out

--- a/unique_sdk/tests/cli/test_shell.py
+++ b/unique_sdk/tests/cli/test_shell.py
@@ -323,6 +323,62 @@ class TestShellSearch:
         assert "Usage:" in out
 
 
+class TestShellRead:
+    def test_read_empty(self) -> None:
+        out = _capture(_shell(), "read")
+        assert "Usage:" in out
+
+    @patch("unique_sdk.cli.commands.read.cmd_read")
+    def test_read_basic(self, mock_read: MagicMock) -> None:
+        mock_read.return_value = "OUT"
+        out = _capture(_shell(), "read cont_abc")
+        assert "OUT" in out
+        assert mock_read.call_args.args[1] == "cont_abc"
+        _, kwargs = mock_read.call_args
+        assert kwargs == {"from_page": None, "to_page": None, "max_chars": None}
+
+    @patch("unique_sdk.cli.commands.read.cmd_read")
+    def test_read_single_page(self, mock_read: MagicMock) -> None:
+        mock_read.return_value = "OUT"
+        _capture(_shell(), "read cont_abc --page 12")
+        _, kwargs = mock_read.call_args
+        assert kwargs["from_page"] == 12
+        assert kwargs["to_page"] == 12
+
+    @patch("unique_sdk.cli.commands.read.cmd_read")
+    def test_read_short_page(self, mock_read: MagicMock) -> None:
+        mock_read.return_value = "OUT"
+        _capture(_shell(), "read cont_abc -p 5")
+        _, kwargs = mock_read.call_args
+        assert kwargs["from_page"] == 5
+        assert kwargs["to_page"] == 5
+
+    @patch("unique_sdk.cli.commands.read.cmd_read")
+    def test_read_range_and_max_chars(self, mock_read: MagicMock) -> None:
+        mock_read.return_value = "OUT"
+        _capture(_shell(), "read cont_abc --from-page 5 --to-page 9 --max-chars 100")
+        _, kwargs = mock_read.call_args
+        assert kwargs["from_page"] == 5
+        assert kwargs["to_page"] == 9
+        assert kwargs["max_chars"] == 100
+
+    def test_read_invalid_int(self) -> None:
+        out = _capture(_shell(), "read cont_abc --page abc")
+        assert "Invalid" in out
+
+    def test_read_page_range_conflict(self) -> None:
+        out = _capture(_shell(), "read cont_abc --page 3 --from-page 1")
+        assert "use either" in out
+
+    def test_read_unknown_arg(self) -> None:
+        out = _capture(_shell(), "read cont_abc extra")
+        assert "Unknown argument" in out
+
+    def test_read_only_flags_no_id(self) -> None:
+        out = _capture(_shell(), "read --page 3")
+        assert "Usage:" in out
+
+
 def _mcp_response() -> MagicMock:
     resp = MagicMock()
     resp.name = "tool"

--- a/unique_sdk/unique_sdk/cli/cli.py
+++ b/unique_sdk/unique_sdk/cli/cli.py
@@ -398,9 +398,41 @@ def cite(
 
 @main.command(name="read")
 @click.argument("cont_id")
+@click.option(
+    "--page",
+    "-p",
+    type=int,
+    default=None,
+    help="Read a single page (shorthand for --from-page N --to-page N).",
+)
+@click.option(
+    "--from-page",
+    type=int,
+    default=None,
+    help="First page to include (inclusive).",
+)
+@click.option(
+    "--to-page",
+    type=int,
+    default=None,
+    help="Last page to include (inclusive).",
+)
+@click.option(
+    "--max-chars",
+    type=int,
+    default=None,
+    help="Truncate the printed text to at most N characters.",
+)
 @click.pass_context
-def read_cmd(ctx: click.Context, cont_id: str) -> None:
-    """Read all indexed text chunks for a known content ID.
+def read_cmd(
+    ctx: click.Context,
+    cont_id: str,
+    page: int | None,
+    from_page: int | None,
+    to_page: int | None,
+    max_chars: int | None,
+) -> None:
+    """Read indexed text chunks for a known content ID.
 
     \b
     CONT_ID must be a content ID (cont_...) obtained from a prior `ls` or
@@ -412,10 +444,33 @@ def read_cmd(ctx: click.Context, cont_id: str) -> None:
     Use `read` when you already know the content ID and want the full text.
 
     \b
+    Restrict to a page range with --page (single page) or --from-page/--to-page.
+    A chunk spanning pages 2-4 is returned for any overlapping request; files
+    without page numbers (e.g. plain text/markdown) are returned only without a
+    page range.
+
+    \b
     Examples:
       unique-cli read cont_abc123
+      unique-cli read cont_abc123 --page 12
+      unique-cli read cont_abc123 --from-page 5 --to-page 9
+      unique-cli read cont_abc123 --to-page 3 --max-chars 8000
     """
-    output = cmd_read(LazyState.get(ctx), cont_id)
+    if page is not None and (from_page is not None or to_page is not None):
+        click.echo(
+            "read: use either --page or --from-page/--to-page, not both", err=True
+        )
+        raise SystemExit(1)
+    if page is not None:
+        from_page = page
+        to_page = page
+    output = cmd_read(
+        LazyState.get(ctx),
+        cont_id,
+        from_page=from_page,
+        to_page=to_page,
+        max_chars=max_chars,
+    )
     if _is_read_error_output(output):
         click.echo(output, err=True)
         raise SystemExit(1)

--- a/unique_sdk/unique_sdk/cli/commands/read.py
+++ b/unique_sdk/unique_sdk/cli/commands/read.py
@@ -7,6 +7,10 @@ request, no vector search involved.
 Use this when you already know the ``cont_*`` ID (e.g. from a prior ``ls``
 or ``unique-cli search`` result) and want to read the full document text.
 For discovery or query-based retrieval use ``unique-cli search`` instead.
+
+Pass ``from_page``/``to_page`` to read only part of a long document by page
+range; chunks are filtered client-side on the ``startPage``/``endPage`` the
+platform already returns, so no ingestion changes are required.
 """
 
 from __future__ import annotations
@@ -17,19 +21,73 @@ from unique_sdk.cli.state import ShellState
 READ_ERROR_PREFIX = "read:"
 
 
-def cmd_read(state: ShellState, cont_id: str) -> str:
-    """Return all indexed text chunks for *cont_id* as plain text.
+def _chunk_in_page_range(
+    chunk: dict,
+    from_page: int | None,
+    to_page: int | None,
+) -> bool:
+    """Return True if *chunk* overlaps the requested ``[from_page, to_page]`` span.
+
+    A chunk covers ``startPage``..``endPage`` inclusive. With page-based chunking
+    these are equal (one chunk per page); otherwise a single chunk can span
+    several pages, so we keep any chunk that *overlaps* the requested range
+    rather than one fully contained in it. Chunks without page numbers are
+    excluded, since they cannot be placed on a page. ``from_page``/``to_page``
+    that are ``None`` act as open bounds.
+    """
+    start = chunk.get("startPage")
+    end = chunk.get("endPage")
+    if start is None and end is None:
+        return False
+    if start is None:
+        start = end
+    if end is None:
+        end = start
+
+    low = from_page if from_page is not None else start
+    high = to_page if to_page is not None else end
+    return start <= high and end >= low
+
+
+def _format_requested_range(from_page: int | None, to_page: int | None) -> str:
+    """Human-readable label for a requested page range (for messages)."""
+    if from_page is not None and to_page is not None:
+        return str(from_page) if from_page == to_page else f"{from_page}-{to_page}"
+    if from_page is not None:
+        return f"{from_page}+"
+    return f"up to {to_page}"
+
+
+def cmd_read(
+    state: ShellState,
+    cont_id: str,
+    from_page: int | None = None,
+    to_page: int | None = None,
+    max_chars: int | None = None,
+) -> str:
+    """Return indexed text chunks for *cont_id* as plain text.
 
     Args:
         state: Shell state carrying user/company credentials.
         cont_id: A content ID (``cont_...``) to retrieve.
+        from_page: First page to include (inclusive). ``None`` = open start.
+        to_page: Last page to include (inclusive). ``None`` = open end.
+        max_chars: Truncate the returned text to at most this many characters.
 
     Returns:
         A formatted string of chunks, or an error message prefixed with
         ``read:``.
+
+    When ``from_page``/``to_page`` are given, chunks are filtered to those that
+    overlap the requested pages. The page numbers come from ingestion; nothing
+    needs to change there. A chunk spanning pages 2-4 is returned for any range
+    touching 2-4, so the text may include a little from neighbouring pages.
     """
     if not cont_id.startswith("cont_"):
         return f"{READ_ERROR_PREFIX} expected a content ID starting with 'cont_', got: {cont_id!r}"
+
+    if from_page is not None and to_page is not None and from_page > to_page:
+        return f"{READ_ERROR_PREFIX} invalid page range ({from_page} > {to_page})"
 
     # Enforce the same .unique-search.json workspace boundary as search/ls/rm.
     # Content.search has no scopeIds param, so we guard by owner scope before
@@ -61,6 +119,19 @@ def cmd_read(state: ShellState, cont_id: str) -> str:
 
     sorted_chunks = sorted(chunks, key=lambda c: c.get("order") or 0)
 
+    if from_page is not None or to_page is not None:
+        sorted_chunks = [
+            c for c in sorted_chunks if _chunk_in_page_range(c, from_page, to_page)
+        ]
+        if not sorted_chunks:
+            page_range = _format_requested_range(from_page, to_page)
+            return (
+                f"Content: {title} ({cont_id})\n"
+                f"No indexed chunks found in page range {page_range}. The document "
+                "may not have page numbers (e.g. plain text/markdown) or spans a "
+                "different range — read without a page range to see all text."
+            )
+
     lines: list[str] = [
         f"Content: {title} ({cont_id}) — {len(sorted_chunks)} chunk(s)\n"
     ]
@@ -85,7 +156,13 @@ def cmd_read(state: ShellState, cont_id: str) -> str:
         else:
             lines.append(text)
 
-    return "\n\n".join(lines)
+    output = "\n\n".join(lines)
+    if max_chars is not None and len(output) > max_chars:
+        output = (
+            f"{output[:max_chars]}\n"
+            f"... [truncated at {max_chars} chars; narrow the page range to see more]"
+        )
+    return output
 
 
 def is_error_output(output: str) -> bool:

--- a/unique_sdk/unique_sdk/cli/commands/read.py
+++ b/unique_sdk/unique_sdk/cli/commands/read.py
@@ -160,10 +160,11 @@ def cmd_read(
 
     output = "\n\n".join(lines)
     if max_chars is not None and len(output) > max_chars:
-        output = (
-            f"{output[:max_chars]}\n"
-            f"... [truncated at {max_chars} chars; narrow the page range to see more]"
-        )
+        if from_page is not None or to_page is not None:
+            hint = "narrow the page range or raise --max-chars to see more"
+        else:
+            hint = "use a page range (--page/--from-page/--to-page) or raise --max-chars to see more"
+        output = f"{output[:max_chars]}\n... [truncated at {max_chars} chars; {hint}]"
     return output
 
 

--- a/unique_sdk/unique_sdk/cli/commands/read.py
+++ b/unique_sdk/unique_sdk/cli/commands/read.py
@@ -15,6 +15,8 @@ platform already returns, so no ingestion changes are required.
 
 from __future__ import annotations
 
+from typing import Any
+
 import unique_sdk
 from unique_sdk.cli.state import ShellState
 
@@ -22,7 +24,7 @@ READ_ERROR_PREFIX = "read:"
 
 
 def _chunk_in_page_range(
-    chunk: dict,
+    chunk: dict[str, Any],
     from_page: int | None,
     to_page: int | None,
 ) -> bool:

--- a/unique_sdk/unique_sdk/cli/commands/read.py
+++ b/unique_sdk/unique_sdk/cli/commands/read.py
@@ -91,6 +91,9 @@ def cmd_read(
     if from_page is not None and to_page is not None and from_page > to_page:
         return f"{READ_ERROR_PREFIX} invalid page range ({from_page} > {to_page})"
 
+    if max_chars is not None and max_chars < 1:
+        return f"{READ_ERROR_PREFIX} invalid --max-chars ({max_chars}); must be >= 1"
+
     # Enforce the same .unique-search.json workspace boundary as search/ls/rm.
     # Content.search has no scopeIds param, so we guard by owner scope before
     # the point-lookup — matching rm/mv, not search's API-level scopeIds filter.

--- a/unique_sdk/unique_sdk/cli/commands/read.py
+++ b/unique_sdk/unique_sdk/cli/commands/read.py
@@ -37,14 +37,14 @@ def _chunk_in_page_range(
     excluded, since they cannot be placed on a page. ``from_page``/``to_page``
     that are ``None`` act as open bounds.
     """
-    start = chunk.get("startPage")
-    end = chunk.get("endPage")
-    if start is None and end is None:
-        return False
+    start: int | None = chunk.get("startPage")
+    end: int | None = chunk.get("endPage")
     if start is None:
         start = end
     if end is None:
         end = start
+    if start is None or end is None:
+        return False
 
     low = from_page if from_page is not None else start
     high = to_page if to_page is not None else end

--- a/unique_sdk/unique_sdk/cli/shell.py
+++ b/unique_sdk/unique_sdk/cli/shell.py
@@ -68,7 +68,11 @@ OVERVIEW_HELP = textwrap.dedent("""\
         --folder <path|id>        Restrict to a folder
         --metadata <key=value>    Filter by metadata (repeatable)
         --limit <N>               Max results (default: 200)
-      read <cont_id>            Read all indexed text chunks for a content ID
+      read <cont_id> [options]  Read indexed text chunks for a content ID
+        --page / -p <N>           Read a single page
+        --from-page <N>           First page (inclusive)
+        --to-page <N>             Last page (inclusive)
+        --max-chars <N>           Truncate output to N characters
 
     MCP:
       mcp [options] <json>      Call an MCP server tool
@@ -470,27 +474,102 @@ class UniqueShell(cmd.Cmd):
             return
         self._print(cmd_cite_file(self.state, positional[0], pages))
 
-    def do_read(self, arg: str) -> None:
-        """Read all indexed text chunks for a known content ID.
+    def _parse_int(self, raw: str, flag: str) -> tuple[int | None, bool]:
+        """Parse an int option value, returning (value, ok). Prints on failure."""
+        try:
+            return int(raw), True
+        except ValueError:
+            self._print(f"Invalid {flag}: {raw} (expected an integer)")
+            return None, False
 
-        Usage: read <cont_id>
+    def do_read(self, arg: str) -> None:
+        """Read indexed text chunks for a known content ID (optionally by page).
+
+        Usage: read <cont_id> [--page N | --from-page N --to-page M] [--max-chars N]
 
         Retrieves every indexed chunk for the document directly from the
-        database — no vector search, no query string needed.
+        database — no vector search, no query string needed. Use --page for a
+        single page or --from-page/--to-page for a range; a chunk spanning
+        pages 2-4 is returned for any overlapping request.
 
         Use `search` to find documents by topic; use `read` once you have
         the content ID and want the full text.
 
         Examples:
           /Reports> read cont_abc123
+          /Reports> read cont_abc123 --page 12
+          /Reports> read cont_abc123 --from-page 5 --to-page 9
         """
         from unique_sdk.cli.commands.read import cmd_read
 
         parts = shlex.split(arg)
+        usage = (
+            "Usage: read <cont_id> "
+            "[--page N | --from-page N --to-page M] [--max-chars N]"
+        )
         if not parts:
-            self._print("Usage: read <cont_id>")
+            self._print(usage)
             return
-        self._print(cmd_read(self.state, parts[0]))
+
+        cont_id: str | None = None
+        page: int | None = None
+        from_page: int | None = None
+        to_page: int | None = None
+        max_chars: int | None = None
+
+        i = 0
+        while i < len(parts):
+            tok = parts[i]
+            if tok in ("--page", "-p") and i + 1 < len(parts):
+                value, ok = self._parse_int(parts[i + 1], tok)
+                if not ok:
+                    return
+                page = value
+                i += 2
+            elif tok == "--from-page" and i + 1 < len(parts):
+                value, ok = self._parse_int(parts[i + 1], tok)
+                if not ok:
+                    return
+                from_page = value
+                i += 2
+            elif tok == "--to-page" and i + 1 < len(parts):
+                value, ok = self._parse_int(parts[i + 1], tok)
+                if not ok:
+                    return
+                to_page = value
+                i += 2
+            elif tok == "--max-chars" and i + 1 < len(parts):
+                value, ok = self._parse_int(parts[i + 1], tok)
+                if not ok:
+                    return
+                max_chars = value
+                i += 2
+            elif cont_id is None:
+                cont_id = tok
+                i += 1
+            else:
+                self._print(f"Unknown argument: {tok}")
+                return
+
+        if cont_id is None:
+            self._print(usage)
+            return
+        if page is not None and (from_page is not None or to_page is not None):
+            self._print("read: use either --page or --from-page/--to-page, not both")
+            return
+        if page is not None:
+            from_page = page
+            to_page = page
+
+        self._print(
+            cmd_read(
+                self.state,
+                cont_id,
+                from_page=from_page,
+                to_page=to_page,
+                max_chars=max_chars,
+            )
+        )
 
     def do_rm(self, arg: str) -> None:
         """Delete a file.

--- a/unique_sdk/unique_sdk/cli/shell.py
+++ b/unique_sdk/unique_sdk/cli/shell.py
@@ -517,32 +517,25 @@ class UniqueShell(cmd.Cmd):
         to_page: int | None = None
         max_chars: int | None = None
 
+        int_flags = ("--page", "-p", "--from-page", "--to-page", "--max-chars")
         i = 0
         while i < len(parts):
             tok = parts[i]
-            if tok in ("--page", "-p") and i + 1 < len(parts):
+            if tok in int_flags:
+                if i + 1 >= len(parts):
+                    self._print(f"Missing value for {tok}")
+                    return
                 value, ok = self._parse_int(parts[i + 1], tok)
                 if not ok:
                     return
-                page = value
-                i += 2
-            elif tok == "--from-page" and i + 1 < len(parts):
-                value, ok = self._parse_int(parts[i + 1], tok)
-                if not ok:
-                    return
-                from_page = value
-                i += 2
-            elif tok == "--to-page" and i + 1 < len(parts):
-                value, ok = self._parse_int(parts[i + 1], tok)
-                if not ok:
-                    return
-                to_page = value
-                i += 2
-            elif tok == "--max-chars" and i + 1 < len(parts):
-                value, ok = self._parse_int(parts[i + 1], tok)
-                if not ok:
-                    return
-                max_chars = value
+                if tok in ("--page", "-p"):
+                    page = value
+                elif tok == "--from-page":
+                    from_page = value
+                elif tok == "--to-page":
+                    to_page = value
+                else:  # --max-chars
+                    max_chars = value
                 i += 2
             elif cont_id is None:
                 cont_id = tok

--- a/unique_sdk/unique_sdk/cli/skills/unique-cli-file-management/SKILL.md
+++ b/unique_sdk/unique_sdk/cli/skills/unique-cli-file-management/SKILL.md
@@ -4,6 +4,8 @@ description: >-
   Manage files and folders on the Unique AI Platform using the unique-cli
   command-line tool. Use when the user asks to upload, download, delete,
   rename, list, find, restore versions, list versions, look for, or organize files and folders on Unique,
+  or to read / view / quote the text contents of a known file (optionally by
+  page or page range, e.g. "what's on page 5?", "read pages 10-12"),
   or when working with scope IDs (scope_*) or content IDs (cont_*).
   IMPORTANT: When a user says they are "looking for a file" or wants to
   "find a file", they typically mean locating it within the Unique AI
@@ -63,6 +65,13 @@ unique-cli restore-version cver_abc123
 # Download a file
 unique-cli download report.pdf ./local/
 unique-cli download cont_abc123 ~/Desktop/
+
+# Read a file's extracted text by content ID (whole file)
+unique-cli read cont_abc123
+
+# Read a single page or a page range
+unique-cli read cont_abc123 --page 12
+unique-cli read cont_abc123 --from-page 5 --to-page 9
 
 # Declare page citations after reading a file
 unique-cli cite report.pdf --pages 3,5,7
@@ -140,6 +149,57 @@ unique-cli restore-version cver_abc123
 unique-cli mkdir "2025/Q1/Financials"
 unique-cli upload ./budget.xlsx /2025/Q1/Financials/
 ```
+
+## Reading File Contents (by page range)
+
+Use `read` to retrieve the **extracted text** of a single, known file — for
+example to answer "what does page 5 say?", to quote an exact passage, or to
+read a long document a few pages at a time. This differs from `search`:
+`search` ranks chunks across many files by relevance; `read` returns the text
+of one file in document order.
+
+`read` takes a **content ID** (`cont_...`), not a file name. Get the ID first
+from `ls` or `search`, then pass it to `read`.
+
+```bash
+# Whole file
+unique-cli read cont_abc123
+
+# A single page
+unique-cli read cont_abc123 --page 12
+
+# A page range (inclusive)
+unique-cli read cont_abc123 --from-page 5 --to-page 9
+
+# Cap the output size (protects your context window on huge files)
+unique-cli read cont_abc123 --to-page 3 --max-chars 8000
+```
+
+| Option | Description |
+|--------|-------------|
+| `--page` / `-p N` | Read only page N (shorthand for `--from-page N --to-page N`) |
+| `--from-page N` | First page to include (inclusive) |
+| `--to-page N` | Last page to include (inclusive) |
+| `--max-chars N` | Truncate the printed text to N characters |
+
+Each chunk is prefixed with its source page(s) as `[p.N]` or `[p.N-M]`, so you
+can attribute text to pages.
+
+### How page filtering behaves (important)
+
+- **Page numbers come from ingestion.** Each chunk carries a `startPage` and
+  `endPage`; the page filter is applied to those values. Nothing in the
+  ingestion pipeline needs to change.
+- **Ranges overlap, they don't slice.** A chunk that spans pages 2-4 is
+  returned for `--page 3` (or any range touching 2-4). The returned text is the
+  whole chunk, so it may include a little from neighbouring pages. Treat the
+  result as "the chunks covering these pages", not a pixel-perfect page cut.
+- **Some files have no page numbers.** Plain text, markdown, and similar
+  content has no page numbers; those chunks are returned only when you read
+  **without** a page range. A page-filtered read of such a file returns nothing.
+- **Empty / not indexed?** If `read` reports the file is still ingesting or has
+  no indexed chunks, there is no extracted text to return — use `download` to
+  fetch the original bytes instead.
 
 ## Citing File Pages
 


### PR DESCRIPTION
## Summary

- Extend `unique-cli read <cont_id>` with page-range options: `--page N` (single page), `--from-page`/`--to-page` (inclusive range), and `--max-chars` (output cap).
- Filtering is done client-side over the `startPage`/`endPage` that `content.search` already returns for each chunk, so **no ingestion-pipeline or backend changes are required**.
- Overlap semantics: a chunk spanning pages 2-4 is returned for any request touching those pages; content without page numbers (plain text/markdown) is only returned when no range is given.
- Builds on the existing upstream `read` command (#1833): preserves its `cont_`-ID-only contract, workspace-scope guard, and `[p.N]`/`[p.N-M]` output.
- Documents the feature in the `unique-cli-file-management` skill (one-shot examples + a "Reading File Contents (by page range)" section covering options, output, and semantics).

## Changes

- `cli/commands/read.py` — `from_page`/`to_page`/`max_chars` params, `_chunk_in_page_range` overlap filter, `_format_requested_range`, truncation.
- `cli/cli.py` — `--page/-p`, `--from-page`, `--to-page`, `--max-chars` options (with `--page` vs `--from/--to` mutual-exclusion guard).
- `cli/shell.py` — interactive `do_read` option parsing + overview help.
- `skills/unique-cli-file-management/SKILL.md` — read-by-page docs and agent guidance.
- `tests/cli/test_read.py` — page-range filter, single page, no-match, invalid range, unpaged-chunk exclusion, max-chars truncation.

## Test plan

- [x] `uv run --no-sync pytest unique_sdk/tests/cli` — 599 passed
- [x] `ruff check` + `ruff format --check` clean (pre-commit hooks pass)
- [x] `unique-cli read --help` shows the new options
- [ ] Manual: `unique-cli read cont_<id> --from-page 5 --to-page 9` against a real PDF

Made with [Cursor](https://cursor.com)