### PR TITLE
feat(mcp): reference + groundedness support for MCP tool results

### DIFF
--- a/unique_sdk/tests/cli/test_mcp.py
+++ b/unique_sdk/tests/cli/test_mcp.py
@@ -1,0 +1,224 @@
+"""Tests for the ``unique-cli mcp`` command.
+
+Covers the per-turn output manifest used to ground the hallucination check
+(UN-21951) and the per-turn refs manifest used for MCP citations (UN-21285).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import unique_sdk
+from unique_sdk.cli.commands import mcp as mcp_cmd
+from unique_sdk.cli.commands.mcp import cmd_mcp
+from unique_sdk.cli.config import Config
+from unique_sdk.cli.state import ShellState
+
+_OUTPUT_MANIFEST = Path(".unique") / "mcp-output.jsonl"
+_REFS_MANIFEST = Path(".unique") / "mcp-refs.jsonl"
+
+
+class _FakeMCPResponse:
+    """Stand-in for a unique_sdk.MCP response (attribute access)."""
+
+    def __init__(
+        self,
+        content: list[dict] | None = None,
+        *,
+        is_error: bool = False,
+        mcp_server_id: str | None = None,
+        name: str | None = None,
+    ) -> None:
+        self.content = content or []
+        self.isError = is_error
+        self.mcpServerId = mcp_server_id
+        self.name = name
+
+
+def _config() -> Config:
+    return Config(
+        user_id="u1",
+        company_id="c1",
+        api_key="key",
+        app_id="app",
+        api_base="https://example.com",
+    )
+
+
+def _state() -> ShellState:
+    return ShellState(_config())
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+
+
+def _lines(tmp_path: Path, manifest: Path) -> list[dict]:
+    path = tmp_path / manifest
+    if not path.is_file():
+        return []
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def _run(
+    name: str,
+    response: _FakeMCPResponse,
+    formatted: str = "result",
+    arguments: dict | None = None,
+) -> str:
+    payload = json.dumps({"name": name, "arguments": arguments or {}})
+    with (
+        patch.object(unique_sdk.MCP, "call_tool", return_value=response),
+        patch.object(mcp_cmd, "format_mcp_response", return_value=formatted),
+    ):
+        return cmd_mcp(_state(), "chat_1", "msg_1", payload=payload)
+
+
+# ── Output manifest (UN-21951) ───────────────────────────────────────────────
+
+
+def test_cmd_mcp_writes_output_manifest(tmp_path: Path) -> None:
+    out = _run(
+        "mcp__crm__get_account",
+        _FakeMCPResponse(),
+        formatted="ACME revenue: 1M",
+    )
+    assert out.startswith("ACME revenue: 1M")
+    entries = _lines(tmp_path, _OUTPUT_MANIFEST)
+    assert entries[0]["toolName"] == "mcp__crm__get_account"
+    assert entries[0]["serverName"] == "crm"
+    assert entries[0]["text"] == "ACME revenue: 1M"
+
+
+def test_cmd_mcp_truncates_large_output(tmp_path: Path) -> None:
+    big = "x" * (mcp_cmd._MCP_OUTPUT_TEXT_CHAR_LIMIT + 500)
+    _run("mcp__kb__search", _FakeMCPResponse(), formatted=big)
+    text = _lines(tmp_path, _OUTPUT_MANIFEST)[0]["text"]
+    assert len(text) == mcp_cmd._MCP_OUTPUT_TEXT_CHAR_LIMIT
+
+
+# ── Refs manifest / citations (UN-21285) ─────────────────────────────────────
+#
+# One source per retrieved item — a *title* describing what was retrieved (no
+# URL). Titles come from resource_link names or a JSON-title heuristic; falls
+# back to a title-less tool chip when the result has no recognizable title.
+
+
+def test_resource_link_item_has_title_no_url(tmp_path: Path) -> None:
+    response = _FakeMCPResponse(
+        content=[
+            {
+                "type": "resource_link",
+                "uri": "https://kb.example.com/doc/9",
+                "name": "RAG Retrieval Baseline",
+                "description": "Why retrieval fails",
+            }
+        ]
+    )
+    out = _run("mcp__kb__fetch", response)
+
+    refs = _lines(tmp_path, _REFS_MANIFEST)
+    assert refs == [
+        {
+            "sourceNumber": 1,
+            "toolName": "mcp__kb__fetch",
+            "serverName": "kb",
+            "title": "RAG Retrieval Baseline",
+            "snippet": "Why retrieval fails",
+        }
+    ]
+    assert "[mcpsource1] RAG Retrieval Baseline" in out
+    assert "https://" not in out.split("result", 1)[1]  # no URL leaked into footer
+
+
+def test_json_in_text_yields_title_no_url(tmp_path: Path) -> None:
+    # Atlassian-style: a JSON record in a text block → title only.
+    body = json.dumps(
+        {"title": "RAG Retrieval Baseline", "webUrl": "https://confluence/x/2295"}
+    )
+    response = _FakeMCPResponse(content=[{"type": "text", "text": body}])
+    _run("mcp__atlassian__getConfluencePage", response)
+
+    refs = _lines(tmp_path, _REFS_MANIFEST)
+    assert refs[0]["title"] == "RAG Retrieval Baseline"
+    assert "url" not in refs[0]
+
+
+def test_multiple_items_get_distinct_numbers(tmp_path: Path) -> None:
+    response = _FakeMCPResponse(
+        content=[
+            {"type": "resource_link", "uri": "https://e/a", "name": "Doc A"},
+            {"type": "resource_link", "uri": "https://e/b", "name": "Doc B"},
+        ]
+    )
+    _run("mcp__kb__search", response)
+    refs = _lines(tmp_path, _REFS_MANIFEST)
+    assert {r["title"]: r["sourceNumber"] for r in refs} == {"Doc A": 1, "Doc B": 2}
+
+
+def test_same_title_dedupes_across_calls(tmp_path: Path) -> None:
+    r = _FakeMCPResponse(
+        content=[{"type": "resource_link", "uri": "https://e/a", "name": "Doc A"}]
+    )
+    _run("mcp__kb__fetch", r)
+    _run("mcp__kb__fetch", r)  # same title → reuse source 1
+    refs = _lines(tmp_path, _REFS_MANIFEST)
+    assert len(refs) == 1
+    assert refs[0]["sourceNumber"] == 1
+
+
+def test_titleless_result_falls_back_to_tool_chip(tmp_path: Path) -> None:
+    # No resource blocks, no JSON title → one title-less chip (runner names it
+    # after the tool). No URL is recorded.
+    response = _FakeMCPResponse(content=[{"type": "text", "text": "status: ok"}])
+    _run("mcp__crm__update", response)
+
+    refs = _lines(tmp_path, _REFS_MANIFEST)
+    assert refs[0]["title"] is None
+    assert "url" not in refs[0]
+
+
+def test_server_name_falls_back_to_mcp_server_id(tmp_path: Path) -> None:
+    response = _FakeMCPResponse(
+        content=[{"type": "text", "text": "ok"}],
+        mcp_server_id="srv_42",
+    )
+    _run("plainTool", response)
+    assert _lines(tmp_path, _REFS_MANIFEST)[0]["serverName"] == "srv_42"
+
+
+def test_refs_manifest_failure_does_not_break_tool_call(tmp_path: Path) -> None:
+    response = _FakeMCPResponse(content=[{"type": "text", "text": "x"}])
+    payload = json.dumps({"name": "mcp__crm__get", "arguments": {}})
+    with (
+        patch.object(unique_sdk.MCP, "call_tool", return_value=response),
+        patch.object(mcp_cmd, "format_mcp_response", return_value="result text"),
+        patch.object(
+            mcp_cmd, "_append_turn_refs_manifest_entry", side_effect=OSError("full")
+        ),
+    ):
+        out = cmd_mcp(_state(), "chat_1", "msg_1", payload=payload)
+
+    # Tool result still returned; just no citation footer.
+    assert out.startswith("result text")
+
+
+def test_api_error_writes_no_manifest(tmp_path: Path) -> None:
+    payload = json.dumps({"name": "mcp__crm__get", "arguments": {}})
+    with patch.object(
+        unique_sdk.MCP, "call_tool", side_effect=unique_sdk.APIError("boom")
+    ):
+        out = cmd_mcp(_state(), "chat_1", "msg_1", payload=payload)
+
+    assert out.startswith("mcp:")
+    assert _lines(tmp_path, _REFS_MANIFEST) == []
+    assert _lines(tmp_path, _OUTPUT_MANIFEST) == []

--- a/unique_sdk/tests/cli/test_mcp.py
+++ b/unique_sdk/tests/cli/test_mcp.py
@@ -229,6 +229,59 @@ def test_refs_manifest_failure_does_not_break_tool_call(tmp_path: Path) -> None:
     assert out.startswith("result text")
 
 
+def test_output_manifest_gets_server_id_from_response(tmp_path: Path) -> None:
+    # Bare skill-mode tool names have no mcp__ prefix, so _server_name_from_tool
+    # returns None. The output manifest must still record serverName via the
+    # response's mcpServerId — same logic as the refs manifest.
+    response = _FakeMCPResponse(
+        content=[{"type": "text", "text": "status: ok"}],
+        mcp_server_id="srv_99",
+    )
+    _run("plainTool", response, formatted="ok text")
+    entries = _lines(tmp_path, _OUTPUT_MANIFEST)
+    assert entries[0]["serverName"] == "srv_99"
+
+
+def test_partial_refs_returned_when_later_write_fails(tmp_path: Path) -> None:
+    # When writing the refs manifest entry for a later item fails, items already
+    # successfully written must still appear in the citation footer.
+    from unique_sdk.cli.commands.mcp import _annotate_mcp_results_for_citations
+
+    response = _FakeMCPResponse(
+        content=[
+            {"type": "resource_link", "uri": "https://e/a", "name": "Doc A"},
+            {"type": "resource_link", "uri": "https://e/b", "name": "Doc B"},
+        ]
+    )
+
+    refs_path = tmp_path / ".unique" / "mcp-refs.jsonl"
+    refs_path.parent.mkdir(parents=True, exist_ok=True)
+
+    write_count = [0]
+    original_append = mcp_cmd._append_turn_refs_manifest_entry
+
+    def fail_second_write(path, entry):
+        write_count[0] += 1
+        if write_count[0] == 2:
+            raise OSError("disk full")
+        original_append(path, entry)
+
+    with patch.object(
+        mcp_cmd, "_append_turn_refs_manifest_entry", side_effect=fail_second_write
+    ):
+        annotated = _annotate_mcp_results_for_citations(
+            response,
+            tool_name="mcp__kb__search",
+            server_name="kb",
+            refs_log_path=refs_path,
+        )
+
+    # First item was written and annotated; second was not.
+    assert len(annotated) == 1
+    assert annotated[0][0] == 1
+    assert annotated[0][1]["title"] == "Doc A"
+
+
 def test_api_error_writes_no_manifest(tmp_path: Path) -> None:
     payload = json.dumps({"name": "mcp__crm__get", "arguments": {}})
     with patch.object(

--- a/unique_sdk/tests/cli/test_mcp.py
+++ b/unique_sdk/tests/cli/test_mcp.py
@@ -176,6 +176,23 @@ def test_same_title_dedupes_across_calls(tmp_path: Path) -> None:
     assert refs[0]["sourceNumber"] == 1
 
 
+def test_different_tools_same_title_get_distinct_numbers(tmp_path: Path) -> None:
+    # Tool A records "Doc A" as source 1.
+    r = _FakeMCPResponse(
+        content=[{"type": "resource_link", "uri": "https://e/a", "name": "Doc A"}]
+    )
+    _run("mcp__kb__fetch", r)
+    # Tool B retrieves the same-named doc → different tool → must get source 2,
+    # not reuse source 1 (the bug: prior code used the *current* tool_name when
+    # rebuilding numbers_by_key, making Tool B collide with Tool A's entry).
+    _run("mcp__crm__get", r)
+    refs = _lines(tmp_path, _REFS_MANIFEST)
+    assert len(refs) == 2
+    numbers = {row["toolName"]: row["sourceNumber"] for row in refs}
+    assert numbers["mcp__kb__fetch"] == 1
+    assert numbers["mcp__crm__get"] == 2
+
+
 def test_titleless_result_falls_back_to_tool_chip(tmp_path: Path) -> None:
     # No resource blocks, no JSON title → one title-less chip (runner names it
     # after the tool). No URL is recorded.

--- a/unique_sdk/unique_sdk/cli/commands/mcp.py
+++ b/unique_sdk/unique_sdk/cli/commands/mcp.py
@@ -201,9 +201,15 @@ def _annotate_mcp_results_for_citations(
                         "title": item.get("title"),
                         "snippet": item.get("snippet"),
                     }
+                    try:
+                        _append_turn_refs_manifest_entry(refs_log_path, manifest_entry)
+                    except (UnsafeRefsLogPathError, OSError) as exc:
+                        _LOGGER.warning(
+                            "mcp: failed to append refs manifest entry: %s", exc
+                        )
+                        break
                     numbers_by_key[key] = source_number
                     entries.append(manifest_entry)
-                    _append_turn_refs_manifest_entry(refs_log_path, manifest_entry)
                 annotated.append((source_number, item))
     except (UnsafeRefsLogPathError, OSError) as exc:
         _LOGGER.warning("mcp: failed to append refs manifest: %s", exc)
@@ -225,7 +231,9 @@ def _citation_footer(annotated: list[tuple[int, dict[str, Any]]]) -> str:
     return "\n".join(lines)
 
 
-def _append_mcp_output_manifest(name: str, text: str) -> None:
+def _append_mcp_output_manifest(
+    name: str, text: str, *, server_name: str | None = None
+) -> None:
     """Best-effort append of one MCP tool result to the per-turn manifest.
 
     Never raises: a manifest failure must not change what the agent sees as
@@ -238,7 +246,7 @@ def _append_mcp_output_manifest(name: str, text: str) -> None:
             refs_log_path,
             {
                 "toolName": name,
-                "serverName": _server_name_from_tool(name),
+                "serverName": server_name,
                 "text": text[:_MCP_OUTPUT_TEXT_CHAR_LIMIT],
             },
         )
@@ -326,9 +334,8 @@ def cmd_mcp(
             fallback = repr(response)
         formatted = f"mcp: formatter error ({fmt_exc}); raw response:\n{fallback}"
 
-    _append_mcp_output_manifest(name, formatted)
-
     server_name = _server_name_from_tool(name) or getattr(response, "mcpServerId", None)
+    _append_mcp_output_manifest(name, formatted, server_name=server_name)
     annotated = _annotate_mcp_results_for_citations(
         response, tool_name=name, server_name=server_name
     )

--- a/unique_sdk/unique_sdk/cli/commands/mcp.py
+++ b/unique_sdk/unique_sdk/cli/commands/mcp.py
@@ -169,7 +169,8 @@ def _annotate_mcp_results_for_citations(
             numbers_by_key: dict[str, int] = {}
             for entry in entries:
                 if isinstance(entry.get("sourceNumber"), int):
-                    numbers_by_key[_item_dedup_key(tool_name, entry)] = entry[
+                    stored_tool = entry.get("toolName") or tool_name
+                    numbers_by_key[_item_dedup_key(stored_tool, entry)] = entry[
                         "sourceNumber"
                     ]
             for item in items:

--- a/unique_sdk/unique_sdk/cli/commands/mcp.py
+++ b/unique_sdk/unique_sdk/cli/commands/mcp.py
@@ -43,9 +43,25 @@ _MCP_MAX_ITEMS_PER_CALL = 8
 # Keys an MCP tool's JSON result commonly uses for a record's human title.
 _TITLE_KEYS = ("title", "name", "displayName", "subject", "summary", "key")
 
+# Canonical ``toolName`` written to both manifests: the **bare advertised tool
+# name** (the payload ``name`` the agent passes to ``unique-cli mcp``).
+# ``unique-cli mcp`` only runs in skills mode, where the agent invokes a tool by
+# its bare advertised name (the SI ``mcp_skill_generator`` renders the example
+# payload with that bare name). The SI runner therefore resolves a friendly
+# display label by keying its tool-config map on this bare name. The
+# ``mcp__<server>__<tool>`` parsing below is a defensive fallback for that
+# double-underscore convention and does not fire in skills mode; there
+# ``serverName`` is sourced from ``response.mcpServerId`` instead (see
+# ``cmd_mcp``).
+
 
 def _server_name_from_tool(name: str) -> str | None:
-    """Best-effort server name for the ``mcp__<server>__<tool>`` convention."""
+    """Best-effort server name for the ``mcp__<server>__<tool>`` convention.
+
+    Defensive only — the bare advertised tool name carries no ``mcp__`` prefix
+    in skills mode (the only mode that runs this command), so this returns
+    ``None`` there and the caller falls back to ``response.mcpServerId``.
+    """
     parts = name.split("__")
     if len(parts) >= 3 and parts[0] == "mcp":
         return parts[1]

--- a/unique_sdk/unique_sdk/cli/commands/mcp.py
+++ b/unique_sdk/unique_sdk/cli/commands/mcp.py
@@ -3,13 +3,230 @@
 from __future__ import annotations
 
 import json
+import logging
 import sys
 from pathlib import Path
 from typing import Any
 
 import unique_sdk
+from unique_sdk.cli.commands._citation_manifest import (
+    UnsafeRefsLogPathError,
+    _append_turn_refs_manifest_entry,
+    _locked_turn_refs_manifest,
+    _read_turn_refs_manifest,
+)
 from unique_sdk.cli.formatting import format_mcp_response
 from unique_sdk.cli.state import ShellState
+
+_LOGGER = logging.getLogger(__name__)
+
+# Per-turn manifest of MCP tool output text, consumed by the Swappable
+# Intelligence runner to ground the hallucination check against MCP-retrieved
+# information (UN-21951). Carries *text only* — no source numbers/markers
+# (referencing is UN-21285, tracked separately).
+_MCP_OUTPUT_LOG_RELATIVE_PATH = Path(".unique") / "mcp-output.jsonl"
+# Writer-side cap so a single huge/raw tool result cannot bloat the manifest.
+# The evaluator applies its own per-source cap as well.
+_MCP_OUTPUT_TEXT_CHAR_LIMIT = 50_000
+
+# Per-turn manifest of citable MCP sources, consumed by the runner to stitch
+# ``[mcpsourceN]`` markers into ``<sup>N</sup>`` footnotes + reference chips
+# (UN-21285). One entry per retrieved item: a short *title* describing what was
+# retrieved (no URL — those are technical/misleading). The runner labels the
+# chip with that title + the MCP tool name; falls back to the tool alone when
+# the result carries no recognizable title.
+_MCP_REFS_LOG_RELATIVE_PATH = Path(".unique") / "mcp-refs.jsonl"
+_MCP_REFS_LOCK_FILENAME = "mcp-refs.lock"
+_MCP_SNIPPET_CHAR_LIMIT = 300
+_MCP_MAX_ITEMS_PER_CALL = 8
+
+# Keys an MCP tool's JSON result commonly uses for a record's human title.
+_TITLE_KEYS = ("title", "name", "displayName", "subject", "summary", "key")
+
+
+def _server_name_from_tool(name: str) -> str | None:
+    """Best-effort server name for the ``mcp__<server>__<tool>`` convention."""
+    parts = name.split("__")
+    if len(parts) >= 3 and parts[0] == "mcp":
+        return parts[1]
+    return None
+
+
+def _snippet(text: str | None) -> str | None:
+    if not isinstance(text, str):
+        return None
+    collapsed = " ".join(text.split())
+    return collapsed[:_MCP_SNIPPET_CHAR_LIMIT] or None
+
+
+def _title_from_json(obj: dict[str, Any]) -> str | None:
+    for key in _TITLE_KEYS:
+        value = obj.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _titles_from_json(text: str) -> list[dict[str, Any]]:
+    """Best-effort: pull a human title out of a JSON result (object or list of
+    objects), e.g. an Atlassian page/issue returned as JSON-in-text. Returns []
+    when the text is not JSON or carries no recognizable title.
+    """
+    try:
+        parsed = json.loads(text)
+    except (ValueError, TypeError):
+        return []
+    candidates = parsed if isinstance(parsed, list) else [parsed]
+    items: list[dict[str, Any]] = []
+    for entry in candidates:
+        if isinstance(entry, dict):
+            title = _title_from_json(entry)
+            if title:
+                items.append({"title": title, "snippet": None})
+    return items
+
+
+def _extract_mcp_citation_items(
+    response: Any,
+    *,
+    tool_name: str,
+    server_name: str | None,
+) -> list[dict[str, Any]]:
+    """Context for what the tool retrieved: ``{title, snippet}`` per item.
+
+    Titles come from MCP ``resource_link`` names (spec-native) or a best-effort
+    JSON-title heuristic over text blocks (for tools like Atlassian that return
+    JSON-in-text). No URLs are extracted — the chip is display-only. Falls back
+    to a single title-less item (the runner names it after the tool) when the
+    result carries no recognizable title.
+    """
+    content = getattr(response, "content", None) or []
+    items: list[dict[str, Any]] = []
+
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") == "resource_link":
+            name = (block.get("name") or "").strip()
+            if name:
+                items.append(
+                    {"title": name, "snippet": _snippet(block.get("description"))}
+                )
+
+    if not items:
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "text":
+                items.extend(_titles_from_json(block.get("text") or ""))
+
+    if not items:
+        # No recognizable title — one chip named after the tool itself.
+        items.append({"title": None, "snippet": None})
+
+    return items[:_MCP_MAX_ITEMS_PER_CALL]
+
+
+def _next_mcp_source_number(entries: list[dict[str, Any]]) -> int:
+    numbers = [
+        entry["sourceNumber"]
+        for entry in entries
+        if isinstance(entry.get("sourceNumber"), int)
+    ]
+    return max(numbers, default=0) + 1
+
+
+def _item_dedup_key(tool_name: str, item: dict[str, Any]) -> str:
+    """Dedup by title when present (same item = one chip), else by tool."""
+    title = item.get("title")
+    if isinstance(title, str) and title.strip():
+        return f"title:{tool_name}:{title.strip()}"
+    return f"tool:{tool_name}"
+
+
+def _annotate_mcp_results_for_citations(
+    response: Any,
+    *,
+    tool_name: str,
+    server_name: str | None,
+    refs_log_path: Path | None = None,
+) -> list[tuple[int, dict[str, Any]]]:
+    """Assign per-turn ``[mcpsourceN]`` numbers to each retrieved item and append
+    the refs manifest. Returns ``[(sourceNumber, item)]`` for the footer.
+
+    Items dedup by title across the turn (same item keeps one number), or by
+    tool for the title-less fallback. Best-effort — returns ``[]`` on any failure
+    (the tool result is unaffected; only the citation footer is skipped).
+    """
+    refs_log_path = refs_log_path or (Path.cwd() / _MCP_REFS_LOG_RELATIVE_PATH)
+    annotated: list[tuple[int, dict[str, Any]]] = []
+    try:
+        items = _extract_mcp_citation_items(
+            response, tool_name=tool_name, server_name=server_name
+        )
+        with _locked_turn_refs_manifest(
+            refs_log_path, lock_filename=_MCP_REFS_LOCK_FILENAME
+        ):
+            entries = _read_turn_refs_manifest(refs_log_path)
+            numbers_by_key: dict[str, int] = {}
+            for entry in entries:
+                if isinstance(entry.get("sourceNumber"), int):
+                    numbers_by_key[_item_dedup_key(tool_name, entry)] = entry[
+                        "sourceNumber"
+                    ]
+            for item in items:
+                key = _item_dedup_key(tool_name, item)
+                source_number = numbers_by_key.get(key)
+                if source_number is None:
+                    source_number = _next_mcp_source_number(entries)
+                    manifest_entry = {
+                        "sourceNumber": source_number,
+                        "toolName": tool_name,
+                        "serverName": server_name,
+                        "title": item.get("title"),
+                        "snippet": item.get("snippet"),
+                    }
+                    numbers_by_key[key] = source_number
+                    entries.append(manifest_entry)
+                    _append_turn_refs_manifest_entry(refs_log_path, manifest_entry)
+                annotated.append((source_number, item))
+    except (UnsafeRefsLogPathError, OSError) as exc:
+        _LOGGER.warning("mcp: failed to append refs manifest: %s", exc)
+        return []
+    except Exception as exc:  # noqa: BLE001 — never break the tool call
+        _LOGGER.warning("mcp: failed to extract citations: %s", exc)
+        return []
+    return annotated
+
+
+def _citation_footer(annotated: list[tuple[int, dict[str, Any]]]) -> str:
+    """Tell the agent which marker to cite each retrieved item with."""
+    if not annotated:
+        return ""
+    lines = ["", "Sources — cite each fact with the marker for the item it came from:"]
+    for source_number, item in annotated:
+        label = item.get("title") or "this MCP tool result"
+        lines.append(f"  [mcpsource{source_number}] {label}")
+    return "\n".join(lines)
+
+
+def _append_mcp_output_manifest(name: str, text: str) -> None:
+    """Best-effort append of one MCP tool result to the per-turn manifest.
+
+    Never raises: a manifest failure must not change what the agent sees as
+    the tool result. The groundedness check simply does not fire for this
+    call when the write fails.
+    """
+    try:
+        refs_log_path = Path.cwd() / _MCP_OUTPUT_LOG_RELATIVE_PATH
+        _append_turn_refs_manifest_entry(
+            refs_log_path,
+            {
+                "toolName": name,
+                "serverName": _server_name_from_tool(name),
+                "text": text[:_MCP_OUTPUT_TEXT_CHAR_LIMIT],
+            },
+        )
+    except (UnsafeRefsLogPathError, OSError) as exc:
+        _LOGGER.warning("mcp: failed to append output manifest: %s", exc)
 
 
 def _read_payload(
@@ -84,10 +301,18 @@ def cmd_mcp(
         return f"mcp: {e}"
 
     try:
-        return format_mcp_response(response, tool_name=name)
+        formatted = format_mcp_response(response, tool_name=name)
     except Exception as fmt_exc:
         try:
             fallback = json.dumps(dict(response), indent=2, default=str)
         except Exception:
             fallback = repr(response)
-        return f"mcp: formatter error ({fmt_exc}); raw response:\n{fallback}"
+        formatted = f"mcp: formatter error ({fmt_exc}); raw response:\n{fallback}"
+
+    _append_mcp_output_manifest(name, formatted)
+
+    server_name = _server_name_from_tool(name) or getattr(response, "mcpServerId", None)
+    annotated = _annotate_mcp_results_for_citations(
+        response, tool_name=name, server_name=server_name
+    )
+    return formatted + _citation_footer(annotated)

--- a/unique_sdk/unique_sdk/cli/skills/unique-cli-mcp/SKILL.md
+++ b/unique_sdk/unique_sdk/cli/skills/unique-cli-mcp/SKILL.md
@@ -130,6 +130,22 @@ unique-cli mcp -c chat_123 -m msg_456 "$payload"
 python generate_payload.py | unique-cli mcp -c chat_123 -m msg_456 --stdin
 ```
 
+## Citation Rules
+
+Cite a fact retrieved from an MCP tool with `[mcpsourceN]`, where `N` matches the `sourceNumber` the command printed in the `Sources` footer beneath the tool output. Each footer line names one retrieved item; cite a fact with the marker of the specific item it came from. The Unique platform's Swappable Intelligence runner converts each `[mcpsourceN]` marker in your final answer into a `<sup>N</sup>` footnote and a display-only reference chip labelled with the retrieved item and the MCP tool name (e.g. "RAG Retrieval Baseline — Retrieve Confluence page (MCP)"). Without `[mcpsourceN]` markers, MCP-retrieved facts in your answer appear as plain text only, with no footnote and no chip.
+
+```
+ACME's Q3 revenue was 1.2M [mcpsource1], up from 0.9M a year earlier [mcpsource2].
+```
+
+**Rules** (enforced by the platform's reference post-processor, which reads `.unique/mcp-refs.jsonl` rather than your prose):
+
+1. **`[mcpsourceN]` is for MCP tool results only.** Knowledge-base results from `unique-cli search` use `[sourceN]`, and public web results from `unique-cli web-search` use `[websourceN]` — never mix the namespaces.
+2. Only cite numbers you saw in the **current** turn's MCP `Sources` footer. Numbers from previous turns are stale and will be silently dropped.
+3. Write `mcpsource` in singular form with the number in digits: `[mcpsource1]`, `[mcpsource2]` — not `[McpSource 1]` or `[mcpsource one]`.
+4. The same retrieved item keeps one stable `[mcpsourceN]` for the whole turn, so every fact from that item uses the same marker.
+5. Do not invent source numbers for remembered or inferred facts.
+
 ## Prerequisites
 
 Requires these environment variables:

--- a/unique_toolkit/tests/content/test_content_schemas_unit.py
+++ b/unique_toolkit/tests/content/test_content_schemas_unit.py
@@ -269,6 +269,27 @@ class TestContentIsExpired:
 # ---------------------------------------------------------------------------
 
 
+class TestContentReferenceUrlOptional:
+    def test_url_can_be_omitted(self):
+        ref = ContentReference(
+            name="crm · get_account",
+            sequence_number=1,
+            source="mcp:crm",
+            source_id="mcp_abc_mcp_abc",
+        )
+        assert ref.url is None
+
+    def test_url_still_accepted_when_present(self):
+        ref = ContentReference(
+            name="Example",
+            sequence_number=1,
+            source="mcp:kb",
+            source_id="mcp_def_mcp_def",
+            url="https://example.com",
+        )
+        assert ref.url == "https://example.com"
+
+
 class TestContentChunkToReference:
     def test_basic_reference_with_pages(self):
         chunk = ContentChunk(

--- a/unique_toolkit/unique_toolkit/agentic/evaluation/hallucination/constants.py
+++ b/unique_toolkit/unique_toolkit/agentic/evaluation/hallucination/constants.py
@@ -52,6 +52,18 @@ class HallucinationConfig(EvaluationMetricConfig):
         default={},
         description="Additional options to pass to the language model.",
     )
+    max_external_context_chars_per_source: SkipJsonSchema[int] = Field(
+        default=20_000,
+        ge=0,
+        description=(
+            "Per-source character cap applied to external (non-chunk) "
+            "context texts, e.g. MCP tool output. Raw/large tool results "
+            "inflate the judge prompt and the eval-LLM call; each external "
+            "text is truncated to this many characters before being added "
+            "to the context. 0 disables truncation. Does not affect "
+            "chunk-derived context."
+        ),
+    )
     score_to_label: dict[str, str] = {
         "LOW": "GREEN",
         "MEDIUM": "YELLOW",

--- a/unique_toolkit/unique_toolkit/agentic/evaluation/hallucination/hallucination_evaluation.py
+++ b/unique_toolkit/unique_toolkit/agentic/evaluation/hallucination/hallucination_evaluation.py
@@ -54,6 +54,17 @@ class HallucinationEvaluation(Evaluation):
             reference_pattern=self.config.reference_pattern,
         )
 
+        # Append non-chunk groundedness context (e.g. MCP tool output). These
+        # are added in full ("all retrieved output as context") rather than via
+        # source-marker selection, since they carry no [sourceN] markers.
+        external_context_texts = self._reference_manager.get_external_context_texts()
+        max_chars = self.config.max_external_context_chars_per_source
+        if max_chars > 0:
+            external_context_texts = [
+                text[:max_chars] for text in external_context_texts
+            ]
+        context_texts = context_texts + external_context_texts
+
         evaluation_result: EvaluationMetricResult = await check_hallucination(
             company_id=self._company_id,
             user_id=self._user_id,

--- a/unique_toolkit/unique_toolkit/agentic/evaluation/tests/test_hallucination_external_context.py
+++ b/unique_toolkit/unique_toolkit/agentic/evaluation/tests/test_hallucination_external_context.py
@@ -1,0 +1,122 @@
+"""Tests that HallucinationEvaluation grounds against non-chunk context.
+
+UN-21951: external context texts (e.g. MCP tool output) registered on the
+ReferenceManager must be appended to the evaluation context — in addition to
+chunk-derived context, capped by ``max_external_context_chars_per_source`` —
+without being converted to ContentChunks.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from unique_toolkit.agentic.evaluation.hallucination import (
+    hallucination_evaluation as he,
+)
+from unique_toolkit.agentic.evaluation.hallucination.constants import (
+    HallucinationConfig,
+    SourceSelectionMode,
+)
+from unique_toolkit.agentic.evaluation.schemas import (
+    EvaluationMetricName,
+    EvaluationMetricResult,
+)
+from unique_toolkit.agentic.reference_manager.reference_manager import (
+    ReferenceManager,
+)
+from unique_toolkit.chat.schemas import ChatMessageRole
+from unique_toolkit.language_model.schemas import (
+    LanguageModelStreamResponse,
+    LanguageModelStreamResponseMessage,
+)
+
+
+def _make_event() -> SimpleNamespace:
+    return SimpleNamespace(
+        company_id="company_1",
+        user_id="user_1",
+        payload=SimpleNamespace(
+            user_message=SimpleNamespace(text="what is ACME revenue?"),
+        ),
+    )
+
+
+def _make_response(text: str = "ACME revenue is 1M.") -> LanguageModelStreamResponse:
+    return LanguageModelStreamResponse(
+        message=LanguageModelStreamResponseMessage(
+            id="msg_1",
+            previous_message_id=None,
+            role=ChatMessageRole.ASSISTANT,
+            text=text,
+            chat_id="chat_1",
+            original_text=text,
+            references=None,
+        ),
+        tool_calls=None,
+    )
+
+
+@pytest.fixture
+def captured_context(monkeypatch: pytest.MonkeyPatch) -> dict:
+    """Patch check_hallucination to capture the context_texts it receives."""
+    captured: dict = {}
+
+    async def _fake_check_hallucination(*, company_id, user_id, input, config):
+        captured["context_texts"] = list(input.context_texts or [])
+        return EvaluationMetricResult(
+            name=EvaluationMetricName.HALLUCINATION,
+            value="LOW",
+            reason="grounded",
+        )
+
+    monkeypatch.setattr(he, "check_hallucination", _fake_check_hallucination)
+    return captured
+
+
+async def test_external_context_is_appended(captured_context: dict) -> None:
+    manager = ReferenceManager()
+    manager.add_external_context_texts(["ACME revenue: 1M"])
+    evaluation = he.HallucinationEvaluation(
+        HallucinationConfig(source_selection_mode=SourceSelectionMode.FROM_IDS),
+        _make_event(),  # type: ignore[arg-type]
+        manager,
+    )
+
+    result = await evaluation.run(_make_response())
+
+    # No chunks → context comes solely from the external (MCP) source.
+    assert captured_context["context_texts"] == ["ACME revenue: 1M"]
+    assert result.value == "LOW"
+    assert result.is_positive is True
+
+
+async def test_external_context_is_truncated(captured_context: dict) -> None:
+    manager = ReferenceManager()
+    manager.add_external_context_texts(["x" * 100])
+    evaluation = he.HallucinationEvaluation(
+        HallucinationConfig(
+            source_selection_mode=SourceSelectionMode.FROM_IDS,
+            max_external_context_chars_per_source=10,
+        ),
+        _make_event(),  # type: ignore[arg-type]
+        manager,
+    )
+
+    await evaluation.run(_make_response())
+
+    assert captured_context["context_texts"] == ["x" * 10]
+
+
+async def test_no_external_context_preserves_chunk_only_behaviour(
+    captured_context: dict,
+) -> None:
+    manager = ReferenceManager()  # no chunks, no external context
+    evaluation = he.HallucinationEvaluation(
+        HallucinationConfig(source_selection_mode=SourceSelectionMode.FROM_IDS),
+        _make_event(),  # type: ignore[arg-type]
+        manager,
+    )
+
+    await evaluation.run(_make_response())
+
+    assert captured_context["context_texts"] == []

--- a/unique_toolkit/unique_toolkit/agentic/reference_manager/reference_manager.py
+++ b/unique_toolkit/unique_toolkit/agentic/reference_manager/reference_manager.py
@@ -32,6 +32,7 @@ class ReferenceManager:
         self._tool_chunks: dict[str, tool_chunks] = {}
         self._chunks: list[ContentChunk] = []
         self._references: list[list[ContentReference]] = []
+        self._external_context_texts: list[str] = []
 
     def extract_referenceable_chunks(
         self, tool_responses: list[ToolCallResponse]
@@ -46,6 +47,21 @@ class ReferenceManager:
 
     def get_chunks(self) -> list[ContentChunk]:
         return self._chunks
+
+    def add_external_context_texts(self, texts: list[str]) -> None:
+        """Register groundedness context that is not backed by ContentChunks.
+
+        Some retrieval sources (e.g. MCP tool output) provide text the answer
+        is built on but are deliberately *not* modelled as ContentChunks — they
+        are a different entity from ingested document chunks and must not flow
+        through the chunk/reference pipeline. They still need to ground the
+        hallucination check, so they are stored here and appended to the
+        evaluation context alongside the chunk-derived texts.
+        """
+        self._external_context_texts.extend(text for text in texts if text)
+
+    def get_external_context_texts(self) -> list[str]:
+        return self._external_context_texts
 
     def get_tool_chunks(self) -> dict[str, tool_chunks]:
         return self._tool_chunks

--- a/unique_toolkit/unique_toolkit/agentic/reference_manager/tests/test_external_context.py
+++ b/unique_toolkit/unique_toolkit/agentic/reference_manager/tests/test_external_context.py
@@ -1,0 +1,35 @@
+"""Tests for non-chunk groundedness context on the ReferenceManager.
+
+External context texts (e.g. MCP tool output, UN-21951) ground the
+hallucination check without being modelled as ContentChunks.
+"""
+
+from unique_toolkit.agentic.reference_manager.reference_manager import (
+    ReferenceManager,
+)
+
+
+def test_external_context_starts_empty() -> None:
+    manager = ReferenceManager()
+    assert manager.get_external_context_texts() == []
+
+
+def test_add_external_context_texts_accumulates() -> None:
+    manager = ReferenceManager()
+    manager.add_external_context_texts(["a", "b"])
+    manager.add_external_context_texts(["c"])
+    assert manager.get_external_context_texts() == ["a", "b", "c"]
+
+
+def test_add_external_context_texts_drops_empty_strings() -> None:
+    manager = ReferenceManager()
+    manager.add_external_context_texts(["keep", "", "also"])
+    assert manager.get_external_context_texts() == ["keep", "also"]
+
+
+def test_external_context_is_independent_of_chunks() -> None:
+    manager = ReferenceManager()
+    manager.add_external_context_texts(["mcp output"])
+    # External context must not leak into the chunk pipeline.
+    assert manager.get_chunks() == []
+    assert manager.get_external_context_texts() == ["mcp output"]

--- a/unique_toolkit/unique_toolkit/content/schemas.py
+++ b/unique_toolkit/unique_toolkit/content/schemas.py
@@ -215,7 +215,15 @@ class ContentReference(BaseModel):
     sequence_number: int
     source: str
     source_id: str
-    url: str
+    url: str | None = Field(
+        default=None,
+        description=(
+            "Link target for the reference. Optional: some sources (e.g. an "
+            "opaque MCP tool result with no resource link) have no URL and "
+            "render as a display-only, non-clickable citation. Nullable "
+            "end-to-end (node-chat persists it as a nullable column)."
+        ),
+    )
     original_index: list[int] = Field(
         default=[],
         description="List of indices in the ChatMessage original_text this reference refers to. This is usually the id in the functionCallResponse. List type due to implementation in node-chat",


### PR DESCRIPTION
## Summary

SDK changes enabling the Swappable Intelligence runner to **reference** and **groundedness-check** information retrieved via MCP tools. Pairs with the monorepo runner/frontend changes (separate PR).

Tickets:
- [UN-21285 — Add referencing when agent uses MCP tools](https://unique-ch.atlassian.net/browse/UN-21285)
- [UN-21951 — Enable hallucination check for MCP tool retrieved information](https://unique-ch.atlassian.net/browse/UN-21951)

## `unique-cli mcp` (`unique_sdk`)
- Writes a per-turn `.unique/mcp-refs.jsonl` manifest — one citable item per retrieved result (a **title** describing what was retrieved) plus a `Sources` footer telling the agent which `[mcpsourceN]` marker to cite. **No URLs** are extracted (they're technical/misleading); references are provenance-only. (UN-21285)
- Captures MCP tool output text in `.unique/mcp-output.jsonl` for the groundedness check. (UN-21951)
- Both writes are best-effort and never alter the tool result returned to the agent.

## `unique_toolkit`
- `ReferenceManager.add_external_context_texts()` / `get_external_context_texts()` — a non-chunk channel for groundedness context. (UN-21951)
- `HallucinationEvaluation.run()` appends external (MCP) context to the judged `context_texts`, with a per-source character cap — the **same** check used for KB/web. (UN-21951)
- `ContentReference.url` is now optional, for display-only references. (UN-21285)

## Tests
- `unique_sdk`: `tests/cli/test_mcp.py` — manifest extraction (resource_link / JSON-title), dedup, footer, failure isolation.
- `unique_toolkit`: external-context store, hallucination eval with non-chunk context + truncation, `ContentReference(url=None)`.

## Rollout
Ship before the monorepo PR: the runner no-ops when the manifests are absent and `ContentReference.url` optional is backward-compatible. The monorepo then bumps its pinned `unique-sdk` / `unique-toolkit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)