### PR TITLE
fix(cli): extract MCP titles from search-style result envelopes [UN-22310]

### DIFF
--- a/unique_sdk/tests/cli/test_mcp.py
+++ b/unique_sdk/tests/cli/test_mcp.py
@@ -154,6 +154,88 @@ def test_json_in_text_yields_title_no_url(tmp_path: Path) -> None:
     assert "url" not in refs[0]
 
 
+def test_search_envelope_yields_one_ref_per_hit(tmp_path: Path) -> None:
+    # Atlassian `search` returns hits nested under `results`: each hit must
+    # become its own titled citation, not collapse to a single "search (MCP)"
+    # title-less chip (UN-22310 follow-up).
+    body = json.dumps(
+        {
+            "results": [
+                {
+                    "title": "RAG Retrieval: Performance & Scalability (V2)",
+                    "url": "https://c/2",
+                },
+                {
+                    "title": "Retrieval Performance and Scalability Evaluation",
+                    "url": "https://c/3",
+                },
+                {"title": "RAG Retrieval Baseline", "url": "https://c/4"},
+            ]
+        }
+    )
+    response = _FakeMCPResponse(content=[{"type": "text", "text": body}])
+    _run("mcp__atlassian__search", response)
+
+    refs = _lines(tmp_path, _REFS_MANIFEST)
+    titles = [r["title"] for r in refs]
+    assert titles == [
+        "RAG Retrieval: Performance & Scalability (V2)",
+        "Retrieval Performance and Scalability Evaluation",
+        "RAG Retrieval Baseline",
+    ]
+    # No URLs leak into the manifest — the chip is display-only.
+    assert all("url" not in r for r in refs)
+
+
+def test_search_envelope_pulls_details_from_hit(tmp_path: Path) -> None:
+    # A nested hit's date/author still feed the details line.
+    body = json.dumps(
+        {
+            "values": [
+                {
+                    "title": "Some page",
+                    "updated": "10/10/2026",
+                    "author": {"displayName": "Jane Roe"},
+                }
+            ]
+        }
+    )
+    response = _FakeMCPResponse(content=[{"type": "text", "text": body}])
+    _run("mcp__atlassian__search", response)
+
+    refs = _lines(tmp_path, _REFS_MANIFEST)
+    assert refs[0]["title"] == "Some page"
+    assert refs[0]["details"] == "10/10/2026 - Jane Roe"
+
+
+def test_titled_object_with_container_prefers_own_title(tmp_path: Path) -> None:
+    # An object that has its OWN title is used as-is; we do not also descend
+    # into an incidental list field.
+    body = json.dumps(
+        {
+            "title": "Parent page",
+            "results": [{"title": "child a"}, {"title": "child b"}],
+        }
+    )
+    response = _FakeMCPResponse(content=[{"type": "text", "text": body}])
+    _run("mcp__atlassian__getConfluencePage", response)
+
+    refs = _lines(tmp_path, _REFS_MANIFEST)
+    assert [r["title"] for r in refs] == ["Parent page"]
+
+
+def test_unrecognized_envelope_falls_back_to_tool_chip(tmp_path: Path) -> None:
+    # A container holding non-dict entries (or no known key) yields no titles →
+    # the title-less tool chip is kept.
+    body = json.dumps({"matches": ["just", "strings"], "count": 2})
+    response = _FakeMCPResponse(content=[{"type": "text", "text": body}])
+    _run("mcp__atlassian__search", response)
+
+    refs = _lines(tmp_path, _REFS_MANIFEST)
+    assert len(refs) == 1
+    assert refs[0]["title"] is None
+
+
 # ── Reference enrichment / details line (UN-22310) ───────────────────────────
 
 

--- a/unique_sdk/unique_sdk/cli/commands/mcp.py
+++ b/unique_sdk/unique_sdk/cli/commands/mcp.py
@@ -44,6 +44,24 @@ _MCP_MAX_ITEMS_PER_CALL = 8
 # Keys an MCP tool's JSON result commonly uses for a record's human title.
 _TITLE_KEYS = ("title", "name", "displayName", "subject", "summary", "key")
 
+# Keys under which search-style MCP tools nest their list of hit records
+# (e.g. Atlassian search returns ``{"results": [{title, url, ...}, ...]}``).
+# When a JSON object carries no title of its own, we descend one level into the
+# first of these holding a list of record dicts, so each hit becomes its own
+# citation instead of collapsing to a single title-less "tool (MCP)" chip.
+_RESULT_CONTAINER_KEYS = (
+    "results",
+    "values",
+    "items",
+    "hits",
+    "sections",
+    "pages",
+    "issues",
+    "records",
+    "documents",
+    "data",
+)
+
 # Keys an MCP tool's JSON result commonly uses for the optional "details" line
 # (UN-22310) — e.g. a date and an author such as "10/10/2026 - Jamie Dimon".
 # Best-effort: only top-level record keys are inspected for these (nested
@@ -152,28 +170,59 @@ def _details_from_json(obj: dict[str, Any]) -> str | None:
     return " - ".join(parts)[:_MCP_DETAILS_CHAR_LIMIT]
 
 
+def _record_dicts(parsed: Any) -> list[dict[str, Any]]:
+    """Flatten a parsed JSON result into the record dicts that each carry a
+    title. Handles three shapes, best-effort:
+
+    * a bare object (``{title, ...}``) — a single page/issue fetch;
+    * a list of objects (``[{title, ...}, ...]``);
+    * a search-style envelope where the hits are nested under a container key
+      (``{"results": [{title, ...}, ...]}``) — when the object has no title of
+      its own, descend one level into the first ``_RESULT_CONTAINER_KEYS`` entry
+      holding a list of dicts.
+
+    Only one level of nesting is unwrapped; deeper/again-nested envelopes fall
+    through and the caller drops to the title-less tool chip.
+    """
+    candidates = parsed if isinstance(parsed, list) else [parsed]
+    records: list[dict[str, Any]] = []
+    for entry in candidates:
+        if not isinstance(entry, dict):
+            continue
+        if _title_from_json(entry):
+            records.append(entry)
+            continue
+        for key in _RESULT_CONTAINER_KEYS:
+            value = entry.get(key)
+            if isinstance(value, list):
+                nested = [item for item in value if isinstance(item, dict)]
+                if nested:
+                    records.extend(nested)
+                    break
+    return records
+
+
 def _titles_from_json(text: str) -> list[dict[str, Any]]:
-    """Best-effort: pull a human title out of a JSON result (object or list of
-    objects), e.g. an Atlassian page/issue returned as JSON-in-text. Returns []
-    when the text is not JSON or carries no recognizable title.
+    """Best-effort: pull human titles out of a JSON result, e.g. an Atlassian
+    page/issue (single object), a list of them, or a search envelope nesting
+    hits under ``results``/``values``/… (see ``_record_dicts``). Returns [] when
+    the text is not JSON or no record carries a recognizable title.
     """
     try:
         parsed = json.loads(text)
     except (ValueError, TypeError):
         return []
-    candidates = parsed if isinstance(parsed, list) else [parsed]
     items: list[dict[str, Any]] = []
-    for entry in candidates:
-        if isinstance(entry, dict):
-            title = _title_from_json(entry)
-            if title:
-                items.append(
-                    {
-                        "title": title,
-                        "snippet": None,
-                        "details": _details_from_json(entry),
-                    }
-                )
+    for entry in _record_dicts(parsed):
+        title = _title_from_json(entry)
+        if title:
+            items.append(
+                {
+                    "title": title,
+                    "snippet": None,
+                    "details": _details_from_json(entry),
+                }
+            )
     return items
 
 


### PR DESCRIPTION
## Problem

A SwappableIntelligence turn that grounds on Atlassian `search` shows a single generic **`search (MCP)`** reference instead of one titled reference per retrieved page — even though each hit has a real title.

Root cause: search-style MCP tools return their hits **nested under a container key**:

```json
{ "results": [
    { "title": "RAG Retrieval: Performance & Scalability Report (V2)", "url": "…" },
    { "title": "Retrieval Performance and Scalability Evaluation",      "url": "…" },
    …
] }
```

`_titles_from_json` only inspected the top-level object (or a top-level list), so `{"results": […]}` carried no title → no items → the title-less fallback chip (the runner names it after the tool).

This is also why the **same prompt** behaved differently across runs: a turn that *also* called `getConfluencePage` per hit (a **flat** `{title, …}` object) produced proper titled refs, while a **search-only** turn produced one generic chip. Same code — different tool-output shape, not an environment/version difference.

## Fix

Add `_record_dicts`, which flattens a parsed JSON result into the record dicts to title:

- a bare object (`{title, …}`) — single page/issue fetch;
- a list of objects;
- a **search envelope**: when an object has no title of its own, descend **one level** into the first of `_RESULT_CONTAINER_KEYS` (`results`, `values`, `items`, `hits`, `sections`, `pages`, `issues`, `records`, `documents`, `data`) that holds a list of dicts.

Each hit becomes its own titled citation, capped by the existing `_MCP_MAX_ITEMS_PER_CALL`. Date/author on a nested hit still feed the optional `details` line. Objects that carry their own title are used as-is (no descent into incidental list fields); unrecognized shapes keep the title-less tool chip. URLs are still not extracted — the chip stays display-only.

## Why deterministic (not LLM-generated titles)

The titles are present as structured fields in the tool response. Reading them is correct, free, and authentic — which is the whole point of the enriched reference card. Asking the model to *generate* a title risks paraphrasing/hallucinating a name that doesn't match the real page, undermining source trust.

## Tests

- `test_search_envelope_yields_one_ref_per_hit` — `{"results": […]}` → one titled ref per hit, no URL leak
- `test_search_envelope_pulls_details_from_hit` — nested hit's date/author still feed `details`
- `test_titled_object_with_container_prefers_own_title` — own title wins; no descent into incidental lists
- `test_unrecognized_envelope_falls_back_to_tool_chip` — non-record container → title-less tool chip
- Existing flat-object / list / `resource_link` paths stay green (25/25)

🤖 Generated with [Claude Code](https://claude.com/claude-code)