### PR TITLE
fix(unique-sdk-cli): include dynamic frontend space urls

### DIFF
--- a/unique_sdk/tests/cli/test_dynamic_frontend.py
+++ b/unique_sdk/tests/cli/test_dynamic_frontend.py
@@ -51,6 +51,7 @@ def _space(
     space_id: str = "space_1",
     name: str = "Revenue Dashboard",
     content_id: str = "cont_1",
+    url: str | None = "https://chat.example.com/space/space_1",
     status: dict[str, object] | None = None,
 ) -> _FakeSpace:
     return _FakeSpace(
@@ -59,6 +60,7 @@ def _space(
             "spaceId": space_id,
             "name": name,
             "contentId": content_id,
+            "url": url,
             "status": status,
         }
     )
@@ -185,6 +187,7 @@ def test_cmd_dynamic_frontend_deploy__uploads_file_and_creates_space(
 
     assert 'Created Dynamic Frontend space "Revenue Dashboard" (space_1)' in output
     assert "Content: cont_1" in output
+    assert "URL: https://chat.example.com/space/space_1" in output
     mock_upload_file.assert_called_once_with(
         userId="user_1",
         companyId="company_1",
@@ -219,6 +222,7 @@ def test_cmd_dynamic_frontend_deploy__updates_existing_space(
     )
 
     assert 'Updated Dynamic Frontend space "Revenue Dashboard" (space_1)' in output
+    assert "URL: https://chat.example.com/space/space_1" in output
     mock_modify.assert_called_once_with(
         "space_1",
         user_id="user_1",
@@ -326,12 +330,11 @@ def test_format_space__includes_status_fields() -> None:
     Why this matters: Operators need deployment status and URL from list output.
     Setup summary: Format a fake space with status metadata and assert tabular fields.
     """
-    output = _format_space(
-        _space(status={"phase": "READY", "url": "https://app.example.com"})
-    )
+    output = _format_space(_space(status={"phase": "READY"}))
 
     assert (
-        output == "space_1\tRevenue Dashboard\tcont_1\tREADY\thttps://app.example.com"
+        output
+        == "space_1\tRevenue Dashboard\tcont_1\tREADY\thttps://chat.example.com/space/space_1"
     )
 
 
@@ -345,7 +348,10 @@ def test_cmd_dynamic_frontend_list__formats_spaces(mock_list: MagicMock) -> None
 
     output = cmd_dynamic_frontend_list(_state())
 
-    assert output == "space_1\tRevenue Dashboard\tcont_1"
+    assert (
+        output
+        == "space_1\tRevenue Dashboard\tcont_1\thttps://chat.example.com/space/space_1"
+    )
     mock_list.assert_called_once_with(user_id="user_1", company_id="company_1")
 
 

--- a/unique_sdk/unique_sdk/api_resources/_dynamic_frontend.py
+++ b/unique_sdk/unique_sdk/api_resources/_dynamic_frontend.py
@@ -16,6 +16,7 @@ class DynamicFrontend(APIResource["DynamicFrontend"]):
     spaceId: str
     name: str
     contentId: str
+    url: str | None
     status: dict[str, object] | None
 
     class CreateParams(RequestOptions):

--- a/unique_sdk/unique_sdk/cli/commands/dynamic_frontend.py
+++ b/unique_sdk/unique_sdk/cli/commands/dynamic_frontend.py
@@ -94,7 +94,9 @@ def cmd_dynamic_frontend_deploy(
         space_id_value = getattr(space, "spaceId", None) or getattr(space, "id", "")
         name_value = getattr(space, "name", name or "")
         url_value = getattr(space, "url", None)
-        url_line = f"\nURL: {url_value}" if isinstance(url_value, str) and url_value else ""
+        url_line = (
+            f"\nURL: {url_value}" if isinstance(url_value, str) and url_value else ""
+        )
         return (
             f'{action} Dynamic Frontend space "{name_value}" ({space_id_value})\n'
             f"Content: {resolved_content_id}"

--- a/unique_sdk/unique_sdk/cli/commands/dynamic_frontend.py
+++ b/unique_sdk/unique_sdk/cli/commands/dynamic_frontend.py
@@ -36,10 +36,10 @@ def _format_space(space: object) -> str:
     content_id = getattr(space, "contentId", "")
     status = getattr(space, "status", None)
     phase = ""
-    url = ""
+    url = str(getattr(space, "url", "") or "")
     if isinstance(status, dict):
         phase = str(status.get("phase") or "")
-        url = str(status.get("url") or "")
+        url = url or str(status.get("url") or "")
     return "\t".join(
         part for part in [str(space_id), str(name), str(content_id), phase, url] if part
     )
@@ -93,9 +93,12 @@ def cmd_dynamic_frontend_deploy(
 
         space_id_value = getattr(space, "spaceId", None) or getattr(space, "id", "")
         name_value = getattr(space, "name", name or "")
+        url_value = getattr(space, "url", None)
+        url_line = f"\nURL: {url_value}" if isinstance(url_value, str) and url_value else ""
         return (
             f'{action} Dynamic Frontend space "{name_value}" ({space_id_value})\n'
             f"Content: {resolved_content_id}"
+            f"{url_line}"
         )
     except (ValueError, unique_sdk.APIError, OSError) as e:
         return f"dynamic-frontend deploy: {e}"

--- a/unique_sdk/unique_sdk/cli/skills/unique-cli-dynamic-frontend/SKILL.md
+++ b/unique_sdk/unique_sdk/cli/skills/unique-cli-dynamic-frontend/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: unique-cli-dynamic-frontend
+description: >-
+  Create, update, and list Unique Dynamic Frontend Spaces using the
+  `unique-cli dynamic-frontend` command. Use when deploying a generated
+  Dynamic Frontend ZIP, updating an existing Dynamic Frontend Space bundle,
+  listing manageable Dynamic Frontend Spaces, or when the user mentions
+  Dynamic Frontend Space deployment through the CLI.
+---
+
+# Unique CLI -- Dynamic Frontend Spaces
+
+Use `unique-cli dynamic-frontend` to create or update Dynamic Frontend Spaces
+from upload-ready ZIP bundles or existing Knowledge Base content IDs.
+
+The CLI is installed via `pip install unique-sdk` and uses the same
+`UNIQUE_USER_ID`, `UNIQUE_COMPANY_ID`, `UNIQUE_API_KEY`, `UNIQUE_APP_ID`, and
+`UNIQUE_API_BASE` environment variables as the rest of `unique-cli`.
+
+## Create a New Space
+
+To upload a ZIP and create a new Dynamic Frontend Space:
+
+```bash
+unique-cli cd /Apps
+unique-cli dynamic-frontend deploy \
+  --file ./revenue-dashboard.zip \
+  --name "Revenue Dashboard"
+```
+
+To create from an already uploaded KB content ID:
+
+```bash
+unique-cli dynamic-frontend deploy \
+  --content-id cont_abc123 \
+  --name "Revenue Dashboard"
+```
+
+The command prints the created `spaceId`, `contentId`, and direct `URL` when the
+API returns it:
+
+```text
+Created Dynamic Frontend space "Revenue Dashboard" (space_abc123)
+Content: cont_abc123
+URL: https://chat.example.com/space/space_abc123
+```
+
+## Update an Existing Space
+
+Use `--space-id` to update an existing Dynamic Frontend Space instead of
+creating a new one.
+
+Upload a new ZIP and point the existing Space at it:
+
+```bash
+unique-cli cd /Apps
+unique-cli dynamic-frontend deploy \
+  --space-id space_abc123 \
+  --file ./revenue-dashboard-1.0.1.zip
+```
+
+Update from an already uploaded KB content ID:
+
+```bash
+unique-cli dynamic-frontend deploy \
+  --space-id space_abc123 \
+  --content-id cont_newbundle123
+```
+
+Rename while updating the bundle:
+
+```bash
+unique-cli dynamic-frontend deploy \
+  --space-id space_abc123 \
+  --file ./revenue-dashboard-1.0.1.zip \
+  --name "Revenue Dashboard"
+```
+
+The update command prints the same `spaceId`, `contentId`, and direct `URL`
+fields as create.
+
+## List Spaces
+
+List Dynamic Frontend Spaces the current user can manage:
+
+```bash
+unique-cli dynamic-frontend list
+```
+
+Use JSON output for scripts:
+
+```bash
+unique-cli dynamic-frontend list --json
+unique-cli dynamic-frontend deploy --space-id space_abc123 --file ./app.zip --json
+```
+
+## Rules
+
+- For `--file`, first `unique-cli cd` into the KB folder where the ZIP should be
+  uploaded; uploading to root is rejected.
+- Use `--space-id` for updates. Without `--space-id`, `deploy` creates a new
+  Dynamic Frontend Space and requires `--name`.
+- `--file` and `--content-id` are mutually exclusive.
+- After create or update, return the CLI output to the user, especially the
+  direct `URL`.


### PR DESCRIPTION
## Summary

- Surfaces Dynamic Frontend Space URLs in `unique-cli dynamic-frontend deploy` output.
- Includes top-level `url` values in list formatting, while keeping the existing status URL fallback.
- Adds a bundled `unique-cli-dynamic-frontend` skill documenting create and update workflows with `--space-id`.

## Test plan

- [x] `.venv/bin/python -m pytest tests/cli/test_dynamic_frontend.py`
- [x] `.venv/bin/python -m ruff check unique_sdk/cli/commands/dynamic_frontend.py unique_sdk/api_resources/_dynamic_frontend.py tests/cli/test_dynamic_frontend.py`
- [x] `git diff --check -- unique_sdk/cli/commands/dynamic_frontend.py unique_sdk/api_resources/_dynamic_frontend.py tests/cli/test_dynamic_frontend.py unique_sdk/cli/skills/unique-cli-dynamic-frontend/SKILL.md`

## Notes

- `uv run ...` is currently blocked locally by a parent-level `/Users/andreashauri/unique/dev/ai/pyproject.toml` / `uv.lock` parse issue, so validation used the repo `.venv` directly.

Made with [Cursor](https://cursor.com)