### PR TITLE
fix(search-proxy): preserve newlines between Cilium egress rules

### DIFF
--- a/connectors/unique_search_proxy/unique_search_proxy_client/deploy/helm-chart/templates/_generated.tpl
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/deploy/helm-chart/templates/_generated.tpl
@@ -296,7 +296,7 @@ library extension hooks (base.externalService.*.ext).
 {{- end -}}
 
 {{- define "base.externalService.networkPolicy.cilium.egress.rules.ext" -}}
-{{- if and .Values.googleSearch .Values.googleSearch.enabled -}}
+{{ if and .Values.googleSearch .Values.googleSearch.enabled }}
 {{- $endpoint := required "googleSearch.connection.apiEndpoint is required when googleSearch.enabled is true. Set it in your environment overlay." .Values.googleSearch.connection.apiEndpoint -}}
 {{- $parsed := urlParse $endpoint -}}
 {{- $hostParts := $parsed.host | splitList ":" -}}
@@ -310,8 +310,8 @@ library extension hooks (base.externalService.*.ext).
   - ports:
     - port: {{ $port | quote }}
       protocol: TCP
-{{- end -}}
-{{- if and .Values.braveSearch .Values.braveSearch.enabled -}}
+{{- end }}
+{{ if and .Values.braveSearch .Values.braveSearch.enabled }}
 {{- $endpoint := required "braveSearch.connection.apiEndpoint is required when braveSearch.enabled is true. Set it in your environment overlay." .Values.braveSearch.connection.apiEndpoint -}}
 {{- $parsed := urlParse $endpoint -}}
 {{- $hostParts := $parsed.host | splitList ":" -}}
@@ -325,8 +325,8 @@ library extension hooks (base.externalService.*.ext).
   - ports:
     - port: {{ $port | quote }}
       protocol: TCP
-{{- end -}}
-{{- if and .Values.perplexitySearch .Values.perplexitySearch.enabled -}}
+{{- end }}
+{{ if and .Values.perplexitySearch .Values.perplexitySearch.enabled }}
 {{- $endpoint := required "perplexitySearch.connection.apiEndpoint is required when perplexitySearch.enabled is true. Set it in your environment overlay." .Values.perplexitySearch.connection.apiEndpoint -}}
 {{- $parsed := urlParse $endpoint -}}
 {{- $hostParts := $parsed.host | splitList ":" -}}
@@ -340,8 +340,8 @@ library extension hooks (base.externalService.*.ext).
   - ports:
     - port: {{ $port | quote }}
       protocol: TCP
-{{- end -}}
-{{- if and .Values.tavily .Values.tavily.enabled -}}
+{{- end }}
+{{ if and .Values.tavily .Values.tavily.enabled }}
 {{- $endpoint := required "tavily.connection.apiEndpoint is required when tavily.enabled is true. Set it in your environment overlay." .Values.tavily.connection.apiEndpoint -}}
 {{- $parsed := urlParse $endpoint -}}
 {{- $hostParts := $parsed.host | splitList ":" -}}
@@ -355,8 +355,8 @@ library extension hooks (base.externalService.*.ext).
   - ports:
     - port: {{ $port | quote }}
       protocol: TCP
-{{- end -}}
-{{- if and .Values.jina .Values.jina.enabled -}}
+{{- end }}
+{{ if and .Values.jina .Values.jina.enabled }}
 {{- $domain := required "jina.connection.apiDomain is required when jina.enabled is true. Set it in your environment overlay." .Values.jina.connection.apiDomain -}}
 - toFQDNs:
   - matchPattern: {{ printf "*.%s" $domain | quote }}
@@ -364,8 +364,8 @@ library extension hooks (base.externalService.*.ext).
   - ports:
     - port: "443"
       protocol: TCP
-{{- end -}}
-{{- if and .Values.firecrawl .Values.firecrawl.enabled -}}
+{{- end }}
+{{ if and .Values.firecrawl .Values.firecrawl.enabled }}
 {{- $endpoint := required "firecrawl.connection.apiEndpoint is required when firecrawl.enabled is true. Set it in your environment overlay." .Values.firecrawl.connection.apiEndpoint -}}
 {{- $parsed := urlParse $endpoint -}}
 {{- $hostParts := $parsed.host | splitList ":" -}}
@@ -379,7 +379,7 @@ library extension hooks (base.externalService.*.ext).
   - ports:
     - port: {{ $port | quote }}
       protocol: TCP
-{{- end -}}
+{{- end }}
 {{- end -}}
 
 {{- define "base.externalService.networkPolicy.cilium.egress.hasRules.ext" -}}

--- a/connectors/unique_search_proxy/unique_search_proxy_client/tests/test_generate_helm_config.py
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/tests/test_generate_helm_config.py
@@ -145,6 +145,27 @@ def test_http_client_env_injection_is_not_enabled_gated() -> None:
     ) in template
 
 
+def test_egress_rules_use_left_trim_only_block_wrappers() -> None:
+    """Consecutive Cilium egress rules must not merge onto one YAML line.
+
+    A right-trim on block ``{{- end -}}`` plus left-trim on the next ``{{- if``
+    eats the newline between list items, producing ``protocol: TCP- toFQDNs:``
+    and invalid YAML when multiple providers are enabled.
+    """
+    template = (CHART_DIR / "templates" / "_generated.tpl").read_text()
+    egress_define = template[
+        template.index(
+            '{{- define "base.externalService.networkPolicy.cilium.egress.rules.ext" -}}',
+        ) :
+    ]
+    egress_define = egress_define[: egress_define.index("{{- define ", 1)]
+    assert "protocol: TCP\n{{- end -}}" not in egress_define
+    assert "{{- if and .Values.googleSearch .Values.googleSearch.enabled" not in (
+        egress_define
+    )
+    assert "protocol: TCP\n{{- end }}\n{{ if and .Values.tavily" in egress_define
+
+
 def test_optional_env_fields_use_left_trim_only_wrappers() -> None:
     """Optional/conditional env blocks must not right-trim their wrappers.
 
@@ -160,7 +181,7 @@ def test_optional_env_fields_use_left_trim_only_wrappers() -> None:
 
     # Inside the env-injection define, every wrapper must be left-trim-only: the
     # only right-trims allowed are the define header/footer themselves. (The
-    # separate egress define legitimately uses -}} for value computation.)
+    # separate egress define uses left-trim-only block wrappers (see egress test).
     env_define = template[
         template.index('{{- define "base.externalService.env.ext" -}}') :
     ]

--- a/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/helm/generator/template.py
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/helm/generator/template.py
@@ -155,7 +155,7 @@ def _emit_endpoint_field_egress(
     fail_msg = _fail_message(group, endpoint_field)
     section = endpoint_field.section
     return [
-        f"{{{{- if and .Values.{group.helm_key} .Values.{group.helm_key}.enabled -}}}}",
+        f"{{{{ if and .Values.{group.helm_key} .Values.{group.helm_key}.enabled }}}}",
         f'{{{{- $endpoint := required "{fail_msg}" '
         f".Values.{group.helm_key}.{section}.{helm_endpoint} -}}}}",
         "{{- $parsed := urlParse $endpoint -}}",
@@ -170,7 +170,7 @@ def _emit_endpoint_field_egress(
         "  - ports:",
         "    - port: {{ $port | quote }}",
         "      protocol: TCP",
-        "{{- end -}}",
+        "{{- end }}",
     ]
 
 
@@ -186,7 +186,7 @@ def _emit_domain_wildcard_egress(
     fail_msg = _fail_message(group, domain_field)
     section = domain_field.section
     return [
-        f"{{{{- if and .Values.{group.helm_key} .Values.{group.helm_key}.enabled -}}}}",
+        f"{{{{ if and .Values.{group.helm_key} .Values.{group.helm_key}.enabled }}}}",
         f'{{{{- $domain := required "{fail_msg}" '
         f".Values.{group.helm_key}.{section}.{helm_domain} -}}}}",
         "- toFQDNs:",
@@ -195,7 +195,7 @@ def _emit_domain_wildcard_egress(
         "  - ports:",
         f'    - port: "{egress.port}"',
         "      protocol: TCP",
-        "{{- end -}}",
+        "{{- end }}",
     ]
 
 


### PR DESCRIPTION
## Summary

- Fix Helm generator egress block wrappers so consecutive provider Cilium rules do not merge onto one YAML line (`protocol: TCP- toFQDNs:`).
- Use left-trim-only `{{- end }}` and non-left-trimmed `{{ if ... }}` openings between egress blocks.
- Add regression test and regenerate `_generated.tpl`.

This unblocks `helm template` with the QA search-proxy overlay when multiple providers (google, tavily, jina, firecrawl) are enabled.

## Test plan

- [x] `uv run pytest tests/test_generate_helm_config.py -q`
- [x] `helm template search-proxy deploy/helm-chart --values <qa search-proxy values.yaml> --api-versions cilium.io/v2`


Made with [Cursor](https://cursor.com)