### PR TITLE
feat(cli): share record_mcp_citations for tools-mode MCP referencing [UN-22484]

### DIFF
--- a/unique_sdk/tests/cli/test_mcp.py
+++ b/unique_sdk/tests/cli/test_mcp.py
@@ -14,7 +14,7 @@ import pytest
 
 import unique_sdk
 from unique_sdk.cli.commands import mcp as mcp_cmd
-from unique_sdk.cli.commands.mcp import cmd_mcp
+from unique_sdk.cli.commands.mcp import cmd_mcp, record_mcp_citations
 from unique_sdk.cli.config import Config
 from unique_sdk.cli.state import ShellState
 
@@ -438,3 +438,135 @@ def test_api_error_writes_no_manifest(tmp_path: Path) -> None:
     assert out.startswith("mcp:")
     assert _lines(tmp_path, _REFS_MANIFEST) == []
     assert _lines(tmp_path, _OUTPUT_MANIFEST) == []
+
+
+# ── record_mcp_citations: shared helper (skills + tools-mode proxy) ───────────
+#
+# The CLI flow defaults to ``Path.cwd()/.unique`` (covered above via cmd_mcp);
+# these exercise the explicit ``unique_dir`` path the in-process tools-mode proxy
+# uses, where cwd is NOT the agent workspace.
+
+
+def _unique_lines(unique_dir: Path, filename: str) -> list[dict]:
+    path = unique_dir / filename
+    if not path.is_file():
+        return []
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def test_record_mcp_citations_writes_both_manifests_under_unique_dir(
+    tmp_path: Path,
+) -> None:
+    unique_dir = tmp_path / "ws" / ".unique"
+    response = _FakeMCPResponse(
+        content=[
+            {
+                "type": "resource_link",
+                "uri": "https://kb.example.com/doc/9",
+                "name": "RAG Retrieval Baseline",
+                "description": "Why retrieval fails",
+            }
+        ],
+        mcp_server_id="kb",
+    )
+
+    footer = record_mcp_citations(
+        response,
+        tool_name="fetch",  # bare advertised name (tools mode)
+        server_name="kb",
+        unique_dir=unique_dir,
+        formatted_text="Why retrieval fails — details here",
+    )
+
+    # No `.unique/.unique/` nesting — filenames join directly onto unique_dir.
+    refs = _unique_lines(unique_dir, "mcp-refs.jsonl")
+    output = _unique_lines(unique_dir, "mcp-output.jsonl")
+    assert refs == [
+        {
+            "sourceNumber": 1,
+            "toolName": "fetch",
+            "serverName": "kb",
+            "title": "RAG Retrieval Baseline",
+            "snippet": "Why retrieval fails",
+            "details": None,
+        }
+    ]
+    assert output == [
+        {
+            "toolName": "fetch",
+            "serverName": "kb",
+            "text": "Why retrieval fails — details here",
+        }
+    ]
+    assert "[mcpsource1] RAG Retrieval Baseline" in footer
+
+
+def test_record_mcp_citations_dedups_title_across_calls(tmp_path: Path) -> None:
+    unique_dir = tmp_path / ".unique"
+
+    def _resp() -> _FakeMCPResponse:
+        return _FakeMCPResponse(
+            content=[{"type": "resource_link", "uri": "x", "name": "Same Doc"}],
+            mcp_server_id="kb",
+        )
+
+    f1 = record_mcp_citations(
+        _resp(),
+        tool_name="fetch",
+        server_name="kb",
+        unique_dir=unique_dir,
+        formatted_text="first",
+    )
+    f2 = record_mcp_citations(
+        _resp(),
+        tool_name="fetch",
+        server_name="kb",
+        unique_dir=unique_dir,
+        formatted_text="second",
+    )
+
+    # Same title → one refs entry / one reused source number; both calls'
+    # output is grounded (no dedup on the output manifest).
+    refs = _unique_lines(unique_dir, "mcp-refs.jsonl")
+    output = _unique_lines(unique_dir, "mcp-output.jsonl")
+    assert len(refs) == 1
+    assert refs[0]["sourceNumber"] == 1
+    assert "[mcpsource1] Same Doc" in f1
+    assert "[mcpsource1] Same Doc" in f2
+    assert [e["text"] for e in output] == ["first", "second"]
+
+
+def test_record_mcp_citations_concurrent_monotonic_numbers(
+    tmp_path: Path,
+) -> None:
+    from concurrent.futures import ThreadPoolExecutor
+
+    unique_dir = tmp_path / ".unique"
+    n = 8
+
+    def _record(i: int) -> str:
+        response = _FakeMCPResponse(
+            content=[{"type": "resource_link", "uri": f"u{i}", "name": f"Doc {i}"}],
+            mcp_server_id="kb",
+        )
+        return record_mcp_citations(
+            response,
+            tool_name="fetch",
+            server_name="kb",
+            unique_dir=unique_dir,
+            formatted_text=f"body {i}",
+        )
+
+    with ThreadPoolExecutor(max_workers=n) as pool:
+        list(pool.map(_record, range(n)))
+
+    refs = _unique_lines(unique_dir, "mcp-refs.jsonl")
+    numbers = sorted(e["sourceNumber"] for e in refs)
+    # Distinct titles → one entry each, with unique consecutive numbers and no
+    # collisions despite concurrent writers (the per-turn flock serializes them).
+    assert numbers == list(range(1, n + 1))
+    assert len(_unique_lines(unique_dir, "mcp-output.jsonl")) == n

--- a/unique_sdk/unique_sdk/cli/commands/mcp.py
+++ b/unique_sdk/unique_sdk/cli/commands/mcp.py
@@ -337,16 +337,25 @@ def _citation_footer(annotated: list[tuple[int, dict[str, Any]]]) -> str:
 
 
 def _append_mcp_output_manifest(
-    name: str, text: str, *, server_name: str | None = None
+    name: str,
+    text: str,
+    *,
+    server_name: str | None = None,
+    output_path: Path | None = None,
 ) -> None:
     """Best-effort append of one MCP tool result to the per-turn manifest.
 
     Never raises: a manifest failure must not change what the agent sees as
     the tool result. The groundedness check simply does not fire for this
     call when the write fails.
+
+    ``output_path`` is the full path of the ``mcp-output.jsonl`` manifest. It
+    defaults to ``Path.cwd() / .unique / mcp-output.jsonl`` so the CLI flow
+    (where cwd is the agent workspace) is unchanged; callers that run outside
+    the workspace cwd (e.g. the in-process tools-mode proxy) pass it explicitly.
     """
     try:
-        refs_log_path = Path.cwd() / _MCP_OUTPUT_LOG_RELATIVE_PATH
+        refs_log_path = output_path or (Path.cwd() / _MCP_OUTPUT_LOG_RELATIVE_PATH)
         _append_turn_refs_manifest_entry(
             refs_log_path,
             {
@@ -357,6 +366,47 @@ def _append_mcp_output_manifest(
         )
     except (UnsafeRefsLogPathError, OSError) as exc:
         _LOGGER.warning("mcp: failed to append output manifest: %s", exc)
+
+
+def record_mcp_citations(
+    response: Any,
+    *,
+    tool_name: str,
+    server_name: str | None,
+    unique_dir: Path,
+    formatted_text: str,
+) -> str:
+    """Write both per-turn MCP manifests under ``unique_dir`` and return the
+    ``[mcpsourceN]`` citation footer for the agent.
+
+    Shared by the ``unique-cli mcp`` skills flow (``cmd_mcp``) and the
+    in-process tools-mode proxy in assistants-core, so both write identical
+    manifests and footers. ``unique_dir`` is the workspace ``.unique`` directory
+    (its filenames are joined directly here — do not pass the workspace root).
+
+    - ``response`` is the raw ``unique_sdk.MCP`` result, used for citation
+      extraction (titles from ``resource_link`` names / JSON bodies).
+    - ``formatted_text`` is the source text the model actually saw for this
+      tool result, recorded as the hallucination groundedness context.
+
+    Best-effort and never raises: the underlying manifest writers swallow their
+    own errors, and ``_annotate_mcp_results_for_citations`` owns the per-turn
+    file lock — this function must stay lock-free to avoid a same-process flock
+    self-deadlock.
+    """
+    _append_mcp_output_manifest(
+        tool_name,
+        formatted_text,
+        server_name=server_name,
+        output_path=unique_dir / _MCP_OUTPUT_LOG_RELATIVE_PATH.name,
+    )
+    annotated = _annotate_mcp_results_for_citations(
+        response,
+        tool_name=tool_name,
+        server_name=server_name,
+        refs_log_path=unique_dir / _MCP_REFS_LOG_RELATIVE_PATH.name,
+    )
+    return _citation_footer(annotated)
 
 
 def _read_payload(
@@ -440,8 +490,11 @@ def cmd_mcp(
         formatted = f"mcp: formatter error ({fmt_exc}); raw response:\n{fallback}"
 
     server_name = _server_name_from_tool(name) or getattr(response, "mcpServerId", None)
-    _append_mcp_output_manifest(name, formatted, server_name=server_name)
-    annotated = _annotate_mcp_results_for_citations(
-        response, tool_name=name, server_name=server_name
+    footer = record_mcp_citations(
+        response,
+        tool_name=name,
+        server_name=server_name,
+        unique_dir=Path.cwd() / ".unique",
+        formatted_text=formatted,
     )
-    return formatted + _citation_footer(annotated)
+    return formatted + footer


### PR DESCRIPTION
## Summary

Shared helper so MCP tool references + hallucination grounding work in **tools mode** (`mcp_integration_mode="tools"`), at parity with skills mode.

- Add public **`record_mcp_citations(response, *, tool_name, server_name, unique_dir, formatted_text) -> str`** in `cli/commands/mcp.py`: writes the per-turn `.unique/mcp-refs.jsonl` (citations) + `.unique/mcp-output.jsonl` (groundedness) manifests under an explicit `.unique` dir and returns the `[mcpsourceN]` Sources footer.
- Parameterize `_append_mcp_output_manifest` with an explicit `output_path` (defaults to the cwd-derived path, so the CLI flow is unchanged).
- Refactor `cmd_mcp` to call the shared helper — **byte-identical** output (verified by the existing 21 tests).
- Helper is **lock-free** and delegates the per-turn flock to `_annotate_mcp_results_for_citations`, so concurrent writers (tools mode can issue parallel native tool calls) stay safe.

### Why
In skills mode only `unique-cli mcp` (`cmd_mcp`) writes these manifests, which the assistants-core runner reads to build reference chips and run the hallucination judge. In tools mode connectors are native in-process SDK tools that bypass the CLI, so nothing wrote the manifests. The monorepo's in-process proxy now calls this shared helper to write the identical manifests + footer.

## Test plan

- [x] `uv run pytest unique_sdk/tests/cli/test_mcp.py` — 24 pass
- [x] Existing `cmd_mcp` tests confirm the refactor is behaviour-preserving
- [x] New tests: explicit-`unique_dir` write of both manifests + footer; cross-call title dedup; 8-thread concurrency → monotonic, non-colliding source numbers
- [x] `ruff check` + `ruff format` clean

## Notes for reviewers

- Companion change in `Unique-AG/monorepo` (assistants-core) calls this helper from the tools-mode proxy; that PR is guarded so it is inert until the `unique-sdk` pin is bumped to a release containing this helper.
- Additive + back-compatible: no change to `cmd_mcp` behaviour or the manifest formats.
- Heads-up: lightly overlaps `fix/mcp-search-envelope-titles-un-22310` (same `mcp.py` helpers) — coordinate merge order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
