### PR TITLE
feat(uqadm): backport assistantPrompts space migration to 2026.26 [UN-22129]

### DIFF
--- a/unique_sdk/unique_sdk/api_resources/_space.py
+++ b/unique_sdk/unique_sdk/api_resources/_space.py
@@ -38,6 +38,12 @@ class Space(APIResource["Space"]):
         description: NotRequired[str | None]
         weight: NotRequired[int | None]
 
+    class AssistantPromptParams(TypedDict):
+        title: str
+        prompt: str
+        id: NotRequired[str | None]
+        order: NotRequired[int | None]
+
     class CreateSpaceParams(RequestOptions):
         name: str
         fallbackModule: str
@@ -50,6 +56,7 @@ class Space(APIResource["Space"]):
         isPinned: NotRequired[bool | None]
         uiType: NotRequired["Space.UiType | None"]
         settings: NotRequired[dict[str, Any] | None]
+        assistantPrompts: NotRequired[list["Space.AssistantPromptParams"] | None]
 
     class UpdateParams(RequestOptions):
         name: NotRequired[str | None]
@@ -63,6 +70,7 @@ class Space(APIResource["Space"]):
         settings: NotRequired[dict[str, Any] | None]
         allowEndUserSpace: NotRequired[bool | None]
         uiType: NotRequired["Space.UiType | None"]
+        assistantPrompts: NotRequired[list["Space.AssistantPromptParams"] | None]
 
     class AccessEntry(TypedDict):
         entityId: str

--- a/uqadm/tests/space/test_upsert.py
+++ b/uqadm/tests/space/test_upsert.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from uqadm.core.payload_files import snapshot_format_for_path
+from uqadm.space.migrate import assistant_prompt_params_from_source
 from uqadm.space.upsert import cmd_upsert, load_space_snapshot
 
 
@@ -121,3 +122,52 @@ def test_upsert_update_dry_run_no_writes(
         mock_get.assert_called_once_with("u", "c", "space_dst")
     out = capsys.readouterr().out
     assert "Dry-run: would update_space" in out
+
+
+def test_assistant_prompt_params_from_source_strips_export_only_fields() -> None:
+    prompts = assistant_prompt_params_from_source(
+        [
+            {
+                "id": "prompt_1",
+                "object": "assistant-prompt",
+                "order": 0,
+                "title": "Summarize",
+                "prompt": "Please summarize",
+            }
+        ]
+    )
+    # The source `id` and `object` must be dropped so prompts are not bound to
+    # the source space's identity; only content + order are forwarded.
+    assert prompts == [
+        {
+            "order": 0,
+            "title": "Summarize",
+            "prompt": "Please summarize",
+        }
+    ]
+
+
+def test_build_update_kwargs_includes_empty_assistant_prompts() -> None:
+    from uqadm.space.migrate import build_update_kwargs
+
+    kwargs = build_update_kwargs({"name": "S", "assistantPrompts": []})
+    assert kwargs["assistantPrompts"] == []
+    assert kwargs["name"] == "S"
+
+
+def test_build_create_params_maps_assistant_prompts() -> None:
+    from uqadm.space.migrate import build_create_params
+
+    params = build_create_params(
+        {
+            "name": "S",
+            "fallbackModule": "fm",
+            "modules": [],
+            "assistantPrompts": [
+                {"title": "T", "prompt": "P", "order": 1},
+            ],
+        }
+    )
+    assert params["assistantPrompts"] == [
+        {"title": "T", "prompt": "P", "order": 1},
+    ]

--- a/uqadm/uqadm/space/migrate.py
+++ b/uqadm/uqadm/space/migrate.py
@@ -53,6 +53,31 @@ def match_modules_by_name(
     return pairs, unmatched_names
 
 
+def assistant_prompt_params_from_source(
+    prompts: list[dict[str, Any]] | None,
+) -> list[dict[str, Any]]:
+    """Map export snapshot prompts to Space API assistantPrompts payloads.
+
+    Source ``id`` values are intentionally dropped: they identify prompts of the
+    *source* space and are meaningless (and unsafe to forward) when creating a
+    new space or migrating/upserting into a different one. Omitting them makes
+    the operation a clean full replacement on the server (delete-all +
+    create-all), mirroring how module creates omit source module ids.
+    """
+    if not prompts:
+        return []
+    out: list[dict[str, Any]] = []
+    for prompt in prompts:
+        item: dict[str, Any] = {
+            "title": prompt["title"],
+            "prompt": prompt["prompt"],
+        }
+        if prompt.get("order") is not None:
+            item["order"] = prompt["order"]
+        out.append(item)
+    return out
+
+
 def build_create_params(src: dict[str, Any]) -> dict[str, Any]:
     modules = [module_params_from_source(m) for m in src.get("modules") or []]
     params: dict[str, Any] = {
@@ -73,6 +98,10 @@ def build_create_params(src: dict[str, Any]) -> dict[str, Any]:
     for key in optional_keys:
         if src.get(key) is not None:
             params[key] = src[key]
+    if src.get("assistantPrompts"):
+        params["assistantPrompts"] = assistant_prompt_params_from_source(
+            src["assistantPrompts"]
+        )
     return params
 
 
@@ -112,6 +141,10 @@ def build_update_kwargs(src: dict[str, Any]) -> dict[str, Any]:
     for key in simple:
         if src.get(key) is not None:
             kwargs[key] = src[key]
+    if "assistantPrompts" in src:
+        kwargs["assistantPrompts"] = assistant_prompt_params_from_source(
+            src["assistantPrompts"]
+        )
     return kwargs
 
 

--- a/uqadm/uqadm/space/upsert.py
+++ b/uqadm/uqadm/space/upsert.py
@@ -43,6 +43,13 @@ def _emit_snapshot_warnings(snapshot: dict[str, Any]) -> None:
             "these are not applied by upsert.",
             err=True,
         )
+    prompts = snapshot.get("assistantPrompts")
+    if prompts:
+        typer.echo(
+            f"Note: snapshot lists {len(prompts)} assistant prompt(s); "
+            "these will be applied on create/update.",
+            err=True,
+        )
 
 
 def _validate_snapshot(snapshot: dict[str, Any], *, creating: bool) -> None:


### PR DESCRIPTION
Backports #1903 (eb7804328) to release/2026.26.

Includes unique_sdk (assistantPrompts create/update params) and uqadm (space migrate/upsert + tests). No unique_toolkit changes.

Merge with **Rebase and merge** (squash blocked / breaks release-please).

Made with [Cursor](https://cursor.com)