### PR TITLE
feat(unique-toolkit): use remote FeatureFlagClient with FeatureFlags settings fallback

### DIFF
--- a/unique_toolkit/tests/agentic/test_loop_token_reducer.py
+++ b/unique_toolkit/tests/agentic/test_loop_token_reducer.py
@@ -110,6 +110,20 @@ def language_model_info() -> LanguageModelInfo:
     return LanguageModelInfo.from_name(LanguageModelName.AZURE_GPT_4o_2024_0513)
 
 
+@pytest.fixture(autouse=True)
+def _default_selected_uploaded_files_ff_off():
+    """`get_history_from_db` now awaits the selected-uploaded-files flag lazily
+    (previously the coroutine was silently dropped — see UN-19522 bugbot fix).
+    Default it to disabled so tests that don't care about this flag don't need
+    live `CONFIGURATION_BACKEND_URL` / `FEATURE_FLAG_SERVICE_ID` env vars.
+    """
+    with patch(
+        "unique_toolkit.agentic.history_manager.utils.is_flag_enabled",
+        AsyncMock(return_value=False),
+    ):
+        yield
+
+
 @pytest.fixture
 def loop_token_reducer(
     mock_logger: Logger,

--- a/unique_toolkit/tests/agentic/test_loop_token_reducer.py
+++ b/unique_toolkit/tests/agentic/test_loop_token_reducer.py
@@ -8,7 +8,7 @@ token reduction in agentic tool loops.
 import json
 from logging import Logger
 from typing import TYPE_CHECKING
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -1552,20 +1552,24 @@ async def test_get_history_from_db__calls_with_tool_calls__when_persistence_enab
 
 
 @pytest.mark.ai
-def test_get_selected_uploaded_content_ids_ff_disabled(test_event):
+@pytest.mark.asyncio
+async def test_get_selected_uploaded_content_ids_ff_disabled(test_event):
     """When the feature flag is disabled, should return None."""
     from unique_toolkit.agentic.history_manager.utils import (
         get_selected_uploaded_content_ids,
     )
 
-    with patch("unique_toolkit.agentic.history_manager.utils.feature_flags") as ff:
-        ff.enable_selected_uploaded_files_un_18215.is_enabled.return_value = False
-        result = get_selected_uploaded_content_ids(test_event)
+    with patch(
+        "unique_toolkit.agentic.history_manager.utils.is_flag_enabled",
+        AsyncMock(return_value=False),
+    ):
+        result = await get_selected_uploaded_content_ids(test_event)
     assert result is None
 
 
 @pytest.mark.ai
-def test_get_selected_uploaded_content_ids_ff_enabled_with_selection(test_event):
+@pytest.mark.asyncio
+async def test_get_selected_uploaded_content_ids_ff_enabled_with_selection(test_event):
     """When FF is enabled and files are selected, should return the selected IDs."""
     from unique_toolkit.agentic.history_manager.utils import (
         get_selected_uploaded_content_ids,
@@ -1575,14 +1579,17 @@ def test_get_selected_uploaded_content_ids_ff_enabled_with_selection(test_event)
     additional.selected_uploaded_file_ids = ["file_1", "file_2"]
     test_event.payload.additional_parameters = additional
 
-    with patch("unique_toolkit.agentic.history_manager.utils.feature_flags") as ff:
-        ff.enable_selected_uploaded_files_un_18215.is_enabled.return_value = True
-        result = get_selected_uploaded_content_ids(test_event)
+    with patch(
+        "unique_toolkit.agentic.history_manager.utils.is_flag_enabled",
+        AsyncMock(return_value=True),
+    ):
+        result = await get_selected_uploaded_content_ids(test_event)
     assert result == {"file_1", "file_2"}
 
 
 @pytest.mark.ai
-def test_get_selected_uploaded_content_ids_ff_enabled_no_additional_params(
+@pytest.mark.asyncio
+async def test_get_selected_uploaded_content_ids_ff_enabled_no_additional_params(
     test_event,
 ):
     """When FF is enabled but additional_parameters is None, should return None."""
@@ -1592,14 +1599,17 @@ def test_get_selected_uploaded_content_ids_ff_enabled_no_additional_params(
 
     test_event.payload.additional_parameters = None
 
-    with patch("unique_toolkit.agentic.history_manager.utils.feature_flags") as ff:
-        ff.enable_selected_uploaded_files_un_18215.is_enabled.return_value = True
-        result = get_selected_uploaded_content_ids(test_event)
+    with patch(
+        "unique_toolkit.agentic.history_manager.utils.is_flag_enabled",
+        AsyncMock(return_value=True),
+    ):
+        result = await get_selected_uploaded_content_ids(test_event)
     assert result is None
 
 
 @pytest.mark.ai
-def test_get_selected_uploaded_content_ids_ff_enabled_empty_selection(test_event):
+@pytest.mark.asyncio
+async def test_get_selected_uploaded_content_ids_ff_enabled_empty_selection(test_event):
     """When FF is enabled but no files selected, should return empty set."""
     from unique_toolkit.agentic.history_manager.utils import (
         get_selected_uploaded_content_ids,
@@ -1609,7 +1619,9 @@ def test_get_selected_uploaded_content_ids_ff_enabled_empty_selection(test_event
     additional.selected_uploaded_file_ids = []
     test_event.payload.additional_parameters = additional
 
-    with patch("unique_toolkit.agentic.history_manager.utils.feature_flags") as ff:
-        ff.enable_selected_uploaded_files_un_18215.is_enabled.return_value = True
-        result = get_selected_uploaded_content_ids(test_event)
+    with patch(
+        "unique_toolkit.agentic.history_manager.utils.is_flag_enabled",
+        AsyncMock(return_value=True),
+    ):
+        result = await get_selected_uploaded_content_ids(test_event)
     assert result == set()

--- a/unique_toolkit/tests/agentic/tools/test_code_interpreter_postprocessors_code_display.py
+++ b/unique_toolkit/tests/agentic/tools/test_code_interpreter_postprocessors_code_display.py
@@ -10,7 +10,18 @@ from unique_toolkit.agentic.tools.openai_builtin.code_interpreter.postprocessors
     ShowExecutedCodePostprocessorConfig,
 )
 
-CODE_DISPLAY_FF = "unique_toolkit.agentic.tools.openai_builtin.code_interpreter.postprocessors.code_display.feature_flags"
+CODE_DISPLAY_FF = "unique_toolkit.agentic.tools.openai_builtin.code_interpreter.postprocessors.code_display.is_flag_enabled"
+
+
+def _build_code_display_postprocessor(
+    config: ShowExecutedCodePostprocessorConfig,
+    company_id: str | None = None,
+    *,
+    is_flag_enabled_return: bool = True,
+) -> ShowExecutedCodePostprocessor:
+    """Patch ``is_flag_enabled`` with a sync bool (production assigns its return value to ``_is_enabled``)."""
+    with patch(CODE_DISPLAY_FF, MagicMock(return_value=is_flag_enabled_return)):
+        return ShowExecutedCodePostprocessor(config=config, company_id=company_id)
 
 
 @pytest.mark.ai
@@ -42,7 +53,9 @@ def test_show_executed_code_postprocessor__apply_postprocessing_to_response__pre
     """
     # Arrange
     config = ShowExecutedCodePostprocessorConfig()
-    postprocessor = ShowExecutedCodePostprocessor(config=config)
+    postprocessor = _build_code_display_postprocessor(
+        config=config, is_flag_enabled_return=True
+    )
     message = SimpleNamespace(text="Existing answer.")
     code_call = SimpleNamespace(code="print(1)")
     loop_response = SimpleNamespace(
@@ -73,7 +86,9 @@ def test_show_executed_code_postprocessor__apply_postprocessing_to_response__ret
     """
     # Arrange
     config = ShowExecutedCodePostprocessorConfig()
-    postprocessor = ShowExecutedCodePostprocessor(config=config)
+    postprocessor = _build_code_display_postprocessor(
+        config=config, is_flag_enabled_return=True
+    )
     message = SimpleNamespace(text="Only text.")
     loop_response = SimpleNamespace(code_interpreter_calls=[], message=message)
 
@@ -97,7 +112,7 @@ async def test_show_executed_code_postprocessor__remove_from_text__strips_detail
     """
     # Arrange
     config = ShowExecutedCodePostprocessorConfig(remove_from_history=True)
-    postprocessor = ShowExecutedCodePostprocessor(config=config)
+    postprocessor = _build_code_display_postprocessor(config=config)
     text = (
         "<details><summary>Code Interpreter Call</summary>\n\n```python\nx = 1\n```\n\n</details>\n\n"
         "Here is the answer."
@@ -124,7 +139,7 @@ async def test_show_executed_code_postprocessor__remove_from_text__leaves_text_u
     """
     # Arrange
     config = ShowExecutedCodePostprocessorConfig(remove_from_history=False)
-    postprocessor = ShowExecutedCodePostprocessor(config=config)
+    postprocessor = _build_code_display_postprocessor(config=config)
     text = "<details><summary>Code Interpreter Call</summary></details>Keep this."
 
     # Act
@@ -146,13 +161,9 @@ def test_show_executed_code_postprocessor__apply_postprocessing_to_response__no_
     """
     # Arrange
     config = ShowExecutedCodePostprocessorConfig()
-    mock_ff = MagicMock()
-    mock_ff.enable_code_execution_fence_un_17972.is_enabled.return_value = True
-
-    with patch(CODE_DISPLAY_FF, mock_ff):
-        postprocessor = ShowExecutedCodePostprocessor(
-            config=config, company_id="company-123"
-        )
+    postprocessor = _build_code_display_postprocessor(
+        config=config, company_id="company-123", is_flag_enabled_return=False
+    )
 
     message = SimpleNamespace(text="Existing answer.")
     code_call = SimpleNamespace(code="print(1)")
@@ -181,17 +192,15 @@ async def test_show_executed_code_postprocessor__run__no_op__when_fence_ff_on() 
     import asyncio
 
     config = ShowExecutedCodePostprocessorConfig()
-    mock_ff = MagicMock()
-    mock_ff.enable_code_execution_fence_un_17972.is_enabled.return_value = True
 
-    with patch(CODE_DISPLAY_FF, mock_ff):
+    with (
+        patch(CODE_DISPLAY_FF, MagicMock(return_value=False)),
+        patch.object(asyncio, "sleep") as mock_sleep,
+    ):
         postprocessor = ShowExecutedCodePostprocessor(
             config=config, company_id="company-123"
         )
-
-    loop_response = SimpleNamespace(code_interpreter_calls=[])
-
-    with patch.object(asyncio, "sleep") as mock_sleep:
+        loop_response = SimpleNamespace(code_interpreter_calls=[])
         await postprocessor.run(loop_response)
 
     mock_sleep.assert_not_called()
@@ -208,7 +217,9 @@ def test_show_executed_code_postprocessor__apply_postprocessing_to_response__no_
     """
     # Arrange
     config = ShowExecutedCodePostprocessorConfig(enable=False)
-    postprocessor = ShowExecutedCodePostprocessor(config=config)
+    postprocessor = _build_code_display_postprocessor(
+        config=config, is_flag_enabled_return=False
+    )
     message = SimpleNamespace(text="Existing answer.")
     code_call = SimpleNamespace(code="print(1)")
     loop_response = SimpleNamespace(
@@ -237,7 +248,9 @@ async def test_show_executed_code_postprocessor__run__no_op__when_enable_false()
     import asyncio
 
     config = ShowExecutedCodePostprocessorConfig(enable=False)
-    postprocessor = ShowExecutedCodePostprocessor(config=config)
+    postprocessor = _build_code_display_postprocessor(
+        config=config, is_flag_enabled_return=False
+    )
     loop_response = SimpleNamespace(code_interpreter_calls=[])
 
     with patch.object(asyncio, "sleep") as mock_sleep:
@@ -257,13 +270,9 @@ def test_show_executed_code_postprocessor__disabled_when_enable_false_even_if_ff
     """
     # Arrange
     config = ShowExecutedCodePostprocessorConfig(enable=False)
-    mock_ff = MagicMock()
-    mock_ff.enable_code_execution_fence_un_17972.is_enabled.return_value = False
-
-    with patch(CODE_DISPLAY_FF, mock_ff):
-        postprocessor = ShowExecutedCodePostprocessor(
-            config=config, company_id="company-123"
-        )
+    postprocessor = _build_code_display_postprocessor(
+        config=config, company_id="company-123", is_flag_enabled_return=False
+    )
 
     message = SimpleNamespace(text="Existing answer.")
     code_call = SimpleNamespace(code="print(1)")

--- a/unique_toolkit/tests/agentic/tools/test_code_interpreter_postprocessors_code_display.py
+++ b/unique_toolkit/tests/agentic/tools/test_code_interpreter_postprocessors_code_display.py
@@ -201,7 +201,7 @@ async def test_show_executed_code_postprocessor__run__no_op__when_fence_ff_on() 
     config = ShowExecutedCodePostprocessorConfig()
 
     with (
-        patch(CODE_DISPLAY_FF, AsyncMock(return_value=False)),
+        patch(CODE_DISPLAY_FF, AsyncMock(return_value=True)),
         patch.object(asyncio, "sleep") as mock_sleep,
     ):
         postprocessor = ShowExecutedCodePostprocessor(

--- a/unique_toolkit/tests/agentic/tools/test_code_interpreter_postprocessors_code_display.py
+++ b/unique_toolkit/tests/agentic/tools/test_code_interpreter_postprocessors_code_display.py
@@ -1,7 +1,7 @@
 """Tests for code interpreter ShowExecutedCode postprocessor (config and behavior)."""
 
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -19,9 +19,16 @@ def _build_code_display_postprocessor(
     *,
     is_flag_enabled_return: bool = True,
 ) -> ShowExecutedCodePostprocessor:
-    """Patch ``is_flag_enabled`` with a sync bool (production assigns its return value to ``_is_enabled``)."""
-    with patch(CODE_DISPLAY_FF, MagicMock(return_value=is_flag_enabled_return)):
-        return ShowExecutedCodePostprocessor(config=config, company_id=company_id)
+    """Build a postprocessor with `_is_enabled` pre-seeded, as `run()` would set it.
+
+    Production resolves the flag asynchronously in `run()` (always awaited by
+    `PostprocessorManager` before `apply_postprocessing_to_response`), so unit
+    tests exercising `apply_postprocessing_to_response` directly seed the
+    post-`run()` state instead of re-patching `is_flag_enabled` per call.
+    """
+    postprocessor = ShowExecutedCodePostprocessor(config=config, company_id=company_id)
+    postprocessor._is_enabled = is_flag_enabled_return
+    return postprocessor
 
 
 @pytest.mark.ai
@@ -194,7 +201,7 @@ async def test_show_executed_code_postprocessor__run__no_op__when_fence_ff_on() 
     config = ShowExecutedCodePostprocessorConfig()
 
     with (
-        patch(CODE_DISPLAY_FF, MagicMock(return_value=False)),
+        patch(CODE_DISPLAY_FF, AsyncMock(return_value=False)),
         patch.object(asyncio, "sleep") as mock_sleep,
     ):
         postprocessor = ShowExecutedCodePostprocessor(
@@ -248,12 +255,13 @@ async def test_show_executed_code_postprocessor__run__no_op__when_enable_false()
     import asyncio
 
     config = ShowExecutedCodePostprocessorConfig(enable=False)
-    postprocessor = _build_code_display_postprocessor(
-        config=config, is_flag_enabled_return=False
-    )
+    postprocessor = ShowExecutedCodePostprocessor(config=config)
     loop_response = SimpleNamespace(code_interpreter_calls=[])
 
-    with patch.object(asyncio, "sleep") as mock_sleep:
+    with (
+        patch(CODE_DISPLAY_FF, AsyncMock(return_value=False)),
+        patch.object(asyncio, "sleep") as mock_sleep,
+    ):
         await postprocessor.run(loop_response)
 
     mock_sleep.assert_not_called()

--- a/unique_toolkit/tests/agentic/tools/test_code_interpreter_postprocessors_code_display.py
+++ b/unique_toolkit/tests/agentic/tools/test_code_interpreter_postprocessors_code_display.py
@@ -9,6 +9,7 @@ from unique_toolkit.agentic.tools.openai_builtin.code_interpreter.postprocessors
     ShowExecutedCodePostprocessor,
     ShowExecutedCodePostprocessorConfig,
 )
+from unique_toolkit.experimental.resources.feature_flags import COMPANY_ID_PLACEHOLDER
 
 CODE_DISPLAY_FF = "unique_toolkit.agentic.tools.openai_builtin.code_interpreter.postprocessors.code_display.is_flag_enabled"
 
@@ -211,6 +212,33 @@ async def test_show_executed_code_postprocessor__run__no_op__when_fence_ff_on() 
         await postprocessor.run(loop_response)
 
     mock_sleep.assert_not_called()
+
+
+@pytest.mark.ai
+@pytest.mark.asyncio
+async def test_show_executed_code_postprocessor__run__uses_placeholder__when_no_company_id() -> (
+    None
+):
+    """
+    Purpose: Verify run() doesn't crash when constructed without a company_id, and
+    passes COMPANY_ID_PLACEHOLDER to is_flag_enabled instead of an empty string.
+    Why this matters: is_flag_enabled() raises on an empty company_id; the old
+    `self._company_id or ""` would crash the whole turn instead of resolving the flag.
+    Setup summary: Construct with company_id=None; assert run() completes and the FF
+    check was called with COMPANY_ID_PLACEHOLDER, not "".
+    """
+    config = ShowExecutedCodePostprocessorConfig()
+    mock_is_flag_enabled = AsyncMock(return_value=False)
+
+    with patch(CODE_DISPLAY_FF, mock_is_flag_enabled):
+        postprocessor = ShowExecutedCodePostprocessor(config=config, company_id=None)
+        loop_response = SimpleNamespace(code_interpreter_calls=[])
+        await postprocessor.run(loop_response)
+
+    mock_is_flag_enabled.assert_awaited_once()
+    _, kwargs = mock_is_flag_enabled.await_args
+    assert kwargs["company_id"] == COMPANY_ID_PLACEHOLDER
+    assert kwargs["company_id"] != ""
 
 
 @pytest.mark.ai

--- a/unique_toolkit/tests/agentic/tools/test_code_interpreter_postprocessors_generated_files.py
+++ b/unique_toolkit/tests/agentic/tools/test_code_interpreter_postprocessors_generated_files.py
@@ -39,7 +39,25 @@ from unique_toolkit.chat.schemas import ChatMessage, ChatMessageRole
 from unique_toolkit.content.schemas import ContentReference
 from unique_toolkit.language_model.schemas import ResponsesLanguageModelStreamResponse
 
-GEN_FILES_FF = "unique_toolkit.agentic.tools.openai_builtin.code_interpreter.postprocessors.generated_files.feature_flags"
+GEN_FILES_FF = (
+    "unique_toolkit.agentic.tools.openai_builtin.code_interpreter."
+    "postprocessors.generated_files.is_flag_enabled"
+)
+
+
+def _patch_gen_files_feature_flags(
+    *,
+    fence_ff_on: bool = False,
+    html_fence_ff_on: bool = False,
+):
+    def side_effect(flag: str, *, company_id: str) -> bool:
+        if "17972" in flag:
+            return fence_ff_on
+        if "17927" in flag:
+            return html_fence_ff_on
+        return False
+
+    return patch(GEN_FILES_FF, MagicMock(side_effect=side_effect))
 
 
 class _MockStreamResponse:
@@ -1737,16 +1755,12 @@ def test_warn_unmatched_code_blocks__skips_none_content_ids(caplog) -> None:
 
 
 @pytest.mark.ai
-@patch(GEN_FILES_FF)
-def test_apply_postprocessing__normalizes_none_message_text__to_empty_string(
-    mock_ff: MagicMock,
-) -> None:
+def test_apply_postprocessing__normalizes_none_message_text__to_empty_string() -> None:
     """
     Purpose: `apply_postprocessing_to_response` must coerce `message.text` None to ''.
     Why this matters: Downstream regex/replace assumes a string; Responses payloads can
     omit text until postprocessing.
     """
-    mock_ff.enable_code_execution_fence_un_17972.is_enabled.return_value = False
     config = DisplayCodeInterpreterFilesPostProcessorConfig()
     proc = DisplayCodeInterpreterFilesPostProcessor(
         client=MagicMock(),
@@ -1764,23 +1778,21 @@ def test_apply_postprocessing__normalizes_none_message_text__to_empty_string(
         references=[],
     )
     loop = ResponsesLanguageModelStreamResponse(message=msg, output=[])
-    proc.apply_postprocessing_to_response(loop)
+    with _patch_gen_files_feature_flags():
+        proc.apply_postprocessing_to_response(loop)
     assert msg.text == ""
 
 
 @pytest.mark.ai
-@patch(GEN_FILES_FF)
-def test_apply_postprocessing__ff_on__does_not_append_reference_for_non_image_file(
-    mock_ff: MagicMock,
-) -> None:
+def test_apply_postprocessing__ff_on__does_not_append_reference_for_non_image_file() -> (
+    None
+):
     """
     Purpose: When fence FF is ON, non-image files must NOT be added to message.references.
     Why this matters: Files are rendered as fence blocks in message.text; references entries
     would incorrectly surface them as source citations in the references panel.
     Setup summary: One .pdf with sandbox link, fence FF ON; assert references stays empty.
     """
-    mock_ff.enable_code_execution_fence_un_17972.is_enabled.return_value = True
-    mock_ff.enable_html_rendering_un_15131.is_enabled.return_value = False
     config = DisplayCodeInterpreterFilesPostProcessorConfig()
     proc = DisplayCodeInterpreterFilesPostProcessor(
         client=MagicMock(),
@@ -1799,22 +1811,18 @@ def test_apply_postprocessing__ff_on__does_not_append_reference_for_non_image_fi
         container_files=[],
         code_interpreter_calls=[],
     )
-    proc.apply_postprocessing_to_response(loop_response)
+    with _patch_gen_files_feature_flags(fence_ff_on=True):
+        proc.apply_postprocessing_to_response(loop_response)
     assert message.references == []
 
 
 @pytest.mark.ai
-@patch(GEN_FILES_FF)
-def test_apply_postprocessing__ff_off__appends_reference_for_non_image_file(
-    mock_ff: MagicMock,
-) -> None:
+def test_apply_postprocessing__ff_off__appends_reference_for_non_image_file() -> None:
     """
     Purpose: When fence FF is OFF, non-image files must still be added to message.references.
     Why this matters: The legacy references UI uses these entries for download/open actions.
     Setup summary: One .pdf with sandbox link, fence FF OFF; assert one ContentReference appended.
     """
-    mock_ff.enable_code_execution_fence_un_17972.is_enabled.return_value = False
-    mock_ff.enable_html_rendering_un_15131.is_enabled.return_value = False
     config = DisplayCodeInterpreterFilesPostProcessorConfig()
     proc = DisplayCodeInterpreterFilesPostProcessor(
         client=MagicMock(),
@@ -1833,7 +1841,8 @@ def test_apply_postprocessing__ff_off__appends_reference_for_non_image_file(
         container_files=[],
         code_interpreter_calls=[],
     )
-    proc.apply_postprocessing_to_response(loop_response)
+    with _patch_gen_files_feature_flags():
+        proc.apply_postprocessing_to_response(loop_response)
     assert len(message.references) == 1
     ref = message.references[0]
     assert ref.source_id == "cid-pdf-1"
@@ -1841,10 +1850,7 @@ def test_apply_postprocessing__ff_off__appends_reference_for_non_image_file(
 
 
 @pytest.mark.ai
-@patch(GEN_FILES_FF)
-def test_apply_postprocessing__ff_off__existing_citation_refs_preserved(
-    mock_ff: MagicMock,
-) -> None:
+def test_apply_postprocessing__ff_off__existing_citation_refs_preserved() -> None:
     """
     Purpose: Pre-existing (ingestion/citation) references are preserved when fence FF is OFF
     and a new artifact reference is appended alongside them.
@@ -1852,8 +1858,6 @@ def test_apply_postprocessing__ff_off__existing_citation_refs_preserved(
     Setup summary: One pre-existing ContentReference; one .xlsx with sandbox link; FF OFF.
     Assert both refs present after postprocessing.
     """
-    mock_ff.enable_code_execution_fence_un_17972.is_enabled.return_value = False
-    mock_ff.enable_html_rendering_un_15131.is_enabled.return_value = False
     config = DisplayCodeInterpreterFilesPostProcessorConfig()
     proc = DisplayCodeInterpreterFilesPostProcessor(
         client=MagicMock(),
@@ -1879,7 +1883,8 @@ def test_apply_postprocessing__ff_off__existing_citation_refs_preserved(
         container_files=[],
         code_interpreter_calls=[],
     )
-    proc.apply_postprocessing_to_response(loop_response)
+    with _patch_gen_files_feature_flags():
+        proc.apply_postprocessing_to_response(loop_response)
     assert len(message.references) == 2
     source_ids = {r.source_id for r in message.references}
     assert "existing-sid" in source_ids
@@ -1887,14 +1892,9 @@ def test_apply_postprocessing__ff_off__existing_citation_refs_preserved(
 
 
 @pytest.mark.ai
-@patch(
-    "unique_toolkit.agentic.tools.openai_builtin.code_interpreter.postprocessors."
-    "generated_files.feature_flags.enable_code_execution_fence_un_17972.is_enabled",
-    return_value=False,
-)
-def test_apply_postprocessing_to_response__html_uses_HtmlRendering__when_fence_ff_off(
-    _mock_fence_ff: MagicMock,
-) -> None:
+def test_apply_postprocessing_to_response__html_uses_HtmlRendering__when_fence_ff_off() -> (
+    None
+):
     """
     Purpose: HTML uses HtmlRendering when the code-execution fence FF is off.
     Why this matters: Default path — HtmlRendering is the correct output when the
@@ -1914,7 +1914,8 @@ def test_apply_postprocessing_to_response__html_uses_HtmlRendering__when_fence_f
         code_interpreter_calls=[],
     )
 
-    changed = proc.apply_postprocessing_to_response(loop_response)
+    with _patch_gen_files_feature_flags():
+        changed = proc.apply_postprocessing_to_response(loop_response)
 
     assert changed is True
     assert "HtmlRendering" in message.text
@@ -1923,14 +1924,9 @@ def test_apply_postprocessing_to_response__html_uses_HtmlRendering__when_fence_f
 
 
 @pytest.mark.ai
-@patch(
-    "unique_toolkit.agentic.tools.openai_builtin.code_interpreter.postprocessors."
-    "generated_files.feature_flags.enable_code_execution_fence_un_17972.is_enabled",
-    return_value=True,
-)
-def test_apply_postprocessing_to_response__html_uses_HtmlRendering__when_fence_ff_on_but_html_fence_ff_off(
-    _mock_fence_ff: MagicMock,
-) -> None:
+def test_apply_postprocessing_to_response__html_uses_HtmlRendering__when_fence_ff_on_but_html_fence_ff_off() -> (
+    None
+):
     """
     Purpose: HTML still uses HtmlRendering when the fence FF is on but the html-fence FF
     (enable_html_with_fence_un_17927) is off (the default).
@@ -1953,7 +1949,8 @@ def test_apply_postprocessing_to_response__html_uses_HtmlRendering__when_fence_f
         code_interpreter_calls=[call],
     )
 
-    changed = proc.apply_postprocessing_to_response(loop_response)
+    with _patch_gen_files_feature_flags(fence_ff_on=True):
+        changed = proc.apply_postprocessing_to_response(loop_response)
 
     assert changed is True
     assert len(refs) == 0
@@ -1963,20 +1960,9 @@ def test_apply_postprocessing_to_response__html_uses_HtmlRendering__when_fence_f
 
 
 @pytest.mark.ai
-@patch(
-    "unique_toolkit.agentic.tools.openai_builtin.code_interpreter.postprocessors."
-    "generated_files.feature_flags.enable_html_with_fence_un_17927.is_enabled",
-    return_value=True,
-)
-@patch(
-    "unique_toolkit.agentic.tools.openai_builtin.code_interpreter.postprocessors."
-    "generated_files.feature_flags.enable_code_execution_fence_un_17972.is_enabled",
-    return_value=True,
-)
-def test_apply_postprocessing_to_response__html_uses_htmlWithSource__when_both_ffs_on(
-    _mock_fence_ff: MagicMock,
-    _mock_html_fence_ff: MagicMock,
-) -> None:
+def test_apply_postprocessing_to_response__html_uses_htmlWithSource__when_both_ffs_on() -> (
+    None
+):
     """
     Purpose: HTML uses htmlWithSource fence injection when BOTH the code-execution
     fence FF and the html-fence FF (enable_html_with_fence_un_17927) are on.
@@ -1998,7 +1984,8 @@ def test_apply_postprocessing_to_response__html_uses_htmlWithSource__when_both_f
         code_interpreter_calls=[call],
     )
 
-    changed = proc.apply_postprocessing_to_response(loop_response)
+    with _patch_gen_files_feature_flags(fence_ff_on=True, html_fence_ff_on=True):
+        changed = proc.apply_postprocessing_to_response(loop_response)
 
     assert changed is True
     assert len(refs) == 0

--- a/unique_toolkit/tests/agentic/tools/test_code_interpreter_postprocessors_generated_files.py
+++ b/unique_toolkit/tests/agentic/tools/test_code_interpreter_postprocessors_generated_files.py
@@ -3,7 +3,7 @@
 import logging
 import time
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from openai.types.responses import ResponseCodeInterpreterToolCall
@@ -39,25 +39,21 @@ from unique_toolkit.chat.schemas import ChatMessage, ChatMessageRole
 from unique_toolkit.content.schemas import ContentReference
 from unique_toolkit.language_model.schemas import ResponsesLanguageModelStreamResponse
 
-GEN_FILES_FF = (
-    "unique_toolkit.agentic.tools.openai_builtin.code_interpreter."
-    "postprocessors.generated_files.is_flag_enabled"
-)
 
-
-def _patch_gen_files_feature_flags(
+def _set_gen_files_feature_flags(
+    proc: DisplayCodeInterpreterFilesPostProcessor,
     *,
     fence_ff_on: bool = False,
     html_fence_ff_on: bool = False,
-):
-    def side_effect(flag: str, *, company_id: str) -> bool:
-        if "17972" in flag:
-            return fence_ff_on
-        if "17927" in flag:
-            return html_fence_ff_on
-        return False
+) -> None:
+    """Seed flag state on the instance, as `run()` would after awaiting it.
 
-    return patch(GEN_FILES_FF, MagicMock(side_effect=side_effect))
+    Production resolves both flags asynchronously in `run()` (always awaited
+    before `apply_postprocessing_to_response`), so unit tests exercising
+    `apply_postprocessing_to_response` directly seed the post-`run()` state.
+    """
+    proc._fence_ff_on = fence_ff_on
+    proc._html_fence_ff_on = html_fence_ff_on
 
 
 class _MockStreamResponse:
@@ -1778,8 +1774,8 @@ def test_apply_postprocessing__normalizes_none_message_text__to_empty_string() -
         references=[],
     )
     loop = ResponsesLanguageModelStreamResponse(message=msg, output=[])
-    with _patch_gen_files_feature_flags():
-        proc.apply_postprocessing_to_response(loop)
+    _set_gen_files_feature_flags(proc)
+    proc.apply_postprocessing_to_response(loop)
     assert msg.text == ""
 
 
@@ -1811,8 +1807,8 @@ def test_apply_postprocessing__ff_on__does_not_append_reference_for_non_image_fi
         container_files=[],
         code_interpreter_calls=[],
     )
-    with _patch_gen_files_feature_flags(fence_ff_on=True):
-        proc.apply_postprocessing_to_response(loop_response)
+    _set_gen_files_feature_flags(proc, fence_ff_on=True)
+    proc.apply_postprocessing_to_response(loop_response)
     assert message.references == []
 
 
@@ -1841,8 +1837,8 @@ def test_apply_postprocessing__ff_off__appends_reference_for_non_image_file() ->
         container_files=[],
         code_interpreter_calls=[],
     )
-    with _patch_gen_files_feature_flags():
-        proc.apply_postprocessing_to_response(loop_response)
+    _set_gen_files_feature_flags(proc)
+    proc.apply_postprocessing_to_response(loop_response)
     assert len(message.references) == 1
     ref = message.references[0]
     assert ref.source_id == "cid-pdf-1"
@@ -1883,8 +1879,8 @@ def test_apply_postprocessing__ff_off__existing_citation_refs_preserved() -> Non
         container_files=[],
         code_interpreter_calls=[],
     )
-    with _patch_gen_files_feature_flags():
-        proc.apply_postprocessing_to_response(loop_response)
+    _set_gen_files_feature_flags(proc)
+    proc.apply_postprocessing_to_response(loop_response)
     assert len(message.references) == 2
     source_ids = {r.source_id for r in message.references}
     assert "existing-sid" in source_ids
@@ -1914,8 +1910,8 @@ def test_apply_postprocessing_to_response__html_uses_HtmlRendering__when_fence_f
         code_interpreter_calls=[],
     )
 
-    with _patch_gen_files_feature_flags():
-        changed = proc.apply_postprocessing_to_response(loop_response)
+    _set_gen_files_feature_flags(proc)
+    changed = proc.apply_postprocessing_to_response(loop_response)
 
     assert changed is True
     assert "HtmlRendering" in message.text
@@ -1949,8 +1945,8 @@ def test_apply_postprocessing_to_response__html_uses_HtmlRendering__when_fence_f
         code_interpreter_calls=[call],
     )
 
-    with _patch_gen_files_feature_flags(fence_ff_on=True):
-        changed = proc.apply_postprocessing_to_response(loop_response)
+    _set_gen_files_feature_flags(proc, fence_ff_on=True)
+    changed = proc.apply_postprocessing_to_response(loop_response)
 
     assert changed is True
     assert len(refs) == 0
@@ -1984,8 +1980,8 @@ def test_apply_postprocessing_to_response__html_uses_htmlWithSource__when_both_f
         code_interpreter_calls=[call],
     )
 
-    with _patch_gen_files_feature_flags(fence_ff_on=True, html_fence_ff_on=True):
-        changed = proc.apply_postprocessing_to_response(loop_response)
+    _set_gen_files_feature_flags(proc, fence_ff_on=True, html_fence_ff_on=True)
+    changed = proc.apply_postprocessing_to_response(loop_response)
 
     assert changed is True
     assert len(refs) == 0

--- a/unique_toolkit/tests/agentic/tools/test_code_interpreter_postprocessors_generated_files.py
+++ b/unique_toolkit/tests/agentic/tools/test_code_interpreter_postprocessors_generated_files.py
@@ -3,7 +3,7 @@
 import logging
 import time
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from openai.types.responses import ResponseCodeInterpreterToolCall
@@ -37,7 +37,10 @@ from unique_toolkit.agentic.tools.openai_builtin.code_interpreter.schemas import
 )
 from unique_toolkit.chat.schemas import ChatMessage, ChatMessageRole
 from unique_toolkit.content.schemas import ContentReference
+from unique_toolkit.experimental.resources.feature_flags import COMPANY_ID_PLACEHOLDER
 from unique_toolkit.language_model.schemas import ResponsesLanguageModelStreamResponse
+
+GENERATED_FILES_FF = "unique_toolkit.agentic.tools.openai_builtin.code_interpreter.postprocessors.generated_files.is_flag_enabled"
 
 
 def _set_gen_files_feature_flags(
@@ -525,6 +528,43 @@ def _make_response(calls, annotations):
     response.code_interpreter_calls = calls
     response.container_files = annotations
     return response
+
+
+@pytest.mark.ai
+@pytest.mark.asyncio
+async def test_display_files_postprocessor__run__uses_placeholder__when_no_company_id() -> (
+    None
+):
+    """
+    Purpose: Verify run() doesn't crash when constructed without a company_id, and
+    passes COMPANY_ID_PLACEHOLDER to is_flag_enabled instead of an empty string.
+    Why this matters: is_flag_enabled() raises on an empty company_id; the old
+    `self._company_id or ""` would crash the whole turn instead of resolving the flag.
+    Setup summary: Construct with company_id=None; assert run() completes and both FF
+    checks were called with COMPANY_ID_PLACEHOLDER, not "".
+    """
+    config = DisplayCodeInterpreterFilesPostProcessorConfig()
+    client = MagicMock()
+    client.with_options.return_value = client
+    proc = DisplayCodeInterpreterFilesPostProcessor(
+        client=client,
+        content_service=MagicMock(),
+        config=config,
+        chat_service=MagicMock(),
+        company_id=None,
+        user_id=None,
+        chat_id=None,
+    )
+    mock_is_flag_enabled = AsyncMock(return_value=False)
+    response = _make_response([], [])
+
+    with patch(GENERATED_FILES_FF, mock_is_flag_enabled):
+        await proc.run(response)
+
+    assert mock_is_flag_enabled.await_count == 2
+    for _, kwargs in mock_is_flag_enabled.await_args_list:
+        assert kwargs["company_id"] == COMPANY_ID_PLACEHOLDER
+        assert kwargs["company_id"] != ""
 
 
 @pytest.mark.ai

--- a/unique_toolkit/tests/agentic/tools/test_mcp_tool_wrapper.py
+++ b/unique_toolkit/tests/agentic/tools/test_mcp_tool_wrapper.py
@@ -839,17 +839,11 @@ class TestMCPToolWrapperRun:
             arguments={"query": "test"},
         )
 
-        # Mock feature flags to return False (new UI disabled)
-        mock_feature_flags = Mock()
-        mock_feature_flags.enable_new_answers_ui_un_14411.is_enabled = Mock(
-            return_value=False,
-        )
-
         with (
             patch("unique_sdk.MCP.call_tool_async") as mock_sdk_call,
             patch(
-                "unique_toolkit.agentic.tools.mcp.tool_wrapper.feature_flags",
-                mock_feature_flags,
+                "unique_toolkit.agentic.tools.mcp.tool_wrapper.is_flag_enabled",
+                AsyncMock(return_value=False),
             ),
             patch.object(wrapper, "_create_or_update_message_log"),
         ):
@@ -906,8 +900,8 @@ class TestMCPToolWrapperRun:
         with (
             patch("unique_sdk.MCP.call_tool_async") as mock_sdk_call,
             patch(
-                "unique_toolkit.agentic.tools.mcp.tool_wrapper.feature_flags.enable_new_answers_ui_un_14411.is_enabled",
-                return_value=True,
+                "unique_toolkit.agentic.tools.mcp.tool_wrapper.is_flag_enabled",
+                AsyncMock(return_value=True),
             ),
             patch.object(wrapper, "_create_or_update_message_log"),
         ):
@@ -955,17 +949,11 @@ class TestMCPToolWrapperRun:
             arguments={"query": "test"},
         )
 
-        # Mock feature flags to return True (new UI enabled)
-        mock_feature_flags = Mock()
-        mock_feature_flags.enable_new_answers_ui_un_14411.is_enabled = Mock(
-            return_value=True,
-        )
-
         with (
             patch("unique_sdk.MCP.call_tool_async") as mock_sdk_call,
             patch(
-                "unique_toolkit.agentic.tools.mcp.tool_wrapper.feature_flags",
-                mock_feature_flags,
+                "unique_toolkit.agentic.tools.mcp.tool_wrapper.is_flag_enabled",
+                AsyncMock(return_value=True),
             ),
             patch.object(wrapper, "_create_or_update_message_log"),
         ):
@@ -1012,17 +1000,11 @@ class TestMCPToolWrapperRun:
             arguments={"query": "test"},
         )
 
-        # Mock feature flags to return False (new UI disabled)
-        mock_feature_flags = Mock()
-        mock_feature_flags.enable_new_answers_ui_un_14411.is_enabled = Mock(
-            return_value=False,
-        )
-
         with (
             patch("unique_sdk.MCP.call_tool_async") as mock_sdk_call,
             patch(
-                "unique_toolkit.agentic.tools.mcp.tool_wrapper.feature_flags",
-                mock_feature_flags,
+                "unique_toolkit.agentic.tools.mcp.tool_wrapper.is_flag_enabled",
+                AsyncMock(return_value=False),
             ),
             patch.object(wrapper, "_create_or_update_message_log"),
         ):
@@ -1071,17 +1053,13 @@ class TestMCPToolWrapperRun:
             arguments={"query": "test"},
         )
 
-        # Mock feature flags to track calls
-        mock_feature_flags = Mock()
-        mock_feature_flags.enable_new_answers_ui_un_14411.is_enabled = Mock(
-            return_value=False,
-        )
+        mock_is_flag = AsyncMock(return_value=False)
 
         with (
             patch("unique_sdk.MCP.call_tool_async") as mock_sdk_call,
             patch(
-                "unique_toolkit.agentic.tools.mcp.tool_wrapper.feature_flags",
-                mock_feature_flags,
+                "unique_toolkit.agentic.tools.mcp.tool_wrapper.is_flag_enabled",
+                mock_is_flag,
             ),
             patch.object(wrapper, "_create_or_update_message_log"),
         ):
@@ -1091,8 +1069,9 @@ class TestMCPToolWrapperRun:
             await wrapper.run(tool_call)
 
             # Assert - feature flag should be called with the company_id from the event
-            mock_feature_flags.enable_new_answers_ui_un_14411.is_enabled.assert_called_with(
-                "company_456"
+            mock_is_flag.assert_awaited_with(
+                "FEATURE_FLAG_ENABLE_NEW_ANSWERS_UI_UN_14411",
+                company_id="company_456",
             )
 
     @pytest.mark.ai

--- a/unique_toolkit/tests/agentic/tools/test_sub_agent_tool.py
+++ b/unique_toolkit/tests/agentic/tools/test_sub_agent_tool.py
@@ -257,8 +257,8 @@ class TestSubAgentToolProgressNotifications:
 
         # Mock the FeatureFlag's is_enabled method to return False
         with patch(
-            "unique_toolkit.agentic.tools.a2a.tool.service.feature_flags.enable_new_answers_ui_un_14411.is_enabled",
-            return_value=False,
+            "unique_toolkit.agentic.tools.a2a.tool.service.is_flag_enabled",
+            new=AsyncMock(return_value=False),
         ):
             # Act
             await tool._notify_progress(
@@ -307,8 +307,8 @@ class TestSubAgentToolProgressNotifications:
 
         # Mock the FeatureFlag's is_enabled method to return True
         with patch(
-            "unique_toolkit.agentic.tools.a2a.tool.service.feature_flags.enable_new_answers_ui_un_14411.is_enabled",
-            return_value=True,
+            "unique_toolkit.agentic.tools.a2a.tool.service.is_flag_enabled",
+            new=AsyncMock(return_value=True),
         ):
             # Act
             await tool._notify_progress(
@@ -377,12 +377,11 @@ class TestSubAgentToolProgressNotifications:
             arguments={"user_message": "test message"},
         )
 
-        # Mock the FeatureFlag's is_enabled method as a Mock to track calls
+        mock_is_flag = AsyncMock(return_value=False)
         with patch(
-            "unique_toolkit.agentic.tools.a2a.tool.service.feature_flags.enable_new_answers_ui_un_14411.is_enabled"
-        ) as mock_is_enabled:
-            mock_is_enabled.return_value = False
-
+            "unique_toolkit.agentic.tools.a2a.tool.service.is_flag_enabled",
+            mock_is_flag,
+        ):
             # Act
             await tool._notify_progress(
                 tool_call=tool_call,
@@ -391,7 +390,10 @@ class TestSubAgentToolProgressNotifications:
             )
 
             # Assert - feature flag should be called with the company_id from the event
-            mock_is_enabled.assert_called_once_with("company_456")
+            mock_is_flag.assert_awaited_once_with(
+                "FEATURE_FLAG_ENABLE_NEW_ANSWERS_UI_UN_14411",
+                company_id="company_456",
+            )
 
 
 class TestSubAgentToolMessageLog:
@@ -549,8 +551,8 @@ class TestSubAgentToolRun:
 
         with (
             patch(
-                "unique_toolkit.agentic.tools.a2a.tool.service.feature_flags.enable_new_answers_ui_un_14411.is_enabled",
-                return_value=False,
+                "unique_toolkit.agentic.tools.a2a.tool.service.is_flag_enabled",
+                new=AsyncMock(return_value=False),
             ),
             patch(
                 "unique_toolkit.agentic.tools.a2a.tool.service.send_message_and_wait_for_completion",
@@ -648,8 +650,8 @@ class TestSubAgentToolRun:
 
         with (
             patch(
-                "unique_toolkit.agentic.tools.a2a.tool.service.feature_flags.enable_new_answers_ui_un_14411.is_enabled",
-                return_value=True,
+                "unique_toolkit.agentic.tools.a2a.tool.service.is_flag_enabled",
+                new=AsyncMock(return_value=True),
             ),
             patch(
                 "unique_toolkit.agentic.tools.a2a.tool.service.send_message_and_wait_for_completion",
@@ -719,8 +721,8 @@ class TestSubAgentToolRun:
 
         with (
             patch(
-                "unique_toolkit.agentic.tools.a2a.tool.service.feature_flags.enable_new_answers_ui_un_14411.is_enabled",
-                return_value=True,
+                "unique_toolkit.agentic.tools.a2a.tool.service.is_flag_enabled",
+                new=AsyncMock(return_value=True),
             ),
             patch(
                 "unique_toolkit.agentic.tools.a2a.tool.service.send_message_and_wait_for_completion",
@@ -786,8 +788,8 @@ class TestSubAgentToolRun:
 
         with (
             patch(
-                "unique_toolkit.agentic.tools.a2a.tool.service.feature_flags.enable_new_answers_ui_un_14411.is_enabled",
-                return_value=True,
+                "unique_toolkit.agentic.tools.a2a.tool.service.is_flag_enabled",
+                new=AsyncMock(return_value=True),
             ),
             patch(
                 "unique_toolkit.agentic.tools.a2a.tool.service.send_message_and_wait_for_completion",
@@ -840,8 +842,8 @@ class TestSubAgentToolRun:
 
         with (
             patch(
-                "unique_toolkit.agentic.tools.a2a.tool.service.feature_flags.enable_new_answers_ui_un_14411.is_enabled",
-                return_value=True,
+                "unique_toolkit.agentic.tools.a2a.tool.service.is_flag_enabled",
+                new=AsyncMock(return_value=True),
             ),
             patch(
                 "unique_toolkit.agentic.tools.a2a.tool.service.send_message_and_wait_for_completion",
@@ -907,8 +909,8 @@ class TestSubAgentToolRun:
 
         with (
             patch(
-                "unique_toolkit.agentic.tools.a2a.tool.service.feature_flags.enable_new_answers_ui_un_14411.is_enabled",
-                return_value=True,
+                "unique_toolkit.agentic.tools.a2a.tool.service.is_flag_enabled",
+                new=AsyncMock(return_value=True),
             ),
             patch(
                 "unique_toolkit.agentic.tools.a2a.tool.service.send_message_and_wait_for_completion",
@@ -980,8 +982,8 @@ class TestSubAgentToolDebugInfo:
 
         with (
             patch(
-                "unique_toolkit.agentic.tools.a2a.tool.service.feature_flags.enable_new_answers_ui_un_14411.is_enabled",
-                return_value=True,
+                "unique_toolkit.agentic.tools.a2a.tool.service.is_flag_enabled",
+                new=AsyncMock(return_value=True),
             ),
             patch(
                 "unique_toolkit.agentic.tools.a2a.tool.service.send_message_and_wait_for_completion",
@@ -1059,8 +1061,8 @@ class TestSubAgentToolDebugInfo:
 
         with (
             patch(
-                "unique_toolkit.agentic.tools.a2a.tool.service.feature_flags.enable_new_answers_ui_un_14411.is_enabled",
-                return_value=True,
+                "unique_toolkit.agentic.tools.a2a.tool.service.is_flag_enabled",
+                new=AsyncMock(return_value=True),
             ),
             patch(
                 "unique_toolkit.agentic.tools.a2a.tool.service.send_message_and_wait_for_completion",

--- a/unique_toolkit/tests/services/test_chat_service_rate_limit.py
+++ b/unique_toolkit/tests/services/test_chat_service_rate_limit.py
@@ -73,9 +73,10 @@ def _patch_stream(return_value=None, side_effect=None):
 
 
 def _patch_feature_flag(enabled: bool):
-    ff = MagicMock()
-    ff.enable_new_answers_ui_un_14411.is_enabled.return_value = enabled
-    return patch(f"{_MODULE}.feature_flags", ff)
+    return patch(
+        f"{_MODULE}.is_flag_enabled",
+        AsyncMock(return_value=enabled),
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/unique_toolkit/unique_toolkit/agentic/feature_flags/__init__.py
+++ b/unique_toolkit/unique_toolkit/agentic/feature_flags/__init__.py
@@ -1,6 +1,7 @@
 from unique_toolkit.agentic.feature_flags.feature_flags import (
+    FeatureFlagNames,
     FeatureFlags,
     feature_flags,
 )
 
-__all__ = ["FeatureFlags", "feature_flags"]
+__all__ = ["FeatureFlagNames", "FeatureFlags", "feature_flags"]

--- a/unique_toolkit/unique_toolkit/agentic/feature_flags/feature_flags.py
+++ b/unique_toolkit/unique_toolkit/agentic/feature_flags/feature_flags.py
@@ -1,9 +1,35 @@
+from enum import StrEnum
 from typing import Any
 
 from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from unique_toolkit._common.config_checker import register_config
+
+
+class FeatureFlagNames(StrEnum):
+    """Flag name constants used by unique_toolkit's own agentic features.
+
+    Values match both the env-var fallback names (``FeatureFlags`` below) and
+    the configuration-backend registry keys used by
+    ``unique_toolkit.experimental.resources.feature_flags.FeatureFlagClient``.
+    """
+
+    enable_selected_uploaded_files_un_18215 = (
+        "FEATURE_FLAG_ENABLE_SELECTED_UPLOADED_FILES_UN_18215"
+    )
+    enable_mcp_metadata_fallback_un_19145 = (
+        "FEATURE_FLAG_ENABLE_MCP_METADATA_FALLBACK_UN_19145"
+    )
+    enable_html_rendering_un_15131 = "FEATURE_FLAG_ENABLE_HTML_RENDERING_UN_15131"
+    enable_code_execution_fence_un_17972 = (
+        "FEATURE_FLAG_ENABLE_CODE_EXECUTION_FENCE_UN_17972"
+    )
+    enable_html_with_fence_un_17927 = "FEATURE_FLAG_ENABLE_HTML_WITH_FENCE_UN_17927"
+    enable_web_search_argument_screening_un_18741 = (
+        "FEATURE_FLAG_ENABLE_WEB_SEARCH_ARGUMENT_SCREENING_UN_18741"
+    )
+    enable_new_answers_ui_un_14411 = "FEATURE_FLAG_ENABLE_NEW_ANSWERS_UI_UN_14411"
 
 
 class FeatureFlag:

--- a/unique_toolkit/unique_toolkit/agentic/feature_flags/feature_flags.py
+++ b/unique_toolkit/unique_toolkit/agentic/feature_flags/feature_flags.py
@@ -181,4 +181,4 @@ class FeatureFlags(BaseSettings):
 # Deprecated, unused elsewhere in this toolkit — kept only for external
 # backward compatibility. Use unique_toolkit.experimental.resources.feature_flags
 # .is_flag_enabled instead.
-feature_flags = FeatureFlags()  # pyright: ignore[reportDeprecated]
+feature_flags = FeatureFlags()

--- a/unique_toolkit/unique_toolkit/agentic/feature_flags/feature_flags.py
+++ b/unique_toolkit/unique_toolkit/agentic/feature_flags/feature_flags.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+from typing_extensions import deprecated
 
 from unique_toolkit._common.config_checker import register_config
 
@@ -32,6 +33,9 @@ class FeatureFlagNames(StrEnum):
     enable_new_answers_ui_un_14411 = "FEATURE_FLAG_ENABLE_NEW_ANSWERS_UI_UN_14411"
 
 
+@deprecated(
+    "Use unique_toolkit.experimental.resources.feature_flags.is_flag_enabled instead"
+)
 class FeatureFlag:
     """A feature flag that can be enabled globally or for specific company IDs.
 
@@ -71,6 +75,9 @@ class FeatureFlag:
         return f"FeatureFlag({self.value})"
 
 
+@deprecated(
+    "Use unique_toolkit.experimental.resources.feature_flags.is_flag_enabled instead"
+)
 @register_config()
 class FeatureFlags(BaseSettings):
     """Feature flags loaded from environment variables.
@@ -171,5 +178,7 @@ class FeatureFlags(BaseSettings):
         return FeatureFlag(False)
 
 
-# Initialize once at module load - import this where needed
-feature_flags = FeatureFlags()
+# Deprecated, unused elsewhere in this toolkit — kept only for external
+# backward compatibility. Use unique_toolkit.experimental.resources.feature_flags
+# .is_flag_enabled instead.
+feature_flags = FeatureFlags()  # pyright: ignore[reportDeprecated]

--- a/unique_toolkit/unique_toolkit/agentic/history_manager/loop_token_reducer.py
+++ b/unique_toolkit/unique_toolkit/agentic/history_manager/loop_token_reducer.py
@@ -110,10 +110,8 @@ class LoopTokenReducer:
         self._db_source_map: dict[int, ContentChunk] = {}
         self._enable_tool_call_persistence = enable_tool_call_persistence
         self._event = event
-        # Resolved lazily on first async use (`get_history_from_db`) since
-        # evaluating the underlying feature flag is async; `_resolved` tracks
-        # whether resolution has happened yet, distinct from a resolved `None`
-        # (flag off — include all uploaded content).
+        # Lazily resolved on first async use since the flag check is async;
+        # `_resolved` distinguishes "not yet checked" from a resolved `None` (flag off).
         self._selected_content_ids: set[str] | None = None
         self._selected_content_ids_resolved = False
 

--- a/unique_toolkit/unique_toolkit/agentic/history_manager/loop_token_reducer.py
+++ b/unique_toolkit/unique_toolkit/agentic/history_manager/loop_token_reducer.py
@@ -109,7 +109,21 @@ class LoopTokenReducer:
         self._max_db_source_number: int = -1
         self._db_source_map: dict[int, ContentChunk] = {}
         self._enable_tool_call_persistence = enable_tool_call_persistence
-        self._selected_content_ids = get_selected_uploaded_content_ids(event)
+        self._event = event
+        # Resolved lazily on first async use (`get_history_from_db`) since
+        # evaluating the underlying feature flag is async; `_resolved` tracks
+        # whether resolution has happened yet, distinct from a resolved `None`
+        # (flag off — include all uploaded content).
+        self._selected_content_ids: set[str] | None = None
+        self._selected_content_ids_resolved = False
+
+    async def _get_selected_content_ids(self) -> set[str] | None:
+        if not self._selected_content_ids_resolved:
+            self._selected_content_ids = await get_selected_uploaded_content_ids(
+                self._event
+            )
+            self._selected_content_ids_resolved = True
+        return self._selected_content_ids
 
     @property
     def max_db_source_number(self) -> int:
@@ -354,6 +368,7 @@ class LoopTokenReducer:
         Returns:
             list[LanguageModelMessage]: The history
         """
+        selected_content_ids = await self._get_selected_content_ids()
         if self._enable_tool_call_persistence:
             (
                 full_history,
@@ -365,7 +380,7 @@ class LoopTokenReducer:
                 chat_service=self._chat_service,
                 content_service=self._content_service,
                 file_content_serializer=self._file_content_serializer,
-                selected_content_ids=self._selected_content_ids,
+                selected_content_ids=selected_content_ids,
             )
             self._max_db_source_number = max_src
             self._db_source_map = src_map
@@ -376,7 +391,7 @@ class LoopTokenReducer:
                 chat_service=self._chat_service,
                 content_service=self._content_service,
                 file_content_serializer=self._file_content_serializer,
-                selected_content_ids=self._selected_content_ids,
+                selected_content_ids=selected_content_ids,
             )
 
         if remove_from_text is not None:

--- a/unique_toolkit/unique_toolkit/agentic/history_manager/utils.py
+++ b/unique_toolkit/unique_toolkit/agentic/history_manager/utils.py
@@ -3,13 +3,11 @@ import logging
 from copy import deepcopy
 from typing import Any
 
+from unique_toolkit.agentic.feature_flags import FeatureFlagNames
 from unique_toolkit.agentic.tools.schemas import Source
 from unique_toolkit.app.schemas import ChatEvent
 from unique_toolkit.content.schemas import ContentChunk
-from unique_toolkit.experimental.resources.feature_flags import (
-    FeatureFlagNames,
-    is_flag_enabled,
-)
+from unique_toolkit.experimental.resources.feature_flags import is_flag_enabled
 from unique_toolkit.language_model.schemas import (
     LanguageModelAssistantMessage,
     LanguageModelMessage,

--- a/unique_toolkit/unique_toolkit/agentic/history_manager/utils.py
+++ b/unique_toolkit/unique_toolkit/agentic/history_manager/utils.py
@@ -3,10 +3,13 @@ import logging
 from copy import deepcopy
 from typing import Any
 
-from unique_toolkit.agentic.feature_flags import feature_flags
 from unique_toolkit.agentic.tools.schemas import Source
 from unique_toolkit.app.schemas import ChatEvent
 from unique_toolkit.content.schemas import ContentChunk
+from unique_toolkit.experimental.resources.feature_flags import (
+    FeatureFlagNames,
+    is_flag_enabled,
+)
 from unique_toolkit.language_model.schemas import (
     LanguageModelAssistantMessage,
     LanguageModelMessage,
@@ -16,15 +19,16 @@ from unique_toolkit.language_model.schemas import (
 logger = logging.getLogger(__name__)
 
 
-def get_selected_uploaded_content_ids(event: ChatEvent) -> set[str] | None:
+async def get_selected_uploaded_content_ids(event: ChatEvent) -> set[str] | None:
     """Derive the set of content IDs the user explicitly selected.
 
     Returns ``None`` when the feature flag is disabled (meaning *all*
     uploaded images should be included), or a ``set[str]`` of IDs when
     only a subset should be attached.
     """
-    if not feature_flags.enable_selected_uploaded_files_un_18215.is_enabled(
-        event.company_id
+    if not await is_flag_enabled(
+        FeatureFlagNames.enable_selected_uploaded_files_un_18215,
+        company_id=event.company_id,
     ):
         return None
 

--- a/unique_toolkit/unique_toolkit/agentic/tools/a2a/tool/service.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/a2a/tool/service.py
@@ -22,6 +22,7 @@ from unique_toolkit._common.referencing import (
 )
 from unique_toolkit._common.utils.jinja.render import render_template
 from unique_toolkit.agentic.evaluation.schemas import EvaluationMetricName
+from unique_toolkit.agentic.feature_flags import FeatureFlagNames
 from unique_toolkit.agentic.message_log_manager.service import MessageStepLogger
 from unique_toolkit.agentic.tools.a2a.response_watcher import SubAgentResponseWatcher
 from unique_toolkit.agentic.tools.a2a.tool._memory import (
@@ -53,10 +54,7 @@ from unique_toolkit.chat.schemas import (
 )
 from unique_toolkit.chat.service import ChatService
 from unique_toolkit.content import ContentChunk, ContentReference
-from unique_toolkit.experimental.resources.feature_flags import (
-    FeatureFlagNames,
-    is_flag_enabled,
-)
+from unique_toolkit.experimental.resources.feature_flags import is_flag_enabled
 from unique_toolkit.language_model import (
     LanguageModelFunction,
     LanguageModelService,

--- a/unique_toolkit/unique_toolkit/agentic/tools/a2a/tool/service.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/a2a/tool/service.py
@@ -22,7 +22,7 @@ from unique_toolkit._common.referencing import (
 )
 from unique_toolkit._common.utils.jinja.render import render_template
 from unique_toolkit.agentic.evaluation.schemas import EvaluationMetricName
-from unique_toolkit.agentic.feature_flags import feature_flags
+from unique_toolkit.agentic.message_log_manager.service import MessageStepLogger
 from unique_toolkit.agentic.tools.a2a.response_watcher import SubAgentResponseWatcher
 from unique_toolkit.agentic.tools.a2a.tool._memory import (
     get_sub_agent_short_term_memory_manager,
@@ -53,6 +53,10 @@ from unique_toolkit.chat.schemas import (
 )
 from unique_toolkit.chat.service import ChatService
 from unique_toolkit.content import ContentChunk, ContentReference
+from unique_toolkit.experimental.resources.feature_flags import (
+    FeatureFlagNames,
+    is_flag_enabled,
+)
 from unique_toolkit.language_model import (
     LanguageModelFunction,
     LanguageModelService,
@@ -431,11 +435,9 @@ class SubAgentTool(Tool[SubAgentToolConfig]):
         message: str,
         state: ProgressState,
     ) -> None:
-        if (
-            self._tool_progress_reporter is not None
-            and not feature_flags.enable_new_answers_ui_un_14411.is_enabled(
-                self._company_id
-            )
+        if self._tool_progress_reporter is not None and not await is_flag_enabled(
+            FeatureFlagNames.enable_new_answers_ui_un_14411,
+            company_id=self._company_id or "",
         ):
             await self._tool_progress_reporter.notify_from_tool_call(
                 tool_call=tool_call,

--- a/unique_toolkit/unique_toolkit/agentic/tools/a2a/tool/service.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/a2a/tool/service.py
@@ -23,7 +23,6 @@ from unique_toolkit._common.referencing import (
 from unique_toolkit._common.utils.jinja.render import render_template
 from unique_toolkit.agentic.evaluation.schemas import EvaluationMetricName
 from unique_toolkit.agentic.feature_flags import FeatureFlagNames
-from unique_toolkit.agentic.message_log_manager.service import MessageStepLogger
 from unique_toolkit.agentic.tools.a2a.response_watcher import SubAgentResponseWatcher
 from unique_toolkit.agentic.tools.a2a.tool._memory import (
     get_sub_agent_short_term_memory_manager,

--- a/unique_toolkit/unique_toolkit/agentic/tools/mcp/tool_wrapper.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/mcp/tool_wrapper.py
@@ -9,6 +9,7 @@ from typing import Any, Dict
 import unique_sdk
 
 from unique_toolkit.agentic.evaluation.schemas import EvaluationMetricName
+from unique_toolkit.agentic.feature_flags import FeatureFlagNames
 from unique_toolkit.agentic.message_log_manager.service import MessageStepLogger
 from unique_toolkit.agentic.tools.mcp.models import MCPToolConfig
 from unique_toolkit.agentic.tools.schemas import ToolCallResponse
@@ -21,10 +22,7 @@ from unique_toolkit.app.schemas import ChatEvent, McpServer, McpTool
 from unique_toolkit.chat.schemas import MessageLog, MessageLogStatus
 from unique_toolkit.chat.service import ChatService
 from unique_toolkit.content.functions import upload_content_from_bytes
-from unique_toolkit.experimental.resources.feature_flags import (
-    FeatureFlagNames,
-    is_flag_enabled,
-)
+from unique_toolkit.experimental.resources.feature_flags import is_flag_enabled
 from unique_toolkit.language_model import LanguageModelService
 from unique_toolkit.language_model.schemas import (
     LanguageModelFunction,

--- a/unique_toolkit/unique_toolkit/agentic/tools/mcp/tool_wrapper.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/mcp/tool_wrapper.py
@@ -10,7 +10,6 @@ import unique_sdk
 
 from unique_toolkit.agentic.evaluation.schemas import EvaluationMetricName
 from unique_toolkit.agentic.feature_flags import FeatureFlagNames
-from unique_toolkit.agentic.message_log_manager.service import MessageStepLogger
 from unique_toolkit.agentic.tools.mcp.models import MCPToolConfig
 from unique_toolkit.agentic.tools.schemas import ToolCallResponse
 from unique_toolkit.agentic.tools.tool import Tool

--- a/unique_toolkit/unique_toolkit/agentic/tools/mcp/tool_wrapper.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/mcp/tool_wrapper.py
@@ -9,7 +9,7 @@ from typing import Any, Dict
 import unique_sdk
 
 from unique_toolkit.agentic.evaluation.schemas import EvaluationMetricName
-from unique_toolkit.agentic.feature_flags import feature_flags
+from unique_toolkit.agentic.message_log_manager.service import MessageStepLogger
 from unique_toolkit.agentic.tools.mcp.models import MCPToolConfig
 from unique_toolkit.agentic.tools.schemas import ToolCallResponse
 from unique_toolkit.agentic.tools.tool import Tool
@@ -21,6 +21,10 @@ from unique_toolkit.app.schemas import ChatEvent, McpServer, McpTool
 from unique_toolkit.chat.schemas import MessageLog, MessageLogStatus
 from unique_toolkit.chat.service import ChatService
 from unique_toolkit.content.functions import upload_content_from_bytes
+from unique_toolkit.experimental.resources.feature_flags import (
+    FeatureFlagNames,
+    is_flag_enabled,
+)
 from unique_toolkit.language_model import LanguageModelService
 from unique_toolkit.language_model.schemas import (
     LanguageModelFunction,
@@ -133,11 +137,9 @@ class MCPToolWrapper(Tool[MCPToolConfig]):
         )
 
         # Notify progress if reporter is available
-        if (
-            self._tool_progress_reporter
-            and not feature_flags.enable_new_answers_ui_un_14411.is_enabled(
-                self._event.company_id
-            )
+        if self._tool_progress_reporter and not await is_flag_enabled(
+            FeatureFlagNames.enable_new_answers_ui_un_14411,
+            company_id=self._event.company_id,
         ):
             await self._tool_progress_reporter.notify_from_tool_call(
                 tool_call=tool_call,
@@ -172,11 +174,9 @@ class MCPToolWrapper(Tool[MCPToolConfig]):
             )
 
             # Notify completion
-            if (
-                self._tool_progress_reporter
-                and not feature_flags.enable_new_answers_ui_un_14411.is_enabled(
-                    self._event.company_id
-                )
+            if self._tool_progress_reporter and not await is_flag_enabled(
+                FeatureFlagNames.enable_new_answers_ui_un_14411,
+                company_id=self._event.company_id,
             ):
                 await self._tool_progress_reporter.notify_from_tool_call(
                     tool_call=tool_call,
@@ -198,11 +198,9 @@ class MCPToolWrapper(Tool[MCPToolConfig]):
             self.logger.error(f"Error executing MCP tool {self.name}: {e}")
 
             # Notify failure
-            if (
-                self._tool_progress_reporter
-                and not feature_flags.enable_new_answers_ui_un_14411.is_enabled(
-                    self._event.company_id
-                )
+            if self._tool_progress_reporter and not await is_flag_enabled(
+                FeatureFlagNames.enable_new_answers_ui_un_14411,
+                company_id=self._event.company_id,
             ):
                 await self._tool_progress_reporter.notify_from_tool_call(
                     tool_call=tool_call,

--- a/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/postprocessors/code_display.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/postprocessors/code_display.py
@@ -63,7 +63,7 @@ class ShowExecutedCodePostprocessor(ResponsesApiPostprocessor):
 
     @override
     async def run(self, loop_response: ResponsesLanguageModelStreamResponse) -> None:
-        self._is_enabled = await is_flag_enabled(
+        self._is_enabled = self._config.enable and not await is_flag_enabled(
             FeatureFlagNames.enable_code_execution_fence_un_17972,
             company_id=self._company_id or "",
         )

--- a/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/postprocessors/code_display.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/postprocessors/code_display.py
@@ -6,11 +6,14 @@ from typing import override
 from pydantic import BaseModel, Field
 from pydantic.json_schema import SkipJsonSchema
 
-from unique_toolkit.agentic.feature_flags.feature_flags import feature_flags
 from unique_toolkit.agentic.postprocessor.postprocessor_manager import (
     ResponsesApiPostprocessor,
 )
 from unique_toolkit.agentic.tools.config import get_configuration_dict
+from unique_toolkit.experimental.resources.feature_flags import (
+    FeatureFlagNames,
+    is_flag_enabled,
+)
 from unique_toolkit.language_model.schemas import ResponsesLanguageModelStreamResponse
 
 _TEMPLATE = """
@@ -56,11 +59,9 @@ class ShowExecutedCodePostprocessor(ResponsesApiPostprocessor):
         super().__init__(self.__class__.__name__)
         self._config = config
         self._company_id = company_id
-        self._is_enabled = (
-            self._config.enable
-            and not feature_flags.enable_code_execution_fence_un_17972.is_enabled(
-                company_id
-            )
+        self._is_enabled = is_flag_enabled(
+            FeatureFlagNames.enable_code_execution_fence_un_17972,
+            company_id=self._company_id or "",
         )
 
     @override

--- a/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/postprocessors/code_display.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/postprocessors/code_display.py
@@ -6,14 +6,12 @@ from typing import override
 from pydantic import BaseModel, Field
 from pydantic.json_schema import SkipJsonSchema
 
+from unique_toolkit.agentic.feature_flags import FeatureFlagNames
 from unique_toolkit.agentic.postprocessor.postprocessor_manager import (
     ResponsesApiPostprocessor,
 )
 from unique_toolkit.agentic.tools.config import get_configuration_dict
-from unique_toolkit.experimental.resources.feature_flags import (
-    FeatureFlagNames,
-    is_flag_enabled,
-)
+from unique_toolkit.experimental.resources.feature_flags import is_flag_enabled
 from unique_toolkit.language_model.schemas import ResponsesLanguageModelStreamResponse
 
 _TEMPLATE = """
@@ -59,13 +57,16 @@ class ShowExecutedCodePostprocessor(ResponsesApiPostprocessor):
         super().__init__(self.__class__.__name__)
         self._config = config
         self._company_id = company_id
-        self._is_enabled = is_flag_enabled(
-            FeatureFlagNames.enable_code_execution_fence_un_17972,
-            company_id=self._company_id or "",
-        )
+        # Resolved in `run()` (awaited by PostprocessorManager before
+        # `apply_postprocessing_to_response`) since flag evaluation is async.
+        self._is_enabled = False
 
     @override
     async def run(self, loop_response: ResponsesLanguageModelStreamResponse) -> None:
+        self._is_enabled = await is_flag_enabled(
+            FeatureFlagNames.enable_code_execution_fence_un_17972,
+            company_id=self._company_id or "",
+        )
         if self._is_enabled:
             await asyncio.sleep(self._config.sleep_time_before_display)
 

--- a/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/postprocessors/code_display.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/postprocessors/code_display.py
@@ -11,7 +11,10 @@ from unique_toolkit.agentic.postprocessor.postprocessor_manager import (
     ResponsesApiPostprocessor,
 )
 from unique_toolkit.agentic.tools.config import get_configuration_dict
-from unique_toolkit.experimental.resources.feature_flags import is_flag_enabled
+from unique_toolkit.experimental.resources.feature_flags import (
+    COMPANY_ID_PLACEHOLDER,
+    is_flag_enabled,
+)
 from unique_toolkit.language_model.schemas import ResponsesLanguageModelStreamResponse
 
 _TEMPLATE = """
@@ -57,15 +60,14 @@ class ShowExecutedCodePostprocessor(ResponsesApiPostprocessor):
         super().__init__(self.__class__.__name__)
         self._config = config
         self._company_id = company_id
-        # Resolved in `run()` (awaited by PostprocessorManager before
-        # `apply_postprocessing_to_response`) since flag evaluation is async.
+        # Resolved in run() (before apply_postprocessing_to_response) since flag evaluation is async.
         self._is_enabled = False
 
     @override
     async def run(self, loop_response: ResponsesLanguageModelStreamResponse) -> None:
         self._is_enabled = self._config.enable and not await is_flag_enabled(
             FeatureFlagNames.enable_code_execution_fence_un_17972,
-            company_id=self._company_id or "",
+            company_id=self._company_id or COMPANY_ID_PLACEHOLDER,
         )
         if self._is_enabled:
             await asyncio.sleep(self._config.sleep_time_before_display)

--- a/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/postprocessors/generated_files.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/postprocessors/generated_files.py
@@ -21,7 +21,6 @@ from tenacity import (
 
 from unique_toolkit import ChatService
 from unique_toolkit._common.execution import failsafe_async
-from unique_toolkit.agentic.feature_flags.feature_flags import feature_flags
 from unique_toolkit.agentic.postprocessor.postprocessor_manager import (
     ResponsesApiPostprocessor,
 )
@@ -39,6 +38,10 @@ from unique_toolkit.agentic.tools.openai_builtin.code_interpreter.schemas import
 )
 from unique_toolkit.content.schemas import ContentReference
 from unique_toolkit.content.service import ContentService
+from unique_toolkit.experimental.resources.feature_flags import (
+    FeatureFlagNames,
+    is_flag_enabled,
+)
 from unique_toolkit.language_model.schemas import ResponsesLanguageModelStreamResponse
 from unique_toolkit.services.knowledge_base import KnowledgeBaseService
 from unique_toolkit.short_term_memory.service import ShortTermMemoryService
@@ -554,8 +557,9 @@ class DisplayCodeInterpreterFilesPostProcessor(
         self._log.info(
             "apply_postprocessing started — %d file(s) in content_map, fence_ff=%s",
             len(self._content_map),
-            feature_flags.enable_code_execution_fence_un_17972.is_enabled(
-                self._company_id
+            is_flag_enabled(
+                FeatureFlagNames.enable_code_execution_fence_un_17972,
+                company_id=self._company_id or "",
             ),
         )
 
@@ -566,17 +570,16 @@ class DisplayCodeInterpreterFilesPostProcessor(
 
         ref_number = _get_next_ref_number(loop_response.message.references)
         changed = False
-        fence_ff_on = feature_flags.enable_code_execution_fence_un_17972.is_enabled(
-            self._company_id
+        fence_ff_on = is_flag_enabled(
+            FeatureFlagNames.enable_code_execution_fence_un_17972,
+            company_id=self._company_id or "",
         )
         # HTML uses htmlWithSource only when BOTH the code-execution fence FF AND the
         # dedicated HTML-fence FF are on. Default (FF off) keeps HtmlRendering so
         # existing deployments are unaffected.
-        html_fence_ff_on = (
-            fence_ff_on
-            and feature_flags.enable_html_with_fence_un_17927.is_enabled(
-                self._company_id
-            )
+        html_fence_ff_on = is_flag_enabled(
+            FeatureFlagNames.enable_html_with_fence_un_17927,
+            company_id=self._company_id or "",
         )
 
         replaced_files: list[str] = []

--- a/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/postprocessors/generated_files.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/postprocessors/generated_files.py
@@ -21,6 +21,7 @@ from tenacity import (
 
 from unique_toolkit import ChatService
 from unique_toolkit._common.execution import failsafe_async
+from unique_toolkit.agentic.feature_flags import FeatureFlagNames
 from unique_toolkit.agentic.postprocessor.postprocessor_manager import (
     ResponsesApiPostprocessor,
 )
@@ -38,10 +39,7 @@ from unique_toolkit.agentic.tools.openai_builtin.code_interpreter.schemas import
 )
 from unique_toolkit.content.schemas import ContentReference
 from unique_toolkit.content.service import ContentService
-from unique_toolkit.experimental.resources.feature_flags import (
-    FeatureFlagNames,
-    is_flag_enabled,
-)
+from unique_toolkit.experimental.resources.feature_flags import is_flag_enabled
 from unique_toolkit.language_model.schemas import ResponsesLanguageModelStreamResponse
 from unique_toolkit.services.knowledge_base import KnowledgeBaseService
 from unique_toolkit.short_term_memory.service import ShortTermMemoryService
@@ -392,6 +390,11 @@ class DisplayCodeInterpreterFilesPostProcessor(
         # Cleared at the start of each run(); holds this-turn download sizes.
         self._file_size_map: dict[str, int] = {}
 
+        # Resolved in `run()` (awaited by PostprocessorManager before
+        # `apply_postprocessing_to_response`) since flag evaluation is async.
+        self._fence_ff_on = False
+        self._html_fence_ff_on = False
+
     def _build_retry(self) -> AsyncRetrying:
         """Build a tenacity retry policy from the current config.
 
@@ -411,6 +414,18 @@ class DisplayCodeInterpreterFilesPostProcessor(
     ) -> ArtifactsDebugInfo | None:
         run_t0 = time.monotonic()
         self._log.info("run() started — fetching and uploading code interpreter files")
+
+        self._fence_ff_on = await is_flag_enabled(
+            FeatureFlagNames.enable_code_execution_fence_un_17972,
+            company_id=self._company_id or "",
+        )
+        # HTML uses htmlWithSource only when BOTH the code-execution fence FF AND the
+        # dedicated HTML-fence FF are on. Default (FF off) keeps HtmlRendering so
+        # existing deployments are unaffected.
+        self._html_fence_ff_on = await is_flag_enabled(
+            FeatureFlagNames.enable_html_with_fence_un_17927,
+            company_id=self._company_id or "",
+        )
 
         container_files = loop_response.container_files
         self._log.info(
@@ -557,10 +572,7 @@ class DisplayCodeInterpreterFilesPostProcessor(
         self._log.info(
             "apply_postprocessing started — %d file(s) in content_map, fence_ff=%s",
             len(self._content_map),
-            is_flag_enabled(
-                FeatureFlagNames.enable_code_execution_fence_un_17972,
-                company_id=self._company_id or "",
-            ),
+            self._fence_ff_on,
         )
 
         if loop_response.message.references is None:
@@ -570,17 +582,6 @@ class DisplayCodeInterpreterFilesPostProcessor(
 
         ref_number = _get_next_ref_number(loop_response.message.references)
         changed = False
-        fence_ff_on = is_flag_enabled(
-            FeatureFlagNames.enable_code_execution_fence_un_17972,
-            company_id=self._company_id or "",
-        )
-        # HTML uses htmlWithSource only when BOTH the code-execution fence FF AND the
-        # dedicated HTML-fence FF are on. Default (FF off) keeps HtmlRendering so
-        # existing deployments are unaffected.
-        html_fence_ff_on = is_flag_enabled(
-            FeatureFlagNames.enable_html_with_fence_un_17927,
-            company_id=self._company_id or "",
-        )
 
         replaced_files: list[str] = []
         missed_files: list[str] = []
@@ -614,7 +615,7 @@ class DisplayCodeInterpreterFilesPostProcessor(
 
             # HTML rendered as HtmlRendering block unless the dedicated html-fence FF
             # is on (enable_html_with_fence_un_17927). Default keeps HtmlRendering.
-            elif is_html and not html_fence_ff_on:
+            elif is_html and not self._html_fence_ff_on:
                 loop_response.message.text, replaced = _replace_container_html_citation(
                     text=loop_response.message.text or "",
                     filename=filename,
@@ -622,7 +623,7 @@ class DisplayCodeInterpreterFilesPostProcessor(
                 )
                 changed |= replaced
 
-            # Non-HTML files, or HTML when html_fence_ff_on → inline content link for
+            # Non-HTML files, or HTML when self._html_fence_ff_on → inline content link for
             # subsequent fence injection (htmlWithSource / imgWithSource / fileWithSource)
             else:
                 loop_response.message.text, replaced = _replace_container_file_citation(
@@ -630,7 +631,7 @@ class DisplayCodeInterpreterFilesPostProcessor(
                     filename=filename,
                     content_id=content_id,
                     ref_number=ref_number,
-                    use_content_link=fence_ff_on,
+                    use_content_link=self._fence_ff_on,
                 )
                 changed |= replaced
 
@@ -647,7 +648,7 @@ class DisplayCodeInterpreterFilesPostProcessor(
 
             # HtmlRendering and htmlWithSource both embed contentId directly — no ContentReference needed
             is_html_rendered = is_html
-            if replaced and not (is_image or is_html_rendered or fence_ff_on):
+            if replaced and not (is_image or is_html_rendered or self._fence_ff_on):
                 loop_response.message.references.append(
                     ContentReference(
                         sequence_number=ref_number,
@@ -666,9 +667,9 @@ class DisplayCodeInterpreterFilesPostProcessor(
             error_files,
         )
 
-        if fence_ff_on:
+        if self._fence_ff_on:
             code_blocks = _build_code_blocks(
-                loop_response, self._content_map, include_html=html_fence_ff_on
+                loop_response, self._content_map, include_html=self._html_fence_ff_on
             )
             self._log.info(
                 "Fence injection — %d code block(s), files: %s",
@@ -676,7 +677,7 @@ class DisplayCodeInterpreterFilesPostProcessor(
                 [f.filename for b in code_blocks for f in b.files],
             )
             _warn_unmatched_code_blocks(
-                self._content_map, code_blocks, include_html=html_fence_ff_on
+                self._content_map, code_blocks, include_html=self._html_fence_ff_on
             )
             text_before = loop_response.message.text
             loop_response.message.text = _inject_code_execution_fences(

--- a/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/postprocessors/generated_files.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/postprocessors/generated_files.py
@@ -39,7 +39,10 @@ from unique_toolkit.agentic.tools.openai_builtin.code_interpreter.schemas import
 )
 from unique_toolkit.content.schemas import ContentReference
 from unique_toolkit.content.service import ContentService
-from unique_toolkit.experimental.resources.feature_flags import is_flag_enabled
+from unique_toolkit.experimental.resources.feature_flags import (
+    COMPANY_ID_PLACEHOLDER,
+    is_flag_enabled,
+)
 from unique_toolkit.language_model.schemas import ResponsesLanguageModelStreamResponse
 from unique_toolkit.services.knowledge_base import KnowledgeBaseService
 from unique_toolkit.short_term_memory.service import ShortTermMemoryService
@@ -390,8 +393,7 @@ class DisplayCodeInterpreterFilesPostProcessor(
         # Cleared at the start of each run(); holds this-turn download sizes.
         self._file_size_map: dict[str, int] = {}
 
-        # Resolved in `run()` (awaited by PostprocessorManager before
-        # `apply_postprocessing_to_response`) since flag evaluation is async.
+        # Resolved in run() (before apply_postprocessing_to_response) since flag evaluation is async.
         self._fence_ff_on = False
         self._html_fence_ff_on = False
 
@@ -417,14 +419,13 @@ class DisplayCodeInterpreterFilesPostProcessor(
 
         self._fence_ff_on = await is_flag_enabled(
             FeatureFlagNames.enable_code_execution_fence_un_17972,
-            company_id=self._company_id or "",
+            company_id=self._company_id or COMPANY_ID_PLACEHOLDER,
         )
-        # HTML uses htmlWithSource only when BOTH the code-execution fence FF AND the
-        # dedicated HTML-fence FF are on. Default (FF off) keeps HtmlRendering so
-        # existing deployments are unaffected.
+        # htmlWithSource requires BOTH the fence FF and the HTML-fence FF on; default
+        # (FF off) keeps HtmlRendering, so existing deployments are unaffected.
         self._html_fence_ff_on = await is_flag_enabled(
             FeatureFlagNames.enable_html_with_fence_un_17927,
-            company_id=self._company_id or "",
+            company_id=self._company_id or COMPANY_ID_PLACEHOLDER,
         )
 
         container_files = loop_response.container_files

--- a/unique_toolkit/unique_toolkit/experimental/resources/feature_flags/__init__.py
+++ b/unique_toolkit/unique_toolkit/experimental/resources/feature_flags/__init__.py
@@ -14,12 +14,13 @@ Quick start — explicit IDs::
 
     from unique_toolkit.experimental.resources.feature_flags import FeatureFlagClient, is_flag_enabled
 
-    # Tries remote client; falls back to FeatureFlags settings when not configured.
+    # Requires CONFIGURATION_BACKEND_URL / FEATURE_FLAG_SERVICE_ID to be set;
+    # falls back to the env-var value (or stale cache) on transport errors.
     enabled = await is_flag_enabled("FEATURE_FLAG_ENABLE_X", company_id=company_id)
 
-    # Or manage the singleton directly (returns None when not configured):
+    # Or manage the singleton directly:
     client = FeatureFlagClient.from_settings()  # raises if URL/service_id absent
-    client = get_feature_flag_client()           # returns None instead of raising
+    client = get_feature_flag_client()          # same — thin passthrough to from_settings()
 
 Per-request binding (when you have UniqueSettings / AuthContext)::
 
@@ -38,7 +39,6 @@ See README.md for the full evaluation-order diagram and adoption steps.
 from .client import (
     BoundFeatureFlagClient,
     FeatureFlagClient,
-    FeatureFlagNames,
     get_feature_flag_client,
     is_flag_enabled,
 )
@@ -46,7 +46,6 @@ from .schemas import FlagEvaluation
 from .settings import FeatureFlagSettings
 
 __all__ = [
-    "FeatureFlagNames",
     "BoundFeatureFlagClient",
     "FeatureFlagClient",
     "FlagEvaluation",

--- a/unique_toolkit/unique_toolkit/experimental/resources/feature_flags/__init__.py
+++ b/unique_toolkit/unique_toolkit/experimental/resources/feature_flags/__init__.py
@@ -12,10 +12,14 @@ Required env vars::
 
 Quick start — explicit IDs::
 
-    from unique_toolkit.experimental.resources.feature_flags import FeatureFlagClient
+    from unique_toolkit.experimental.resources.feature_flags import FeatureFlagClient, is_flag_enabled
 
-    client = FeatureFlagClient.from_settings()  # singleton; call at startup or first request
-    enabled = await client.is_enabled("FEATURE_FLAG_ENABLE_X", company_id=company_id)
+    # Tries remote client; falls back to FeatureFlags settings when not configured.
+    enabled = await is_flag_enabled("FEATURE_FLAG_ENABLE_X", company_id=company_id)
+
+    # Or manage the singleton directly (returns None when not configured):
+    client = FeatureFlagClient.from_settings()  # raises if URL/service_id absent
+    client = get_feature_flag_client()           # returns None instead of raising
 
 Per-request binding (when you have UniqueSettings / AuthContext)::
 
@@ -34,6 +38,7 @@ See README.md for the full evaluation-order diagram and adoption steps.
 from .client import (
     BoundFeatureFlagClient,
     FeatureFlagClient,
+    FeatureFlagNames,
     get_feature_flag_client,
     is_flag_enabled,
 )
@@ -41,6 +46,7 @@ from .schemas import FlagEvaluation
 from .settings import FeatureFlagSettings
 
 __all__ = [
+    "FeatureFlagNames",
     "BoundFeatureFlagClient",
     "FeatureFlagClient",
     "FlagEvaluation",

--- a/unique_toolkit/unique_toolkit/experimental/resources/feature_flags/__init__.py
+++ b/unique_toolkit/unique_toolkit/experimental/resources/feature_flags/__init__.py
@@ -37,6 +37,7 @@ See README.md for the full evaluation-order diagram and adoption steps.
 """
 
 from .client import (
+    COMPANY_ID_PLACEHOLDER,
     BoundFeatureFlagClient,
     FeatureFlagClient,
     get_feature_flag_client,
@@ -46,6 +47,7 @@ from .schemas import FlagEvaluation
 from .settings import FeatureFlagSettings
 
 __all__ = [
+    "COMPANY_ID_PLACEHOLDER",
     "BoundFeatureFlagClient",
     "FeatureFlagClient",
     "FlagEvaluation",

--- a/unique_toolkit/unique_toolkit/experimental/resources/feature_flags/client.py
+++ b/unique_toolkit/unique_toolkit/experimental/resources/feature_flags/client.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 import logging
 import os
-from enum import StrEnum
 from typing import ClassVar
 
 import httpx
 from tenacity import retry, retry_if_exception, stop_after_attempt
 
+from unique_toolkit.agentic.feature_flags.feature_flags import FeatureFlags
 from unique_toolkit.app.unique_settings import AuthContextProtocol, UniqueSettings
 
 from ._graphql_client import evaluate_flag
@@ -16,24 +16,6 @@ from .schemas import FlagEvaluation
 from .settings import FeatureFlagSettings
 
 logger = logging.getLogger(__name__)
-
-
-class FeatureFlagNames(StrEnum):
-    enable_selected_uploaded_files_un_18215 = (
-        "FEATURE_FLAG_ENABLE_SELECTED_UPLOADED_FILES_UN_18215"
-    )
-    enable_mcp_metadata_fallback_un_19145 = (
-        "FEATURE_FLAG_ENABLE_MCP_METADATA_FALLBACK_UN_19145"
-    )
-    enable_html_rendering_un_15131 = "FEATURE_FLAG_ENABLE_HTML_RENDERING_UN_15131"
-    enable_code_execution_fence_un_17972 = (
-        "FEATURE_FLAG_ENABLE_CODE_EXECUTION_FENCE_UN_17972"
-    )
-    enable_html_with_fence_un_17927 = "FEATURE_FLAG_ENABLE_HTML_WITH_FENCE_UN_17927"
-    enable_web_search_argument_screening_un_18741 = (
-        "FEATURE_FLAG_ENABLE_WEB_SEARCH_ARGUMENT_SCREENING_UN_18741"
-    )
-    enable_new_answers_ui_un_14411 = "FEATURE_FLAG_ENABLE_NEW_ANSWERS_UI_UN_14411"
 
 
 class FeatureFlagClient:
@@ -198,19 +180,13 @@ class FeatureFlagClient:
     def _env_fallback(flag: str, company_id: str | None = None) -> bool:
         """Read *flag* from env vars using the same semantics as ``FeatureFlag``.
 
-        Supports both plain booleans (``"true"`` / ``"false"``) and
-        comma-separated company-ID allowlists (``"company1,company2"``),
-        consistent with ``unique_toolkit.agentic.feature_flags.FeatureFlags``.
+        Delegates parsing to ``FeatureFlags.parse_feature_flag`` (plain booleans
+        or comma-separated company-ID allowlists) so the two env-var fallback
+        paths — this client and ``unique_toolkit.agentic.feature_flags`` —
+        can't drift apart.
         """
-        raw = os.getenv(flag, "false").strip()
-        raw_lower = raw.lower()
-        if raw_lower in ("true", "1", "yes"):
-            return True
-        if raw_lower in ("false", "0", "no", ""):
-            return False
-        # Comma-separated company-ID allowlist
-        allowed = {part.strip() for part in raw.split(",") if part.strip()}
-        return company_id in allowed if company_id else False
+        raw = os.getenv(flag, "false")
+        return FeatureFlags.parse_feature_flag(raw).is_enabled(company_id)
 
 
 class BoundFeatureFlagClient:
@@ -237,9 +213,10 @@ class BoundFeatureFlagClient:
 def get_feature_flag_client() -> FeatureFlagClient:
     """Return the process-level :class:`FeatureFlagClient` singleton.
 
-    Built lazily via :meth:`FeatureFlagClient.from_settings` which reads
-    ``CONFIGURATION_BACKEND_URL`` and ``FEATURE_FLAG_SERVICE_ID`` from env.
-    Falls back to env-var defaults on missing config or transport errors.
+    Built lazily via :meth:`FeatureFlagClient.from_settings`, which reads
+    ``CONFIGURATION_BACKEND_URL`` and ``FEATURE_FLAG_SERVICE_ID`` from env and
+    raises :class:`ValueError` if either is missing. Evaluations fall back to
+    env-var defaults (or a stale cached value) only on *transport* errors.
     """
     return FeatureFlagClient.from_settings()
 

--- a/unique_toolkit/unique_toolkit/experimental/resources/feature_flags/client.py
+++ b/unique_toolkit/unique_toolkit/experimental/resources/feature_flags/client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
+from enum import StrEnum
 from typing import ClassVar
 
 import httpx
@@ -15,6 +16,24 @@ from .schemas import FlagEvaluation
 from .settings import FeatureFlagSettings
 
 logger = logging.getLogger(__name__)
+
+
+class FeatureFlagNames(StrEnum):
+    enable_selected_uploaded_files_un_18215 = (
+        "FEATURE_FLAG_ENABLE_SELECTED_UPLOADED_FILES_UN_18215"
+    )
+    enable_mcp_metadata_fallback_un_19145 = (
+        "FEATURE_FLAG_ENABLE_MCP_METADATA_FALLBACK_UN_19145"
+    )
+    enable_html_rendering_un_15131 = "FEATURE_FLAG_ENABLE_HTML_RENDERING_UN_15131"
+    enable_code_execution_fence_un_17972 = (
+        "FEATURE_FLAG_ENABLE_CODE_EXECUTION_FENCE_UN_17972"
+    )
+    enable_html_with_fence_un_17927 = "FEATURE_FLAG_ENABLE_HTML_WITH_FENCE_UN_17927"
+    enable_web_search_argument_screening_un_18741 = (
+        "FEATURE_FLAG_ENABLE_WEB_SEARCH_ARGUMENT_SCREENING_UN_18741"
+    )
+    enable_new_answers_ui_un_14411 = "FEATURE_FLAG_ENABLE_NEW_ANSWERS_UI_UN_14411"
 
 
 class FeatureFlagClient:

--- a/unique_toolkit/unique_toolkit/experimental/resources/feature_flags/client.py
+++ b/unique_toolkit/unique_toolkit/experimental/resources/feature_flags/client.py
@@ -7,7 +7,6 @@ from typing import ClassVar
 import httpx
 from tenacity import retry, retry_if_exception, stop_after_attempt
 
-from unique_toolkit.agentic.feature_flags.feature_flags import FeatureFlags
 from unique_toolkit.app.unique_settings import AuthContextProtocol, UniqueSettings
 
 from ._graphql_client import evaluate_flag
@@ -178,15 +177,15 @@ class FeatureFlagClient:
 
     @staticmethod
     def _env_fallback(flag: str, company_id: str | None = None) -> bool:
-        """Read *flag* from env vars using the same semantics as ``FeatureFlag``.
-
-        Delegates parsing to ``FeatureFlags.parse_feature_flag`` (plain booleans
-        or comma-separated company-ID allowlists) so the two env-var fallback
-        paths — this client and ``unique_toolkit.agentic.feature_flags`` —
-        can't drift apart.
-        """
+        """Read *flag* from env vars: plain booleans or comma-separated company-ID allowlists."""
         raw = os.getenv(flag, "false")
-        return FeatureFlags.parse_feature_flag(raw).is_enabled(company_id)
+        raw_lower = raw.strip().lower()
+        if raw_lower in ("true", "1", "yes"):
+            return True
+        if raw_lower in ("false", "0", "no", ""):
+            return False
+        allowlist = [c.strip() for c in raw.split(",") if c.strip()]
+        return company_id in allowlist if company_id else False
 
 
 class BoundFeatureFlagClient:
@@ -208,6 +207,11 @@ class BoundFeatureFlagClient:
 
     async def is_enabled(self, flag: str) -> bool:
         return (await self.evaluate(flag)).value
+
+
+# For is_flag_enabled() callers with no real company_id. Not a real company:
+# bool-configured flags still resolve correctly; allowlist-configured ones safely read as off.
+COMPANY_ID_PLACEHOLDER = "company_id_placeholder"
 
 
 def get_feature_flag_client() -> FeatureFlagClient:

--- a/unique_toolkit/unique_toolkit/services/chat_service.py
+++ b/unique_toolkit/unique_toolkit/services/chat_service.py
@@ -22,6 +22,7 @@ from unique_toolkit._common.metadata_filter_scope import (
     merge_scope_clause_into_metadata_filter,
 )
 from unique_toolkit._common.utils.files import is_file_content, is_image_content
+from unique_toolkit.agentic.feature_flags import FeatureFlagNames
 from unique_toolkit.agentic.message_log_order import next_message_log_order
 from unique_toolkit.app.unique_settings import UniqueContext, UniqueSettings
 from unique_toolkit.chat.cancellation import CancellationWatcher
@@ -99,10 +100,7 @@ from unique_toolkit.content.schemas import (
     ContentSearchType,
 )
 from unique_toolkit.elicitation.service import ElicitationService
-from unique_toolkit.experimental.resources.feature_flags import (
-    FeatureFlagNames,
-    is_flag_enabled,
-)
+from unique_toolkit.experimental.resources.feature_flags import is_flag_enabled
 from unique_toolkit.language_model.constants import (
     DEFAULT_COMPLETE_TEMPERATURE,
     DEFAULT_COMPLETE_TIMEOUT,

--- a/unique_toolkit/unique_toolkit/services/chat_service.py
+++ b/unique_toolkit/unique_toolkit/services/chat_service.py
@@ -1809,7 +1809,7 @@ class ChatService(ChatServiceDeprecated):
             if not rate_limit_retry_config.log_message_on_retry:
                 return
             if not await is_flag_enabled(
-                FeatureFlagNames.ENABLE_NEW_ANSWERS_UI_UN_14411,
+                FeatureFlagNames.enable_new_answers_ui_un_14411,
                 company_id=self._company_id,
             ):
                 return

--- a/unique_toolkit/unique_toolkit/services/chat_service.py
+++ b/unique_toolkit/unique_toolkit/services/chat_service.py
@@ -22,7 +22,6 @@ from unique_toolkit._common.metadata_filter_scope import (
     merge_scope_clause_into_metadata_filter,
 )
 from unique_toolkit._common.utils.files import is_file_content, is_image_content
-from unique_toolkit.agentic.feature_flags import feature_flags
 from unique_toolkit.agentic.message_log_order import next_message_log_order
 from unique_toolkit.app.unique_settings import UniqueContext, UniqueSettings
 from unique_toolkit.chat.cancellation import CancellationWatcher
@@ -100,6 +99,10 @@ from unique_toolkit.content.schemas import (
     ContentSearchType,
 )
 from unique_toolkit.elicitation.service import ElicitationService
+from unique_toolkit.experimental.resources.feature_flags import (
+    FeatureFlagNames,
+    is_flag_enabled,
+)
 from unique_toolkit.language_model.constants import (
     DEFAULT_COMPLETE_TEMPERATURE,
     DEFAULT_COMPLETE_TIMEOUT,
@@ -1805,8 +1808,9 @@ class ChatService(ChatServiceDeprecated):
 
             if not rate_limit_retry_config.log_message_on_retry:
                 return
-            if not feature_flags.enable_new_answers_ui_un_14411.is_enabled(
-                self._company_id
+            if not await is_flag_enabled(
+                FeatureFlagNames.ENABLE_NEW_ANSWERS_UI_UN_14411,
+                company_id=self._company_id,
             ):
                 return
 


### PR DESCRIPTION
## Summary

- `FeatureFlagClient` is now the primary evaluation path for all feature flags; `FeatureFlags` env-var settings are the last-resort fallback (via `_env_fallback`), used only on transport errors once the client is already configured
- `get_feature_flag_client()` **raises by design** when `CONFIGURATION_BACKEND_URL` / `FEATURE_FLAG_SERVICE_ID` are not set — this is intentional fail-fast behavior (see the module's README/docstrings and `test_from_settings__no_url__raises_value_error`), not a bug to fix. Verified safe in practice: the only two real consumers of this client (`assistants-core`, `agentic-ingestion`) both have these env vars set in Prod and QA.
- Replaced all `feature_flags.xxx.is_enabled(company_id)` call sites with `await is_flag_enabled(flag, company_id=...)`
- Fixed a bug (found during review) where postprocessors passed `company_id=self._company_id or ""` into `is_flag_enabled`, which raises on an empty string — the old sync check tolerated `None` gracefully. Now uses `COMPANY_ID_PLACEHOLDER`, a non-empty, non-real value: bool-configured flags still resolve correctly, allowlist-configured ones safely read as off.
- Deprecated the legacy `agentic.feature_flags.FeatureFlags`/`FeatureFlag` (marked `@deprecated`, zero remaining consumers in this toolkit) and decoupled `FeatureFlagClient._env_fallback` from it — the parsing logic is now inlined in the new client instead of importing from the old module.

## Fallback chain (per flag evaluation, once the client is already constructed)

1. Remote GraphQL (TTL cached)
2. Stale cache (on transport error)
3. Env-var settings fallback (only when the remote call fails and no stale value exists yet — a missing/unconfigured client raises instead, per the point above)

## Call-site migration strategy

| Context | Approach |
|---------|----------|
| Already async (a2a, mcp, chat_service) | Direct `await is_flag_enabled(...)` replacement |
| Sync method with async parent (postprocessors) | Pre-compute flag in `run()`/`build_tool()`, cache as instance var |
| Sync utility called from `__init__` (history_manager) | Make function async, evaluate lazily in first async call |

## Test plan

- [x] Existing suite passes, including `experimental/resources/feature_flags` client tests (cache, stale-fallback, env-var fallback) and all migrated call sites
- [x] New tests cover the no-`company_id` path in both code-interpreter postprocessors — verifies `COMPANY_ID_PLACEHOLDER` is used and `run()` doesn't crash
- [x] All `feature_flags` mock patches updated to `AsyncMock` on `is_flag_enabled`
- [x] Additionally verified against live infrastructure (real `configuration-backend` + `assistants-core`, not mocks): both the remote and env-fallback paths, multiple flag states, and the actual downstream behavior (fence-display text transformation, selected-uploaded-files filtering) — not just the flag's boolean resolution