### PR TITLE
fix(sdk): filter nullable request headers

### DIFF
--- a/pr-1803-typecheck-findings.md
+++ b/pr-1803-typecheck-findings.md
@@ -1,0 +1,61 @@
+# PR 1803 Typecheck Failure Findings
+
+## Summary
+
+PR [#1803](https://github.com/Unique-AG/ai/pull/1803) fails the CI Gatekeeper because the strict typecheck jobs for `unique_sdk` and `unique_toolkit` fail.
+
+Tracking ticket: [UN-22137](https://unique-ch.atlassian.net/browse/UN-22137)
+
+The failing diagnostics are:
+
+- `unique_sdk/unique_sdk/utils/file_io.py`: `requests.get(..., headers=headers)` receives `dict[str, str | None]`.
+- `unique_toolkit/unique_toolkit/content/functions.py`: `requests.get(..., headers=headers)` receives `dict[str, str | None]`.
+
+`requests` now types `headers` as requiring non-`None` values. The local header dictionaries include `unique_sdk.app_id`, which is declared as `str | None`.
+
+## Root Cause
+
+The sync download helpers build headers directly from nullable SDK globals:
+
+- `unique_sdk.app_id: str | None`
+- `unique_sdk.api_key: str | None`
+
+Because at least one header value can be `None`, basedpyright infers the whole dictionary as `dict[str, str | None]`. That is not assignable to the `requests.get` `headers` parameter.
+
+The async toolkit helper already uses the safer pattern: build `raw_headers: dict[str, str | None]`, then filter out `None` values into `dict[str, str]` before calling the HTTP client.
+
+## Where This Was Introduced
+
+The underlying code paths are old, but the CI-visible regression was introduced by PR [#1771 feat: User Memory](https://github.com/Unique-AG/ai/pull/1771).
+
+That PR updated `uv.lock`, including:
+
+- `basedpyright` from `1.39.1` to `1.39.6`
+- `pyright` from `1.1.408` to `1.1.410`
+- `requests` from `2.33.1` to `2.34.2`
+
+Those updated type definitions made the existing nullable header construction fail strict typechecking.
+
+## Why It Was Not Caught Earlier
+
+CI selects package checks from changed paths. PR #1771 changed `uv.lock` and package paths for `unique_orchestrator` and `unique_user_memory`, so the typecheck jobs that ran were:
+
+- `types-orchestrator`
+- `types-user_memory`
+
+It did not run:
+
+- `types-sdk`
+- `types-toolkit`
+
+The release PR #1803 updates many package `pyproject.toml` files, so the strict `unique_sdk` and `unique_toolkit` typecheck jobs run and expose the existing issue.
+
+## Fix Direction
+
+Use a consistent header construction helper or local pattern for sync code:
+
+1. Build `raw_headers: dict[str, str | None]`.
+2. Filter out `None` values.
+3. Pass the resulting `dict[str, str]` to `requests.get`.
+
+This preserves runtime behavior for optional SDK globals and satisfies the stricter `requests` header type.

--- a/unique_sdk/unique_sdk/utils/file_io.py
+++ b/unique_sdk/unique_sdk/utils/file_io.py
@@ -349,13 +349,14 @@ def download_content(
     if chat_id:
         url = f"{url}?chatId={chat_id}"
 
-    headers = {
+    raw_headers: dict[str, str | None] = {
         "x-api-version": unique_sdk.api_version,
         "x-app-id": unique_sdk.app_id,
         "x-user-id": userId,
         "x-company-id": companyId,
         "Authorization": "Bearer %s" % (unique_sdk.api_key,),
     }
+    headers: dict[str, str] = {k: v for k, v in raw_headers.items() if v is not None}
 
     # Issue the request before resolving the destination. A non-200
     # response should never leave a half-created directory or empty

--- a/unique_toolkit/unique_toolkit/content/functions.py
+++ b/unique_toolkit/unique_toolkit/content/functions.py
@@ -681,13 +681,14 @@ def request_content_by_id(
         url = f"{url}?chatId={chat_id}"
 
     # Download the file and save it to the random directory
-    headers = {
+    raw_headers: dict[str, str | None] = {
         "x-api-version": unique_sdk.api_version,
         "x-app-id": unique_sdk.app_id,
         "x-user-id": user_id,
         "x-company-id": company_id,
         "Authorization": "Bearer %s" % (unique_sdk.api_key,),
     }
+    headers: dict[str, str] = {k: v for k, v in raw_headers.items() if v is not None}
 
     return requests.get(url, headers=headers)
 


### PR DESCRIPTION
## Summary
- Filter optional SDK header values before sync `requests.get` calls in `unique_sdk` and `unique_toolkit`.
- Document the PR #1803 typecheck failure, the PR that introduced the CI-visible regression, and why path-based CI missed it.

## Changes
- Mirror the existing async header pattern by building `raw_headers: dict[str, str | None]` and passing only non-`None` values to `requests.get`.
- Add `pr-1803-typecheck-findings.md` with the investigation notes and Jira link.

## Test plan
- [x] `uv run --frozen basedpyright` from `unique_sdk`
- [x] `uv run --frozen basedpyright` from `unique_toolkit`

## Risk / rollout
- Low risk: unset optional headers are omitted instead of being passed as `None`, matching existing async behavior.

Refs: UN-22137

Made with [Cursor](https://cursor.com)