### PR TITLE
feat(sdk): add autoApproveElicitation to Space.CreateMessageParams

### DIFF
--- a/unique_sdk/unique_sdk/api_resources/_space.py
+++ b/unique_sdk/unique_sdk/api_resources/_space.py
@@ -92,6 +92,7 @@ class Space(APIResource["Space"]):
         skillChoices: NotRequired[list[dict[str, Any]]]
         scopeRules: NotRequired[dict[str, Any] | None]
         correlation: NotRequired["Space.Correlation | None"]
+        autoApproveElicitation: NotRequired[bool]
 
     class GetChatMessagesParams(RequestOptions):
         """

--- a/unique_sdk/unique_sdk/utils/chat_in_space.py
+++ b/unique_sdk/unique_sdk/utils/chat_in_space.py
@@ -25,6 +25,7 @@ async def send_message_and_wait_for_completion(
     stop_condition: Literal["stoppedStreamingAt", "completedAt"] = "stoppedStreamingAt",
     correlation: "Space.Correlation | None" = None,
     on_message_update: Callable[["Space.Message"], Awaitable[None]] | None = None,
+    auto_approve_elicitation: bool | None = None,
 ) -> "Space.Message":
     """
     Sends a prompt asynchronously and polls for completion. (until stoppedStreamingAt is not None)
@@ -45,6 +46,8 @@ async def send_message_and_wait_for_completion(
             Should contain: parentMessageId, parentChatId, parentAssistantId.
         on_message_update: Optional async callback called whenever the latest assistant
             message changes while waiting for completion.
+        auto_approve_elicitation: When True, automatically approves any elicitation requests
+            triggered during the assistant run. Use for non-interactive (SDK/automation) contexts.
 
     Returns:
         The completed Space.Message.
@@ -59,6 +62,7 @@ async def send_message_and_wait_for_completion(
         skillChoices=list(skill_choices),
         scopeRules=scope_rules,
         correlation=correlation,
+        **({"autoApproveElicitation": auto_approve_elicitation} if auto_approve_elicitation is not None else {}),
     )
     chat_id = response.get("chatId")
     message_id = response.get("id")


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `autoApproveElicitation: NotRequired[bool]` to `Space.CreateMessageParams`
- Adds `auto_approve_elicitation: bool | None = None` parameter to `send_message_and_wait_for_completion()`

## Motivation

Allows SDK callers to pass `auto_approve_elicitation=True` when making non-interactive space calls, preventing indefinite hangs when MCP tools trigger elicitation prompts that no user is present to answer.

## Usage

```python
response = await send_message_and_wait_for_completion(
    user_id=user_id,
    company_id=company_id,
    assistant_id=assistant_id,
    text="Run the analysis",
    auto_approve_elicitation=True,
)
```

## Jira

https://unique-ch.atlassian.net/browse/UN-21650
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TrkztSfqDU6w7vgMCcfmH1)_