### PR TITLE
feat: carry MCP reference enrichment fields end to end [UN-22310]

### DIFF
--- a/unique_sdk/tests/cli/test_mcp.py
+++ b/unique_sdk/tests/cli/test_mcp.py
@@ -226,6 +226,48 @@ def test_same_title_dedupes_across_calls(tmp_path: Path) -> None:
     assert refs[0]["sourceNumber"] == 1
 
 
+def test_dedup_backfills_details_from_later_call(tmp_path: Path) -> None:
+    # First call retrieves "Doc A" as a bare resource_link (no date/author) →
+    # source 1 with no details. A later call returns the same titled record as
+    # JSON carrying a date + author. The dedup reuses source 1, and the newly
+    # extracted details must be backfilled onto the existing entry (the runner
+    # reads one entry per source number, so an empty details would otherwise
+    # stick for the whole turn).
+    first = _FakeMCPResponse(
+        content=[{"type": "resource_link", "uri": "https://e/a", "name": "Doc A"}]
+    )
+    _run("mcp__kb__fetch", first)
+    assert _lines(tmp_path, _REFS_MANIFEST)[0]["details"] is None
+
+    enriched_body = json.dumps(
+        {"title": "Doc A", "updated": "10/10/2026", "author": {"displayName": "Jamie Dimon"}}
+    )
+    second = _FakeMCPResponse(content=[{"type": "text", "text": enriched_body}])
+    _run("mcp__kb__fetch", second)
+
+    refs = _lines(tmp_path, _REFS_MANIFEST)
+    assert len(refs) == 1  # still deduped — one entry, one source number
+    assert refs[0]["sourceNumber"] == 1
+    assert refs[0]["details"] == "10/10/2026 - Jamie Dimon"
+
+
+def test_dedup_does_not_clobber_existing_details(tmp_path: Path) -> None:
+    # First call already has details; a later detail-less call must not erase
+    # them (backfill only fills an empty details, never overwrites).
+    enriched_body = json.dumps({"title": "Doc A", "updated": "01/01/2026"})
+    first = _FakeMCPResponse(content=[{"type": "text", "text": enriched_body}])
+    _run("mcp__kb__fetch", first)
+
+    bare = _FakeMCPResponse(
+        content=[{"type": "resource_link", "uri": "https://e/a", "name": "Doc A"}]
+    )
+    _run("mcp__kb__fetch", bare)
+
+    refs = _lines(tmp_path, _REFS_MANIFEST)
+    assert len(refs) == 1
+    assert refs[0]["details"] == "01/01/2026"
+
+
 def test_different_tools_same_title_get_distinct_numbers(tmp_path: Path) -> None:
     # Tool A records "Doc A" as source 1.
     r = _FakeMCPResponse(

--- a/unique_sdk/tests/cli/test_mcp.py
+++ b/unique_sdk/tests/cli/test_mcp.py
@@ -374,6 +374,34 @@ def test_partial_refs_returned_when_later_write_fails(tmp_path: Path) -> None:
     assert annotated[0][1]["title"] == "Doc A"
 
 
+def test_rewrite_failure_preserves_live_manifest(tmp_path: Path) -> None:
+    # A failed/partial rewrite must never truncate the live manifest: the new
+    # content goes to a temp file that is os.replace-d into place only on
+    # success, so a mid-write error leaves the original intact and no temp file
+    # behind.
+    from unique_sdk.cli.commands._citation_manifest import (
+        _append_turn_refs_manifest_entry,
+        _rewrite_turn_refs_manifest,
+    )
+
+    refs_path = tmp_path / ".unique" / "mcp-refs.jsonl"
+    original = {"sourceNumber": 1, "toolName": "mcp__kb__fetch", "title": "Doc A"}
+    _append_turn_refs_manifest_entry(refs_path, original)
+
+    with patch(
+        "unique_sdk.cli.commands._citation_manifest.json.dumps",
+        side_effect=OSError("disk full"),
+    ):
+        with pytest.raises(OSError):
+            _rewrite_turn_refs_manifest(
+                refs_path, [{**original, "details": "10/10/2026"}]
+            )
+
+    # Original content survives; no leftover temp file in the directory.
+    assert _lines(tmp_path, _REFS_MANIFEST) == [original]
+    assert list(refs_path.parent.glob("*.tmp")) == []
+
+
 def test_api_error_writes_no_manifest(tmp_path: Path) -> None:
     payload = json.dumps({"name": "mcp__crm__get", "arguments": {}})
     with patch.object(

--- a/unique_sdk/tests/cli/test_mcp.py
+++ b/unique_sdk/tests/cli/test_mcp.py
@@ -406,6 +406,28 @@ def test_rewrite_failure_preserves_live_manifest(tmp_path: Path) -> None:
     assert list(refs_path.parent.glob("*.tmp")) == []
 
 
+def test_rewrite_succeeds_despite_stale_temp_file(tmp_path: Path) -> None:
+    # A leftover temp file from an earlier crashed rewrite must not block the
+    # next one: each call uses a fresh unique temp name (mkstemp), so it cannot
+    # collide with stale debris.
+    from unique_sdk.cli.commands._citation_manifest import (
+        _append_turn_refs_manifest_entry,
+        _rewrite_turn_refs_manifest,
+    )
+
+    refs_path = tmp_path / ".unique" / "mcp-refs.jsonl"
+    original = {"sourceNumber": 1, "toolName": "mcp__kb__fetch", "title": "Doc A"}
+    _append_turn_refs_manifest_entry(refs_path, original)
+
+    # Simulate debris from a prior process that died mid-rewrite.
+    (refs_path.parent / "mcp-refs.jsonl.12345.tmp").write_text("garbage")
+
+    updated = {**original, "details": "10/10/2026"}
+    _rewrite_turn_refs_manifest(refs_path, [updated])
+
+    assert _lines(tmp_path, _REFS_MANIFEST) == [updated]
+
+
 def test_api_error_writes_no_manifest(tmp_path: Path) -> None:
     payload = json.dumps({"name": "mcp__crm__get", "arguments": {}})
     with patch.object(

--- a/unique_sdk/tests/cli/test_mcp.py
+++ b/unique_sdk/tests/cli/test_mcp.py
@@ -240,7 +240,11 @@ def test_dedup_backfills_details_from_later_call(tmp_path: Path) -> None:
     assert _lines(tmp_path, _REFS_MANIFEST)[0]["details"] is None
 
     enriched_body = json.dumps(
-        {"title": "Doc A", "updated": "10/10/2026", "author": {"displayName": "Jamie Dimon"}}
+        {
+            "title": "Doc A",
+            "updated": "10/10/2026",
+            "author": {"displayName": "Jamie Dimon"},
+        }
     )
     second = _FakeMCPResponse(content=[{"type": "text", "text": enriched_body}])
     _run("mcp__kb__fetch", second)

--- a/unique_sdk/tests/cli/test_mcp.py
+++ b/unique_sdk/tests/cli/test_mcp.py
@@ -134,6 +134,7 @@ def test_resource_link_item_has_title_no_url(tmp_path: Path) -> None:
             "serverName": "kb",
             "title": "RAG Retrieval Baseline",
             "snippet": "Why retrieval fails",
+            "details": None,
         }
     ]
     assert "[mcpsource1] RAG Retrieval Baseline" in out
@@ -151,6 +152,55 @@ def test_json_in_text_yields_title_no_url(tmp_path: Path) -> None:
     refs = _lines(tmp_path, _REFS_MANIFEST)
     assert refs[0]["title"] == "RAG Retrieval Baseline"
     assert "url" not in refs[0]
+
+
+# ── Reference enrichment / details line (UN-22310) ───────────────────────────
+
+
+def test_json_in_text_extracts_details_date_and_author(tmp_path: Path) -> None:
+    # Atlassian-style record carrying a date + a nested author object.
+    body = json.dumps(
+        {
+            "title": "Unique <> JP Morgan Introduction Meeting",
+            "updated": "10/10/2026",
+            "author": {"displayName": "Jamie Dimon"},
+        }
+    )
+    response = _FakeMCPResponse(content=[{"type": "text", "text": body}])
+    _run("mcp__atlassian__getConfluencePage", response)
+
+    refs = _lines(tmp_path, _REFS_MANIFEST)
+    assert refs[0]["title"] == "Unique <> JP Morgan Introduction Meeting"
+    assert refs[0]["details"] == "10/10/2026 - Jamie Dimon"
+
+
+def test_json_in_text_details_author_only(tmp_path: Path) -> None:
+    body = json.dumps({"title": "Some email", "creator": "Jane Roe"})
+    response = _FakeMCPResponse(content=[{"type": "text", "text": body}])
+    _run("mcp__mail__get", response)
+
+    refs = _lines(tmp_path, _REFS_MANIFEST)
+    assert refs[0]["details"] == "Jane Roe"
+
+
+def test_json_in_text_no_details_when_absent(tmp_path: Path) -> None:
+    body = json.dumps({"title": "Some email"})
+    response = _FakeMCPResponse(content=[{"type": "text", "text": body}])
+    _run("mcp__mail__get", response)
+
+    refs = _lines(tmp_path, _REFS_MANIFEST)
+    assert refs[0]["details"] is None
+
+
+def test_resource_link_item_has_no_details(tmp_path: Path) -> None:
+    # resource_link blocks carry no date/author → details omitted (None).
+    response = _FakeMCPResponse(
+        content=[{"type": "resource_link", "uri": "https://e/a", "name": "Doc A"}]
+    )
+    _run("mcp__kb__fetch", response)
+
+    refs = _lines(tmp_path, _REFS_MANIFEST)
+    assert refs[0]["details"] is None
 
 
 def test_multiple_items_get_distinct_numbers(tmp_path: Path) -> None:

--- a/unique_sdk/unique_sdk/cli/commands/_citation_manifest.py
+++ b/unique_sdk/unique_sdk/cli/commands/_citation_manifest.py
@@ -148,9 +148,13 @@ def _rewrite_turn_refs_manifest(
     lacked. Must be called while holding ``_locked_turn_refs_manifest`` so the
     read → mutate → rewrite sequence does not race a concurrent append.
 
-    Same symlink/regular-file safety discipline as the append path: rejects a
-    symlinked dir/file and opens with ``O_NOFOLLOW`` so a swap between the check
-    and the open still fails closed.
+    Crash-safe: the new content is written to a sibling temp file and then
+    ``os.replace``-d over the manifest, so a failed/partial write never
+    truncates or corrupts the live manifest (the runner keeps reading the old
+    file until the rename succeeds). Same symlink/regular-file safety discipline
+    as the append path — rejects a symlinked dir/file and creates the temp file
+    with ``O_EXCL | O_NOFOLLOW`` so a swap between the check and the open still
+    fails closed.
     """
     _assert_safe_refs_log_path(refs_log_path)
     try:
@@ -160,19 +164,30 @@ def _rewrite_turn_refs_manifest(
             f"failed to create refs log directory: {refs_log_path.parent}"
         ) from exc
     _assert_safe_refs_log_path(refs_log_path)
-    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+
+    # Unique temp name in the same directory (so os.replace is an atomic
+    # same-filesystem rename). O_EXCL makes the create fail if the name already
+    # exists, so the pid-based name needs no randomness.
+    tmp_path = refs_log_path.with_name(f"{refs_log_path.name}.{os.getpid()}.tmp")
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_TRUNC
     flags |= getattr(os, "O_NOFOLLOW", 0)
     try:
-        fd = os.open(refs_log_path, flags, 0o600)
+        fd = os.open(tmp_path, flags, 0o600)
     except OSError as exc:
         raise UnsafeRefsLogPathError(
-            f"failed to open refs log safely: {refs_log_path}"
+            f"failed to open refs log temp file safely: {tmp_path}"
         ) from exc
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as fp:
             for entry in entries:
                 fp.write(json.dumps(entry, default=str, ensure_ascii=False) + "\n")
+        os.replace(tmp_path, refs_log_path)
     except OSError as exc:
+        # The live manifest is untouched; drop the partial temp file.
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
         raise UnsafeRefsLogPathError(
             f"failed to write refs log: {refs_log_path}"
         ) from exc

--- a/unique_sdk/unique_sdk/cli/commands/_citation_manifest.py
+++ b/unique_sdk/unique_sdk/cli/commands/_citation_manifest.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import fcntl
 import json
 import os
+import tempfile
 from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
@@ -152,9 +153,9 @@ def _rewrite_turn_refs_manifest(
     ``os.replace``-d over the manifest, so a failed/partial write never
     truncates or corrupts the live manifest (the runner keeps reading the old
     file until the rename succeeds). Same symlink/regular-file safety discipline
-    as the append path — rejects a symlinked dir/file and creates the temp file
-    with ``O_EXCL | O_NOFOLLOW`` so a swap between the check and the open still
-    fails closed.
+    as the append path — rejects a symlinked dir/file, and the temp file is
+    created fresh with ``O_CREAT | O_EXCL | O_NOFOLLOW`` (via ``mkstemp``) so a
+    symlink swap between the check and the open still fails closed.
     """
     _assert_safe_refs_log_path(refs_log_path)
     try:
@@ -165,18 +166,22 @@ def _rewrite_turn_refs_manifest(
         ) from exc
     _assert_safe_refs_log_path(refs_log_path)
 
-    # Unique temp name in the same directory (so os.replace is an atomic
-    # same-filesystem rename). O_EXCL makes the create fail if the name already
-    # exists, so the pid-based name needs no randomness.
-    tmp_path = refs_log_path.with_name(f"{refs_log_path.name}.{os.getpid()}.tmp")
-    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_TRUNC
-    flags |= getattr(os, "O_NOFOLLOW", 0)
+    # Unique temp name per call in the same directory (so os.replace is an
+    # atomic same-filesystem rename). ``mkstemp`` generates a fresh random name
+    # and opens it with ``O_CREAT | O_EXCL | O_NOFOLLOW`` (POSIX) at mode 0600 —
+    # a leftover temp from an earlier crashed rewrite can never collide and
+    # block subsequent backfills.
     try:
-        fd = os.open(tmp_path, flags, 0o600)
+        fd, tmp_name = tempfile.mkstemp(
+            dir=refs_log_path.parent,
+            prefix=f"{refs_log_path.name}.",
+            suffix=".tmp",
+        )
     except OSError as exc:
         raise UnsafeRefsLogPathError(
-            f"failed to open refs log temp file safely: {tmp_path}"
+            f"failed to open refs log temp file safely: {refs_log_path}"
         ) from exc
+    tmp_path = Path(tmp_name)
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as fp:
             for entry in entries:

--- a/unique_sdk/unique_sdk/cli/commands/_citation_manifest.py
+++ b/unique_sdk/unique_sdk/cli/commands/_citation_manifest.py
@@ -30,6 +30,7 @@ __all__ = [
     "_append_turn_refs_manifest_entry",
     "_locked_turn_refs_manifest",
     "_read_turn_refs_manifest",
+    "_rewrite_turn_refs_manifest",
 ]
 
 
@@ -129,6 +130,48 @@ def _append_turn_refs_manifest_entry(
     try:
         with os.fdopen(fd, "a", encoding="utf-8") as fp:
             fp.write(json.dumps(payload, default=str, ensure_ascii=False) + "\n")
+    except OSError as exc:
+        raise UnsafeRefsLogPathError(
+            f"failed to write refs log: {refs_log_path}"
+        ) from exc
+
+
+def _rewrite_turn_refs_manifest(
+    refs_log_path: Path,
+    entries: list[dict[str, Any]],
+) -> None:
+    """Atomically replace the manifest with ``entries`` (one JSON object per
+    line, in order).
+
+    Used to backfill a previously-appended entry in place — e.g. when a later
+    tool call re-cites a deduped item and extracts ``details`` the first call
+    lacked. Must be called while holding ``_locked_turn_refs_manifest`` so the
+    read → mutate → rewrite sequence does not race a concurrent append.
+
+    Same symlink/regular-file safety discipline as the append path: rejects a
+    symlinked dir/file and opens with ``O_NOFOLLOW`` so a swap between the check
+    and the open still fails closed.
+    """
+    _assert_safe_refs_log_path(refs_log_path)
+    try:
+        refs_log_path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise UnsafeRefsLogPathError(
+            f"failed to create refs log directory: {refs_log_path.parent}"
+        ) from exc
+    _assert_safe_refs_log_path(refs_log_path)
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    try:
+        fd = os.open(refs_log_path, flags, 0o600)
+    except OSError as exc:
+        raise UnsafeRefsLogPathError(
+            f"failed to open refs log safely: {refs_log_path}"
+        ) from exc
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fp:
+            for entry in entries:
+                fp.write(json.dumps(entry, default=str, ensure_ascii=False) + "\n")
     except OSError as exc:
         raise UnsafeRefsLogPathError(
             f"failed to write refs log: {refs_log_path}"

--- a/unique_sdk/unique_sdk/cli/commands/mcp.py
+++ b/unique_sdk/unique_sdk/cli/commands/mcp.py
@@ -43,6 +43,38 @@ _MCP_MAX_ITEMS_PER_CALL = 8
 # Keys an MCP tool's JSON result commonly uses for a record's human title.
 _TITLE_KEYS = ("title", "name", "displayName", "subject", "summary", "key")
 
+# Keys an MCP tool's JSON result commonly uses for the optional "details" line
+# (UN-22310) — e.g. a date and an author such as "10/10/2026 - Jamie Dimon".
+# Best-effort and flat: only top-level keys are inspected (nested provenance is
+# too tool-specific to generalize), and the details line is omitted when none
+# are present.
+_DETAILS_DATE_KEYS = (
+    "date",
+    "updated",
+    "updatedAt",
+    "updatedDate",
+    "lastModified",
+    "modified",
+    "created",
+    "createdAt",
+    "createdDate",
+    "timestamp",
+)
+_DETAILS_AUTHOR_KEYS = (
+    "author",
+    "creator",
+    "owner",
+    "createdBy",
+    "updatedBy",
+    "by",
+    "sender",
+    "from",
+)
+# Keys to read a human name out of an author value that is itself an object
+# (e.g. Atlassian's ``{"displayName": "Jamie Dimon"}``).
+_AUTHOR_NAME_KEYS = ("displayName", "name", "fullName", "emailAddress", "email")
+_MCP_DETAILS_CHAR_LIMIT = 200
+
 # Canonical ``toolName`` written to both manifests: the **bare advertised tool
 # name** (the payload ``name`` the agent passes to ``unique-cli mcp``).
 # ``unique-cli mcp`` only runs in skills mode, where the agent invokes a tool by
@@ -83,6 +115,39 @@ def _title_from_json(obj: dict[str, Any]) -> str | None:
     return None
 
 
+def _first_str_by_keys(obj: dict[str, Any], keys: tuple[str, ...]) -> str | None:
+    for key in keys:
+        value = obj.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _author_display(obj: dict[str, Any]) -> str | None:
+    """Read an author name from a record, whether the author value is a plain
+    string or a nested object (e.g. ``{"displayName": "..."}``)."""
+    for key in _DETAILS_AUTHOR_KEYS:
+        value = obj.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+        if isinstance(value, dict):
+            name = _first_str_by_keys(value, _AUTHOR_NAME_KEYS)
+            if name:
+                return name
+    return None
+
+
+def _details_from_json(obj: dict[str, Any]) -> str | None:
+    """Best-effort optional "details" line (UN-22310): a date and/or author
+    composed as "<date> - <author>". Returns ``None`` when neither is found."""
+    date = _first_str_by_keys(obj, _DETAILS_DATE_KEYS)
+    author = _author_display(obj)
+    parts = [part for part in (date, author) if part]
+    if not parts:
+        return None
+    return " - ".join(parts)[:_MCP_DETAILS_CHAR_LIMIT]
+
+
 def _titles_from_json(text: str) -> list[dict[str, Any]]:
     """Best-effort: pull a human title out of a JSON result (object or list of
     objects), e.g. an Atlassian page/issue returned as JSON-in-text. Returns []
@@ -98,7 +163,13 @@ def _titles_from_json(text: str) -> list[dict[str, Any]]:
         if isinstance(entry, dict):
             title = _title_from_json(entry)
             if title:
-                items.append({"title": title, "snippet": None})
+                items.append(
+                    {
+                        "title": title,
+                        "snippet": None,
+                        "details": _details_from_json(entry),
+                    }
+                )
     return items
 
 
@@ -200,6 +271,7 @@ def _annotate_mcp_results_for_citations(
                         "serverName": server_name,
                         "title": item.get("title"),
                         "snippet": item.get("snippet"),
+                        "details": item.get("details"),
                     }
                     try:
                         _append_turn_refs_manifest_entry(refs_log_path, manifest_entry)
@@ -224,7 +296,12 @@ def _citation_footer(annotated: list[tuple[int, dict[str, Any]]]) -> str:
     """Tell the agent which marker to cite each retrieved item with."""
     if not annotated:
         return ""
-    lines = ["", "Sources — cite each fact with the marker for the item it came from:"]
+    lines = [
+        "",
+        "Sources — MANDATORY: every fact you take from this result MUST be "
+        "cited inline with its [mcpsourceN] marker below, or it will not be "
+        "referenced in the answer:",
+    ]
     for source_number, item in annotated:
         label = item.get("title") or "this MCP tool result"
         lines.append(f"  [mcpsource{source_number}] {label}")

--- a/unique_sdk/unique_sdk/cli/commands/mcp.py
+++ b/unique_sdk/unique_sdk/cli/commands/mcp.py
@@ -14,6 +14,7 @@ from unique_sdk.cli.commands._citation_manifest import (
     _append_turn_refs_manifest_entry,
     _locked_turn_refs_manifest,
     _read_turn_refs_manifest,
+    _rewrite_turn_refs_manifest,
 )
 from unique_sdk.cli.formatting import format_mcp_response
 from unique_sdk.cli.state import ShellState
@@ -45,9 +46,12 @@ _TITLE_KEYS = ("title", "name", "displayName", "subject", "summary", "key")
 
 # Keys an MCP tool's JSON result commonly uses for the optional "details" line
 # (UN-22310) — e.g. a date and an author such as "10/10/2026 - Jamie Dimon".
-# Best-effort and flat: only top-level keys are inspected (nested provenance is
-# too tool-specific to generalize), and the details line is omitted when none
-# are present.
+# Best-effort: only top-level record keys are inspected for these (nested
+# provenance is too tool-specific to generalize). The values themselves may be
+# nested one level — a date is read as a top-level string, while an author may
+# be a plain string or an object whose name is pulled via `_AUTHOR_NAME_KEYS`
+# (e.g. Atlassian's `{"displayName": "..."}`). The line is omitted when neither
+# a date nor an author is found.
 _DETAILS_DATE_KEYS = (
     "date",
     "updated",
@@ -260,6 +264,12 @@ def _annotate_mcp_results_for_citations(
                     numbers_by_key[_item_dedup_key(stored_tool, entry)] = entry[
                         "sourceNumber"
                     ]
+            entries_by_number = {
+                entry["sourceNumber"]: entry
+                for entry in entries
+                if isinstance(entry.get("sourceNumber"), int)
+            }
+            needs_rewrite = False
             for item in items:
                 key = _item_dedup_key(tool_name, item)
                 source_number = numbers_by_key.get(key)
@@ -282,7 +292,25 @@ def _annotate_mcp_results_for_citations(
                         break
                     numbers_by_key[key] = source_number
                     entries.append(manifest_entry)
+                    entries_by_number[source_number] = manifest_entry
+                else:
+                    # Deduped: a prior call already claimed this source number.
+                    # Backfill ``details`` the first call may have lacked (the
+                    # runner reads one entry per source number, so enriching it
+                    # in place is sufficient) — only when newly extracted.
+                    stored = entries_by_number.get(source_number)
+                    new_details = item.get("details")
+                    if stored is not None and new_details and not stored.get("details"):
+                        stored["details"] = new_details
+                        needs_rewrite = True
                 annotated.append((source_number, item))
+            if needs_rewrite:
+                try:
+                    _rewrite_turn_refs_manifest(refs_log_path, entries)
+                except (UnsafeRefsLogPathError, OSError) as exc:
+                    _LOGGER.warning(
+                        "mcp: failed to backfill refs manifest details: %s", exc
+                    )
     except (UnsafeRefsLogPathError, OSError) as exc:
         _LOGGER.warning("mcp: failed to append refs manifest: %s", exc)
         return []

--- a/unique_toolkit/tests/chat/test_chat_functions_unit.py
+++ b/unique_toolkit/tests/chat/test_chat_functions_unit.py
@@ -278,6 +278,34 @@ def test_map_references():
     assert result[0]["sequenceNumber"] == 1
     assert result[0]["sourceId"] == "src123"
     assert result[0]["source"] == "web"
+    # description is always emitted (None when unset; node-chat drops empties).
+    assert result[0]["description"] is None
+
+
+def test_map_references_carries_mcp_description_payload():
+    # UN-22310: MCP references carry an enriched JSON payload in `description`.
+    mcp_description = (
+        '{"mcp": {"connectorName": "Outlook", "title": "Intro Meeting", '
+        '"details": "10/10/2026 - Jamie Dimon"}}'
+    )
+    references = [
+        ContentReference(
+            id="ref123",
+            message_id="msg123",
+            name="Intro Meeting",
+            description=mcp_description,
+            url=None,
+            sequence_number=1,
+            source_id="mcp_aaa_mcp_aaa",
+            source="mcp:outlook",
+        )
+    ]
+
+    result = map_references(references)
+
+    assert result[0]["description"] == mcp_description
+    assert result[0]["source"] == "mcp:outlook"
+    assert result[0]["url"] is None
 
 
 @pytest.mark.asyncio

--- a/unique_toolkit/tests/chat/test_chat_service_unit.py
+++ b/unique_toolkit/tests/chat/test_chat_service_unit.py
@@ -159,6 +159,7 @@ class TestChatServiceUnit:
                 references=[
                     {
                         "name": "Document 1",
+                        "description": None,
                         "url": "http://example.com",
                         "sequenceNumber": 1,
                         "sourceId": "source123",
@@ -202,6 +203,7 @@ class TestChatServiceUnit:
                 references=[
                     {
                         "name": "Document 1",
+                        "description": None,
                         "url": "http://example.com",
                         "sequenceNumber": 1,
                         "sourceId": "source123",
@@ -450,6 +452,7 @@ class TestChatServiceUnit:
                 references=[
                     {
                         "name": "Document 1",
+                        "description": None,
                         "url": "http://example.com",
                         "sequenceNumber": 1,
                         "sourceId": "source123",
@@ -493,6 +496,7 @@ class TestChatServiceUnit:
                 references=[
                     {
                         "name": "Document 1",
+                        "description": None,
                         "url": "http://example.com",
                         "sequenceNumber": 1,
                         "sourceId": "source123",

--- a/unique_toolkit/tests/content/test_content_schemas_unit.py
+++ b/unique_toolkit/tests/content/test_content_schemas_unit.py
@@ -290,6 +290,55 @@ class TestContentReferenceUrlOptional:
         assert ref.url == "https://example.com"
 
 
+class TestContentReferenceDescription:
+    """UN-22310: optional ``description`` carries the enriched MCP JSON payload."""
+
+    def test_description_defaults_to_none(self):
+        ref = ContentReference(
+            name="Doc",
+            sequence_number=1,
+            source="web",
+            source_id="src",
+        )
+        assert ref.description is None
+
+    def test_description_accepted_when_present(self):
+        payload = '{"mcp": {"connectorName": "Outlook", "title": "Intro"}}'
+        ref = ContentReference(
+            name="Intro",
+            sequence_number=1,
+            source="mcp:outlook",
+            source_id="mcp_abc_mcp_abc",
+            description=payload,
+        )
+        assert ref.description == payload
+
+    def test_from_sdk_reference_round_trips_description(self):
+        ref = ContentReference.from_sdk_reference(
+            {  # type: ignore[arg-type]
+                "name": "Intro",
+                "description": '{"mcp": {"connectorName": "Outlook"}}',
+                "url": None,
+                "sequenceNumber": 1,
+                "source": "mcp:outlook",
+                "sourceId": "mcp_abc_mcp_abc",
+            }
+        )
+        assert ref.description == '{"mcp": {"connectorName": "Outlook"}}'
+
+    def test_from_sdk_reference_without_description_defaults_none(self):
+        ref = ContentReference.from_sdk_reference(
+            {  # type: ignore[arg-type]
+                "name": "Doc",
+                "url": "https://example.com",
+                "sequenceNumber": 1,
+                "source": "web",
+                "sourceId": "src",
+            }
+        )
+        assert ref.description is None
+
+
 class TestContentChunkToReference:
     def test_basic_reference_with_pages(self):
         chunk = ContentChunk(

--- a/unique_toolkit/unique_toolkit/chat/functions.py
+++ b/unique_toolkit/unique_toolkit/chat/functions.py
@@ -180,6 +180,7 @@ def map_references(references: list[ContentReference]) -> list[dict[str, Any]]:
     return [
         {
             "name": ref.name,
+            "description": ref.description,
             "url": ref.url,
             "sequenceNumber": ref.sequence_number,
             "sourceId": ref.source_id,
@@ -199,6 +200,7 @@ def map_references_with_original_index(
     return [
         {
             "name": ref.name,
+            "description": ref.description,
             "url": ref.url,
             "sequenceNumber": ref.sequence_number,
             "sourceId": ref.source_id,

--- a/unique_toolkit/unique_toolkit/content/schemas.py
+++ b/unique_toolkit/unique_toolkit/content/schemas.py
@@ -220,7 +220,7 @@ class ContentReference(BaseModel):
         description=(
             "Optional free-text/structured description carried alongside the "
             "reference. Used by MCP tool references (UN-22310) to carry an "
-            'enriched ``{"mcp": {connectorName, title, details?, iconUrl?}}`` '
+            'enriched ``{"mcp": {connectorName, title, details?, mcpServerId?}}`` '
             "JSON payload the chat frontend renders as a card. Nullable "
             "end-to-end (node-chat persists it as a nullable column; empty "
             "values are dropped before sending)."

--- a/unique_toolkit/unique_toolkit/content/schemas.py
+++ b/unique_toolkit/unique_toolkit/content/schemas.py
@@ -215,6 +215,17 @@ class ContentReference(BaseModel):
     sequence_number: int
     source: str
     source_id: str
+    description: str | None = Field(
+        default=None,
+        description=(
+            "Optional free-text/structured description carried alongside the "
+            "reference. Used by MCP tool references (UN-22310) to carry an "
+            'enriched ``{"mcp": {connectorName, title, details?, iconUrl?}}`` '
+            "JSON payload the chat frontend renders as a card. Nullable "
+            "end-to-end (node-chat persists it as a nullable column; empty "
+            "values are dropped before sending)."
+        ),
+    )
     url: str | None = Field(
         default=None,
         description=(
@@ -241,6 +252,8 @@ class ContentReference(BaseModel):
             "source": reference["source"],
             "source_id": reference["sourceId"],
         }
+        if "description" in reference:
+            kwargs["description"] = reference["description"]
         if "originalIndex" in reference:
             kwargs["original_index"] = reference["originalIndex"]
 


### PR DESCRIPTION
## Summary

SDK support for enriching MCP tool references with their connector identity (companion to the monorepo PR `Unique-AG/monorepo#25922`).

- **unique_toolkit**: add an optional `description` field to `ContentReference` and round-trip it in `from_sdk_reference`; forward `description` in `map_references` and `map_references_with_original_index` so it reaches node-chat (which already persists a nullable `description` column). The SwappableIntelligence runner packs a `{ "mcp": { connectorName, title, details?, mcpServerId? } }` JSON payload into this field.
- **unique_sdk (`unique-cli mcp`)**: extract an optional `details` line (date and/or author, incl. nested author objects like `{"displayName": ...}`) from JSON-in-text MCP results into each `mcp-refs.jsonl` entry; make the per-result citation footer an explicit **MANDATORY** instruction so the agent reliably emits `[mcpsourceN]` markers.

Refs: UN-22310

## Test plan

- [x] `unique_sdk` `tests/cli/test_mcp.py` (details extraction: date+author, author-only, absent, resource_link) — pass
- [x] `unique_toolkit` `test_content_schemas_unit.py` (`description` field + `from_sdk_reference`), `test_chat_functions_unit.py` (`map_references` forwards `description`), `test_chat_service_unit.py` (modify/create payloads) — pass
- [x] Ruff lint + format clean

## Notes for reviewers

- Backward compatible: `description` is optional and defaults to `None`; node-chat already accepts and drops empty descriptions.
- No version bumps included — release-please owns versioning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)