### PR TITLE
feat(unique-sdk-cli): add dynamic frontend delete

### DIFF
--- a/unique_sdk/tests/cli/test_dynamic_frontend.py
+++ b/unique_sdk/tests/cli/test_dynamic_frontend.py
@@ -14,6 +14,7 @@ from unique_sdk.api_resources._dynamic_frontend import DynamicFrontend
 from unique_sdk.cli.cli import main
 from unique_sdk.cli.commands.dynamic_frontend import (
     _format_space,
+    cmd_dynamic_frontend_delete,
     cmd_dynamic_frontend_deploy,
     cmd_dynamic_frontend_list,
 )
@@ -128,6 +129,31 @@ def test_dynamic_frontend_modify__calls_expected_endpoint(
         "user_1",
         "company_1",
         params={"contentId": "cont_2", "name": None},
+    )
+
+
+@patch.object(DynamicFrontend, "_static_request", autospec=True)
+def test_dynamic_frontend_delete__calls_expected_endpoint(
+    mock_request: MagicMock,
+) -> None:
+    """Purpose: Verify deleting a Dynamic Frontend space sends the expected request.
+    Why this matters: Delete must target the existing space by id via DELETE.
+    Setup summary: Mock _static_request, call delete, and assert DELETE path.
+    """
+    mock_request.return_value = _FakeSpace({"spaceId": "space_1", "deleted": True})
+
+    result = DynamicFrontend.delete(
+        "space_1",
+        user_id="user_1",
+        company_id="company_1",
+    )
+
+    assert result["spaceId"] == "space_1"
+    mock_request.assert_called_once_with(
+        "delete",
+        "/dynamic-frontend/space_1",
+        "user_1",
+        "company_1",
     )
 
 
@@ -331,6 +357,60 @@ def test_cmd_dynamic_frontend_deploy__api_error_is_returned(
     )
 
     assert "dynamic-frontend deploy: upstream boom" in output
+
+
+@patch("unique_sdk.DynamicFrontend.delete")
+def test_cmd_dynamic_frontend_delete__deletes_space(mock_delete: MagicMock) -> None:
+    """Purpose: Verify delete removes a space and reports the deleted id.
+    Why this matters: Operators need confirmation the space was removed.
+    Setup summary: Mock delete, call the command, and assert output plus API args.
+    """
+    mock_delete.return_value = _FakeSpace({"spaceId": "space_1", "deleted": True})
+
+    output = cmd_dynamic_frontend_delete(_state(), "space_1")
+
+    assert output == "Deleted Dynamic Frontend space space_1"
+    mock_delete.assert_called_once_with(
+        "space_1",
+        user_id="user_1",
+        company_id="company_1",
+    )
+
+
+def test_cmd_dynamic_frontend_delete__requires_space_id() -> None:
+    """Purpose: Verify delete rejects an empty space id before any API call.
+    Why this matters: A missing id should produce a clear error, not a bad request.
+    Setup summary: Call delete with an empty id and assert the validation message.
+    """
+    assert "provide a space id" in cmd_dynamic_frontend_delete(_state(), "")
+
+
+@patch("unique_sdk.DynamicFrontend.delete")
+def test_cmd_dynamic_frontend_delete__json_output(mock_delete: MagicMock) -> None:
+    """Purpose: Verify delete can emit raw JSON for scripting.
+    Why this matters: Automation consumers need machine-readable confirmation.
+    Setup summary: Mock delete, request JSON output, and parse the result.
+    """
+    mock_delete.return_value = _FakeSpace({"spaceId": "space_1", "deleted": True})
+
+    output = cmd_dynamic_frontend_delete(_state(), "space_1", output_json=True)
+
+    assert json.loads(output)["deleted"] is True
+
+
+@patch("unique_sdk.DynamicFrontend.delete")
+def test_cmd_dynamic_frontend_delete__api_error_is_returned(
+    mock_delete: MagicMock,
+) -> None:
+    """Purpose: Verify delete reports SDK API errors as CLI output.
+    Why this matters: CLI callers should receive actionable errors instead of tracebacks.
+    Setup summary: Make delete raise APIError and assert the returned message.
+    """
+    mock_delete.side_effect = unique_sdk.APIError("upstream boom")
+
+    output = cmd_dynamic_frontend_delete(_state(), "space_1")
+
+    assert "dynamic-frontend delete: upstream boom" in output
 
 
 def test_format_space__includes_status_fields() -> None:

--- a/unique_sdk/unique_sdk/api_resources/_dynamic_frontend.py
+++ b/unique_sdk/unique_sdk/api_resources/_dynamic_frontend.py
@@ -66,6 +66,24 @@ class DynamicFrontend(APIResource["DynamicFrontend"]):
         )
 
     @classmethod
+    def delete(
+        cls,
+        space_id: str,
+        user_id: str,
+        company_id: str,
+    ) -> "DynamicFrontend":
+        """Delete a deployed Dynamic Frontend space."""
+        return cast(
+            DynamicFrontend,
+            cls._static_request(
+                "delete",
+                f"/dynamic-frontend/{space_id}",
+                user_id,
+                company_id,
+            ),
+        )
+
+    @classmethod
     def list(
         cls,
         user_id: str,

--- a/unique_sdk/unique_sdk/cli/cli.py
+++ b/unique_sdk/unique_sdk/cli/cli.py
@@ -9,6 +9,7 @@ import click
 from unique_sdk.cli import __version__
 from unique_sdk.cli.commands.cite_file import cmd_cite_file
 from unique_sdk.cli.commands.dynamic_frontend import (
+    cmd_dynamic_frontend_delete,
     cmd_dynamic_frontend_deploy,
     cmd_dynamic_frontend_list,
 )
@@ -480,7 +481,7 @@ def read_cmd(
 
 @main.group(name="dynamic-frontend")
 def dynamic_frontend() -> None:
-    """Deploy and list Dynamic Frontend spaces."""
+    """Deploy, list, and delete Dynamic Frontend spaces."""
 
 
 @dynamic_frontend.command(name="deploy")
@@ -545,6 +546,29 @@ def dynamic_frontend_deploy(
 def dynamic_frontend_list(ctx: click.Context, output_json: bool) -> None:
     """List Dynamic Frontend spaces the current user can manage."""
     output = cmd_dynamic_frontend_list(LazyState.get(ctx), output_json=output_json)
+    click.echo(output)
+    if output.startswith(_DYNAMIC_FRONTEND_ERROR_PREFIX):
+        ctx.exit(1)
+
+
+@dynamic_frontend.command(name="delete")
+@click.argument("space_id")
+@click.option(
+    "--json", "output_json", is_flag=True, default=False, help="Print raw JSON."
+)
+@click.pass_context
+def dynamic_frontend_delete(
+    ctx: click.Context, space_id: str, output_json: bool
+) -> None:
+    """Delete a deployed Dynamic Frontend space by its space id.
+
+    \b
+    Example:
+      unique-cli dynamic-frontend delete assistant_123
+    """
+    output = cmd_dynamic_frontend_delete(
+        LazyState.get(ctx), space_id, output_json=output_json
+    )
     click.echo(output)
     if output.startswith(_DYNAMIC_FRONTEND_ERROR_PREFIX):
         ctx.exit(1)

--- a/unique_sdk/unique_sdk/cli/commands/dynamic_frontend.py
+++ b/unique_sdk/unique_sdk/cli/commands/dynamic_frontend.py
@@ -133,9 +133,7 @@ def cmd_dynamic_frontend_delete(
         if output_json:
             return json.dumps(dict(result), indent=2, default=str)
         deleted_id = (
-            getattr(result, "spaceId", None)
-            or getattr(result, "id", None)
-            or space_id
+            getattr(result, "spaceId", None) or getattr(result, "id", None) or space_id
         )
         return f"Deleted Dynamic Frontend space {deleted_id}"
     except (ValueError, unique_sdk.APIError) as e:

--- a/unique_sdk/unique_sdk/cli/commands/dynamic_frontend.py
+++ b/unique_sdk/unique_sdk/cli/commands/dynamic_frontend.py
@@ -116,6 +116,32 @@ def cmd_dynamic_frontend_deploy(
         return f"dynamic-frontend deploy: {e}"
 
 
+def cmd_dynamic_frontend_delete(
+    state: ShellState,
+    space_id: str,
+    *,
+    output_json: bool = False,
+) -> str:
+    try:
+        if not space_id:
+            return "dynamic-frontend delete: provide a space id."
+        result = unique_sdk.DynamicFrontend.delete(
+            space_id,
+            user_id=state.config.user_id,
+            company_id=state.config.company_id,
+        )
+        if output_json:
+            return json.dumps(dict(result), indent=2, default=str)
+        deleted_id = (
+            getattr(result, "spaceId", None)
+            or getattr(result, "id", None)
+            or space_id
+        )
+        return f"Deleted Dynamic Frontend space {deleted_id}"
+    except (ValueError, unique_sdk.APIError) as e:
+        return f"dynamic-frontend delete: {e}"
+
+
 def cmd_dynamic_frontend_list(state: ShellState, *, output_json: bool = False) -> str:
     try:
         spaces = unique_sdk.DynamicFrontend.list(

--- a/unique_sdk/unique_sdk/cli/skills/unique-cli-dynamic-frontend/SKILL.md
+++ b/unique_sdk/unique_sdk/cli/skills/unique-cli-dynamic-frontend/SKILL.md
@@ -1,17 +1,19 @@
 ---
 name: unique-cli-dynamic-frontend
 description: >-
-  Create, update, and list Unique Dynamic Frontend Spaces using the
+  Create, update, list, and delete Unique Dynamic Frontend Spaces using the
   `unique-cli dynamic-frontend` command. Use when deploying a generated
   Dynamic Frontend ZIP, updating an existing Dynamic Frontend Space bundle,
-  listing manageable Dynamic Frontend Spaces, or when the user mentions
-  Dynamic Frontend Space deployment through the CLI.
+  listing manageable Dynamic Frontend Spaces, deleting a deployed Dynamic
+  Frontend Space, or when the user mentions Dynamic Frontend Space deployment
+  through the CLI.
 ---
 
 # Unique CLI -- Dynamic Frontend Spaces
 
-Use `unique-cli dynamic-frontend` to create or update Dynamic Frontend Spaces
-from upload-ready ZIP bundles or existing Knowledge Base content IDs.
+Use `unique-cli dynamic-frontend` to create, update, list, and delete Dynamic
+Frontend Spaces from upload-ready ZIP bundles or existing Knowledge Base
+content IDs.
 
 The CLI is installed via `pip install unique-sdk` and uses the same
 `UNIQUE_USER_ID`, `UNIQUE_COMPANY_ID`, `UNIQUE_API_KEY`, `UNIQUE_APP_ID`, and
@@ -130,6 +132,7 @@ Use JSON output for scripts:
 ```bash
 unique-cli dynamic-frontend list --json
 unique-cli dynamic-frontend deploy --space-id space_abc123 --file ./app.zip --json
+unique-cli dynamic-frontend delete space_abc123 --json
 ```
 
 ## Rules

--- a/unique_sdk/unique_sdk/cli/skills/unique-cli-dynamic-frontend/SKILL.md
+++ b/unique_sdk/unique_sdk/cli/skills/unique-cli-dynamic-frontend/SKILL.md
@@ -98,6 +98,25 @@ unique-cli dynamic-frontend deploy \
 The update command prints the same `spaceId`, `contentId`, view `URL`, and
 `Config URL` fields as create.
 
+## Delete a Space
+
+Remove a deployed Dynamic Frontend Space by its space id. This deletes the
+backing BYOC app and the owning space (and its access grants):
+
+```bash
+unique-cli dynamic-frontend delete space_abc123
+```
+
+The command prints a confirmation:
+
+```text
+Deleted Dynamic Frontend space space_abc123
+```
+
+Deletion is permanent and requires manage access on the space (or a
+company-wide space-admin role). Always confirm the correct `spaceId` with the
+user before deleting — there is no undo.
+
 ## List Spaces
 
 List Dynamic Frontend Spaces the current user can manage:
@@ -120,6 +139,8 @@ unique-cli dynamic-frontend deploy --space-id space_abc123 --file ./app.zip --js
 - Use `--space-id` for updates. Without `--space-id`, `deploy` creates a new
   Dynamic Frontend Space and requires `--name`.
 - `--file` and `--content-id` are mutually exclusive.
+- `delete` is permanent and has no undo — confirm the `spaceId` with the user
+  first, and never guess which space to delete.
 - After create or update, return the CLI output to the user, especially both the
   view `URL` (jump to the Space) and the `Config URL` (configure/share the Space).
 - Never report the BYOC iframe runtime URL


### PR DESCRIPTION
## Summary

Adds support for **removing a deployed Dynamic Frontend space** via the SDK and CLI, matching the new public `DELETE /dynamic-frontend/:spaceId` endpoint (Unique-AG/monorepo PR #25394).

- `DynamicFrontend.delete(space_id, user_id, company_id)` → calls `DELETE /dynamic-frontend/{space_id}`.
- `unique-cli dynamic-frontend delete <spaceId>` → prints `Deleted Dynamic Frontend space <spaceId>`, supports `--json`, exits non-zero on error.
- `unique-cli-dynamic-frontend` skill documents the command with a permanent/no-undo warning.

## Test plan

- [x] `tests/cli/test_dynamic_frontend.py` — 24 passed (resource DELETE path, CLI delete success/json/validation/API-error)
- [x] ruff clean

Made with [Cursor](https://cursor.com)