### PR TITLE
fix(chat): resolve namespace-package KeyError for unique_toolkit.chat.deprecated

### DIFF
--- a/unique_mcp/tests/conftest.py
+++ b/unique_mcp/tests/conftest.py
@@ -1,10 +1,6 @@
 """Shared pytest fixtures and configuration."""
 
-# avoid a Python importlib bug: unique_toolkit.chat.deprecated is a namespace
-# package; if unique_toolkit.chat isn't in sys.modules when its _NamespacePath
-# recalculates after a sys.path insertion, Python raises KeyError.
 import pytest
-import unique_toolkit.chat  # noqa: F401 - must be imported before unique_mcp to
 
 
 @pytest.fixture

--- a/unique_toolkit/unique_toolkit/chat/__init__.py
+++ b/unique_toolkit/unique_toolkit/chat/__init__.py
@@ -1,4 +1,4 @@
-import warnings
+from typing import TYPE_CHECKING, Any
 
 from .cancellation import CancellationEvent as CancellationEvent
 from .cancellation import CancellationWatcher as CancellationWatcher
@@ -9,12 +9,25 @@ from .schemas import ChatMessageAssessmentLabel as ChatMessageAssessmentLabel
 from .schemas import ChatMessageAssessmentStatus as ChatMessageAssessmentStatus
 from .schemas import ChatMessageAssessmentType as ChatMessageAssessmentType
 from .schemas import ChatMessageRole as ChatMessageRole
-
-# Import ChatService with deprecation warning suppressed for internal use
-with warnings.catch_warnings():
-    warnings.simplefilter("ignore", DeprecationWarning)
-    from .service import ChatService as ChatService
-
 from .utils import (
     convert_chat_history_to_injectable_string as convert_chat_history_to_injectable_string,
 )
+
+if TYPE_CHECKING:
+    from .service import ChatService as ChatService
+
+
+def __getattr__(name: str) -> Any:
+    # Lazy import to break the circular dependency:
+    # chat/__init__ → chat/service → chat/deprecated/service → chat/functions → chat/__init__
+    # ChatService here is the deprecated shim; the canonical path is
+    # unique_toolkit.services.chat_service.ChatService.
+    if name == "ChatService":
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            from unique_toolkit.chat.service import ChatService
+
+        return ChatService
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/unique_toolkit/unique_toolkit/chat/__init__.py
+++ b/unique_toolkit/unique_toolkit/chat/__init__.py
@@ -29,5 +29,9 @@ def __getattr__(name: str) -> Any:
             warnings.simplefilter("ignore", DeprecationWarning)
             from unique_toolkit.chat.service import ChatService
 
+        # Cache in globals() per PEP 562: subsequent access resolves via
+        # normal attribute lookup, never re-entering __getattr__ (and
+        # never re-opening the non-thread-safe warnings.catch_warnings()).
+        globals()["ChatService"] = ChatService
         return ChatService
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
## Summary

- `unique_toolkit.chat.deprecated/` was a namespace subpackage (no `__init__.py`), which caused Python's `_NamespacePath._recalculate()` to look up `sys.modules['unique_toolkit.chat']` before the parent module was fully registered — a `KeyError` in Python 3.14 and a circular-import error under pytest `--import-mode=importlib` on earlier versions.
- A temporary `import unique_toolkit.chat` workaround had been added to `unique_mcp/tests/conftest.py` to paper over the symptom; this PR fixes the root cause and removes it.

## Changes

### `unique_toolkit/unique_toolkit/chat/deprecated/__init__.py` (new, empty)
Converts `deprecated/` from a namespace package to a regular package, eliminating the `_NamespacePath` recalculation entirely.

### `unique_toolkit/unique_toolkit/chat/__init__.py`
Replaces the eager `from .service import ChatService` with a `__getattr__`-based lazy import. The eager import created a cycle that was exposed once `deprecated/` became a regular package:
```
chat/__init__ → chat/service (shim)
  → chat/deprecated/service → chat/functions
    → chat/__init__  (re-triggered while partially initialised)
```
A `TYPE_CHECKING` guard keeps the type annotation intact for static analysers.

### `unique_mcp/tests/conftest.py`
Removes the `import unique_toolkit.chat  # noqa: F401` workaround that is no longer needed.

## Test plan

- [x] `cd unique_mcp && uv run pytest` — 77 passed, 0 failed
- [x] `cd unique_toolkit && uv run pytest` — 2899 passed, 12 skipped, 0 failed

## Risk / rollout

Low risk. The public API of `unique_toolkit.chat.ChatService` is unchanged — it still resolves to the same deprecated shim via `__getattr__`. Direct imports (`from unique_toolkit.chat.deprecated.service import ChatServiceDeprecated`) continue to work identically. No migrations required.

Made with [Cursor](https://cursor.com)