### PR TITLE
fix(unique_search_proxy): exact host match in test URL gate (CodeQL py/incomplete-url-substring-sanitization)

### DIFF
--- a/connectors/unique_search_proxy/unique_search_proxy_client/tests/test_m3_basic_crawler.py
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/tests/test_m3_basic_crawler.py
@@ -29,8 +29,8 @@ def _is_example_com_request(request: httpx.Request) -> bool:
     host_header = request.headers.get("host", "")
     if isinstance(host_header, bytes):
         host_header = host_header.decode()
-    url = str(request.url)
-    return "example.com" in host_header or "example.com" in url
+    host_from_header = host_header.split(":", 1)[0]
+    return request.url.host == "example.com" or host_from_header == "example.com"
 
 
 @pytest.fixture

--- a/connectors/unique_search_proxy/unique_search_proxy_client/tests/test_m3_url_safety_gate.py
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/tests/test_m3_url_safety_gate.py
@@ -22,8 +22,8 @@ def _is_example_com_request(request: httpx.Request) -> bool:
     host_header = request.headers.get("host", "")
     if isinstance(host_header, bytes):
         host_header = host_header.decode()
-    url = str(request.url)
-    return "example.com" in host_header or "example.com" in url
+    host_from_header = host_header.split(":", 1)[0]
+    return request.url.host == "example.com" or host_from_header == "example.com"
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

Resolves the 4 open CodeQL `py/incomplete-url-substring-sanitization` findings (alerts 47-50) in the `unique_search_proxy_client` test helpers.

The `_is_example_com_request` helper matched the target with substring checks (`"example.com" in str(request.url)` / host header). CodeQL flags this because a host such as `example.com.evil.com` would also match. The helper now compares the parsed `request.url.host` and the host header (port stripped) for exact equality.

## Test plan
- [x] `pytest tests/test_m3_url_safety_gate.py tests/test_m3_basic_crawler.py` -> 14 passed
- [ ] CI green

Refs: UN-19570

Made with [Cursor](https://cursor.com)