### PR TITLE
feat(cli): per-task uploaded documents via uploaded-search [UN-21780]

### DIFF
--- a/unique_sdk/tests/cli/test_search.py
+++ b/unique_sdk/tests/cli/test_search.py
@@ -34,11 +34,14 @@ from unique_sdk.cli.commands._citation_manifest import (
 )
 from unique_sdk.cli.commands.search import (
     SEARCH_ERROR_PREFIX,
+    UPLOADED_SEARCH_ERROR_PREFIX,
     _build_metadata_filter,
     _format_source_block,
     _result_to_chunk_payload,
     cmd_search,
+    cmd_uploaded_search,
     is_error_output,
+    is_uploaded_search_error_output,
 )
 from unique_sdk.cli.config import Config
 from unique_sdk.cli.state import ShellState
@@ -565,3 +568,154 @@ class TestCmdSearchCallShapes:
         out = cmd_search(_state(), "q", folder="/Anupriya Test/Answer Library")
         assert out.startswith(SEARCH_ERROR_PREFIX)
         assert "not found" in out
+
+
+def _uploaded_state(
+    *,
+    chat_id: str | None = "chat_parent",
+    content_ids: list[str] | None = None,
+) -> ShellState:
+    """A state carrying an uploaded-document scope (as the runner would write).
+
+    ``ShellState`` loads ``.unique-uploaded.json`` from cwd at construction; the
+    autouse fixture pins cwd to an empty ``tmp_path`` so nothing is loaded, and
+    we set the resolved attributes directly to mimic a populated config.
+    """
+    s = _state()
+    s.uploaded_search_chat_id = chat_id
+    s.uploaded_search_content_ids = (
+        content_ids if content_ids is not None else ["cont_up1", "cont_up2"]
+    )
+    return s
+
+
+class TestCmdUploadedSearch:
+    @patch("unique_sdk.Search.create")
+    def test_no_uploaded_scope_returns_prefix_and_no_api_call(
+        self, mock: MagicMock
+    ) -> None:
+        out = cmd_uploaded_search(
+            _uploaded_state(chat_id=None, content_ids=[]), "anything"
+        )
+        assert out.startswith(UPLOADED_SEARCH_ERROR_PREFIX)
+        mock.assert_not_called()
+        assert not (Path.cwd() / ".unique").exists()
+
+    @patch("unique_sdk.Search.create")
+    def test_passes_chat_only_chat_id_and_content_ids(self, mock: MagicMock) -> None:
+        mock.return_value = []
+        cmd_uploaded_search(
+            _uploaded_state(chat_id="chat_p", content_ids=["cont_a", "cont_b"]),
+            "fee structure",
+        )
+        kwargs = mock.call_args[1]
+        assert kwargs["searchString"] == "fee structure"
+        assert kwargs["searchType"] == "COMBINED"
+        assert kwargs["chatOnly"] is True
+        assert kwargs["chatId"] == "chat_p"
+        assert kwargs["contentIds"] == ["cont_a", "cont_b"]
+        # Uploaded search must never carry a KB folder/metadata scope.
+        assert "scopeIds" not in kwargs
+        assert "metaDataFilter" not in kwargs
+
+    @patch("unique_sdk.Search.create")
+    def test_chat_id_only_omits_content_ids(self, mock: MagicMock) -> None:
+        mock.return_value = []
+        cmd_uploaded_search(_uploaded_state(chat_id="chat_p", content_ids=[]), "q")
+        kwargs = mock.call_args[1]
+        assert kwargs["chatId"] == "chat_p"
+        assert "contentIds" not in kwargs
+
+    @patch("unique_sdk.Search.create")
+    def test_writes_block_and_manifest(self, mock: MagicMock) -> None:
+        mock.return_value = [_make_search_result(content_id="cont_up1")]
+        out = cmd_uploaded_search(_uploaded_state(), "target asset classes")
+        assert "Found 1 result(s):" in out
+        assert "<source1>" in out
+        manifest = Path.cwd() / ".unique" / "kb-search-refs.jsonl"
+        lines = manifest.read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 1
+        assert json.loads(lines[0])["id"] == "cont_up1"
+
+    @patch("unique_sdk.Search.create")
+    def test_numbering_continues_across_search_and_uploaded_search(
+        self, mock: MagicMock
+    ) -> None:
+        # A KB search then an uploaded search in the same turn must share the
+        # per-turn manifest so [sourceN] numbering stays continuous.
+        mock.side_effect = [
+            [_make_search_result(content_id="cont_kb", chunk_id="chunk_kb")],
+            [_make_search_result(content_id="cont_up", chunk_id="chunk_up")],
+        ]
+        first = cmd_search(_state(), "kb query")
+        second = cmd_uploaded_search(_uploaded_state(), "uploaded query")
+        assert "<source1>" in first
+        assert "<source2>" in second
+        manifest = Path.cwd() / ".unique" / "kb-search-refs.jsonl"
+        ids = [
+            json.loads(line)["id"]
+            for line in manifest.read_text(encoding="utf-8").splitlines()
+        ]
+        assert ids == ["cont_kb", "cont_up"]
+
+    @patch("unique_sdk.Search.create")
+    def test_api_error_returns_prefix_and_writes_nothing(self, mock: MagicMock) -> None:
+        mock.side_effect = unique_sdk.APIError("oops")
+        out = cmd_uploaded_search(_uploaded_state(), "q")
+        assert out.startswith(UPLOADED_SEARCH_ERROR_PREFIX)
+        assert "oops" in out
+        assert not (Path.cwd() / ".unique").exists()
+
+    @patch("unique_sdk.Search.create")
+    def test_empty_results_no_manifest_write(self, mock: MagicMock) -> None:
+        mock.return_value = []
+        out = cmd_uploaded_search(_uploaded_state(), "no hits")
+        assert "No results found" in out
+        assert not (Path.cwd() / ".unique").exists()
+
+
+class TestUploadedConfigLoading:
+    # The autouse ``_isolate_kb_search_refs_manifest`` fixture pins cwd to this
+    # test's ``tmp_path``, so writing ``.unique-uploaded.json`` there and then
+    # constructing ``ShellState`` exercises the real cwd-based loader.
+    def test_loads_chat_id_and_content_ids_from_file(self, tmp_path: Path) -> None:
+        (tmp_path / ".unique-uploaded.json").write_text(
+            json.dumps({"chatId": "chat_x", "contentIds": ["cont_1", "cont_2"]}),
+            encoding="utf-8",
+        )
+        s = ShellState(_config())
+        assert s.uploaded_search_chat_id == "chat_x"
+        assert s.uploaded_search_content_ids == ["cont_1", "cont_2"]
+        assert s.uploaded_search_available is True
+
+    def test_absent_file_yields_empty_scope(self) -> None:
+        s = ShellState(_config())
+        assert s.uploaded_search_chat_id is None
+        assert s.uploaded_search_content_ids == []
+        assert s.uploaded_search_available is False
+
+    def test_malformed_file_yields_empty_scope(self, tmp_path: Path) -> None:
+        (tmp_path / ".unique-uploaded.json").write_text("{not json", encoding="utf-8")
+        s = ShellState(_config())
+        assert s.uploaded_search_available is False
+
+    def test_non_string_content_ids_rejected(self, tmp_path: Path) -> None:
+        (tmp_path / ".unique-uploaded.json").write_text(
+            json.dumps({"chatId": "chat_x", "contentIds": ["cont_1", 42]}),
+            encoding="utf-8",
+        )
+        s = ShellState(_config())
+        # The list is rejected wholesale (mixed types), chat id still loads.
+        assert s.uploaded_search_content_ids == []
+        assert s.uploaded_search_chat_id == "chat_x"
+
+
+class TestIsUploadedSearchErrorOutput:
+    def test_error_string_is_error(self) -> None:
+        assert (
+            is_uploaded_search_error_output(f"{UPLOADED_SEARCH_ERROR_PREFIX} no docs")
+            is True
+        )
+
+    def test_normal_output_is_not_error(self) -> None:
+        assert is_uploaded_search_error_output("Found 1 result(s):") is False

--- a/unique_sdk/tests/cli/test_search.py
+++ b/unique_sdk/tests/cli/test_search.py
@@ -619,12 +619,16 @@ class TestCmdUploadedSearch:
         assert "metaDataFilter" not in kwargs
 
     @patch("unique_sdk.Search.create")
-    def test_chat_id_only_omits_content_ids(self, mock: MagicMock) -> None:
-        mock.return_value = []
-        cmd_uploaded_search(_uploaded_state(chat_id="chat_p", content_ids=[]), "q")
-        kwargs = mock.call_args[1]
-        assert kwargs["chatId"] == "chat_p"
-        assert "contentIds" not in kwargs
+    def test_chat_id_without_content_ids_is_unavailable(self, mock: MagicMock) -> None:
+        # A chat id with no selected content ids must NOT fall back to a
+        # chatOnly search over every upload in the chat — that silently widens
+        # scope past the row's selection. The guard returns the error prefix and
+        # never hits the API. See UN-21780.
+        out = cmd_uploaded_search(
+            _uploaded_state(chat_id="chat_p", content_ids=[]), "q"
+        )
+        assert out.startswith(UPLOADED_SEARCH_ERROR_PREFIX)
+        mock.assert_not_called()
 
     @patch("unique_sdk.Search.create")
     def test_writes_block_and_manifest(self, mock: MagicMock) -> None:
@@ -708,6 +712,9 @@ class TestUploadedConfigLoading:
         # The list is rejected wholesale (mixed types), chat id still loads.
         assert s.uploaded_search_content_ids == []
         assert s.uploaded_search_chat_id == "chat_x"
+        # ...but a chat id without valid content ids must not enable an
+        # all-uploads search (UN-21780): treat it as no uploaded scope.
+        assert s.uploaded_search_available is False
 
 
 class TestIsUploadedSearchErrorOutput:

--- a/unique_sdk/tests/cli/test_search.py
+++ b/unique_sdk/tests/cli/test_search.py
@@ -550,3 +550,18 @@ class TestCmdSearchCallShapes:
         out = cmd_search(_state(), "q")
         assert out.startswith(SEARCH_ERROR_PREFIX)
         assert "oops" in out
+
+    @patch("unique_sdk.Folder.get_info")
+    def test_folder_not_found_returns_prefix_not_raise(self, mock: MagicMock) -> None:
+        # Regression (UN-21780, QA): a non-existent --folder makes
+        # Folder.get_info raise InvalidRequestError, which is a UniqueError
+        # but NOT an APIError. The handler used to catch only APIError, so the
+        # error escaped cmd_search as an uncaught traceback (exit 1). It must
+        # surface as a clean "search:" error string instead.
+        mock.side_effect = unique_sdk.InvalidRequestError(
+            "Folder with id or path /Anupriya Test/Answer Library not found",
+            "folderPath",
+        )
+        out = cmd_search(_state(), "q", folder="/Anupriya Test/Answer Library")
+        assert out.startswith(SEARCH_ERROR_PREFIX)
+        assert "not found" in out

--- a/unique_sdk/unique_sdk/cli/cli.py
+++ b/unique_sdk/unique_sdk/cli/cli.py
@@ -53,9 +53,13 @@ from unique_sdk.cli.commands.scheduled_tasks import (
 )
 from unique_sdk.cli.commands.search import (
     cmd_search,
+    cmd_uploaded_search,
 )
 from unique_sdk.cli.commands.search import (
     is_error_output as _is_search_error_output,
+)
+from unique_sdk.cli.commands.search import (
+    is_uploaded_search_error_output as _is_uploaded_search_error_output,
 )
 from unique_sdk.cli.commands.subagent import cmd_subagent
 from unique_sdk.cli.commands.subagent import (
@@ -736,6 +740,43 @@ def search(
     )
     click.echo(output)
     if _is_search_error_output(output):
+        ctx.exit(1)
+
+
+@main.command(name="uploaded-search")
+@click.argument("query")
+@click.option(
+    "--limit",
+    "-l",
+    default=200,
+    show_default=True,
+    help="Maximum number of results to return.",
+)
+@click.pass_context
+def uploaded_search(
+    ctx: click.Context,
+    query: str,
+    limit: int,
+) -> None:
+    """Search the documents uploaded for this task (not the knowledge base).
+
+    \b
+    QUERY is the search text. This searches only the files attached to this
+    row/task (e.g. an Agentic Table row's uploaded documents), which are NOT
+    part of the knowledge-base folder scope and therefore never appear in
+    `unique-cli search`. Results are ranked the same way and cite as
+    `[sourceN]`, with numbering continuous across `search` and
+    `uploaded-search` within a turn.
+
+    \b
+    Examples:
+      unique-cli uploaded-search "target asset classes"
+      unique-cli uploaded-search "fee structure" --limit 50
+    """
+    state = LazyState.get(ctx)
+    output = cmd_uploaded_search(state, query, limit=limit)
+    click.echo(output)
+    if _is_uploaded_search_error_output(output):
         ctx.exit(1)
 
 

--- a/unique_sdk/unique_sdk/cli/commands/files.py
+++ b/unique_sdk/unique_sdk/cli/commands/files.py
@@ -358,7 +358,7 @@ def cmd_upload(
         ).get("folderPath", scope_id)
         return f"Uploaded: {display_name} ({content_id}) to {folder_path}"
 
-    except (ValueError, unique_sdk.APIError, OSError) as e:
+    except (ValueError, unique_sdk.UniqueError, OSError) as e:
         return f"upload: {e}"
 
 
@@ -384,7 +384,7 @@ def cmd_versions(
         )
         data = result.get("data", [])
         return f"Versions for {display_name} ({content_id}):\n{_format_content_versions(data)}"
-    except (ValueError, unique_sdk.APIError) as e:
+    except (ValueError, unique_sdk.UniqueError) as e:
         return f"versions: {e}"
 
 
@@ -414,7 +414,7 @@ def cmd_restore_version(state: ShellState, content_version_id: str) -> str:
         title = result.get("title") or result.get("key") or result.get("id", "?")
         content_id = result.get("id", "?")
         return f"Restored: {title} ({content_id}) from version {content_version_id}"
-    except (ValueError, unique_sdk.APIError) as e:
+    except (ValueError, unique_sdk.UniqueError) as e:
         return f"restore-version: {e}"
 
 
@@ -449,7 +449,7 @@ def cmd_download(
         shutil.move(str(downloaded_path), str(final_dest))
         return f"Downloaded: {display_name} -> {final_dest}"
 
-    except (ValueError, unique_sdk.APIError, OSError) as e:
+    except (ValueError, unique_sdk.UniqueError, OSError) as e:
         return f"download: {e}"
 
 
@@ -468,7 +468,7 @@ def cmd_rm(state: ShellState, name_or_id: str) -> str:
             contentId=content_id,
         )
         return f"Deleted: {display_name} ({content_id})"
-    except (ValueError, unique_sdk.APIError) as e:
+    except (ValueError, unique_sdk.UniqueError) as e:
         return f"rm: {e}"
 
 
@@ -488,7 +488,7 @@ def cmd_mv_file(state: ShellState, old_name: str, new_name: str) -> str:
             title=new_name,
         )
         return f"Renamed: {display_name} -> {result.get('title', new_name)}\n{format_content_info(result)}"
-    except (ValueError, unique_sdk.APIError) as e:
+    except (ValueError, unique_sdk.UniqueError) as e:
         return f"mv: {e}"
 
 

--- a/unique_sdk/unique_sdk/cli/commands/folders.py
+++ b/unique_sdk/unique_sdk/cli/commands/folders.py
@@ -70,7 +70,7 @@ def cmd_mkdir(state: ShellState, name: str) -> str:
             last = created[-1]
             return f"Created: {full_path} ({last['id']})"
         return f"Created: {full_path}"
-    except (ValueError, unique_sdk.APIError) as e:
+    except (ValueError, unique_sdk.UniqueError) as e:
         return f"mkdir: {e}"
 
 
@@ -108,7 +108,7 @@ def cmd_rmdir(state: ShellState, target: str, recursive: bool = False) -> str:
                 recursive=recursive,
             )
             return f"Deleted folder: {target}"
-    except (ValueError, unique_sdk.APIError) as e:
+    except (ValueError, unique_sdk.UniqueError) as e:
         return f"rmdir: {e}"
 
 
@@ -145,5 +145,5 @@ def cmd_mvdir(state: ShellState, old_name: str, new_name: str) -> str:
                 name=new_name,
             )
         return f"Renamed folder -> {result.get('name', new_name)}\n{format_folder_info(result)}"
-    except (ValueError, unique_sdk.APIError) as e:
+    except (ValueError, unique_sdk.UniqueError) as e:
         return f"mvdir: {e}"

--- a/unique_sdk/unique_sdk/cli/commands/navigation.py
+++ b/unique_sdk/unique_sdk/cli/commands/navigation.py
@@ -19,7 +19,7 @@ def cmd_cd(state: ShellState, target: str) -> str:
     try:
         new_path = state.cd(target)
         return new_path
-    except (ValueError, unique_sdk.APIError) as e:
+    except (ValueError, unique_sdk.UniqueError) as e:
         return f"cd: {e}"
 
 
@@ -65,7 +65,7 @@ def cmd_ls(state: ShellState, target: str | None = None) -> str:
                             scopeId=sid,
                         )
                     )
-                except unique_sdk.APIError:
+                except unique_sdk.UniqueError:
                     pass
             scoped_files: list[Any] = []
             for cid in content_ids:
@@ -86,7 +86,7 @@ def cmd_ls(state: ShellState, target: str | None = None) -> str:
                     items = info.get("contentInfo", [])
                     if items:
                         scoped_files.append(items[0])
-                except unique_sdk.APIError:
+                except unique_sdk.UniqueError:
                     pass
             output = format_ls(scoped_folders, scoped_files)
             summary = (
@@ -107,7 +107,7 @@ def cmd_ls(state: ShellState, target: str | None = None) -> str:
                         scopeId=ws_id,
                     )
                     folders.append(info)
-                except unique_sdk.APIError:
+                except unique_sdk.UniqueError:
                     pass
             output = format_ls(folders, [])
             summary = f"\n{len(folders)} folder(s), 0 file(s)"
@@ -161,5 +161,5 @@ def cmd_ls(state: ShellState, target: str | None = None) -> str:
         summary = f"\n{total_folders} folder(s), {total_files} file(s)"
         return output + summary
 
-    except (ValueError, unique_sdk.APIError) as e:
+    except (ValueError, unique_sdk.UniqueError) as e:
         return f"ls: {e}"

--- a/unique_sdk/unique_sdk/cli/commands/read.py
+++ b/unique_sdk/unique_sdk/cli/commands/read.py
@@ -110,7 +110,7 @@ def cmd_read(
             company_id=state.config.company_id,
             where={"id": {"equals": cont_id}},
         )
-    except unique_sdk.APIError as e:
+    except unique_sdk.UniqueError as e:
         return f"{READ_ERROR_PREFIX} {e}"
 
     if not results:

--- a/unique_sdk/unique_sdk/cli/commands/search.py
+++ b/unique_sdk/unique_sdk/cli/commands/search.py
@@ -272,7 +272,7 @@ def cmd_search(
             **search_params,
         )
 
-    except (ValueError, unique_sdk.APIError) as e:
+    except (ValueError, unique_sdk.UniqueError) as e:
         return f"{SEARCH_ERROR_PREFIX} {e}"
 
     log_path = refs_log_path or (Path.cwd() / _REFS_LOG_RELATIVE_PATH)

--- a/unique_sdk/unique_sdk/cli/commands/search.py
+++ b/unique_sdk/unique_sdk/cli/commands/search.py
@@ -30,6 +30,7 @@ from unique_sdk.cli.state import ShellState
 DEFAULT_LIMIT = 200
 
 SEARCH_ERROR_PREFIX = "search:"
+UPLOADED_SEARCH_ERROR_PREFIX = "uploaded-search:"
 
 _REFS_LOG_RELATIVE_PATH = Path(".unique") / "kb-search-refs.jsonl"
 _LOCK_FILENAME = "kb-search-refs.lock"
@@ -282,6 +283,69 @@ def cmd_search(
         return f"{SEARCH_ERROR_PREFIX} {exc}"
 
 
+def cmd_uploaded_search(
+    state: ShellState,
+    query: str,
+    limit: int = DEFAULT_LIMIT,
+    *,
+    refs_log_path: Path | None = None,
+) -> str:
+    """Search this task's per-row **uploaded** documents.
+
+    Uploaded files (e.g. an Agentic Table row's attached documents) live
+    outside the knowledge-base folder scopes, so the scope-bound
+    ``unique-cli search`` cannot return them. This mirrors the platform's
+    UploadedSearch tool: a chat-scoped ``Search.create`` (``chatOnly=True``)
+    over the owning chat and the selected content ids, both written by the
+    Swappable Intelligence runner to ``.unique-uploaded.json``. See UN-21780.
+
+    Results share the same per-turn ``<sourceN>`` manifest as
+    ``unique-cli search`` (``_format_results_with_citations`` appends under the
+    same lock), so ``[sourceN]`` citation numbering stays continuous across
+    both commands within a turn.
+
+    Args:
+        state: Shell state carrying user/company credentials and the uploaded
+            document scope loaded from ``.unique-uploaded.json``.
+        query: Search string.
+        limit: Maximum number of results.
+        refs_log_path: Override the per-turn citation manifest path — for
+            tests; production callers leave this ``None``.
+    """
+    if not state.uploaded_search_available:
+        return (
+            f"{UPLOADED_SEARCH_ERROR_PREFIX} no uploaded documents are "
+            "available for this task. Use `unique-cli search` for the "
+            "knowledge base."
+        )
+
+    try:
+        search_params: dict[str, Any] = {
+            "searchString": query,
+            "searchType": "COMBINED",
+            "chatOnly": True,
+            "limit": limit,
+        }
+        if state.uploaded_search_chat_id:
+            search_params["chatId"] = state.uploaded_search_chat_id
+        if state.uploaded_search_content_ids:
+            search_params["contentIds"] = state.uploaded_search_content_ids
+
+        results = unique_sdk.Search.create(
+            user_id=state.config.user_id,
+            company_id=state.config.company_id,
+            **search_params,
+        )
+    except (ValueError, unique_sdk.UniqueError) as e:
+        return f"{UPLOADED_SEARCH_ERROR_PREFIX} {e}"
+
+    log_path = refs_log_path or (Path.cwd() / _REFS_LOG_RELATIVE_PATH)
+    try:
+        return _format_results_with_citations(results, refs_log_path=log_path)
+    except UnsafeRefsLogPathError as exc:
+        return f"{UPLOADED_SEARCH_ERROR_PREFIX} {exc}"
+
+
 def is_error_output(output: str) -> bool:
     """Return ``True`` when ``output`` is a CLI error message.
 
@@ -290,3 +354,8 @@ def is_error_output(output: str) -> bool:
     exit code without changing the existing string-returning contract.
     """
     return output.startswith(SEARCH_ERROR_PREFIX)
+
+
+def is_uploaded_search_error_output(output: str) -> bool:
+    """Return ``True`` when ``output`` is an ``uploaded-search`` error message."""
+    return output.startswith(UPLOADED_SEARCH_ERROR_PREFIX)

--- a/unique_sdk/unique_sdk/cli/skills/unique-cli-search/SKILL.md
+++ b/unique_sdk/unique_sdk/cli/skills/unique-cli-search/SKILL.md
@@ -64,6 +64,9 @@ When no `--folder` is given:
 - If the task defines a scope (a per-message scope filter): that scope is the
   search boundary, regardless of the current directory. `cd`/cwd does **not**
   narrow further — only an explicit `--folder` ANDs an additional constraint.
+  **You do not need `--folder` here** — just run `unique-cli search "<query>"`.
+  Passing a folder *path* that isn't navigable to your user errors with
+  `Folder ... not found`; only narrow within the scope via a `scope_` id.
 - Otherwise, in interactive mode: searches within the current directory
 - Otherwise, at root `/`: searches the entire knowledge base
 

--- a/unique_sdk/unique_sdk/cli/skills/unique-cli-search/SKILL.md
+++ b/unique_sdk/unique_sdk/cli/skills/unique-cli-search/SKILL.md
@@ -7,7 +7,10 @@ description: >-
   platform. Use whenever the user asks to find, search, or query documents
   or content on Unique, including filtering by folder or metadata.
   Also covers `unique-cli read <cont_id>` for reading the full indexed text
-  of a document when its content ID is already known.
+  of a document when its content ID is already known, and
+  `unique-cli uploaded-search "<query>"` for searching documents uploaded for
+  the current task/row, which are NOT in the knowledge-base scope and never
+  appear in `unique-cli search`.
   NOTE: This search uses combined vector + full-text indexing. Excel
   (.xlsx/.xls), CSV (.csv), and image files are NOT full-text indexed,
   so they will not appear in search results. To locate these file types,
@@ -92,10 +95,43 @@ unique-cli search "audit" -m department=Legal -m year=2025
 unique-cli search "regulatory" -f /Legal -m year=2025 -l 50
 ```
 
+## Searching Uploaded Documents (`uploaded-search`)
+
+Documents **uploaded for the current task** (e.g. an Agentic Table row's
+attached files) are **not** part of the knowledge-base folder scope. They will
+**never** appear in `unique-cli search` results, no matter the folder or
+metadata filters — uploaded files are scoped to the chat, not to a KB folder.
+Use `uploaded-search` to retrieve them:
+
+```bash
+# Search the documents uploaded for this row/task
+unique-cli uploaded-search "target asset classes and investment strategy"
+
+# Limit results
+unique-cli uploaded-search "fee structure" --limit 50
+```
+
+When to use which:
+
+| You want to search… | Command |
+|---------------------|---------|
+| The knowledge base (folders the task scope grants) | `unique-cli search "<query>"` |
+| Documents uploaded for **this** row/task | `unique-cli uploaded-search "<query>"` |
+
+`uploaded-search` returns the same `<sourceN>...</sourceN>` blocks as `search`
+and shares the **same per-turn citation manifest**, so `[sourceN]` numbering is
+continuous across both commands within a turn — cite an uploaded-document fact
+exactly the same way (`[sourceN]`). If no documents were uploaded for the task,
+the command reports that and you should fall back to `unique-cli search`.
+
+> **Note:** there is no `--folder`/`--metadata` for `uploaded-search` — the set
+> of uploaded documents is fixed by what was attached to the task.
+
 ## Command Reference
 
 ```
 unique-cli search <query> [--folder <path|scope_id>] [--metadata <key=value>]... [--limit <N>]
+unique-cli uploaded-search <query> [--limit <N>]
 ```
 
 | Option | Short | Default | Description |

--- a/unique_sdk/unique_sdk/cli/state.py
+++ b/unique_sdk/unique_sdk/cli/state.py
@@ -12,6 +12,7 @@ from unique_sdk.cli.config import Config
 from unique_sdk.cli.metadata_filter import MetadataFilter
 
 _SEARCH_CONFIG_FILENAME = ".unique-search.json"
+_UPLOADED_CONFIG_FILENAME = ".unique-uploaded.json"
 _CHAT_FILES_MANIFEST_PATH = Path(".unique") / "chat-files.json"
 
 
@@ -25,6 +26,38 @@ def _load_search_config() -> dict[str, Any]:
     except (json.JSONDecodeError, OSError):
         return {}
     return data if isinstance(data, dict) else {}
+
+
+def _load_uploaded_config() -> dict[str, Any]:
+    """Load ``.unique-uploaded.json`` from the cwd, or ``{}`` when absent/invalid.
+
+    Written by the Swappable Intelligence runner when the task carries per-row
+    uploaded documents (an Agentic Table row's ``selectedUploadedFiles``). It
+    holds the chat that owns those uploads and their content ids so
+    ``unique-cli uploaded-search`` can reach them: uploaded files live outside
+    the knowledge-base folder scopes, so the scope-bound ``unique-cli search``
+    structurally cannot return them. See UN-21780.
+    """
+    config_path = Path.cwd() / _UPLOADED_CONFIG_FILENAME
+    if not config_path.is_file():
+        return {}
+    try:
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _load_uploaded_content_ids(data: dict[str, Any]) -> list[str]:
+    content_ids = data.get("contentIds")
+    if isinstance(content_ids, list) and all(isinstance(c, str) for c in content_ids):
+        return content_ids
+    return []
+
+
+def _load_uploaded_chat_id(data: dict[str, Any]) -> str | None:
+    chat_id = data.get("chatId")
+    return chat_id if isinstance(chat_id, str) and chat_id else None
 
 
 def _load_workspace_scope_ids(data: dict[str, Any]) -> list[str]:
@@ -100,6 +133,23 @@ class ShellState:
         self._workspace_metadata_filter: dict[str, Any] | None = None
         self._metadata_filter: MetadataFilter | None = None
         self.workspace_metadata_filter = _load_workspace_metadata_filter(_search_config)
+        # Per-row uploaded documents reachable via ``unique-cli uploaded-search``.
+        # Loaded from ``.unique-uploaded.json`` (written by the runner). The chat
+        # id is the chat that *owns* the uploads — for a subagent this is the
+        # parent chat — and is required for the chat-scoped uploaded search.
+        # See UN-21780.
+        _uploaded_config = _load_uploaded_config()
+        self.uploaded_search_chat_id: str | None = _load_uploaded_chat_id(
+            _uploaded_config
+        )
+        self.uploaded_search_content_ids: list[str] = _load_uploaded_content_ids(
+            _uploaded_config
+        )
+
+    @property
+    def uploaded_search_available(self) -> bool:
+        """True when this task has per-row uploaded documents to search."""
+        return bool(self.uploaded_search_content_ids or self.uploaded_search_chat_id)
 
     @property
     def workspace_metadata_filter(self) -> dict[str, Any] | None:

--- a/unique_sdk/unique_sdk/cli/state.py
+++ b/unique_sdk/unique_sdk/cli/state.py
@@ -148,8 +148,20 @@ class ShellState:
 
     @property
     def uploaded_search_available(self) -> bool:
-        """True when this task has per-row uploaded documents to search."""
-        return bool(self.uploaded_search_content_ids or self.uploaded_search_chat_id)
+        """True when this task has per-row uploaded documents to search.
+
+        Requires *both* a non-empty selected content-id set and the owning
+        chat id. The owning chat id alone is not enough: ``cmd_uploaded_search``
+        would then issue a ``chatOnly`` ``Search.create`` with no ``contentIds``
+        filter, silently widening scope from the row's selected files to *every*
+        upload in the chat. That degenerate state arises when the runner wrote
+        a ``.unique-uploaded.json`` whose ``contentIds`` were absent or
+        malformed (e.g. mixed types, rejected wholesale by
+        ``_load_uploaded_content_ids``) while the ``chatId`` still parsed — so
+        we treat it as "no uploaded scope" rather than "all chat uploads".
+        See UN-21780.
+        """
+        return bool(self.uploaded_search_content_ids and self.uploaded_search_chat_id)
 
     @property
     def workspace_metadata_filter(self) -> dict[str, Any] | None:


### PR DESCRIPTION
## Summary

Two CLI changes that let a Conduct subagent reach per-row uploaded documents (e.g. an Agentic Table row's attached files), which the scope-bound `unique-cli search` structurally cannot return.

- **`feat(cli)`: add `unique-cli uploaded-search`.** Documents uploaded for a task are chat-scoped, not part of any KB folder scope. `cmd_uploaded_search` issues a chat-scoped `Search.create(chatOnly=True, chatId=<owning chat>, contentIds=<selected>)`, reading the owning chat id + selected content ids from a new read-only `.unique-uploaded.json` (written by the runner, monorepo side). Results reuse the same per-turn `<sourceN>` citation manifest as `search`, so `[sourceN]` numbering stays continuous across both commands within a turn.
- **`fix(cli)`: don't crash on folder-not-found.** A non-navigable `--folder` path (e.g. a task-scope path that isn't a real KB folder reachable by the user) made `unique-cli search --folder` raise `InvalidRequestError` and exit non-zero, crashing the agent turn. Broadens the caught exception from `APIError` to `UniqueError` across the search/read/navigation/files/folders handlers so a bad folder/id resolves to a clean `<cmd>: ...` error string.

Refs: UN-21780

## Test plan

- [x] Unit tests: `uploaded-search` call-shape, citation continuity with `search`, error handling, config loading
- [x] Regression test: `search --folder` against a nonexistent folder returns a clean error string instead of a traceback

## Notes for reviewers

- This is the SDK half of UN-21780. The runner side (writing `.unique-uploaded.json` from the event's `selectedUploadedFiles`, flag-gated) lands in a separate monorepo PR that depends on this being published + version-pinned.

Made with [Cursor](https://cursor.com)