### PR TITLE
feat(unique-sdk-cli): surface dynamic frontend view and config/share urls

### DIFF
--- a/unique_sdk/tests/cli/test_dynamic_frontend.py
+++ b/unique_sdk/tests/cli/test_dynamic_frontend.py
@@ -52,6 +52,7 @@ def _space(
     name: str = "Revenue Dashboard",
     content_id: str = "cont_1",
     url: str | None = "https://chat.example.com/space/space_1",
+    config_url: str | None = "https://admin.example.com/dynamic-frontend-space/space_1",
     status: dict[str, object] | None = None,
 ) -> _FakeSpace:
     return _FakeSpace(
@@ -61,6 +62,7 @@ def _space(
             "name": name,
             "contentId": content_id,
             "url": url,
+            "configUrl": config_url,
             "status": status,
         }
     )
@@ -188,6 +190,9 @@ def test_cmd_dynamic_frontend_deploy__uploads_file_and_creates_space(
     assert 'Created Dynamic Frontend space "Revenue Dashboard" (space_1)' in output
     assert "Content: cont_1" in output
     assert "URL: https://chat.example.com/space/space_1" in output
+    assert (
+        "Config URL: https://admin.example.com/dynamic-frontend-space/space_1" in output
+    )
     mock_upload_file.assert_called_once_with(
         userId="user_1",
         companyId="company_1",
@@ -223,6 +228,9 @@ def test_cmd_dynamic_frontend_deploy__updates_existing_space(
 
     assert 'Updated Dynamic Frontend space "Revenue Dashboard" (space_1)' in output
     assert "URL: https://chat.example.com/space/space_1" in output
+    assert (
+        "Config URL: https://admin.example.com/dynamic-frontend-space/space_1" in output
+    )
     mock_modify.assert_called_once_with(
         "space_1",
         user_id="user_1",
@@ -332,9 +340,10 @@ def test_format_space__includes_status_fields() -> None:
     """
     output = _format_space(_space(status={"phase": "READY"}))
 
-    assert (
-        output
-        == "space_1\tRevenue Dashboard\tcont_1\tREADY\thttps://chat.example.com/space/space_1"
+    assert output == (
+        "space_1\tRevenue Dashboard\tcont_1\tREADY"
+        "\thttps://chat.example.com/space/space_1"
+        "\thttps://admin.example.com/dynamic-frontend-space/space_1"
     )
 
 
@@ -348,9 +357,10 @@ def test_cmd_dynamic_frontend_list__formats_spaces(mock_list: MagicMock) -> None
 
     output = cmd_dynamic_frontend_list(_state())
 
-    assert (
-        output
-        == "space_1\tRevenue Dashboard\tcont_1\thttps://chat.example.com/space/space_1"
+    assert output == (
+        "space_1\tRevenue Dashboard\tcont_1"
+        "\thttps://chat.example.com/space/space_1"
+        "\thttps://admin.example.com/dynamic-frontend-space/space_1"
     )
     mock_list.assert_called_once_with(user_id="user_1", company_id="company_1")
 

--- a/unique_sdk/unique_sdk/api_resources/_dynamic_frontend.py
+++ b/unique_sdk/unique_sdk/api_resources/_dynamic_frontend.py
@@ -17,6 +17,7 @@ class DynamicFrontend(APIResource["DynamicFrontend"]):
     name: str
     contentId: str
     url: str | None
+    configUrl: str | None
     status: dict[str, object] | None
 
     class CreateParams(RequestOptions):

--- a/unique_sdk/unique_sdk/cli/commands/dynamic_frontend.py
+++ b/unique_sdk/unique_sdk/cli/commands/dynamic_frontend.py
@@ -37,11 +37,14 @@ def _format_space(space: object) -> str:
     status = getattr(space, "status", None)
     phase = ""
     url = str(getattr(space, "url", "") or "")
+    config_url = str(getattr(space, "configUrl", "") or "")
     if isinstance(status, dict):
         phase = str(status.get("phase") or "")
         url = url or str(status.get("url") or "")
     return "\t".join(
-        part for part in [str(space_id), str(name), str(content_id), phase, url] if part
+        part
+        for part in [str(space_id), str(name), str(content_id), phase, url, config_url]
+        if part
     )
 
 
@@ -94,13 +97,20 @@ def cmd_dynamic_frontend_deploy(
         space_id_value = getattr(space, "spaceId", None) or getattr(space, "id", "")
         name_value = getattr(space, "name", name or "")
         url_value = getattr(space, "url", None)
+        config_url_value = getattr(space, "configUrl", None)
         url_line = (
             f"\nURL: {url_value}" if isinstance(url_value, str) and url_value else ""
+        )
+        config_url_line = (
+            f"\nConfig URL: {config_url_value}"
+            if isinstance(config_url_value, str) and config_url_value
+            else ""
         )
         return (
             f'{action} Dynamic Frontend space "{name_value}" ({space_id_value})\n'
             f"Content: {resolved_content_id}"
             f"{url_line}"
+            f"{config_url_line}"
         )
     except (ValueError, unique_sdk.APIError, OSError) as e:
         return f"dynamic-frontend deploy: {e}"

--- a/unique_sdk/unique_sdk/cli/skills/unique-cli-dynamic-frontend/SKILL.md
+++ b/unique_sdk/unique_sdk/cli/skills/unique-cli-dynamic-frontend/SKILL.md
@@ -36,13 +36,26 @@ unique-cli dynamic-frontend deploy \
   --name "Revenue Dashboard"
 ```
 
-The command prints the created `spaceId`, `contentId`, and direct `URL` when the
-API returns it:
+The command prints the created `spaceId`, `contentId`, and direct user-facing
+Chat Space `URL` when the API returns it:
 
 ```text
 Created Dynamic Frontend space "Revenue Dashboard" (space_abc123)
 Content: cont_abc123
-URL: https://chat.example.com/space/space_abc123
+URL: https://next.qa.unique.app/chat/space/space_abc123
+```
+
+If the installed SDK/CLI version does not print `URL` yet, construct the
+user-facing Space URL from the Chat frontend base URL and `spaceId`:
+
+```text
+<chat-frontend-url>/space/<spaceId>
+```
+
+On QA, that is:
+
+```text
+https://next.qa.unique.app/chat/space/<spaceId>
 ```
 
 ## Update an Existing Space
@@ -76,8 +89,8 @@ unique-cli dynamic-frontend deploy \
   --name "Revenue Dashboard"
 ```
 
-The update command prints the same `spaceId`, `contentId`, and direct `URL`
-fields as create.
+The update command prints the same `spaceId`, `contentId`, and user-facing
+Chat Space `URL` fields as create.
 
 ## List Spaces
 
@@ -103,3 +116,6 @@ unique-cli dynamic-frontend deploy --space-id space_abc123 --file ./app.zip --js
 - `--file` and `--content-id` are mutually exclusive.
 - After create or update, return the CLI output to the user, especially the
   direct `URL`.
+- Never report the BYOC iframe runtime URL
+  (`https://byoc.../serve/df-assistant-...`) as the Space URL; it is an
+  internal iframe launch URL, not the navigation link users need.

--- a/unique_sdk/unique_sdk/cli/skills/unique-cli-dynamic-frontend/SKILL.md
+++ b/unique_sdk/unique_sdk/cli/skills/unique-cli-dynamic-frontend/SKILL.md
@@ -36,26 +36,32 @@ unique-cli dynamic-frontend deploy \
   --name "Revenue Dashboard"
 ```
 
-The command prints the created `spaceId`, `contentId`, and direct user-facing
-Chat Space `URL` when the API returns it:
+The command prints the created `spaceId`, `contentId`, and **two** URLs when the
+API returns them — the user-facing view `URL` (jump into the Space in the chat
+app) and the `Config URL` (configure and share the Space in the admin app):
 
 ```text
 Created Dynamic Frontend space "Revenue Dashboard" (space_abc123)
 Content: cont_abc123
 URL: https://next.qa.unique.app/chat/space/space_abc123
+Config URL: https://next.qa.unique.app/admin/dynamic-frontend-space/space_abc123
 ```
 
-If the installed SDK/CLI version does not print `URL` yet, construct the
-user-facing Space URL from the Chat frontend base URL and `spaceId`:
+If the installed SDK/CLI version does not print one of these URLs yet, construct
+it from the known frontend base URLs and `spaceId`:
 
 ```text
+# View URL (chat app)
 <chat-frontend-url>/space/<spaceId>
+# Config/share URL (admin app)
+<admin-frontend-url>/dynamic-frontend-space/<spaceId>
 ```
 
-On QA, that is:
+On QA, those are:
 
 ```text
 https://next.qa.unique.app/chat/space/<spaceId>
+https://next.qa.unique.app/admin/dynamic-frontend-space/<spaceId>
 ```
 
 ## Update an Existing Space
@@ -89,8 +95,8 @@ unique-cli dynamic-frontend deploy \
   --name "Revenue Dashboard"
 ```
 
-The update command prints the same `spaceId`, `contentId`, and user-facing
-Chat Space `URL` fields as create.
+The update command prints the same `spaceId`, `contentId`, view `URL`, and
+`Config URL` fields as create.
 
 ## List Spaces
 
@@ -114,8 +120,8 @@ unique-cli dynamic-frontend deploy --space-id space_abc123 --file ./app.zip --js
 - Use `--space-id` for updates. Without `--space-id`, `deploy` creates a new
   Dynamic Frontend Space and requires `--name`.
 - `--file` and `--content-id` are mutually exclusive.
-- After create or update, return the CLI output to the user, especially the
-  direct `URL`.
+- After create or update, return the CLI output to the user, especially both the
+  view `URL` (jump to the Space) and the `Config URL` (configure/share the Space).
 - Never report the BYOC iframe runtime URL
   (`https://byoc.../serve/df-assistant-...`) as the Space URL; it is an
   internal iframe launch URL, not the navigation link users need.


### PR DESCRIPTION
## Summary

The public Dynamic Frontend API returns two URLs per space — a user-facing **view** URL and an admin **config/share** URL. This PR makes the SDK and CLI surface both, and clarifies the related skill so agents never report the internal BYOC iframe URL.

- `DynamicFrontend` resource gains a `configUrl` field.
- `dynamic-frontend deploy` prints a `Config URL:` line (admin configuration/sharing link) alongside the existing `URL:` (chat view link).
- `dynamic-frontend list` appends the config URL as a trailing column.
- `unique-cli-dynamic-frontend` skill documents both URLs, fallback construction, and the BYOC-URL warning.

URL patterns:
- View: `<chat-frontend-url>/space/<spaceId>`
- Config/share: `<admin-frontend-url>/dynamic-frontend-space/<spaceId>`

## Test plan

- [x] `tests/cli/test_dynamic_frontend.py` (19 passed)
- [x] ruff clean