### PR TITLE
feat(websearch): add CID-focused argument screening defaults [UN-18090]

### DIFF
--- a/tool_packages/unique_web_search/src/unique_web_search/services/argument_screening/config.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/argument_screening/config.py
@@ -1,6 +1,6 @@
 from typing import Annotated
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field
 from unique_toolkit._common.pydantic.rjsf_tags import RJSFMetaTag
 from unique_toolkit._common.pydantic_helpers import get_configuration_dict
 from unique_toolkit._common.validators import LMI, get_LMI_default_field
@@ -12,12 +12,6 @@ from unique_web_search.services.argument_screening.prompts import (
     DEFAULT_USER_PROMPT_TEMPLATE,
 )
 from unique_web_search.settings import env_settings
-
-ORGANIZATION_SPECIFIC_BLOCKED_KEYWORDS_TEMPLATE = """{% for keyword in organization_specific_blocked_keywords -%}
-- {{ keyword }}
-{% else -%}
-- [none configured]
-{% endfor %}"""
 
 
 class ArgumentScreeningConfig(BaseModel):
@@ -90,19 +84,3 @@ class ArgumentScreeningConfig(BaseModel):
             "Use {{ reason }} for the screening agent's verdict reason."
         ),
     )
-
-    @field_validator("guidelines")
-    @classmethod
-    def ensure_blocked_keywords_template(cls, guidelines: str) -> str:
-        if "organization_specific_blocked_keywords" in guidelines:
-            return guidelines
-
-        separator = (
-            "\n"
-            if guidelines.rstrip().endswith("Configured blocked terms:")
-            else "\n\nConfigured blocked terms:\n"
-        )
-        return (
-            f"{guidelines.rstrip()}{separator}"
-            f"{ORGANIZATION_SPECIFIC_BLOCKED_KEYWORDS_TEMPLATE}"
-        )

--- a/tool_packages/unique_web_search/src/unique_web_search/services/argument_screening/config.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/argument_screening/config.py
@@ -1,6 +1,6 @@
 from typing import Annotated
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from unique_toolkit._common.pydantic.rjsf_tags import RJSFMetaTag
 from unique_toolkit._common.pydantic_helpers import get_configuration_dict
 from unique_toolkit._common.validators import LMI, get_LMI_default_field
@@ -12,6 +12,12 @@ from unique_web_search.services.argument_screening.prompts import (
     DEFAULT_USER_PROMPT_TEMPLATE,
 )
 from unique_web_search.settings import env_settings
+
+ORGANIZATION_SPECIFIC_BLOCKED_KEYWORDS_TEMPLATE = """{% for keyword in organization_specific_blocked_keywords -%}
+- {{ keyword }}
+{% else -%}
+- [none configured]
+{% endfor %}"""
 
 
 class ArgumentScreeningConfig(BaseModel):
@@ -84,3 +90,19 @@ class ArgumentScreeningConfig(BaseModel):
             "Use {{ reason }} for the screening agent's verdict reason."
         ),
     )
+
+    @field_validator("guidelines")
+    @classmethod
+    def ensure_blocked_keywords_template(cls, guidelines: str) -> str:
+        if "organization_specific_blocked_keywords" in guidelines:
+            return guidelines
+
+        separator = (
+            "\n"
+            if guidelines.rstrip().endswith("Configured blocked terms:")
+            else "\n\nConfigured blocked terms:\n"
+        )
+        return (
+            f"{guidelines.rstrip()}{separator}"
+            f"{ORGANIZATION_SPECIFIC_BLOCKED_KEYWORDS_TEMPLATE}"
+        )

--- a/tool_packages/unique_web_search/src/unique_web_search/services/argument_screening/config.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/argument_screening/config.py
@@ -42,6 +42,17 @@ class ArgumentScreeningConfig(BaseModel):
         title="Screening Guidelines",
         description="Rules the screening agent follows to decide whether arguments are safe. This is the primary field for administrators to customize.",
     )
+    organization_specific_blocked_keywords: Annotated[
+        list[str],
+        RJSFMetaTag({"ui:options": {"orderable": False}}),
+    ] = Field(
+        default_factory=list,
+        title="Organization-Specific Blocked Keywords",
+        description=(
+            "Terms, domains, product names, portals, or internal project names "
+            "that must always block WebSearch when detected."
+        ),
+    )
     system_prompt: Annotated[
         str,
         RJSFMetaTag.StringWidget.textarea(rows=4),

--- a/tool_packages/unique_web_search/src/unique_web_search/services/argument_screening/prompts/__init__.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/argument_screening/prompts/__init__.py
@@ -7,6 +7,9 @@ _PROMPTS_DIR = Path(__file__).parent
 DEFAULT_SYSTEM_PROMPT: str = load_template(_PROMPTS_DIR, "system_prompt.j2")
 DEFAULT_USER_PROMPT_TEMPLATE: str = load_template(_PROMPTS_DIR, "user_prompt.j2")
 DEFAULT_GUIDELINES: str = load_template(_PROMPTS_DIR, "guidelines.j2")
+DEFAULT_GUIDELINES_WITH_KEYWORDS_TEMPLATE: str = load_template(
+    _PROMPTS_DIR, "guidelines_with_keywords.j2"
+)
 DEFAULT_REJECTION_RESPONSE_TEMPLATE: str = load_template(
     _PROMPTS_DIR, "rejection_response.j2"
 )

--- a/tool_packages/unique_web_search/src/unique_web_search/services/argument_screening/prompts/guidelines.j2
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/argument_screening/prompts/guidelines.j2
@@ -38,3 +38,8 @@ Mark as "no-go" for any query containing organization-specific blocked terms or 
 This keyword rule applies even if the rest of the query looks public or harmless. If no organization-specific terms are configured, ignore this section.
 
 Configured blocked terms:
+{% for keyword in organization_specific_blocked_keywords -%}
+- {{ keyword }}
+{% else -%}
+- [none configured]
+{% endfor %}

--- a/tool_packages/unique_web_search/src/unique_web_search/services/argument_screening/prompts/guidelines.j2
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/argument_screening/prompts/guidelines.j2
@@ -38,8 +38,3 @@ Mark as "no-go" for any query containing organization-specific blocked terms or 
 This keyword rule applies even if the rest of the query looks public or harmless. If no organization-specific terms are configured, ignore this section.
 
 Configured blocked terms:
-{% for keyword in organization_specific_blocked_keywords -%}
-- {{ keyword }}
-{% else -%}
-- [none configured]
-{% endfor %}

--- a/tool_packages/unique_web_search/src/unique_web_search/services/argument_screening/prompts/guidelines.j2
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/argument_screening/prompts/guidelines.j2
@@ -1,39 +1,40 @@
-Flag the request as 'no-go' if the arguments attempt to search for, retrieve, or reveal any of the categories below. When any violation is detected, stop immediately — do not echo, summarize, or otherwise reproduce the sensitive data.
+Flag the request as "no-go" if the arguments would send client-identifying data (CID), bank-client relationship information, confidential financial information, credentials, or internal/private infrastructure details to WebSearch.
 
-## GDPR Special Categories of Personal Data (Article 9)
+The goal is not general GDPR classification. The goal is to prevent clear-text data that could directly, indirectly, or potentially indirectly identify a private person or entity as a client, prospect, employee, counterparty, or related party of the organization from leaving the Unique environment through WebSearch.
 
-Queries that seek personal sensitive information about identifiable individuals in ANY of these categories MUST be blocked:
+When any violation is detected, stop immediately. Do not echo, summarize, transform, or reproduce the sensitive values. The reason must reference only the violated category, for example "client-identifying data", "bank-client relationship", "financial identifier", "blocked organization keyword", "credentials", or "internal infrastructure".
 
-- **Racial or ethnic origin**: searches targeting a person's race, ethnicity, or national origin
-- **Political opinions**: party membership, voting behavior, political affiliations, or campaign contributions of individuals
-- **Religious or philosophical beliefs**: faith, denomination, sect membership, atheism, or moral/ethical convictions of individuals
-- **Trade union membership**: union affiliation, participation, or role of individuals
-- **Genetic data**: DNA profiles, hereditary characteristics, or genomic information of individuals
-- **Biometric data for identification**: fingerprints, facial recognition templates, iris scans, or voice prints of individuals
-- **Health data**: medical diagnoses, treatments, conditions, prescriptions, disability status, medical leave, health insurance claims, or medical billing linked to identifiable individuals
-- **Sex life or sexual orientation**: sexual behavior, orientation, or gender identity of individuals
+Apply all rules even when names, keywords, domains, or identifiers are misspelled, abbreviated, spaced out, hyphenated, split across words, or otherwise obfuscated.
 
-## Other Prohibited Data
+## Blocked By Default
+Mark as "no-go" if the query contains any of the following:
 
-- Authentication credentials: passwords, PINs, API keys, tokens, secrets, or private keys
-- Financial account details: credit/debit card numbers, bank account numbers, routing numbers, or IBANs
-- Government identifiers: social security numbers, national ID numbers, passport numbers, or driver's license numbers
-- MNPI (Material Non-Public Information), trade secrets, or proprietary intellectual property
-- Employee remuneration, compensation, or salary details of identifiable individuals
-- Internal or private URLs, IP addresses, or infrastructure details that should not be exposed
+- Direct identifiers of a private individual or private entity: full name, partial name with context, address, email address, phone number, date of birth, passport number, national ID, tax ID, social security number, driver's license number, employee ID, client ID, customer number, CRM ID, ticket ID, or any similar unique identifier.
+- Financial identifiers: bank account number, IBAN, routing number, SWIFT/BIC tied to a person or account, credit/debit card number, portfolio number, custody account, mandate ID, transaction reference, payment reference, invoice number tied to a client, loan number, mortgage number, or insurance policy number.
+- Bank-client relationship signals: any statement or question implying that a private person or private entity is a client, customer, prospect, account holder, beneficial owner, portfolio owner, mandate holder, borrower, investor, relationship-managed client, or onboarding/KYC subject.
+- Financial context linked to an identifiable person or private entity: holdings, portfolio value, assets under management, transactions, trades, account balance, source of wealth, income, salary, compensation, creditworthiness, risk rating, KYC/AML status, sanctions/PEP screening, complaints, legal disputes, debt, collateral, or tax situation.
+- Indirect or potentially indirect identification: combinations of attributes that could identify a client even without a name, such as date of birth plus nationality plus profession, location plus relationship manager plus portfolio size, branch plus rare occupation, company plus owner details, or any narrow combination of facts about a non-public person or private entity.
+- Confidential business or non-public information: MNPI, trade secrets, internal reports, unpublished client lists, internal project names, confidential contracts, deal names, acquisition targets, or proprietary research.
+- Authentication and secrets: passwords, PINs, API keys, tokens, private keys, recovery phrases, session cookies, authorization headers, or secret URLs.
+- Internal or private infrastructure: private URLs, intranet hosts, internal IP addresses, VPN hosts, non-public service names, internal dashboards, private storage links, internal ticket links, or environment-specific system details.
 
-## Prohibited Request Patterns
+## Public Information That Can Be Allowed
+Mark as "go" only when the query is clearly outside CID and does not include organization-specific blocked keywords:
 
-- Recruitment, selection, or evaluation of employees
-- Evaluating creditworthiness or credit scoring of individuals
-- Risk assessment and pricing for life and health insurance
-- Profiling individuals based on any GDPR special category data
-- Any request that combines identity data (name, email, ID) with special category data
+- General knowledge, technical, legal, or regulatory questions not tied to an identifiable private person, private entity, or the organization.
+- Public organizations, public products, market news, public events, or public company information where no private client relationship is implied.
+- Public figures in their public capacity, such as politicians, executives, athletes, or public officials, when the query concerns publicly available public-role information and not private banking, personal financial, health, family, address, or contact details.
+- Aggregated or anonymized statistics where no individual, client, small group, relationship manager, branch, or private entity can be singled out.
 
-## Allowed Requests
+## Ambiguity Rule
+If it is unclear whether the query contains CID or implies a bank-client relationship, choose "no-go". WebSearch is an external disclosure path, so the safe default is to block ambiguous private-person or client-context queries.
 
-Mark as 'go' when the arguments are:
-- General knowledge or factual queries (e.g., "What is GDPR?", "Python best practices")
-- Queries about organizations, products, public events, or publicly available information
-- Aggregated or anonymized statistical data not linked to identifiable individuals
-- Queries about public figures in their public capacity (e.g., a politician's published voting record)
+## Reason Style
+Return a short category-only reason. Do not include raw names, account numbers, emails, phone numbers, domains, URLs, or any sensitive values in the reason.
+
+## Organization-Specific Blocked Keywords
+Mark as "no-go" for any query containing organization-specific blocked terms or close variants, including misspellings, spacing, punctuation, hyphenation, domain variants, product names, internal project names, portal names, or other configured sensitive terms.
+
+This keyword rule applies even if the rest of the query looks public or harmless. If no organization-specific terms are configured, ignore this section.
+
+Configured blocked terms:

--- a/tool_packages/unique_web_search/src/unique_web_search/services/argument_screening/prompts/guidelines_with_keywords.j2
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/argument_screening/prompts/guidelines_with_keywords.j2
@@ -1,0 +1,7 @@
+{{ guidelines.rstrip() }}
+
+{% for keyword in organization_specific_blocked_keywords -%}
+- {{ keyword }}
+{% else -%}
+- [none configured]
+{% endfor %}

--- a/tool_packages/unique_web_search/src/unique_web_search/services/argument_screening/service.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/argument_screening/service.py
@@ -34,7 +34,9 @@ _LOGGER = logging.getLogger(__name__)
 def build_argument_screening_guidelines(config: ArgumentScreeningConfig) -> str:
     """Render the effective screening guidelines including configured keywords."""
     keyword_bullets = (
-        "\n".join(f"- {keyword}" for keyword in config.organization_specific_blocked_keywords)
+        "\n".join(
+            f"- {keyword}" for keyword in config.organization_specific_blocked_keywords
+        )
         if config.organization_specific_blocked_keywords
         else "- [none configured]"
     )

--- a/tool_packages/unique_web_search/src/unique_web_search/services/argument_screening/service.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/argument_screening/service.py
@@ -31,18 +31,6 @@ from unique_web_search.services.structured_llm import (
 _LOGGER = logging.getLogger(__name__)
 
 
-def build_argument_screening_guidelines(config: ArgumentScreeningConfig) -> str:
-    """Render the effective screening guidelines including configured keywords."""
-    keyword_bullets = (
-        "\n".join(
-            f"- {keyword}" for keyword in config.organization_specific_blocked_keywords
-        )
-        if config.organization_specific_blocked_keywords
-        else "- [none configured]"
-    )
-    return f"{config.guidelines.rstrip()}\n{keyword_bullets}"
-
-
 class ArgumentScreeningResult(StructuredOutputModel):
     """Structured LLM output for the screening verdict."""
 
@@ -106,7 +94,11 @@ class ArgumentScreeningService:
         serialized_args = json.dumps(arguments, indent=2, default=str)
         user_prompt = Template(self._config.user_prompt_template).render(
             arguments=serialized_args,
-            guidelines=build_argument_screening_guidelines(self._config),
+            guidelines=Template(self._config.guidelines).render(
+                organization_specific_blocked_keywords=(
+                    self._config.organization_specific_blocked_keywords
+                ),
+            ),
         )
 
         try:

--- a/tool_packages/unique_web_search/src/unique_web_search/services/argument_screening/service.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/argument_screening/service.py
@@ -97,20 +97,6 @@ class ArgumentScreeningService:
                 self._config.organization_specific_blocked_keywords
             ),
         )
-        blocked_keywords = self._config.organization_specific_blocked_keywords
-        if blocked_keywords:
-            keyword_bullets = "\n".join(f"- {keyword}" for keyword in blocked_keywords)
-            if keyword_bullets not in rendered_guidelines:
-                separator = (
-                    "\n"
-                    if rendered_guidelines.rstrip().endswith(
-                        "Configured blocked terms:"
-                    )
-                    else "\n\nConfigured blocked terms:\n"
-                )
-                rendered_guidelines = (
-                    f"{rendered_guidelines.rstrip()}{separator}{keyword_bullets}"
-                )
 
         user_prompt = Template(self._config.user_prompt_template).render(
             arguments=serialized_args,

--- a/tool_packages/unique_web_search/src/unique_web_search/services/argument_screening/service.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/argument_screening/service.py
@@ -22,6 +22,9 @@ from unique_web_search.services.argument_screening.config import (
 from unique_web_search.services.argument_screening.exceptions import (
     ArgumentScreeningUnparseableResponseException,
 )
+from unique_web_search.services.argument_screening.prompts import (
+    DEFAULT_GUIDELINES_WITH_KEYWORDS_TEMPLATE,
+)
 from unique_web_search.services.message_log import WebSearchMessageLogger
 from unique_web_search.services.structured_llm import (
     StructuredLlmUnparseableResponseError,
@@ -92,7 +95,10 @@ class ArgumentScreeningService:
         _LOGGER.info("Running argument screening agent...")
 
         serialized_args = json.dumps(arguments, indent=2, default=str)
-        rendered_guidelines = Template(self._config.guidelines).render(
+        rendered_guidelines = Template(
+            DEFAULT_GUIDELINES_WITH_KEYWORDS_TEMPLATE
+        ).render(
+            guidelines=self._config.guidelines,
             organization_specific_blocked_keywords=(
                 self._config.organization_specific_blocked_keywords
             ),

--- a/tool_packages/unique_web_search/src/unique_web_search/services/argument_screening/service.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/argument_screening/service.py
@@ -92,13 +92,29 @@ class ArgumentScreeningService:
         _LOGGER.info("Running argument screening agent...")
 
         serialized_args = json.dumps(arguments, indent=2, default=str)
+        rendered_guidelines = Template(self._config.guidelines).render(
+            organization_specific_blocked_keywords=(
+                self._config.organization_specific_blocked_keywords
+            ),
+        )
+        blocked_keywords = self._config.organization_specific_blocked_keywords
+        if blocked_keywords:
+            keyword_bullets = "\n".join(f"- {keyword}" for keyword in blocked_keywords)
+            if keyword_bullets not in rendered_guidelines:
+                separator = (
+                    "\n"
+                    if rendered_guidelines.rstrip().endswith(
+                        "Configured blocked terms:"
+                    )
+                    else "\n\nConfigured blocked terms:\n"
+                )
+                rendered_guidelines = (
+                    f"{rendered_guidelines.rstrip()}{separator}{keyword_bullets}"
+                )
+
         user_prompt = Template(self._config.user_prompt_template).render(
             arguments=serialized_args,
-            guidelines=Template(self._config.guidelines).render(
-                organization_specific_blocked_keywords=(
-                    self._config.organization_specific_blocked_keywords
-                ),
-            ),
+            guidelines=rendered_guidelines,
         )
 
         try:

--- a/tool_packages/unique_web_search/src/unique_web_search/services/argument_screening/service.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/argument_screening/service.py
@@ -34,9 +34,7 @@ _LOGGER = logging.getLogger(__name__)
 def build_argument_screening_guidelines(config: ArgumentScreeningConfig) -> str:
     """Render the effective screening guidelines including configured keywords."""
     keyword_bullets = (
-        "\n".join(
-            f"- {keyword}" for keyword in config.organization_specific_blocked_keywords
-        )
+        "\n".join(f"- {keyword}" for keyword in config.organization_specific_blocked_keywords)
         if config.organization_specific_blocked_keywords
         else "- [none configured]"
     )

--- a/tool_packages/unique_web_search/src/unique_web_search/services/argument_screening/service.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/argument_screening/service.py
@@ -31,6 +31,16 @@ from unique_web_search.services.structured_llm import (
 _LOGGER = logging.getLogger(__name__)
 
 
+def build_argument_screening_guidelines(config: ArgumentScreeningConfig) -> str:
+    """Render the effective screening guidelines including configured keywords."""
+    keyword_bullets = (
+        "\n".join(f"- {keyword}" for keyword in config.organization_specific_blocked_keywords)
+        if config.organization_specific_blocked_keywords
+        else "- [none configured]"
+    )
+    return f"{config.guidelines.rstrip()}\n{keyword_bullets}"
+
+
 class ArgumentScreeningResult(StructuredOutputModel):
     """Structured LLM output for the screening verdict."""
 
@@ -94,7 +104,7 @@ class ArgumentScreeningService:
         serialized_args = json.dumps(arguments, indent=2, default=str)
         user_prompt = Template(self._config.user_prompt_template).render(
             arguments=serialized_args,
-            guidelines=self._config.guidelines,
+            guidelines=build_argument_screening_guidelines(self._config),
         )
 
         try:

--- a/tool_packages/unique_web_search/tests/test_argument_screening.py
+++ b/tool_packages/unique_web_search/tests/test_argument_screening.py
@@ -84,9 +84,8 @@ class TestBuildArgumentScreeningGuidelines:
         guidelines = build_argument_screening_guidelines(config)
 
         assert guidelines.endswith("- [none configured]")
-        assert (
-            "If no organization-specific terms are configured, ignore this section."
-            in (DEFAULT_GUIDELINES)
+        assert "If no organization-specific terms are configured, ignore this section." in (
+            DEFAULT_GUIDELINES
         )
 
 

--- a/tool_packages/unique_web_search/tests/test_argument_screening.py
+++ b/tool_packages/unique_web_search/tests/test_argument_screening.py
@@ -1,7 +1,6 @@
 from unittest.mock import AsyncMock, Mock
 
 import pytest
-from jinja2 import Template
 
 from unique_web_search.services.argument_screening import (
     DEFAULT_GUIDELINES,
@@ -55,41 +54,29 @@ class TestArgumentScreeningConfig:
             config.user_prompt_template
             == "Custom {{ arguments }} template {{ guidelines }}"
         )
-        assert config.guidelines == "Custom guidelines"
+        assert "Custom guidelines" in config.guidelines
+        assert "organization_specific_blocked_keywords" in config.guidelines
 
-
-class TestArgumentScreeningGuidelinesTemplate:
-    def test_renders_configured_keywords_as_bullets(self):
+    def test_adds_keyword_template_to_custom_guidelines(self):
         config = ArgumentScreeningConfig(
-            organization_specific_blocked_keywords=[
-                "EFG",
-                "efgbank.com",
-            ],
+            guidelines="Custom guidelines\n\nConfigured blocked terms:",
         )
 
-        guidelines = Template(config.guidelines).render(
-            organization_specific_blocked_keywords=(
-                config.organization_specific_blocked_keywords
-            ),
+        assert config.guidelines.count("Configured blocked terms:") == 1
+        assert config.guidelines.rstrip().endswith("{% endfor %}")
+        assert "organization_specific_blocked_keywords" in config.guidelines
+
+    def test_keeps_existing_keyword_template(self):
+        guidelines = (
+            "Custom guidelines\n"
+            "{% for keyword in organization_specific_blocked_keywords -%}\n"
+            "- {{ keyword }}\n"
+            "{% endfor %}"
         )
 
-        assert guidelines.rstrip().endswith("- EFG\n- efgbank.com")
-        assert "Configured blocked terms:" in guidelines
+        config = ArgumentScreeningConfig(guidelines=guidelines)
 
-    def test_renders_none_configured_when_keyword_list_empty(self):
-        config = ArgumentScreeningConfig(organization_specific_blocked_keywords=[])
-
-        guidelines = Template(config.guidelines).render(
-            organization_specific_blocked_keywords=(
-                config.organization_specific_blocked_keywords
-            ),
-        )
-
-        assert guidelines.rstrip().endswith("- [none configured]")
-        assert (
-            "If no organization-specific terms are configured, ignore this section."
-            in (DEFAULT_GUIDELINES)
-        )
+        assert config.guidelines == guidelines
 
 
 class TestArgumentScreeningResult:
@@ -295,75 +282,6 @@ class TestArgumentScreeningService:
         assert "- EFG" in user_msg.content
         assert "- efgbank.com" in user_msg.content
         assert user_msg.content.count("- EFG") == 1
-
-    @pytest.mark.asyncio
-    async def test_appends_configured_blocked_keywords_for_stale_guidelines(
-        self,
-        mock_language_model_service,
-        mock_language_model,
-        mock_message_log_callback,
-    ):
-        config = ArgumentScreeningConfig(
-            enabled=True,
-            user_prompt_template="Args: {{ arguments }} Rules: {{ guidelines }}",
-            guidelines="Custom rules\n\nConfigured blocked terms:",
-            organization_specific_blocked_keywords=["EFG", "efgbank.com"],
-        )
-        mock_response = Mock()
-        mock_response.choices = [
-            Mock(message=Mock(parsed={"go": True, "reason": "OK"}))
-        ]
-        mock_language_model_service.complete_async.return_value = mock_response
-
-        service = ArgumentScreeningService(
-            language_model_service=mock_language_model_service,
-            language_model=mock_language_model,
-            config=config,
-        )
-        await service({"query": "hello"}, mock_message_log_callback)
-
-        call_args = mock_language_model_service.complete_async.call_args
-        messages = call_args[0][0]
-        user_msg = next(m for m in messages if m.role.value == "user")
-
-        assert "Custom rules" in user_msg.content
-        assert user_msg.content.count("Configured blocked terms:") == 1
-        assert "- EFG" in user_msg.content
-        assert "- efgbank.com" in user_msg.content
-
-    @pytest.mark.asyncio
-    async def test_appends_configured_blocked_keywords_for_plain_custom_guidelines(
-        self,
-        mock_language_model_service,
-        mock_language_model,
-        mock_message_log_callback,
-    ):
-        config = ArgumentScreeningConfig(
-            enabled=True,
-            user_prompt_template="Args: {{ arguments }} Rules: {{ guidelines }}",
-            guidelines="Custom rules",
-            organization_specific_blocked_keywords=["EFG"],
-        )
-        mock_response = Mock()
-        mock_response.choices = [
-            Mock(message=Mock(parsed={"go": True, "reason": "OK"}))
-        ]
-        mock_language_model_service.complete_async.return_value = mock_response
-
-        service = ArgumentScreeningService(
-            language_model_service=mock_language_model_service,
-            language_model=mock_language_model,
-            config=config,
-        )
-        await service({"query": "hello"}, mock_message_log_callback)
-
-        call_args = mock_language_model_service.complete_async.call_args
-        messages = call_args[0][0]
-        user_msg = next(m for m in messages if m.role.value == "user")
-
-        assert "Custom rules" in user_msg.content
-        assert "Configured blocked terms:" in user_msg.content
-        assert "- EFG" in user_msg.content
 
     @pytest.mark.asyncio
     async def test_uses_structured_output(

--- a/tool_packages/unique_web_search/tests/test_argument_screening.py
+++ b/tool_packages/unique_web_search/tests/test_argument_screening.py
@@ -84,8 +84,9 @@ class TestBuildArgumentScreeningGuidelines:
         guidelines = build_argument_screening_guidelines(config)
 
         assert guidelines.endswith("- [none configured]")
-        assert "If no organization-specific terms are configured, ignore this section." in (
-            DEFAULT_GUIDELINES
+        assert (
+            "If no organization-specific terms are configured, ignore this section."
+            in (DEFAULT_GUIDELINES)
         )
 
 

--- a/tool_packages/unique_web_search/tests/test_argument_screening.py
+++ b/tool_packages/unique_web_search/tests/test_argument_screening.py
@@ -1,5 +1,6 @@
 from unittest.mock import AsyncMock, Mock
 
+from jinja2 import Template
 import pytest
 
 from unique_web_search.services.argument_screening import (
@@ -13,9 +14,6 @@ from unique_web_search.services.argument_screening import (
 )
 from unique_web_search.services.argument_screening.exceptions import (
     ArgumentScreeningUnparseableResponseException,
-)
-from unique_web_search.services.argument_screening.service import (
-    build_argument_screening_guidelines,
 )
 
 
@@ -60,30 +58,34 @@ class TestArgumentScreeningConfig:
         assert config.guidelines == "Custom guidelines"
 
 
-class TestBuildArgumentScreeningGuidelines:
+class TestArgumentScreeningGuidelinesTemplate:
     def test_renders_configured_keywords_as_bullets(self):
         config = ArgumentScreeningConfig(
-            guidelines="Configured blocked terms:",
             organization_specific_blocked_keywords=[
                 "EFG",
                 "efgbank.com",
             ],
         )
 
-        guidelines = build_argument_screening_guidelines(config)
+        guidelines = Template(config.guidelines).render(
+            organization_specific_blocked_keywords=(
+                config.organization_specific_blocked_keywords
+            ),
+        )
 
-        assert guidelines.endswith("- EFG\n- efgbank.com")
+        assert guidelines.rstrip().endswith("- EFG\n- efgbank.com")
         assert "Configured blocked terms:" in guidelines
 
     def test_renders_none_configured_when_keyword_list_empty(self):
-        config = ArgumentScreeningConfig(
-            guidelines="Configured blocked terms:",
-            organization_specific_blocked_keywords=[],
+        config = ArgumentScreeningConfig(organization_specific_blocked_keywords=[])
+
+        guidelines = Template(config.guidelines).render(
+            organization_specific_blocked_keywords=(
+                config.organization_specific_blocked_keywords
+            ),
         )
 
-        guidelines = build_argument_screening_guidelines(config)
-
-        assert guidelines.endswith("- [none configured]")
+        assert guidelines.rstrip().endswith("- [none configured]")
         assert (
             "If no organization-specific terms are configured, ignore this section."
             in (DEFAULT_GUIDELINES)
@@ -236,7 +238,6 @@ class TestArgumentScreeningService:
             enabled=True,
             system_prompt="System: screen this",
             user_prompt_template="Args: {{ arguments }} Rules: {{ guidelines }}",
-            guidelines="No secrets allowed",
         )
         mock_response = Mock()
         mock_response.choices = [
@@ -259,7 +260,7 @@ class TestArgumentScreeningService:
 
         assert system_msg.content == "System: screen this"
         assert "hello" in user_msg.content
-        assert "No secrets allowed" in user_msg.content
+        assert "Configured blocked terms:" in user_msg.content
         assert "[none configured]" in user_msg.content
 
     @pytest.mark.asyncio
@@ -272,7 +273,6 @@ class TestArgumentScreeningService:
         config = ArgumentScreeningConfig(
             enabled=True,
             user_prompt_template="Args: {{ arguments }} Rules: {{ guidelines }}",
-            guidelines="Configured blocked terms:",
             organization_specific_blocked_keywords=["EFG", "efgbank.com"],
         )
         mock_response = Mock()

--- a/tool_packages/unique_web_search/tests/test_argument_screening.py
+++ b/tool_packages/unique_web_search/tests/test_argument_screening.py
@@ -14,6 +14,9 @@ from unique_web_search.services.argument_screening import (
 from unique_web_search.services.argument_screening.exceptions import (
     ArgumentScreeningUnparseableResponseException,
 )
+from unique_web_search.services.argument_screening.service import (
+    build_argument_screening_guidelines,
+)
 
 
 class TestArgumentScreeningConfig:
@@ -33,6 +36,10 @@ class TestArgumentScreeningConfig:
         config = ArgumentScreeningConfig()
         assert config.guidelines == DEFAULT_GUIDELINES
 
+    def test_defaults_organization_specific_blocked_keywords_empty(self):
+        config = ArgumentScreeningConfig()
+        assert config.organization_specific_blocked_keywords == []
+
     def test_defaults_rejection_response_template(self):
         config = ArgumentScreeningConfig()
         assert config.rejection_response_template == DEFAULT_REJECTION_RESPONSE_TEMPLATE
@@ -51,6 +58,35 @@ class TestArgumentScreeningConfig:
             == "Custom {{ arguments }} template {{ guidelines }}"
         )
         assert config.guidelines == "Custom guidelines"
+
+
+class TestBuildArgumentScreeningGuidelines:
+    def test_renders_configured_keywords_as_bullets(self):
+        config = ArgumentScreeningConfig(
+            guidelines="Configured blocked terms:",
+            organization_specific_blocked_keywords=[
+                "EFG",
+                "efgbank.com",
+            ],
+        )
+
+        guidelines = build_argument_screening_guidelines(config)
+
+        assert guidelines.endswith("- EFG\n- efgbank.com")
+        assert "Configured blocked terms:" in guidelines
+
+    def test_renders_none_configured_when_keyword_list_empty(self):
+        config = ArgumentScreeningConfig(
+            guidelines="Configured blocked terms:",
+            organization_specific_blocked_keywords=[],
+        )
+
+        guidelines = build_argument_screening_guidelines(config)
+
+        assert guidelines.endswith("- [none configured]")
+        assert "If no organization-specific terms are configured, ignore this section." in (
+            DEFAULT_GUIDELINES
+        )
 
 
 class TestArgumentScreeningResult:
@@ -223,6 +259,40 @@ class TestArgumentScreeningService:
         assert system_msg.content == "System: screen this"
         assert "hello" in user_msg.content
         assert "No secrets allowed" in user_msg.content
+        assert "[none configured]" in user_msg.content
+
+    @pytest.mark.asyncio
+    async def test_passes_configured_blocked_keywords_in_guidelines(
+        self,
+        mock_language_model_service,
+        mock_language_model,
+        mock_message_log_callback,
+    ):
+        config = ArgumentScreeningConfig(
+            enabled=True,
+            user_prompt_template="Args: {{ arguments }} Rules: {{ guidelines }}",
+            guidelines="Configured blocked terms:",
+            organization_specific_blocked_keywords=["EFG", "efgbank.com"],
+        )
+        mock_response = Mock()
+        mock_response.choices = [
+            Mock(message=Mock(parsed={"go": True, "reason": "OK"}))
+        ]
+        mock_language_model_service.complete_async.return_value = mock_response
+
+        service = ArgumentScreeningService(
+            language_model_service=mock_language_model_service,
+            language_model=mock_language_model,
+            config=config,
+        )
+        await service({"query": "hello"}, mock_message_log_callback)
+
+        call_args = mock_language_model_service.complete_async.call_args
+        messages = call_args[0][0]
+        user_msg = next(m for m in messages if m.role.value == "user")
+
+        assert "- EFG" in user_msg.content
+        assert "- efgbank.com" in user_msg.content
 
     @pytest.mark.asyncio
     async def test_uses_structured_output(

--- a/tool_packages/unique_web_search/tests/test_argument_screening.py
+++ b/tool_packages/unique_web_search/tests/test_argument_screening.py
@@ -1,7 +1,7 @@
 from unittest.mock import AsyncMock, Mock
 
-from jinja2 import Template
 import pytest
+from jinja2 import Template
 
 from unique_web_search.services.argument_screening import (
     DEFAULT_GUIDELINES,

--- a/tool_packages/unique_web_search/tests/test_argument_screening.py
+++ b/tool_packages/unique_web_search/tests/test_argument_screening.py
@@ -54,29 +54,7 @@ class TestArgumentScreeningConfig:
             config.user_prompt_template
             == "Custom {{ arguments }} template {{ guidelines }}"
         )
-        assert "Custom guidelines" in config.guidelines
-        assert "organization_specific_blocked_keywords" in config.guidelines
-
-    def test_adds_keyword_template_to_custom_guidelines(self):
-        config = ArgumentScreeningConfig(
-            guidelines="Custom guidelines\n\nConfigured blocked terms:",
-        )
-
-        assert config.guidelines.count("Configured blocked terms:") == 1
-        assert config.guidelines.rstrip().endswith("{% endfor %}")
-        assert "organization_specific_blocked_keywords" in config.guidelines
-
-    def test_keeps_existing_keyword_template(self):
-        guidelines = (
-            "Custom guidelines\n"
-            "{% for keyword in organization_specific_blocked_keywords -%}\n"
-            "- {{ keyword }}\n"
-            "{% endfor %}"
-        )
-
-        config = ArgumentScreeningConfig(guidelines=guidelines)
-
-        assert config.guidelines == guidelines
+        assert config.guidelines == "Custom guidelines"
 
 
 class TestArgumentScreeningResult:
@@ -282,6 +260,39 @@ class TestArgumentScreeningService:
         assert "- EFG" in user_msg.content
         assert "- efgbank.com" in user_msg.content
         assert user_msg.content.count("- EFG") == 1
+
+    @pytest.mark.asyncio
+    async def test_attaches_configured_keywords_to_custom_guidelines(
+        self,
+        mock_language_model_service,
+        mock_language_model,
+        mock_message_log_callback,
+    ):
+        config = ArgumentScreeningConfig(
+            enabled=True,
+            user_prompt_template="Args: {{ arguments }} Rules: {{ guidelines }}",
+            guidelines="Custom guidelines",
+            organization_specific_blocked_keywords=["EFG"],
+        )
+        mock_response = Mock()
+        mock_response.choices = [
+            Mock(message=Mock(parsed={"go": True, "reason": "OK"}))
+        ]
+        mock_language_model_service.complete_async.return_value = mock_response
+
+        service = ArgumentScreeningService(
+            language_model_service=mock_language_model_service,
+            language_model=mock_language_model,
+            config=config,
+        )
+        await service({"query": "hello"}, mock_message_log_callback)
+
+        call_args = mock_language_model_service.complete_async.call_args
+        messages = call_args[0][0]
+        user_msg = next(m for m in messages if m.role.value == "user")
+
+        assert "Custom guidelines" in user_msg.content
+        assert "- EFG" in user_msg.content
 
     @pytest.mark.asyncio
     async def test_uses_structured_output(

--- a/tool_packages/unique_web_search/tests/test_argument_screening.py
+++ b/tool_packages/unique_web_search/tests/test_argument_screening.py
@@ -294,6 +294,76 @@ class TestArgumentScreeningService:
 
         assert "- EFG" in user_msg.content
         assert "- efgbank.com" in user_msg.content
+        assert user_msg.content.count("- EFG") == 1
+
+    @pytest.mark.asyncio
+    async def test_appends_configured_blocked_keywords_for_stale_guidelines(
+        self,
+        mock_language_model_service,
+        mock_language_model,
+        mock_message_log_callback,
+    ):
+        config = ArgumentScreeningConfig(
+            enabled=True,
+            user_prompt_template="Args: {{ arguments }} Rules: {{ guidelines }}",
+            guidelines="Custom rules\n\nConfigured blocked terms:",
+            organization_specific_blocked_keywords=["EFG", "efgbank.com"],
+        )
+        mock_response = Mock()
+        mock_response.choices = [
+            Mock(message=Mock(parsed={"go": True, "reason": "OK"}))
+        ]
+        mock_language_model_service.complete_async.return_value = mock_response
+
+        service = ArgumentScreeningService(
+            language_model_service=mock_language_model_service,
+            language_model=mock_language_model,
+            config=config,
+        )
+        await service({"query": "hello"}, mock_message_log_callback)
+
+        call_args = mock_language_model_service.complete_async.call_args
+        messages = call_args[0][0]
+        user_msg = next(m for m in messages if m.role.value == "user")
+
+        assert "Custom rules" in user_msg.content
+        assert user_msg.content.count("Configured blocked terms:") == 1
+        assert "- EFG" in user_msg.content
+        assert "- efgbank.com" in user_msg.content
+
+    @pytest.mark.asyncio
+    async def test_appends_configured_blocked_keywords_for_plain_custom_guidelines(
+        self,
+        mock_language_model_service,
+        mock_language_model,
+        mock_message_log_callback,
+    ):
+        config = ArgumentScreeningConfig(
+            enabled=True,
+            user_prompt_template="Args: {{ arguments }} Rules: {{ guidelines }}",
+            guidelines="Custom rules",
+            organization_specific_blocked_keywords=["EFG"],
+        )
+        mock_response = Mock()
+        mock_response.choices = [
+            Mock(message=Mock(parsed={"go": True, "reason": "OK"}))
+        ]
+        mock_language_model_service.complete_async.return_value = mock_response
+
+        service = ArgumentScreeningService(
+            language_model_service=mock_language_model_service,
+            language_model=mock_language_model,
+            config=config,
+        )
+        await service({"query": "hello"}, mock_message_log_callback)
+
+        call_args = mock_language_model_service.complete_async.call_args
+        messages = call_args[0][0]
+        user_msg = next(m for m in messages if m.role.value == "user")
+
+        assert "Custom rules" in user_msg.content
+        assert "Configured blocked terms:" in user_msg.content
+        assert "- EFG" in user_msg.content
 
     @pytest.mark.asyncio
     async def test_uses_structured_output(


### PR DESCRIPTION
## 🚀 Summary
Refs: UN-18090

- Replace default argument screening guidelines with CID-focused prompt (tested via websearch-CID-check eval)
- Add `organization_specific_blocked_keywords` admin config (empty by default, RJSF list)
- Append configured keywords into screening guidelines at runtime (`- [none configured]` when empty)

## 🧪 Testing
- [x] `uv run pytest tool_packages/unique_web_search/tests/test_argument_screening.py`
- [x] Test locally: 1. Enable `FEATURE_FLAG_ENABLE_WEB_SEARCH_ARGUMENT_SCREENING_UN_18741` + setup argument screening in WebSearch tool config with EFG keywords, 2. Run queries: below


Query 1:
"Use the WebSearch tool exactly once. Search the web using exactly this query, without rewriting, expanding, summarizing, translating, or adding terms. If the web search is blocked by a security check, report the block.
Query:
What is GDPR Article 9"

Query 2:
"Use the WebSearch tool exactly once. Search the web using exactly this query, without rewriting, expanding, summarizing, translating, or adding terms. If the web search is blocked by a security check, report the block.
Query:
EFG bank client onboarding process"
