### PR TITLE
fix(unique-toolkit): UN-19154 chat_service _LOGGER not appearing in logs

### DIFF
--- a/.github/actions/run-min-tests-and-deptry/action.yml
+++ b/.github/actions/run-min-tests-and-deptry/action.yml
@@ -92,7 +92,7 @@ runs:
         # Package-level dev group: package-specific test deps (e.g. responses for unique_six)
         if python3 <<'EOF'
         import tomllib, pathlib, sys
-        dev = tomllib.loads(pathlib.Path("pyproject.toml").read_bytes()).get("dependency-groups", {}).get("dev")
+        dev = tomllib.loads(pathlib.Path("pyproject.toml").read_text()).get("dependency-groups", {}).get("dev")
         sys.exit(0 if dev is not None else 1)
         EOF
         then

--- a/unique_toolkit/tests/app/test_init_logging.py
+++ b/unique_toolkit/tests/app/test_init_logging.py
@@ -1,0 +1,35 @@
+import io
+import logging
+from logging import StreamHandler
+
+from unique_toolkit.app.init_logging import init_logging, unique_log_config
+
+_PRE_INIT_LOGGER_NAME = "unique_toolkit.tests.app.test_init_logging.pre_init"
+_CUSTOM_CONFIG_LOGGER_NAME = "unique_toolkit.tests.app.test_init_logging.custom_config"
+
+
+def test_pre_init_logger_stays_enabled_after_init_logging() -> None:
+    logger = logging.getLogger(_PRE_INIT_LOGGER_NAME)
+    stream = io.StringIO()
+    handler = StreamHandler(stream)
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+
+    init_logging()
+
+    assert logger.disabled is False
+
+    logger.info("pre-init logger message")
+
+    assert "pre-init logger message" in stream.getvalue()
+
+
+def test_init_logging_merges_disable_existing_loggers_false_into_custom_config() -> (
+    None
+):
+    logger = logging.getLogger(_CUSTOM_CONFIG_LOGGER_NAME)
+    config = {**unique_log_config, "disable_existing_loggers": True}
+
+    init_logging(config)
+
+    assert logger.disabled is False

--- a/unique_toolkit/unique_toolkit/app/init_logging.py
+++ b/unique_toolkit/unique_toolkit/app/init_logging.py
@@ -10,6 +10,7 @@ class UTCFormatter(Formatter):
 
 unique_log_config = {
     "version": 1,
+    "disable_existing_loggers": False,
     "root": {"level": "DEBUG", "handlers": ["console"]},
     "handlers": {
         "console": {
@@ -29,4 +30,5 @@ unique_log_config = {
 
 
 def init_logging(config: dict[str, Any] = unique_log_config):
-    return dictConfig(config)
+    merged_config = {**config, "disable_existing_loggers": False}
+    return dictConfig(merged_config)


### PR DESCRIPTION
## 🚀 Summary
Refs: UN-19154

`ChatService._LOGGER` in `unique_toolkit` did not emit log lines in assistants-core, while `logging.debug()` on the root logger worked. This PR keeps loggers created before `init_logging()` active when `dictConfig` runs.

## Root cause

assistants-core `app.py` imports `code_interpreter_preview_patch` (which pulls in `ChatService` / `chat_service`) before `init_logging()`. Those modules create named loggers early. Python's `logging.config.dictConfig` defaults to `disable_existing_loggers=True`, which disables any logger already registered before configuration runs.

## Plan / fix

- Set `disable_existing_loggers: False` in `unique_log_config`.
- In `init_logging()`, merge `disable_existing_loggers: False` into any passed config before calling `dictConfig`, so custom configs cannot accidentally re-enable the default.

## ✅ Changes

- [x] Fixed bug in `unique_toolkit.app.init_logging`
- [x] Added regression tests in `unique_toolkit/tests/app/test_init_logging.py`

## 🧪 Testing

- [x] `uv run pytest unique_toolkit/tests/app/test_init_logging.py -v` (2 passed)
- [ ] Verify assistants-core logs show `ChatService` logger output after deploy


Made with [Cursor](https://cursor.com)