### PR TITLE
chore(ci): verify release/* backports are patch-equivalent to main

### DIFF
--- a/.claude/skills/ci-local-parity/references/ci-gaps.md
+++ b/.claude/skills/ci-local-parity/references/ci-gaps.md
@@ -44,6 +44,7 @@ uv run python -m unique_toolkit._common.config_checker check \
 
 - **PR title**: semantic PR title format validation (GitHub Action).
 - **No-manual-release**: `bash .github/scripts/check-no-manual-release.sh <base_sha> <head_sha>`
+- **Release-lineage** (PRs targeting `release/*` only): `git fetch origin main && bash .github/scripts/check-release-lineage.sh <base_sha> <head_sha> origin/main`
 - **Gatekeeper**: aggregates all job statuses; posts commit status via `gh api`.
 
 These are governance checks; they have no local Poe equivalent.

--- a/.claude/skills/hotfix-backport/SKILL.md
+++ b/.claude/skills/hotfix-backport/SKILL.md
@@ -29,7 +29,8 @@ metadata:
 
 ## CI guardrails
 
-- `.github/scripts/check-release-lineage.sh` — each PR commit must be on `main` or patch-equivalent (`git cherry -` prefix). Cherry-picks get new SHAs; identical hashes are not required.
+- `.github/scripts/check-release-lineage.sh` — each PR commit must be on `main` or patch-equivalent (`git cherry -` prefix). Cherry-picks get new SHAs; identical hashes are not required. No commit-metadata bypass (author/subject are forgeable).
+- `release-please--*` PRs skip lineage in `ci.yaml` (automation-owned version/changelog bumps).
 - Do not squash-merge: one squashed commit breaks release-please changelog generation.
 
 ## After the fix PR merges

--- a/.claude/skills/hotfix-backport/SKILL.md
+++ b/.claude/skills/hotfix-backport/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: hotfix-backport
+description: Backport fixes from main onto release/YYYY.WW in the ai repo with cherry-pick and rebase merge so release-please changelogs stay correct. Use when hotfixing a release branch, cherry-picking to release/*, or preparing a release backport PR.
+license: MIT
+compatibility: claude cursor opencode
+metadata:
+  version: "1.0.0"
+  languages: all
+  audience: developers
+  workflow: release
+---
+
+# Hotfix backport to `release/*`
+
+## Workflow
+
+1. Identify commits on `main` to backport (merge commits or PR numbers).
+2. Branch from the target release branch:
+   ```bash
+   git fetch origin main release/YYYY.WW
+   git checkout -b hotfix/UN-XXXXX origin/release/YYYY.WW
+   ```
+3. Cherry-pick in order (oldest first):
+   ```bash
+   git cherry-pick <sha1> <sha2> ...
+   ```
+4. Open a PR targeting `release/YYYY.WW` with a list of backported commits/PRs in the description.
+5. Merge with **Rebase and merge** only (squash is blocked by branch rules).
+
+## CI guardrails
+
+- `.github/scripts/check-release-lineage.sh` — each PR commit must be on `main` or patch-equivalent (`git cherry`). Cherry-picks get new SHAs; identical hashes are not required.
+- Do not squash-merge: one squashed commit breaks release-please changelog generation.
+
+## After the fix PR merges
+
+release-please opens `chore: hotfix release/YYYY.WW to YYYY.WW.N`. Approve and **rebase-merge** that PR too. PyPI publish follows the GitHub Release event.
+
+## Related
+
+- `release-process` — versioning and changelog ownership
+- `git-conventional-commits` — commit subjects on cherry-picked commits must stay conventional
+- `model-deployment` LESSONS-LEARNED — monorepo pins after AI packages ship

--- a/.claude/skills/hotfix-backport/SKILL.md
+++ b/.claude/skills/hotfix-backport/SKILL.md
@@ -29,7 +29,7 @@ metadata:
 
 ## CI guardrails
 
-- `.github/scripts/check-release-lineage.sh` — each PR commit must be on `main` or patch-equivalent (`git cherry`). Cherry-picks get new SHAs; identical hashes are not required.
+- `.github/scripts/check-release-lineage.sh` — each PR commit must be on `main` or patch-equivalent (`git cherry -` prefix). Cherry-picks get new SHAs; identical hashes are not required.
 - Do not squash-merge: one squashed commit breaks release-please changelog generation.
 
 ## After the fix PR merges

--- a/.claude/skills/model-deployment/references/LESSONS-LEARNED.md
+++ b/.claude/skills/model-deployment/references/LESSONS-LEARNED.md
@@ -37,6 +37,7 @@ When cherry-picking model support into a release branch, **all cross-repo depend
 This is **not** a manual ai-repo `CHANGELOG.md` / `version` edit — after the toolkit ships from the ai repo, bump the **dependency constraint** in the monorepo (e.g. `assistants-core` `pyproject.toml` or the monorepo's AI version sync workflow).
 
 Checklist for cherry-picks:
+- [ ] AI repo: cherry-pick from `main` onto `release/YYYY.WW` and **rebase-merge** the PR (squash breaks release-please changelogs; see `hotfix-backport` skill)
 - [ ] Node-chat TypeScript changes (language-model enum, factory, service)
 - [ ] Monorepo: `assistants-core` (or equivalent) pins the new published `unique_toolkit` version
 - [ ] LiteLLM overlay changes (if applicable)

--- a/.claude/skills/release-process/SKILL.md
+++ b/.claude/skills/release-process/SKILL.md
@@ -57,11 +57,25 @@ CalVer scheme: `YYYY.WW.PATCH` — see `docs/contributing/release-process.md`.
 2. Ensure their work is committed with the right conventional commit type/scope.
 3. Point them to merge the Release PR or read `docs/contributing/release-process.md` for hotfixes/RC/dev cuts.
 
+## Hotfixes on `release/*`
+
+Backport fixes from `main` with **cherry-pick**, not direct edits on the release branch.
+
+| Rule | Why |
+|------|-----|
+| Cherry-pick from `main` | CI checks patch equivalence (`git cherry` vs `main`), not identical SHAs |
+| **Rebase and merge** only | Squash collapses N commits → 1; release-please loses per-commit changelog entries |
+| Conventional commit subjects | release-please attributes each merged commit to changelog sections |
+| Skip release-please bot PRs | `chore: hotfix release/...` PRs are automation — approve and rebase-merge |
+
+Script: `.github/scripts/check-release-lineage.sh` (runs in CI for PRs targeting `release/*`).
+
 ## Monorepo consumers (different repo)
 
 Bumping a **published** `unique_toolkit` / `unique_sdk` version inside the **monorepo** (e.g. `assistants-core` `pyproject.toml`) is a separate step after a stable AI release — not a manual ai-repo changelog edit. See `model-deployment` LESSONS-LEARNED for cherry-pick checklists.
 
 ## Related skills
 
+- `hotfix-backport` — cherry-pick workflow and rebase-merge rules for `release/*`
 - `git-conventional-commits` — commit/PR title format
 - `security-maintenance` — same no-manual-release rules for CVE/CodeQL PRs

--- a/.claude/skills/release-process/SKILL.md
+++ b/.claude/skills/release-process/SKILL.md
@@ -66,9 +66,9 @@ Backport fixes from `main` with **cherry-pick**, not direct edits on the release
 | Cherry-pick from `main` | CI checks patch equivalence (`git cherry` vs `main`), not identical SHAs |
 | **Rebase and merge** only | Squash collapses N commits → 1; release-please loses per-commit changelog entries |
 | Conventional commit subjects | release-please attributes each merged commit to changelog sections |
-| Skip release-please bot PRs | `chore: hotfix release/...` PRs are automation — approve and rebase-merge |
+| Skip release-please bot PRs | `chore: hotfix release/...` PRs are automation — CI skips lineage for `release-please--*` branches |
 
-Script: `.github/scripts/check-release-lineage.sh` (runs in CI for PRs targeting `release/*`).
+Script: `.github/scripts/check-release-lineage.sh` (runs in CI for human PRs targeting `release/*`; patch-equivalence only, no commit-metadata allowlist).
 
 ## Monorepo consumers (different repo)
 

--- a/.github/scripts/check-release-lineage.sh
+++ b/.github/scripts/check-release-lineage.sh
@@ -7,6 +7,9 @@ set -euo pipefail
 # rather than requiring identical commit hashes on main.
 # Sign convention: `-` = patch exists on upstream (backport), `+` = release-only.
 #
+# Release-please and other automation PRs are skipped in ci.yaml (workflow `if`),
+# not here — commit author/subject are forgeable and must not bypass this check.
+#
 # Usage: check-release-lineage.sh <base-sha> <head-sha> [upstream-ref]
 #   upstream-ref defaults to origin/main
 
@@ -29,51 +32,11 @@ fi
 
 CHERRY_LINES=$(git cherry -v "$UPSTREAM" "$HEAD")
 
-is_allowlisted() {
-  local sha="$1"
-  local subject author email
-
-  subject=$(git log -1 --format=%s "$sha")
-  author=$(git log -1 --format=%an "$sha")
-  email=$(git log -1 --format=%ae "$sha")
-
-  if [[ "$author" == "release-please[bot]" ]]; then
-    return 0
-  fi
-
-  if [[ "$email" == *"github-actions"* || "$email" == *"release-workflow"* ]]; then
-    return 0
-  fi
-
-  if [[ "$subject" == chore:\ hotfix\ release/* ]]; then
-    return 0
-  fi
-  if [[ "$subject" == chore:\ stable\ release\ * ]]; then
-    return 0
-  fi
-  if [[ "$subject" == chore:\ arm\ release\ * ]]; then
-    return 0
-  fi
-  if [[ "$subject" == chore\(release-please\):* ]]; then
-    return 0
-  fi
-  if [[ "$subject" == chore\(release\):* ]]; then
-    return 0
-  fi
-
-  return 1
-}
-
 ERRORS=()
 
 for sha in "${COMMITS[@]}"; do
   short_sha=${sha:0:7}
   subject=$(git log -1 --format=%s "$sha")
-
-  if is_allowlisted "$sha"; then
-    echo "allowlisted: $short_sha $subject"
-    continue
-  fi
 
   if git merge-base --is-ancestor "$sha" "$UPSTREAM" 2>/dev/null; then
     echo "on-main: $short_sha $subject"
@@ -92,7 +55,7 @@ for sha in "${COMMITS[@]}"; do
     continue
   fi
 
-  ERRORS+=("$short_sha $subject (patch not found on $UPSTREAM — cherry-pick from main or use release automation)")
+  ERRORS+=("$short_sha $subject (patch not found on $UPSTREAM — cherry-pick from main)")
 done
 
 if [[ ${#ERRORS[@]} -gt 0 ]]; then

--- a/.github/scripts/check-release-lineage.sh
+++ b/.github/scripts/check-release-lineage.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 #
 # Cherry-picks create new SHAs, so we compare patch equivalence via `git cherry`
 # rather than requiring identical commit hashes on main.
+# Sign convention: `-` = patch exists on upstream (backport), `+` = release-only.
 #
 # Usage: check-release-lineage.sh <base-sha> <head-sha> [upstream-ref]
 #   upstream-ref defaults to origin/main
@@ -86,7 +87,7 @@ for sha in "${COMMITS[@]}"; do
     continue
   fi
 
-  if [[ "$cherry_line" == +* ]]; then
+  if [[ "$cherry_line" == -* ]]; then
     echo "backport: $short_sha $subject"
     continue
   fi

--- a/.github/scripts/check-release-lineage.sh
+++ b/.github/scripts/check-release-lineage.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Verifies commits introduced by a PR targeting release/* are backports from main.
+#
+# Cherry-picks create new SHAs, so we compare patch equivalence via `git cherry`
+# rather than requiring identical commit hashes on main.
+#
+# Usage: check-release-lineage.sh <base-sha> <head-sha> [upstream-ref]
+#   upstream-ref defaults to origin/main
+
+BASE="${1:?Usage: $0 <base-sha> <head-sha> [upstream-ref]}"
+HEAD="${2:?Usage: $0 <base-sha> <head-sha> [upstream-ref]}"
+UPSTREAM="${3:-origin/main}"
+
+if ! git rev-parse --verify "$UPSTREAM" >/dev/null 2>&1; then
+  echo "::error::Upstream ref $UPSTREAM not found. Fetch main before running this script."
+  exit 1
+fi
+
+MERGE_BASE=$(git merge-base "$BASE" "$HEAD")
+mapfile -t COMMITS < <(git rev-list --reverse "$MERGE_BASE".."$HEAD")
+
+if [[ ${#COMMITS[@]} -eq 0 ]]; then
+  echo "No commits to check."
+  exit 0
+fi
+
+CHERRY_LINES=$(git cherry -v "$UPSTREAM" "$HEAD")
+
+is_allowlisted() {
+  local sha="$1"
+  local subject author email
+
+  subject=$(git log -1 --format=%s "$sha")
+  author=$(git log -1 --format=%an "$sha")
+  email=$(git log -1 --format=%ae "$sha")
+
+  if [[ "$author" == "release-please[bot]" ]]; then
+    return 0
+  fi
+
+  if [[ "$email" == *"github-actions"* || "$email" == *"release-workflow"* ]]; then
+    return 0
+  fi
+
+  if [[ "$subject" == chore:\ hotfix\ release/* ]]; then
+    return 0
+  fi
+  if [[ "$subject" == chore:\ stable\ release\ * ]]; then
+    return 0
+  fi
+  if [[ "$subject" == chore:\ arm\ release\ * ]]; then
+    return 0
+  fi
+  if [[ "$subject" == chore\(release-please\):* ]]; then
+    return 0
+  fi
+  if [[ "$subject" == chore\(release\):* ]]; then
+    return 0
+  fi
+
+  return 1
+}
+
+ERRORS=()
+
+for sha in "${COMMITS[@]}"; do
+  short_sha=${sha:0:7}
+  subject=$(git log -1 --format=%s "$sha")
+
+  if is_allowlisted "$sha"; then
+    echo "allowlisted: $short_sha $subject"
+    continue
+  fi
+
+  if git merge-base --is-ancestor "$sha" "$UPSTREAM" 2>/dev/null; then
+    echo "on-main: $short_sha $subject"
+    continue
+  fi
+
+  cherry_line=$(printf '%s\n' "$CHERRY_LINES" | grep -E "^[+-] $sha " || true)
+
+  if [[ -z "$cherry_line" ]]; then
+    ERRORS+=("$short_sha $subject (not on $UPSTREAM and no patch-equivalence result)")
+    continue
+  fi
+
+  if [[ "$cherry_line" == +* ]]; then
+    echo "backport: $short_sha $subject"
+    continue
+  fi
+
+  ERRORS+=("$short_sha $subject (patch not found on $UPSTREAM — cherry-pick from main or use release automation)")
+done
+
+if [[ ${#ERRORS[@]} -gt 0 ]]; then
+  echo "::error::Release PR contains commits without a matching patch on main."
+  echo ""
+  echo "Merge hotfix PRs with Rebase and merge (squash collapses commits and breaks release-please changelogs)."
+  echo "Each fix commit must be cherry-picked from main so release-please can attribute changelog entries."
+  echo ""
+  echo "Offending commits:"
+  for err in "${ERRORS[@]}"; do
+    echo "  - $err"
+  done
+  exit 1
+fi
+
+echo "All ${#COMMITS[@]} commit(s) are on main or patch-equivalent backports."

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -118,9 +118,29 @@ jobs:
             "${{ github.event.pull_request.base.sha }}" \
             "${{ github.event.pull_request.head.sha }}"
 
+  release-lineage:
+    name: Release Branch Lineage
+    if: >-
+      github.event_name == 'pull_request'
+      && startsWith(github.event.pull_request.base.ref, 'release/')
+      && github.actor != 'release-please[bot]'
+      && !startsWith(github.head_ref, 'release-please--')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Verify backports match main
+        run: |
+          git fetch origin main
+          bash .github/scripts/check-release-lineage.sh \
+            "${{ github.event.pull_request.base.sha }}" \
+            "${{ github.event.pull_request.head.sha }}" \
+            origin/main
+
   status:
     name: Gatekeeper
-    needs: [detect-changes, lint, test, types, coverage, deps, containerize, helm-lint, config, pr-title, no-manual-release]
+    needs: [detect-changes, lint, test, types, coverage, deps, containerize, helm-lint, config, pr-title, no-manual-release, release-lineage]
     if: always()
     runs-on: ubuntu-latest
     permissions:
@@ -140,6 +160,7 @@ jobs:
           CONFIG: ${{ needs.config.result }}
           PR_TITLE: ${{ needs.pr-title.result }}
           NO_MANUAL_RELEASE: ${{ needs.no-manual-release.result }}
+          RELEASE_LINEAGE: ${{ needs.release-lineage.result }}
         run: |
           echo "=== CI Status Summary ==="
           echo "detect-changes: $DETECT_CHANGES"
@@ -153,13 +174,14 @@ jobs:
           echo "config: $CONFIG"
           echo "pr-title: $PR_TITLE"
           echo "no-manual-release: $NO_MANUAL_RELEASE"
+          echo "release-lineage: $RELEASE_LINEAGE"
           echo "========================="
 
           failed=false
 
           # Required checks (skipped is OK for when no packages changed or merge_group).
           # Types: failure means a package with typecheck_require_zero_errors failed, so we treat it as blocking.
-          for check in "detect-changes:$DETECT_CHANGES" "lint:$LINT" "test:$TEST" "types:$TYPES" "coverage:$COVERAGE" "deps:$DEPS" "containerize:$CONTAINERIZE" "helm-lint:$HELM_LINT" "config:$CONFIG" "pr-title:$PR_TITLE" "no-manual-release:$NO_MANUAL_RELEASE"; do
+          for check in "detect-changes:$DETECT_CHANGES" "lint:$LINT" "test:$TEST" "types:$TYPES" "coverage:$COVERAGE" "deps:$DEPS" "containerize:$CONTAINERIZE" "helm-lint:$HELM_LINT" "config:$CONFIG" "pr-title:$PR_TITLE" "no-manual-release:$NO_MANUAL_RELEASE" "release-lineage:$RELEASE_LINEAGE"; do
             name="${check%%:*}"
             result="${check##*:}"
             if [[ "$result" == "failure" || "$result" == "cancelled" ]]; then

--- a/docs/contributing/release-process.md
+++ b/docs/contributing/release-process.md
@@ -202,8 +202,8 @@ flowchart TD
 
 **Workflow:** `.github/workflows/cd-release.yaml` (running on a `release/*` branch) + `cd-publish.yaml`
 
-1. Create a branch off `release/YYYY.WW`, commit or cherry-pick the fix, and open a PR targeting `release/YYYY.WW`.
-2. Get the PR reviewed and merged normally (standard review process applies).
+1. Create a branch off `release/YYYY.WW`, cherry-pick the fix(es) from `main`, and open a PR targeting `release/YYYY.WW`.
+2. Get the PR reviewed and merge with **Rebase and merge** only. Squash merge is disabled on `release/*` because it collapses multiple cherry-picks into one commit and breaks release-please changelogs. CI (`check-release-lineage.sh`) verifies each PR commit is patch-equivalent to a commit on `main`.
 3. release-please opens a second PR on the release branch with title:
    ```
    chore: hotfix release/YYYY.WW to <version>


### PR DESCRIPTION
## Summary

Hotfix PRs into `release/*` were often squash-merged, collapsing cherry-picked commits and producing incorrect release-please changelogs. This adds CI enforcement and documentation so each backport commit stays distinct and is patch-equivalent to `main`.

- Add `.github/scripts/check-release-lineage.sh` (`git cherry` vs `origin/main`, with allowlists for release automation)
- Run as **Release Branch Lineage** job in CI Gatekeeper for PRs targeting `release/*`
- Document rebase-merge requirement and new `hotfix-backport` skill

Pair with infrastructure PR that disables squash on `release/*` merge buttons.

## Test plan

- [ ] CI passes on this PR (lineage job skipped — base is `main`)
- [ ] Open a test PR targeting `release/YYYY.WW` with cherry-picks from `main` and confirm lineage passes
- [ ] Confirm a release-only commit (no `main` patch) fails lineage

Refs: UN-*

Made with [Cursor](https://cursor.com)