### PR TITLE
feat(uqadm): add kb download to export KB scope to local folder

### DIFF
--- a/uqadm/CHANGELOG.md
+++ b/uqadm/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-## Unreleased
-
-### Features
-
-* **uqadm:** add `kb download` to export KB scope contents to a local folder ([UN-22079](https://unique-ch.atlassian.net/browse/UN-22079))
-
 ## [2026.24.0](https://github.com/Unique-AG/ai/compare/uqadm-v2026.22.0...uqadm-v2026.24.0) (2026-06-04)
 
 

--- a/uqadm/CHANGELOG.md
+++ b/uqadm/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+* **uqadm:** add `kb download` to export KB scope contents to a local folder ([UN-22079](https://unique-ch.atlassian.net/browse/UN-22079))
+
 ## [2026.24.0](https://github.com/Unique-AG/ai/compare/uqadm-v2026.22.0...uqadm-v2026.24.0) (2026-06-04)
 
 

--- a/uqadm/README.md
+++ b/uqadm/README.md
@@ -3,7 +3,7 @@
 Admin CLI for the Unique platform. It groups these command families:
 
 - **`space`** — list, export, diff, migrate, upsert, access grants, ingestion settings, and delete assistant spaces.
-- **`kb`** — knowledge-base folders: create paths, grant group access, set folder ingestion config.
+- **`kb`** — knowledge-base folders: create paths, sync/download files, grant group access, set folder ingestion config.
 - **`chat`** — send messages to an assistant and inspect chat history.
 - **`env`** — manage named credential slots stored in `~/.uqadm/envs/`.
 - **`install`** — one-time bootstrap: create directories, install shell completion, set up your first slot.
@@ -425,6 +425,27 @@ uqadm kb sync ./docs --scope-id scope_abc -r --slot qa
 | `--scope-id` | Target folder scope id (mutually exclusive with ``--folder-path``). |
 | `-r`, `--recursive` | Recurse into subdirectories, mirroring them as child KB folders. |
 | `--dry-run` | Show planned uploads without writing anything. |
+| `--slot SLOT` | Credential slot. |
+
+### `kb download`
+
+Download files from a KB folder scope into a local directory. Requires exactly
+one of ``--folder-path`` or ``--scope-id``. Without ``--recursive`` only
+top-level files are downloaded; with it, subfolders are recreated as child
+directories under ``LOCAL_DIR``.
+
+```bash
+uqadm kb download ./out --folder-path /Dept/HR
+uqadm kb download ./out --folder-path /Dept/HR -r --dry-run
+uqadm kb download ./out --scope-id scope_abc -r --slot qa
+```
+
+| Option | Description |
+|--------|-------------|
+| `--folder-path` | Source KB folder path (mutually exclusive with ``--scope-id``). |
+| `--scope-id` | Source folder scope id (mutually exclusive with ``--folder-path``). |
+| `-r`, `--recursive` | Recurse into subfolders, mirroring them as local subdirectories. |
+| `--dry-run` | Show planned downloads without writing anything. |
 | `--slot SLOT` | Credential slot. |
 
 ### `kb access grant`

--- a/uqadm/tests/test_cli_help.py
+++ b/uqadm/tests/test_cli_help.py
@@ -171,6 +171,17 @@ def test_kb_ingestion_set_help() -> None:
     assert "uqadm kb ingestion set" in result_output
 
 
+def test_kb_download_help() -> None:
+    invoke_help = _make_help_invoker()
+    result_output = invoke_help(["kb", "download", "--help"])
+    assert "--folder-path" in result_output
+    assert "--scope-id" in result_output
+    assert "--recursive" in result_output or "-r" in result_output
+    assert "--dry-run" in result_output
+    assert "Examples:" in result_output
+    assert "uqadm kb download" in result_output
+
+
 def test_space_access_grant_help() -> None:
     invoke_help = _make_help_invoker()
     result_output = invoke_help(["space", "access-grant", "--help"])

--- a/uqadm/tests/test_kb_cli.py
+++ b/uqadm/tests/test_kb_cli.py
@@ -100,6 +100,25 @@ def test_kb_download_cli_invokes_helper(
     assert kw["dry_run"] is True
 
 
+@patch("uqadm.kb.cmd_download")
+@patch("uqadm.kb.config_for_slot")
+@patch("uqadm.kb.resolve_slot", return_value="qa")
+def test_kb_download_rejects_existing_file_target(
+    mock_resolve: MagicMock,
+    mock_cfg: MagicMock,
+    mock_download: MagicMock,
+    tmp_path: Path,
+) -> None:
+    existing_file = tmp_path / "out.txt"
+    existing_file.write_text("data", encoding="utf-8")
+    result = _runner().invoke(
+        app,
+        ["kb", "download", str(existing_file), "--scope-id", "scope_x"],
+    )
+    assert result.exit_code == 2
+    mock_download.assert_not_called()
+
+
 @patch("uqadm.kb.cmd_access_grant")
 @patch("uqadm.kb.config_for_slot")
 @patch("uqadm.kb.resolve_slot", return_value="qa")

--- a/uqadm/tests/test_kb_cli.py
+++ b/uqadm/tests/test_kb_cli.py
@@ -75,6 +75,31 @@ def test_kb_sync_cli_invokes_helper(
     assert kw["dry_run"] is True
 
 
+@patch("uqadm.kb.cmd_download")
+@patch("uqadm.kb.config_for_slot")
+@patch("uqadm.kb.resolve_slot", return_value="qa")
+def test_kb_download_cli_invokes_helper(
+    mock_resolve: MagicMock,
+    mock_cfg: MagicMock,
+    mock_download: MagicMock,
+    tmp_path: Path,
+) -> None:
+    mock_cfg.return_value = MagicMock(user_id="u1", company_id="c1")
+    out_dir = tmp_path / "out"
+    result = _runner().invoke(
+        app,
+        ["kb", "download", str(out_dir), "--scope-id", "scope_x", "-r", "--dry-run"],
+    )
+    assert result.exit_code == 0
+    mock_download.assert_called_once()
+    kw = mock_download.call_args.kwargs
+    assert kw["local_dir"] == out_dir
+    assert kw["folder_path"] is None
+    assert kw["scope_id"] == "scope_x"
+    assert kw["recursive"] is True
+    assert kw["dry_run"] is True
+
+
 @patch("uqadm.kb.cmd_access_grant")
 @patch("uqadm.kb.config_for_slot")
 @patch("uqadm.kb.resolve_slot", return_value="qa")

--- a/uqadm/tests/test_kb_download.py
+++ b/uqadm/tests/test_kb_download.py
@@ -215,5 +215,116 @@ def test_scope_id_entry_point(
     )
 
     folder.resolve_scope_id_from_folder_path.assert_not_called()
+    folder.get_folder_path.assert_called_once()
     download.assert_called_once()
     assert download.call_args.kwargs["content_id"] == "cont_1"
+
+
+@patch("uqadm.kb.download.download_content")
+@patch("uqadm.kb.download.Folder")
+@patch("uqadm.kb.download.Content")
+def test_invalid_scope_id_exits_1(
+    content: MagicMock,
+    folder: MagicMock,
+    download: MagicMock,
+    tmp_path: Path,
+) -> None:
+    folder.get_folder_path.side_effect = Exception("not found")
+    out_dir = tmp_path / "out"
+
+    with pytest.raises(SystemExit) as exc:
+        cmd_download(
+            _cfg(),
+            local_dir=out_dir,
+            folder_path=None,
+            scope_id="scope_missing",
+            recursive=False,
+            dry_run=False,
+        )
+    assert exc.value.code == 1
+    content.get_infos.assert_not_called()
+    download.assert_not_called()
+
+
+@patch("uqadm.kb.download.download_content")
+@patch("uqadm.kb.download.Folder")
+@patch("uqadm.kb.download.Content")
+def test_path_traversal_key_is_rejected(
+    content: MagicMock,
+    folder: MagicMock,
+    download: MagicMock,
+    tmp_path: Path,
+) -> None:
+    folder.resolve_scope_id_from_folder_path.return_value = "scope1"
+    content.get_infos.return_value = {
+        "contentInfos": [{"id": "cont_evil", "key": "../../escape.txt"}],
+        "totalCount": 1,
+    }
+    out_dir = tmp_path / "out"
+
+    with pytest.raises(SystemExit) as exc:
+        cmd_download(
+            _cfg(),
+            local_dir=out_dir,
+            folder_path="/X",
+            scope_id=None,
+            recursive=False,
+            dry_run=False,
+        )
+    assert exc.value.code == 1
+    download.assert_not_called()
+    assert not (tmp_path / "escape.txt").exists()
+
+
+@patch("uqadm.kb.download.download_content")
+@patch("uqadm.kb.download.Folder")
+@patch("uqadm.kb.download.Content")
+def test_path_traversal_via_subfolder_is_rejected(
+    content: MagicMock,
+    folder: MagicMock,
+    download: MagicMock,
+    tmp_path: Path,
+) -> None:
+    folder.resolve_scope_id_from_folder_path.return_value = "scope1"
+
+    def content_side_effect(
+        user_id: str,
+        company_id: str,
+        **kwargs: object,
+    ) -> dict[str, object]:
+        if kwargs.get("parentId") == "scope_evil":
+            return {
+                "contentInfos": [{"id": "cont_x", "key": "loot.txt"}],
+                "totalCount": 1,
+            }
+        return _no_content()
+
+    content.get_infos.side_effect = content_side_effect
+
+    def folder_side_effect(
+        user_id: str,
+        company_id: str,
+        **kwargs: object,
+    ) -> dict[str, object]:
+        if kwargs.get("parentId") == "scope1":
+            return {
+                "folderInfos": [{"id": "scope_evil", "name": "../.."}],
+                "totalCount": 1,
+            }
+        return _no_folders()
+
+    folder.get_infos.side_effect = folder_side_effect
+    out_dir = tmp_path / "out"
+
+    with pytest.raises(SystemExit) as exc:
+        cmd_download(
+            _cfg(),
+            local_dir=out_dir,
+            folder_path="/X",
+            scope_id=None,
+            recursive=True,
+            dry_run=False,
+        )
+    assert exc.value.code == 1
+    download.assert_not_called()
+    assert not (tmp_path / "loot.txt").exists()

--- a/uqadm/tests/test_kb_download.py
+++ b/uqadm/tests/test_kb_download.py
@@ -142,6 +142,7 @@ def test_dry_run_does_not_download(
     )
 
     download.assert_not_called()
+    assert not out_dir.exists()
 
 
 def test_missing_target_selector_exits_2(tmp_path: Path) -> None:

--- a/uqadm/tests/test_kb_download.py
+++ b/uqadm/tests/test_kb_download.py
@@ -1,0 +1,218 @@
+"""Unit tests for ``uqadm kb download`` (``cmd_download``)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from uqadm.kb.download import cmd_download
+
+
+def _cfg() -> SimpleNamespace:
+    return SimpleNamespace(user_id="u1", company_id="c1")
+
+
+def _no_content() -> dict[str, object]:
+    return {"contentInfos": [], "totalCount": 0}
+
+
+def _no_folders() -> dict[str, object]:
+    return {"folderInfos": [], "totalCount": 0}
+
+
+@patch("uqadm.kb.download.download_content")
+@patch("uqadm.kb.download.Folder")
+@patch("uqadm.kb.download.Content")
+def test_single_file_downloaded(
+    content: MagicMock,
+    folder: MagicMock,
+    download: MagicMock,
+    tmp_path: Path,
+) -> None:
+    folder.resolve_scope_id_from_folder_path.return_value = "scope1"
+    content.get_infos.return_value = {
+        "contentInfos": [{"id": "cont_1", "key": "a.txt"}],
+        "totalCount": 1,
+    }
+    out_dir = tmp_path / "out"
+
+    cmd_download(
+        _cfg(),
+        local_dir=out_dir,
+        folder_path="/X",
+        scope_id=None,
+        recursive=False,
+        dry_run=False,
+    )
+
+    download.assert_called_once()
+    kwargs = download.call_args.kwargs
+    assert kwargs["content_id"] == "cont_1"
+    assert kwargs["target_path"] == out_dir / "a.txt"
+
+
+@patch("uqadm.kb.download.download_content")
+@patch("uqadm.kb.download.Folder")
+@patch("uqadm.kb.download.Content")
+def test_recursive_downloads_nested_folder_files(
+    content: MagicMock,
+    folder: MagicMock,
+    download: MagicMock,
+    tmp_path: Path,
+) -> None:
+    folder.resolve_scope_id_from_folder_path.return_value = "scope1"
+
+    def content_side_effect(
+        user_id: str,
+        company_id: str,
+        **kwargs: object,
+    ) -> dict[str, object]:
+        parent_id = kwargs.get("parentId")
+        if parent_id == "scope1":
+            return {
+                "contentInfos": [{"id": "cont_top", "key": "top.txt"}],
+                "totalCount": 1,
+            }
+        if parent_id == "scope_sub":
+            return {
+                "contentInfos": [{"id": "cont_nested", "key": "nested.txt"}],
+                "totalCount": 1,
+            }
+        return _no_content()
+
+    content.get_infos.side_effect = content_side_effect
+
+    def folder_side_effect(
+        user_id: str,
+        company_id: str,
+        **kwargs: object,
+    ) -> dict[str, object]:
+        parent_id = kwargs.get("parentId")
+        if parent_id == "scope1":
+            return {
+                "folderInfos": [{"id": "scope_sub", "name": "sub"}],
+                "totalCount": 1,
+            }
+        return _no_folders()
+
+    folder.get_infos.side_effect = folder_side_effect
+    out_dir = tmp_path / "out"
+
+    cmd_download(
+        _cfg(),
+        local_dir=out_dir,
+        folder_path="/X",
+        scope_id=None,
+        recursive=True,
+        dry_run=False,
+    )
+
+    assert download.call_count == 2
+    paths = {call.kwargs["target_path"] for call in download.call_args_list}
+    assert out_dir / "top.txt" in paths
+    assert out_dir / "sub" / "nested.txt" in paths
+
+
+@patch("uqadm.kb.download.download_content")
+@patch("uqadm.kb.download.Folder")
+@patch("uqadm.kb.download.Content")
+def test_dry_run_does_not_download(
+    content: MagicMock,
+    folder: MagicMock,
+    download: MagicMock,
+    tmp_path: Path,
+) -> None:
+    folder.resolve_scope_id_from_folder_path.return_value = "scope1"
+    content.get_infos.return_value = {
+        "contentInfos": [{"id": "cont_1", "key": "a.txt"}],
+        "totalCount": 1,
+    }
+    out_dir = tmp_path / "out"
+
+    cmd_download(
+        _cfg(),
+        local_dir=out_dir,
+        folder_path="/X",
+        scope_id=None,
+        recursive=False,
+        dry_run=True,
+    )
+
+    download.assert_not_called()
+
+
+def test_missing_target_selector_exits_2(tmp_path: Path) -> None:
+    with pytest.raises(SystemExit) as exc:
+        cmd_download(
+            _cfg(),
+            local_dir=tmp_path,
+            folder_path=None,
+            scope_id=None,
+            recursive=False,
+            dry_run=False,
+        )
+    assert exc.value.code == 2
+
+
+@patch("uqadm.kb.download.download_content")
+@patch("uqadm.kb.download.Folder")
+@patch("uqadm.kb.download.Content")
+def test_partial_failure_exits_1(
+    content: MagicMock,
+    folder: MagicMock,
+    download: MagicMock,
+    tmp_path: Path,
+) -> None:
+    folder.resolve_scope_id_from_folder_path.return_value = "scope1"
+    content.get_infos.return_value = {
+        "contentInfos": [
+            {"id": "cont_ok", "key": "ok.txt"},
+            {"id": "cont_bad", "key": "bad.txt"},
+        ],
+        "totalCount": 2,
+    }
+    download.side_effect = [Path(tmp_path / "ok.txt"), Exception("network error")]
+    out_dir = tmp_path / "out"
+
+    with pytest.raises(SystemExit) as exc:
+        cmd_download(
+            _cfg(),
+            local_dir=out_dir,
+            folder_path="/X",
+            scope_id=None,
+            recursive=False,
+            dry_run=False,
+        )
+    assert exc.value.code == 1
+
+
+@patch("uqadm.kb.download.download_content")
+@patch("uqadm.kb.download.Folder")
+@patch("uqadm.kb.download.Content")
+def test_scope_id_entry_point(
+    content: MagicMock,
+    folder: MagicMock,
+    download: MagicMock,
+    tmp_path: Path,
+) -> None:
+    content.get_infos.return_value = {
+        "contentInfos": [{"id": "cont_1", "key": "doc.pdf"}],
+        "totalCount": 1,
+    }
+    out_dir = tmp_path / "out"
+
+    cmd_download(
+        _cfg(),
+        local_dir=out_dir,
+        folder_path=None,
+        scope_id="scope_abc",
+        recursive=False,
+        dry_run=False,
+    )
+
+    folder.resolve_scope_id_from_folder_path.assert_not_called()
+    download.assert_called_once()
+    assert download.call_args.kwargs["content_id"] == "cont_1"

--- a/uqadm/tests/test_kb_paths.py
+++ b/uqadm/tests/test_kb_paths.py
@@ -1,0 +1,30 @@
+"""Unit tests for the shared kb path-join helper."""
+
+from __future__ import annotations
+
+import pytest
+
+from uqadm.kb._paths import join_path_segments
+
+
+@pytest.mark.parametrize(
+    ("left", "right", "expected"),
+    [
+        # Absolute KB folder paths (kb sync): leading slash preserved.
+        ("/some/path", "", "/some/path"),
+        ("/some/path", "sub", "/some/path/sub"),
+        ("/some/path", "a/b", "/some/path/a/b"),
+        # KB root: the leading slash must survive even though rstrip empties it.
+        ("/", "sub", "/sub"),
+        ("/", "", ""),
+        # Relative subdirs (kb download): no spurious leading slash.
+        ("", "child", "child"),
+        ("a/b", "child", "a/b/child"),
+        ("a/b", "", "a/b"),
+        # Whitespace and redundant separators are collapsed.
+        (" /some/path/ ", " sub ", "/some/path/sub"),
+        ("/some/path/", "/sub", "/some/path/sub"),
+    ],
+)
+def test_join_path_segments(left: str, right: str, expected: str) -> None:
+    assert join_path_segments(left, right) == expected

--- a/uqadm/uqadm/kb/__init__.py
+++ b/uqadm/uqadm/kb/__init__.py
@@ -10,6 +10,7 @@ import typer
 from uqadm.core.env import MissingSlotEnvFileError, config_for_slot
 from uqadm.core.slot import MissingDefaultSlotError, resolve_slot
 from uqadm.kb.access import cmd_access_grant
+from uqadm.kb.download import cmd_download
 from uqadm.kb.ingestion import cmd_ingestion_set
 from uqadm.kb.mkdir import cmd_mkdir
 from uqadm.kb.sync import cmd_sync
@@ -18,7 +19,8 @@ kb_app = typer.Typer(
     name="kb",
     help=(
         "Knowledge-base folder administration: create paths (Folder.create_paths), "
-        "grant group access (Folder.add_access), set ingestion (Folder.update_ingestion_config)."
+        "sync/download files, grant group access (Folder.add_access), set ingestion "
+        "(Folder.update_ingestion_config)."
     ),
     no_args_is_help=True,
 )
@@ -186,6 +188,72 @@ def kb_sync(
     resolved_slot = _resolve(slot)
     cfg = _load_cfg(resolved_slot, _get_cwd(ctx))
     cmd_sync(
+        cfg,
+        local_dir=local_dir,
+        folder_path=folder_path,
+        scope_id=scope_id,
+        recursive=recursive,
+        dry_run=dry_run,
+    )
+
+
+@kb_app.command(
+    "download", short_help="Download KB scope contents into a local folder."
+)
+def kb_download(
+    ctx: typer.Context,
+    local_dir: Annotated[
+        Path,
+        typer.Argument(
+            help="Local folder where KB files are written.",
+        ),
+    ],
+    slot: Annotated[Optional[str], typer.Option("--slot", help=_SLOT_HELP)] = None,
+    folder_path: Annotated[
+        Optional[str],
+        typer.Option(
+            "--folder-path",
+            help="Source KB folder path (mutually exclusive with --scope-id).",
+        ),
+    ] = None,
+    scope_id: Annotated[
+        Optional[str],
+        typer.Option(
+            "--scope-id",
+            help="Source folder scope id (mutually exclusive with --folder-path).",
+        ),
+    ] = None,
+    recursive: Annotated[
+        bool,
+        typer.Option(
+            "--recursive",
+            "-r",
+            help="Recurse into subfolders, mirroring them as local subdirectories.",
+        ),
+    ] = False,
+    dry_run: Annotated[
+        bool,
+        typer.Option(
+            "--dry-run",
+            help="Show planned downloads without writing anything.",
+        ),
+    ] = False,
+) -> None:
+    """Download files from a knowledge-base folder into LOCAL_DIR.
+
+    Requires exactly one of ``--folder-path`` or ``--scope-id`` to name the
+    source scope. Without ``--recursive`` only top-level files are downloaded;
+    with it, subfolders are recreated as child directories under LOCAL_DIR.
+
+    Examples:
+
+      uqadm kb download ./out --folder-path /Dept/HR
+      uqadm kb download ./out --folder-path /Dept/HR -r --dry-run
+      uqadm kb download ./out --scope-id scope_abc -r --slot qa
+    """
+    resolved_slot = _resolve(slot)
+    cfg = _load_cfg(resolved_slot, _get_cwd(ctx))
+    cmd_download(
         cfg,
         local_dir=local_dir,
         folder_path=folder_path,

--- a/uqadm/uqadm/kb/__init__.py
+++ b/uqadm/uqadm/kb/__init__.py
@@ -205,7 +205,9 @@ def kb_download(
     local_dir: Annotated[
         Path,
         typer.Argument(
-            help="Local folder where KB files are written.",
+            file_okay=False,
+            writable=True,
+            help="Local folder where KB files are written (created if missing).",
         ),
     ],
     slot: Annotated[Optional[str], typer.Option("--slot", help=_SLOT_HELP)] = None,

--- a/uqadm/uqadm/kb/_paths.py
+++ b/uqadm/uqadm/kb/_paths.py
@@ -7,15 +7,17 @@ def join_path_segments(left: str, right: str) -> str:
     """Join two path segments with a single ``/`` separator.
 
     Strips surrounding whitespace from both sides and collapses the boundary so
-    there is exactly one separator between them. A leading slash on ``left``
-    (used for absolute KB folder paths in ``kb sync``) is preserved, while an
-    empty side is dropped so a relative subdirectory join (``kb download``)
+    there is exactly one separator between them. A leading slash on ``left`` is
+    preserved -- including when ``left`` is the bare root ``/`` -- so absolute
+    KB folder paths in ``kb sync`` keep their leading slash. An empty ``left``
+    yields just ``right`` so a relative subdirectory join (``kb download``)
     never gains a spurious leading slash.
     """
+    rooted = left.strip().startswith("/")
     left = left.strip().rstrip("/")
     right = right.strip().lstrip("/")
-    if left == "":
-        return right
     if right == "":
         return left
+    if left == "":
+        return f"/{right}" if rooted else right
     return f"{left}/{right}"

--- a/uqadm/uqadm/kb/_paths.py
+++ b/uqadm/uqadm/kb/_paths.py
@@ -1,0 +1,21 @@
+"""Shared path-joining helpers for knowledge-base commands."""
+
+from __future__ import annotations
+
+
+def join_path_segments(left: str, right: str) -> str:
+    """Join two path segments with a single ``/`` separator.
+
+    Strips surrounding whitespace from both sides and collapses the boundary so
+    there is exactly one separator between them. A leading slash on ``left``
+    (used for absolute KB folder paths in ``kb sync``) is preserved, while an
+    empty side is dropped so a relative subdirectory join (``kb download``)
+    never gains a spurious leading slash.
+    """
+    left = left.strip().rstrip("/")
+    right = right.strip().lstrip("/")
+    if left == "":
+        return right
+    if right == "":
+        return left
+    return f"{left}/{right}"

--- a/uqadm/uqadm/kb/download.py
+++ b/uqadm/uqadm/kb/download.py
@@ -1,0 +1,148 @@
+"""Download knowledge-base scope contents into a local folder."""
+
+from __future__ import annotations
+
+import sys
+from collections import deque
+from pathlib import Path
+
+import typer
+from unique_sdk import Content, Folder
+from unique_sdk.cli.config import Config
+from unique_sdk.utils.file_io import download_content
+
+from uqadm.core.auth_debug import echo_credential_debug_if_auth_failure
+
+_PAGE_SIZE = 100
+
+
+def _list_content_infos(cfg: Config, scope_id: str) -> list[dict[str, object]]:
+    """Return all content infos in a folder scope (paginated)."""
+    infos: list[dict[str, object]] = []
+    skip = 0
+    while True:
+        page = Content.get_infos(
+            cfg.user_id,
+            cfg.company_id,
+            parentId=scope_id,
+            skip=skip,
+            take=_PAGE_SIZE,
+        )
+        batch = page.get("contentInfos") or []
+        infos.extend(batch)
+        skip += len(batch)
+        if not batch or skip >= page.get("totalCount", 0):
+            break
+    return infos
+
+
+def _list_child_folders(cfg: Config, scope_id: str) -> list[dict[str, object]]:
+    """Return all child folder infos under a scope (paginated)."""
+    folders: list[dict[str, object]] = []
+    skip = 0
+    while True:
+        page = Folder.get_infos(
+            cfg.user_id,
+            cfg.company_id,
+            parentId=scope_id,
+            skip=skip,
+            take=_PAGE_SIZE,
+        )
+        batch = page.get("folderInfos") or []
+        folders.extend(batch)
+        skip += len(batch)
+        if not batch or skip >= page.get("totalCount", 0):
+            break
+    return folders
+
+
+def _join_rel_subdir(parent: str, child_name: str) -> str:
+    parent = parent.strip()
+    child_name = child_name.strip()
+    if parent == "":
+        return child_name
+    return f"{parent}/{child_name}"
+
+
+def cmd_download(
+    cfg: Config,
+    *,
+    local_dir: Path,
+    folder_path: str | None,
+    scope_id: str | None,
+    recursive: bool,
+    dry_run: bool,
+) -> None:
+    if bool(folder_path) == bool(scope_id):
+        typer.echo("Specify exactly one of --folder-path or --scope-id.", err=True)
+        sys.exit(2)
+
+    if folder_path and not folder_path.startswith("/"):
+        typer.echo(
+            f"--folder-path must be an absolute path (start with '/'): {folder_path}",
+            err=True,
+        )
+        sys.exit(2)
+
+    if folder_path:
+        try:
+            base_scope_id = Folder.resolve_scope_id_from_folder_path(
+                cfg.user_id, cfg.company_id, folder_path=folder_path
+            )
+        except Exception as exc:
+            typer.echo(f"failed to resolve folder {folder_path!r}: {exc}", err=True)
+            echo_credential_debug_if_auth_failure(cfg, exc, label="kb download")
+            sys.exit(1)
+    else:
+        assert scope_id is not None
+        base_scope_id = scope_id
+
+    local_dir.mkdir(parents=True, exist_ok=True)
+
+    queue: deque[tuple[str, str]] = deque([(base_scope_id, "")])
+    counts = {"downloaded": 0, "failed": 0}
+
+    while queue:
+        current_scope_id, rel_subdir = queue.popleft()
+
+        for info in _list_content_infos(cfg, current_scope_id):
+            key = str(info["key"])
+            content_id = str(info["id"])
+            display = key if rel_subdir == "" else f"{rel_subdir}/{key}"
+            local_path = local_dir / rel_subdir / key if rel_subdir else local_dir / key
+
+            if dry_run:
+                typer.echo(f"[dry-run] downloaded: {display}")
+                counts["downloaded"] += 1
+                continue
+
+            try:
+                download_content(
+                    companyId=cfg.company_id,
+                    userId=cfg.user_id,
+                    content_id=content_id,
+                    filename=key,
+                    target_path=local_path,
+                )
+            except Exception as exc:
+                typer.echo(f"failed: {display}: {exc}", err=True)
+                echo_credential_debug_if_auth_failure(cfg, exc, label="kb download")
+                counts["failed"] += 1
+                continue
+
+            typer.echo(f"downloaded: {display}")
+            counts["downloaded"] += 1
+
+        if recursive:
+            for folder_info in _list_child_folders(cfg, current_scope_id):
+                child_scope_id = str(folder_info["id"])
+                child_name = str(folder_info["name"])
+                queue.append((child_scope_id, _join_rel_subdir(rel_subdir, child_name)))
+
+    if counts["downloaded"] == 0 and counts["failed"] == 0:
+        typer.echo("No files to download.")
+        return
+
+    typer.echo(f"Done: {counts['downloaded']} downloaded, {counts['failed']} failed.")
+    if counts["failed"]:
+        sys.exit(1)

--- a/uqadm/uqadm/kb/download.py
+++ b/uqadm/uqadm/kb/download.py
@@ -16,9 +16,9 @@ from uqadm.core.auth_debug import echo_credential_debug_if_auth_failure
 _PAGE_SIZE = 100
 
 
-def _list_content_infos(cfg: Config, scope_id: str) -> list[dict[str, object]]:
+def _list_content_infos(cfg: Config, scope_id: str) -> list[Content.ContentInfo]:
     """Return all content infos in a folder scope (paginated)."""
-    infos: list[dict[str, object]] = []
+    infos: list[Content.ContentInfo] = []
     skip = 0
     while True:
         page = Content.get_infos(
@@ -36,9 +36,9 @@ def _list_content_infos(cfg: Config, scope_id: str) -> list[dict[str, object]]:
     return infos
 
 
-def _list_child_folders(cfg: Config, scope_id: str) -> list[dict[str, object]]:
+def _list_child_folders(cfg: Config, scope_id: str) -> list[Folder.FolderInfo]:
     """Return all child folder infos under a scope (paginated)."""
-    folders: list[dict[str, object]] = []
+    folders: list[Folder.FolderInfo] = []
     skip = 0
     while True:
         page = Folder.get_infos(
@@ -86,18 +86,23 @@ def cmd_download(
 
     if folder_path:
         try:
-            base_scope_id = Folder.resolve_scope_id_from_folder_path(
+            resolved_scope_id = Folder.resolve_scope_id_from_folder_path(
                 cfg.user_id, cfg.company_id, folder_path=folder_path
             )
         except Exception as exc:
             typer.echo(f"failed to resolve folder {folder_path!r}: {exc}", err=True)
             echo_credential_debug_if_auth_failure(cfg, exc, label="kb download")
             sys.exit(1)
+        if resolved_scope_id is None:
+            typer.echo(f"failed to resolve folder {folder_path!r}: not found", err=True)
+            sys.exit(1)
+        base_scope_id = resolved_scope_id
     else:
         assert scope_id is not None
         base_scope_id = scope_id
 
-    local_dir.mkdir(parents=True, exist_ok=True)
+    if not dry_run:
+        local_dir.mkdir(parents=True, exist_ok=True)
 
     queue: deque[tuple[str, str]] = deque([(base_scope_id, "")])
     counts = {"downloaded": 0, "failed": 0}
@@ -106,8 +111,8 @@ def cmd_download(
         current_scope_id, rel_subdir = queue.popleft()
 
         for info in _list_content_infos(cfg, current_scope_id):
-            key = str(info["key"])
-            content_id = str(info["id"])
+            key = info["key"]
+            content_id = info["id"]
             display = key if rel_subdir == "" else f"{rel_subdir}/{key}"
             local_path = local_dir / rel_subdir / key if rel_subdir else local_dir / key
 
@@ -117,7 +122,7 @@ def cmd_download(
                 continue
 
             try:
-                download_content(
+                _ = download_content(
                     companyId=cfg.company_id,
                     userId=cfg.user_id,
                     content_id=content_id,
@@ -135,8 +140,8 @@ def cmd_download(
 
         if recursive:
             for folder_info in _list_child_folders(cfg, current_scope_id):
-                child_scope_id = str(folder_info["id"])
-                child_name = str(folder_info["name"])
+                child_scope_id = folder_info["id"]
+                child_name = folder_info["name"]
                 queue.append((child_scope_id, _join_rel_subdir(rel_subdir, child_name)))
 
     if counts["downloaded"] == 0 and counts["failed"] == 0:

--- a/uqadm/uqadm/kb/download.py
+++ b/uqadm/uqadm/kb/download.py
@@ -12,6 +12,7 @@ from unique_sdk.cli.config import Config
 from unique_sdk.utils.file_io import download_content
 
 from uqadm.core.auth_debug import echo_credential_debug_if_auth_failure
+from uqadm.kb._paths import join_path_segments
 
 _PAGE_SIZE = 100
 
@@ -54,14 +55,6 @@ def _list_child_folders(cfg: Config, scope_id: str) -> list[Folder.FolderInfo]:
         if not batch or skip >= page.get("totalCount", 0):
             break
     return folders
-
-
-def _join_rel_subdir(parent: str, child_name: str) -> str:
-    parent = parent.strip()
-    child_name = child_name.strip()
-    if parent == "":
-        return child_name
-    return f"{parent}/{child_name}"
 
 
 def _safe_local_path(local_dir: Path, *parts: str) -> Path | None:
@@ -174,7 +167,9 @@ def cmd_download(
             for folder_info in _list_child_folders(cfg, current_scope_id):
                 child_scope_id = folder_info["id"]
                 child_name = folder_info["name"]
-                queue.append((child_scope_id, _join_rel_subdir(rel_subdir, child_name)))
+                queue.append(
+                    (child_scope_id, join_path_segments(rel_subdir, child_name))
+                )
 
     if counts["downloaded"] == 0 and counts["failed"] == 0:
         typer.echo("No files to download.")

--- a/uqadm/uqadm/kb/download.py
+++ b/uqadm/uqadm/kb/download.py
@@ -64,6 +64,24 @@ def _join_rel_subdir(parent: str, child_name: str) -> str:
     return f"{parent}/{child_name}"
 
 
+def _safe_local_path(local_dir: Path, *parts: str) -> Path | None:
+    """Join ``parts`` under ``local_dir``, guarding against path traversal.
+
+    ``key`` and recursive folder names come from remote KB metadata and are not
+    trusted. A crafted value containing ``..`` segments or a leading ``/`` could
+    otherwise escape the destination. Returns the resolved path when it stays
+    inside ``local_dir``, or ``None`` when it would escape.
+    """
+    base = local_dir.resolve()
+    candidate = base
+    for part in parts:
+        candidate = candidate / part
+    candidate = candidate.resolve()
+    if candidate == base or base in candidate.parents:
+        return candidate
+    return None
+
+
 def cmd_download(
     cfg: Config,
     *,
@@ -99,6 +117,12 @@ def cmd_download(
         base_scope_id = resolved_scope_id
     else:
         assert scope_id is not None
+        try:
+            _ = Folder.get_folder_path(cfg.user_id, cfg.company_id, scope_id)
+        except Exception as exc:
+            typer.echo(f"failed to resolve scope {scope_id!r}: {exc}", err=True)
+            echo_credential_debug_if_auth_failure(cfg, exc, label="kb download")
+            sys.exit(1)
         base_scope_id = scope_id
 
     if not dry_run:
@@ -114,7 +138,15 @@ def cmd_download(
             key = info["key"]
             content_id = info["id"]
             display = key if rel_subdir == "" else f"{rel_subdir}/{key}"
-            local_path = local_dir / rel_subdir / key if rel_subdir else local_dir / key
+            parts = (rel_subdir, key) if rel_subdir else (key,)
+            local_path = _safe_local_path(local_dir, *parts)
+            if local_path is None:
+                typer.echo(
+                    f"failed: {display}: refusing to write outside {local_dir}",
+                    err=True,
+                )
+                counts["failed"] += 1
+                continue
 
             if dry_run:
                 typer.echo(f"[dry-run] downloaded: {display}")

--- a/uqadm/uqadm/kb/sync.py
+++ b/uqadm/uqadm/kb/sync.py
@@ -13,6 +13,7 @@ from unique_sdk.cli.config import Config
 from unique_sdk.utils.file_io import upload_file
 
 from uqadm.core.auth_debug import echo_credential_debug_if_auth_failure
+from uqadm.kb._paths import join_path_segments
 
 _PAGE_SIZE = 100
 
@@ -23,18 +24,6 @@ def _collect_files(folder: Path, recursive: bool) -> list[Path]:
     else:
         walker = folder.iterdir()
     return sorted(p for p in walker if p.is_file())
-
-
-def _join_folder_paths(left: str, right: str) -> str:
-    """Join a relative subdirectory onto the base KB folder path."""
-    left = left.strip()
-    right = right.strip()
-
-    joined = left.rstrip("/")
-    if right != "":
-        joined += f"/{right.lstrip('/')}"
-
-    return joined
 
 
 def _resolve_scope(cfg: Config, folder_path: str, *, create: bool) -> str | None:
@@ -128,7 +117,7 @@ def cmd_sync(
 
     counts = {"new": 0, "replaced": 0, "failed": 0}
     for rel_parent, paths in sorted(groups.items()):
-        target_path = _join_folder_paths(base_path, rel_parent)
+        target_path = join_path_segments(base_path, rel_parent)
         try:
             target_scope = _resolve_scope(cfg, target_path, create=not dry_run)
         except Exception as exc:


### PR DESCRIPTION
## Summary
- Adds `uqadm kb download` as the inverse of `kb sync`: bulk-export files from a KB folder path or scope id into a local directory
- Supports `--recursive` (mirror subfolders locally), `--dry-run`, and `--slot` (same conventions as other kb commands)
- Reuses existing `unique_sdk` APIs (`Content.get_infos`, `Folder.get_infos`, `download_content`) — no SDK changes

## Jira
[UN-22079](https://unique-ch.atlassian.net/browse/UN-22079)

## Test plan
- [x] Unit tests: single-file download, recursive walk, dry-run, missing target selector (exit 2), partial failure (exit 1), scope-id entry point
- [x] CLI wiring and help text tests
- [x] `ruff check` on changed files
- [ ] Manual: `uqadm kb download ./out --folder-path /some/path -r --dry-run` against QA slot


Made with [Cursor](https://cursor.com)

[UN-22079]: https://unique-ch.atlassian.net/browse/UN-22079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ