### PR TITLE
fix(sdk): omit versioningEnabled when None on file upload

### DIFF
--- a/unique_sdk/tests/test_file_io_preview_pdf.py
+++ b/unique_sdk/tests/test_file_io_preview_pdf.py
@@ -313,3 +313,79 @@ class TestUploadFilePreviewPdfPath:
                 chat_id="chat-1",
                 preview_pdf_path="/definitely/not/a/real/file.pdf",
             )
+
+
+class TestUploadFileVersioningEnabled:
+    """Pin the contract that ``versioning_enabled`` is forwarded as a
+    boolean only when the caller opted in.
+
+    The default of ``None`` must NOT reach ``Content.upsert`` as
+    ``versioningEnabled=None``: the HTTP layer would serialize that as
+    JSON ``null``, which node-ingestion rejects because the Prisma
+    ``Content.versioningEnabled`` column is a non-null boolean. Omitting
+    the key lets the backend apply its own default (legacy behavior).
+    """
+
+    def _run_upload(
+        self, sample_pptx: str, **extra_kwargs: Any
+    ) -> list[dict[str, Any]]:
+        created = _fake_created_content()
+        upsert_calls: list[dict[str, Any]] = []
+
+        def upsert(**kwargs: Any) -> Any:
+            upsert_calls.append(kwargs)
+            return created
+
+        with (
+            patch.object(file_io.Content, "upsert", side_effect=upsert),
+            patch.object(file_io.unique_sdk.Content, "upsert", side_effect=upsert),
+            patch.object(
+                file_io.requests,
+                "put",
+                MagicMock(return_value=MagicMock(status_code=200)),
+            ),
+        ):
+            file_io.upload_file(
+                userId="user-1",
+                companyId="company-1",
+                path_to_file=sample_pptx,
+                displayed_filename="deck.pptx",
+                mime_type=(
+                    "application/vnd.openxmlformats-officedocument."
+                    "presentationml.presentation"
+                ),
+                chat_id="chat-1",
+                **extra_kwargs,
+            )
+
+        return upsert_calls
+
+    def test_default_omits_versioning_enabled(self, sample_pptx: str) -> None:
+        """Not passing ``versioning_enabled`` (the ``None`` default) must
+        leave ``versioningEnabled`` absent from every upsert — never
+        present-as-None, which would serialize as JSON ``null`` and fail
+        Prisma validation in node-ingestion."""
+        upsert_calls = self._run_upload(sample_pptx)
+
+        assert upsert_calls, "expected at least one upsert call"
+        for call in upsert_calls:
+            assert "versioningEnabled" not in call
+
+    def test_explicit_true_forwards_boolean(self, sample_pptx: str) -> None:
+        """``versioning_enabled=True`` is forwarded verbatim on every
+        upsert so the platform archives previous blobs."""
+        upsert_calls = self._run_upload(sample_pptx, versioning_enabled=True)
+
+        assert upsert_calls, "expected at least one upsert call"
+        for call in upsert_calls:
+            assert call["versioningEnabled"] is True
+
+    def test_explicit_false_forwards_boolean(self, sample_pptx: str) -> None:
+        """``versioning_enabled=False`` is a deliberate opt-out and must
+        be forwarded as the boolean ``False`` (distinct from omitting
+        the key, which defers to the backend default)."""
+        upsert_calls = self._run_upload(sample_pptx, versioning_enabled=False)
+
+        assert upsert_calls, "expected at least one upsert call"
+        for call in upsert_calls:
+            assert call["versioningEnabled"] is False

--- a/unique_sdk/unique_sdk/utils/file_io.py
+++ b/unique_sdk/unique_sdk/utils/file_io.py
@@ -20,6 +20,20 @@ class _PreviewKwargs(TypedDict, total=False):
     previewPdfFileName: str
 
 
+class _VersioningKwargs(TypedDict, total=False):
+    """Subset of ``Content.UpsertParams`` carrying ``versioningEnabled``,
+    forwarded conditionally for the same reason as ``_PreviewKwargs``.
+
+    Forwarding ``versioningEnabled=None`` would serialize as JSON
+    ``null``, which node-ingestion rejects (the Prisma
+    ``Content.versioningEnabled`` column is a non-null boolean). Omitting
+    the key entirely lets the backend apply its own default, preserving
+    the legacy upload behavior for callers that never opt into
+    versioning."""
+
+    versioningEnabled: bool
+
+
 # download readUrl a random directory in /tmp
 def download_file(url: str, filename: str):
     # Guard for callers without a type checker: fail fast with a clear error before reaching requests.
@@ -163,6 +177,17 @@ def upload_file(
 
     size = os.path.getsize(path_to_file)
 
+    # Forward ``versioningEnabled`` only when the caller opted in. A
+    # default of ``None`` would otherwise serialize as JSON ``null``,
+    # which node-ingestion rejects on the non-null Prisma column; an
+    # omitted key lets the backend apply its own default (legacy
+    # behavior).
+    versioning_kwargs: _VersioningKwargs = (
+        {"versioningEnabled": versioning_enabled}
+        if versioning_enabled is not None
+        else {}
+    )
+
     # Step 1 — first upsert WITHOUT ``previewPdfFileName``. The id we
     # need to derive a collision-free preview blob name does not exist
     # yet; deriving from ``displayed_filename`` instead would race
@@ -181,7 +206,7 @@ def upload_file(
         },
         scopeId=scope_or_unique_path,
         chatId=chat_id,
-        versioningEnabled=versioning_enabled,
+        **versioning_kwargs,
     )
 
     # Step 2 — PUT the original bytes to the SAS URL minted by Step 1.
@@ -234,7 +259,7 @@ def upload_file(
             },
             fileUrl=createdContent.readUrl,
             chatId=chat_id,
-            versioningEnabled=versioning_enabled,
+            **versioning_kwargs,
             **preview_kwargs,
         )
     else:
@@ -252,7 +277,7 @@ def upload_file(
             },
             fileUrl=createdContent.readUrl,
             scopeId=scope_or_unique_path,
-            versioningEnabled=versioning_enabled,
+            **versioning_kwargs,
             **preview_kwargs,
         )
 


### PR DESCRIPTION
## Summary

- `unique_sdk.utils.file_io.upload_file(...)` always forwarded `versioningEnabled=versioning_enabled` into every `Content.upsert(...)` call. When callers did not pass `versioning_enabled` (default `None`), the HTTP layer serialized it as JSON `null`.
- `node-ingestion` rejects an explicit `null` because the Prisma `Content.versioningEnabled` column is a non-null boolean, so content creation failed for default uploads (agent workspace outputs, Office PDF previews, workspace checkpoints).
- Now the kwarg is forwarded conditionally (mirroring the existing `preview_kwargs` pattern): `None` omits the key so the backend applies its default (legacy behavior), while `True`/`False` are still sent verbatim.

## Test plan

- [x] Added `TestUploadFileVersioningEnabled` covering default-omit, explicit `True`, and explicit `False` — asserts `versioningEnabled` is absent / forwarded as the correct boolean on every upsert.
- [x] `pytest tests/test_file_io_preview_pdf.py` — 9 passed (3 new + 6 existing).
- [x] `ruff check`, `ruff format --check`, and `basedpyright` clean on the touched files.

Refs: UN-21785

Made with [Cursor](https://cursor.com)