### PR TITLE
fix(search-proxy): use LogSecretStr for Bing agent secret fields

### DIFF
--- a/connectors/unique_search_proxy/unique_search_proxy_client/deploy/helm-chart/templates/_generated.tpl
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/deploy/helm-chart/templates/_generated.tpl
@@ -35,16 +35,22 @@ library extension hooks (base.externalService.*.ext).
   value: {{ .Values.perplexitySearch.connection.apiEndpoint | quote }}
 {{- end }}
 {{- if and .Values.bingAgent .Values.bingAgent.enabled }}
-- name: BING_AGENT_ENDPOINT
-  value: {{ required "bingAgent.connection.endpoint is required when bingAgent.enabled is true. Set it in your environment overlay." .Values.bingAgent.connection.endpoint | quote }}
-- name: BING_AGENT_BING_RESOURCE_CONNECTION_STRING
-  value: {{ required "bingAgent.connection.bingResourceConnectionString is required when bingAgent.enabled is true. Set it in your environment overlay." .Values.bingAgent.connection.bingResourceConnectionString | quote }}
+{{- if not .Values.bingAgent.connection.endpoint }}
+{{- fail "bingAgent.connection.endpoint is required when bingAgent.enabled is true. Set it in your environment overlay." }}
+{{- end }}
+{{ include "base.valueSource.env" (dict "name" "BING_AGENT_ENDPOINT" "src" .Values.bingAgent.connection.endpoint "ctx" .) }}
+{{- if not .Values.bingAgent.connection.bingResourceConnectionString }}
+{{- fail "bingAgent.connection.bingResourceConnectionString is required when bingAgent.enabled is true. Set it in your environment overlay." }}
+{{- end }}
+{{ include "base.valueSource.env" (dict "name" "BING_AGENT_BING_RESOURCE_CONNECTION_STRING" "src" .Values.bingAgent.connection.bingResourceConnectionString "ctx" .) }}
 {{- if .Values.bingAgent.connection.agentId }}
 - name: BING_AGENT_AGENT_ID
   value: {{ .Values.bingAgent.connection.agentId | quote }}
 {{- end }}
-- name: BING_AGENT_BING_AGENT_MODEL
-  value: {{ .Values.bingAgent.connection.bingAgentModel | quote }}
+{{- if not .Values.bingAgent.connection.bingAgentModel }}
+{{- fail "bingAgent.connection.bingAgentModel is required when bingAgent.enabled is true. Set it in your environment overlay." }}
+{{- end }}
+{{ include "base.valueSource.env" (dict "name" "BING_AGENT_BING_AGENT_MODEL" "src" .Values.bingAgent.connection.bingAgentModel "ctx" .) }}
 - name: BING_AGENT_AZURE_IDENTITY_CREDENTIAL_TYPE
   value: {{ .Values.bingAgent.connection.azureIdentityCredentialType | quote }}
 - name: BING_AGENT_AZURE_IDENTITY_VALIDATE_TOKEN_URL
@@ -173,16 +179,22 @@ library extension hooks (base.externalService.*.ext).
   value: {{ .ctx.Values.perplexitySearch.connection.apiEndpoint | quote }}
 {{- end }}
 {{- if and .ctx.Values.bingAgent .ctx.Values.bingAgent.enabled }}
-- name: BING_AGENT_ENDPOINT
-  value: {{ required "bingAgent.connection.endpoint is required when bingAgent.enabled is true. Set it in your environment overlay." .ctx.Values.bingAgent.connection.endpoint | quote }}
-- name: BING_AGENT_BING_RESOURCE_CONNECTION_STRING
-  value: {{ required "bingAgent.connection.bingResourceConnectionString is required when bingAgent.enabled is true. Set it in your environment overlay." .ctx.Values.bingAgent.connection.bingResourceConnectionString | quote }}
+{{- if not .ctx.Values.bingAgent.connection.endpoint }}
+{{- fail "bingAgent.connection.endpoint is required when bingAgent.enabled is true. Set it in your environment overlay." }}
+{{- end }}
+{{ include "base.valueSource.env" (dict "name" "BING_AGENT_ENDPOINT" "src" .ctx.Values.bingAgent.connection.endpoint "ctx" .ctx) }}
+{{- if not .ctx.Values.bingAgent.connection.bingResourceConnectionString }}
+{{- fail "bingAgent.connection.bingResourceConnectionString is required when bingAgent.enabled is true. Set it in your environment overlay." }}
+{{- end }}
+{{ include "base.valueSource.env" (dict "name" "BING_AGENT_BING_RESOURCE_CONNECTION_STRING" "src" .ctx.Values.bingAgent.connection.bingResourceConnectionString "ctx" .ctx) }}
 {{- if .ctx.Values.bingAgent.connection.agentId }}
 - name: BING_AGENT_AGENT_ID
   value: {{ .ctx.Values.bingAgent.connection.agentId | quote }}
 {{- end }}
-- name: BING_AGENT_BING_AGENT_MODEL
-  value: {{ .ctx.Values.bingAgent.connection.bingAgentModel | quote }}
+{{- if not .ctx.Values.bingAgent.connection.bingAgentModel }}
+{{- fail "bingAgent.connection.bingAgentModel is required when bingAgent.enabled is true. Set it in your environment overlay." }}
+{{- end }}
+{{ include "base.valueSource.env" (dict "name" "BING_AGENT_BING_AGENT_MODEL" "src" .ctx.Values.bingAgent.connection.bingAgentModel "ctx" .ctx) }}
 - name: BING_AGENT_AZURE_IDENTITY_CREDENTIAL_TYPE
   value: {{ .ctx.Values.bingAgent.connection.azureIdentityCredentialType | quote }}
 - name: BING_AGENT_AZURE_IDENTITY_VALIDATE_TOKEN_URL
@@ -386,6 +398,9 @@ library extension hooks (base.externalService.*.ext).
 {{- end -}}
 {{- if and .ctx.Values.perplexitySearch .ctx.Values.perplexitySearch.enabled -}}
 {{ include "base.conn.secretProvider.fields" (dict "extByVault" .extByVault "fields" (list .ctx.Values.perplexitySearch.connection.apiKey)) }}
+{{- end -}}
+{{- if and .ctx.Values.bingAgent .ctx.Values.bingAgent.enabled -}}
+{{ include "base.conn.secretProvider.fields" (dict "extByVault" .extByVault "fields" (list .ctx.Values.bingAgent.connection.endpoint .ctx.Values.bingAgent.connection.bingResourceConnectionString .ctx.Values.bingAgent.connection.bingAgentModel)) }}
 {{- end -}}
 {{- if and .ctx.Values.vertexaiAgent .ctx.Values.vertexaiAgent.enabled -}}
 {{ include "base.conn.secretProvider.fields" (dict "extByVault" .extByVault "fields" (list .ctx.Values.vertexaiAgent.connection.serviceAccountCredentials)) }}

--- a/connectors/unique_search_proxy/unique_search_proxy_client/deploy/helm-chart/values.additional.schema.json
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/deploy/helm-chart/values.additional.schema.json
@@ -177,11 +177,11 @@
           "properties": {
             "endpoint": {
               "description": "Maps to env var BING_AGENT_ENDPOINT.",
-              "$ref": "#/$defs/valueSourceString"
+              "$ref": "#/$defs/valueSourceSensitive"
             },
             "bingResourceConnectionString": {
               "description": "Maps to env var BING_AGENT_BING_RESOURCE_CONNECTION_STRING.",
-              "$ref": "#/$defs/valueSourceString"
+              "$ref": "#/$defs/valueSourceSensitive"
             },
             "agentId": {
               "description": "Maps to env var BING_AGENT_AGENT_ID.",
@@ -189,7 +189,7 @@
             },
             "bingAgentModel": {
               "description": "Maps to env var BING_AGENT_BING_AGENT_MODEL.",
-              "$ref": "#/$defs/valueSourceString"
+              "$ref": "#/$defs/valueSourceSensitive"
             },
             "azureIdentityCredentialType": {
               "description": "Maps to env var BING_AGENT_AZURE_IDENTITY_CREDENTIAL_TYPE.",
@@ -227,7 +227,8 @@
               "connection": {
                 "required": [
                   "endpoint",
-                  "bingResourceConnectionString"
+                  "bingResourceConnectionString",
+                  "bingAgentModel"
                 ]
               }
             }

--- a/connectors/unique_search_proxy/unique_search_proxy_client/deploy/helm-chart/values.schema.json
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/deploy/helm-chart/values.schema.json
@@ -1964,11 +1964,11 @@
           "properties": {
             "endpoint": {
               "description": "Maps to env var BING_AGENT_ENDPOINT.",
-              "$ref": "#/$defs/valueSourceString"
+              "$ref": "#/$defs/valueSourceSensitive"
             },
             "bingResourceConnectionString": {
               "description": "Maps to env var BING_AGENT_BING_RESOURCE_CONNECTION_STRING.",
-              "$ref": "#/$defs/valueSourceString"
+              "$ref": "#/$defs/valueSourceSensitive"
             },
             "agentId": {
               "description": "Maps to env var BING_AGENT_AGENT_ID.",
@@ -1976,7 +1976,7 @@
             },
             "bingAgentModel": {
               "description": "Maps to env var BING_AGENT_BING_AGENT_MODEL.",
-              "$ref": "#/$defs/valueSourceString"
+              "$ref": "#/$defs/valueSourceSensitive"
             },
             "azureIdentityCredentialType": {
               "description": "Maps to env var BING_AGENT_AZURE_IDENTITY_CREDENTIAL_TYPE.",
@@ -2014,7 +2014,8 @@
               "connection": {
                 "required": [
                   "endpoint",
-                  "bingResourceConnectionString"
+                  "bingResourceConnectionString",
+                  "bingAgentModel"
                 ]
               }
             }

--- a/connectors/unique_search_proxy/unique_search_proxy_client/deploy/helm-chart/values.yaml
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/deploy/helm-chart/values.yaml
@@ -117,12 +117,12 @@ perplexitySearch:
 bingAgent:
   enabled: false
   connection:
-    bingAgentModel: "gpt-4o-deployment"
     azureIdentityCredentialType: default
     azureIdentityValidateTokenUrl: "https://management.azure.com/.default"
     usePrivateEndpointTransport: false
-    # endpoint: <set in cluster overlay when enabled>
-    # bingResourceConnectionString: <set in cluster overlay when enabled>
+    # endpoint: <fromSecret or fromSecretProvider>
+    # bingResourceConnectionString: <fromSecret or fromSecretProvider>
+    # bingAgentModel: <fromSecret or fromSecretProvider>
 
 vertexaiAgent:
   enabled: false

--- a/connectors/unique_search_proxy/unique_search_proxy_client/tests/test_m4_bing_agent.py
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/tests/test_m4_bing_agent.py
@@ -31,6 +31,7 @@ def bing_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "/subscriptions/test/resourceGroups/r/providers/...",
     )
     monkeypatch.setenv("BING_AGENT_AGENT_ID", "agent-123")
+    monkeypatch.setenv("BING_AGENT_BING_AGENT_MODEL", "gpt-4o-deployment")
     from unique_search_proxy_client.web.settings.providers import bing_agent
 
     monkeypatch.setattr(

--- a/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/core/agent_engines/bing/client.py
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/core/agent_engines/bing/client.py
@@ -11,7 +11,7 @@ from azure.identity.aio import DefaultAzureCredential, WorkloadIdentityCredentia
 from unique_search_proxy_client.web.settings.providers.bing_agent import (
     bing_agent_credentials,
 )
-from unique_search_proxy_client.web.settings.secret_str import NOT_PROVIDED
+from unique_search_proxy_client.web.settings.secret_str import NOT_PROVIDED, read_secret
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -35,7 +35,7 @@ def get_project_client(
     *,
     endpoint: str | None = None,
 ) -> AIProjectClient:
-    resolved_endpoint = endpoint or bing_agent_credentials.endpoint
+    resolved_endpoint = endpoint or read_secret(bing_agent_credentials.endpoint)
     if not resolved_endpoint or resolved_endpoint == NOT_PROVIDED:
         msg = "Bing agent Azure AI project endpoint is not configured"
         raise ValueError(msg)

--- a/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/core/agent_engines/bing/runner.py
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/core/agent_engines/bing/runner.py
@@ -20,6 +20,7 @@ from unique_search_proxy_client.web.core.agent_engines.structured_output import 
     build_agent_instructions,
 )
 from unique_search_proxy_client.web.settings.providers import bing_agent as settings
+from unique_search_proxy_client.web.settings.secret_str import NOT_PROVIDED, read_secret
 
 _LOGGER = logging.getLogger(__name__)
 _AGENT_NAME_IDENTIFIER = "UNIQUE_GROUNDING_WITH_BING_AGENT"
@@ -38,7 +39,7 @@ async def _create_agent_id(agent_client: AIProjectClient) -> str:
     creds = settings.bing_agent_credentials
     agent = await agent_client.agents.create_agent(
         name=_AGENT_NAME_IDENTIFIER,
-        model=creds.bing_agent_model,
+        model=read_secret(creds.bing_agent_model),
     )
     return agent.id
 
@@ -55,8 +56,10 @@ async def get_or_create_agent_id(agent_client: AIProjectClient) -> str:
 
 
 def get_bing_grounding_tool(fetch_size: int) -> BingGroundingTool:
-    connection_id = settings.bing_agent_credentials.bing_resource_connection_string
-    if not connection_id or connection_id == "NOT_PROVIDED":
+    connection_id = read_secret(
+        settings.bing_agent_credentials.bing_resource_connection_string,
+    )
+    if not connection_id or connection_id == NOT_PROVIDED:
         msg = "Bing agent resource connection string is not configured"
         raise ValueError(msg)
     return BingGroundingTool(connection_id=connection_id, count=fetch_size)
@@ -130,7 +133,7 @@ async def _create_agent_and_run_thread(
     resolved_agent_id = await get_or_create_agent_id(agent_client)
     return await agent_client.agents.create_thread_and_process_run(
         agent_id=resolved_agent_id,
-        model=creds.bing_agent_model,
+        model=read_secret(creds.bing_agent_model),
         toolset=get_bing_grounding_tool(fetch_size=fetch_size),  # type: ignore[arg-type]
         instructions=instructions,
         thread=AgentThreadCreationOptions(

--- a/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/core/agent_engines/bing/service.py
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/core/agent_engines/bing/service.py
@@ -31,6 +31,7 @@ from unique_search_proxy_client.web.core.provider_response import transport_erro
 from unique_search_proxy_client.web.settings.providers.bing_agent import (
     bing_agent_credentials,
 )
+from unique_search_proxy_client.web.settings.secret_str import read_secret
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -59,7 +60,7 @@ class BingAgentSearchService(AgentSearchEngineService[BingAgentSearchRequest]):
         try:
             agent_client = get_project_client(
                 get_credentials(),
-                endpoint=creds.endpoint,
+                endpoint=read_secret(creds.endpoint),
             )
             output_schema = resolve_output_schema_for_engine(request.engine)
             async with agent_client:

--- a/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/settings/providers/bing_agent.py
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/settings/providers/bing_agent.py
@@ -8,7 +8,10 @@ from unique_search_proxy_client.web.settings.providers.base import (
     ProviderCredentials,
     provider_credentials,
 )
-from unique_search_proxy_client.web.settings.secret_str import NOT_PROVIDED
+from unique_search_proxy_client.web.settings.secret_str import (
+    NOT_PROVIDED,
+    LogSecretStr,
+)
 
 _ENV_PREFIX = "BING_AGENT_"
 
@@ -18,10 +21,12 @@ _ENV_PREFIX = "BING_AGENT_"
 class _BingAgentCredentials(ProviderCredentials):
     """Environment-backed credentials for Bing grounding via Azure AI Projects."""
 
-    endpoint: str = Field(default=NOT_PROVIDED)
-    bing_resource_connection_string: str = Field(default=NOT_PROVIDED)
+    endpoint: LogSecretStr = Field(default=LogSecretStr(NOT_PROVIDED))
+    bing_resource_connection_string: LogSecretStr = Field(
+        default=LogSecretStr(NOT_PROVIDED),
+    )
     agent_id: str | None = Field(default=None)
-    bing_agent_model: str = Field(default="gpt-4o-deployment")
+    bing_agent_model: LogSecretStr = Field(default=LogSecretStr(NOT_PROVIDED))
     azure_identity_credential_type: str = Field(default="default")
     azure_identity_validate_token_url: str = Field(
         default="https://management.azure.com/.default",


### PR DESCRIPTION
## Summary

- Change Bing agent `endpoint`, `bing_resource_connection_string`, and `bing_agent_model` settings to `LogSecretStr` with `NOT_PROVIDED` defaults so the Helm generator emits `base.valueSource.env` wiring for `fromSecret` overlays.
- Unwrap secret fields at runtime via `read_secret()` in Bing agent client/runner/service code.
- Regenerate Helm chart artifacts (`_generated.tpl`, schemas, values) and update Bing agent tests.

## Test plan

- [x] `uv run pytest tests/test_m4_bing_agent.py -q`
- [x] `uv run python scripts/generate_helm_config.py --check`
- [ ] After chart publish, verify QA search-proxy startup log shows Bing agent credentials as configured (not `NOT_PROVIDED`)


Made with [Cursor](https://cursor.com)