### PR TITLE
feat(sdk): add UniqueClient and AsyncUniqueClient with per-instance headers

### DIFF
--- a/unique_sdk/tests/cli/test_dynamic_frontend.py
+++ b/unique_sdk/tests/cli/test_dynamic_frontend.py
@@ -101,6 +101,7 @@ def test_dynamic_frontend_create__calls_expected_endpoint(
         "user_1",
         "company_1",
         params={"name": "Revenue Dashboard", "contentId": "cont_1"},
+        client=None,
     )
 
 
@@ -129,6 +130,7 @@ def test_dynamic_frontend_modify__calls_expected_endpoint(
         "user_1",
         "company_1",
         params={"contentId": "cont_2", "name": None},
+        client=None,
     )
 
 
@@ -154,6 +156,7 @@ def test_dynamic_frontend_delete__calls_expected_endpoint(
         "/dynamic-frontend/space_1",
         "user_1",
         "company_1",
+        client=None,
     )
 
 
@@ -175,6 +178,7 @@ def test_dynamic_frontend_list__returns_response_data(
         "/dynamic-frontend",
         "user_1",
         "company_1",
+        client=None,
     )
 
 

--- a/unique_sdk/tests/test_message_tool.py
+++ b/unique_sdk/tests/test_message_tool.py
@@ -143,6 +143,7 @@ def test_create_many__success__returns_list_object(mocker):
         "user",
         "company",
         params={"messageId": "msg-1", "tools": []},
+        client=None,
     )
 
 
@@ -191,6 +192,7 @@ def test_get_message_tools__single_chunk__calls_api_once(mocker):
         "user",
         "company",
         params={"messageIds": "msg-1,msg-2"},
+        client=None,
     )
 
 
@@ -324,6 +326,7 @@ async def test_get_message_tools_async__single_chunk__calls_api_once(mocker):
         "user",
         "company",
         params={"messageIds": "msg-1,msg-2"},
+        client=None,
     )
 
 

--- a/unique_sdk/tests/test_space_subagents.py
+++ b/unique_sdk/tests/test_space_subagents.py
@@ -41,6 +41,7 @@ def test_create_space_forwards_sub_agent_fields() -> None:
             "subAgentSettings": sub_agent_settings,
             "subAgentIds": ["assistant_sub_1", "assistant_sub_2"],
         },
+        client=None,
     )
 
 
@@ -96,6 +97,7 @@ def test_update_space_forwards_sub_agent_fields() -> None:
             "subAgentSettings": sub_agent_settings,
             "subAgentIds": ["assistant_sub_1", "assistant_sub_2"],
         },
+        client=None,
     )
 
 

--- a/unique_sdk/unique_sdk/__init__.py
+++ b/unique_sdk/unique_sdk/__init__.py
@@ -61,6 +61,8 @@ from unique_sdk._unique_response import (
 from unique_sdk._util import (
     convert_to_unique_object as convert_to_unique_object,
 )
+from unique_sdk._client import UniqueClient as UniqueClient
+from unique_sdk._client import AsyncUniqueClient as AsyncUniqueClient
 from unique_sdk._webhook import (
     Webhook as Webhook,
 )

--- a/unique_sdk/unique_sdk/_api_requestor.py
+++ b/unique_sdk/unique_sdk/_api_requestor.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import calendar
 import datetime
 import json
@@ -5,12 +7,15 @@ import platform
 import time
 from collections import OrderedDict
 from collections.abc import Mapping
-from typing import Any, Callable, NoReturn, cast
+from typing import TYPE_CHECKING, Any, Callable, NoReturn, cast
 from urllib.parse import urlencode, urlsplit, urlunsplit
 
 import unique_sdk
 from unique_sdk import _error, _http_client, _util, _version
 from unique_sdk._unique_response import UniqueResponse
+
+if TYPE_CHECKING:
+    from unique_sdk._client import _BaseClient
 
 
 def _encode_datetime(dttime: datetime.datetime):
@@ -87,6 +92,7 @@ class APIRequestor(object):
     api_version: str
     user_id: str | None
     company_id: str | None
+    _additional_headers: dict[str, str]
 
     def __init__(
         self,
@@ -94,15 +100,26 @@ class APIRequestor(object):
         company_id: str | None,
         key=None,
         app_id=None,
+        client: "_BaseClient | None" = None,
     ):
-        self.api_base = unique_sdk.api_base
-        self.api_key = key
-        self.app_id = app_id
-        self.api_version = unique_sdk.api_version
+        if client is not None:
+            self.api_base = client.api_base
+            self.api_key = client.api_key
+            self.app_id = client.app_id
+            self.api_version = client.api_version
+            self._additional_headers = client.additional_headers
+        else:
+            self.api_base = unique_sdk.api_base
+            self.api_key = key
+            self.app_id = app_id
+            self.api_version = unique_sdk.api_version
+            self._additional_headers = {}
         self.user_id = user_id
         self.company_id = company_id
 
-        if unique_sdk.default_http_client:
+        if client is not None and client._http_client is not None:
+            self._client = client._http_client
+        elif unique_sdk.default_http_client:
             self._client = unique_sdk.default_http_client
         else:
             unique_sdk.default_http_client = _http_client.new_default_http_client(
@@ -321,6 +338,8 @@ class APIRequestor(object):
             )
 
         headers = self.request_headers(my_api_key, my_app_id, method)
+        for key, value in self._additional_headers.items():
+            headers[key] = value
         if supplied_headers_dict is not None:
             for key, value in supplied_headers_dict.items():
                 headers[key] = value

--- a/unique_sdk/unique_sdk/_api_resource.py
+++ b/unique_sdk/unique_sdk/_api_resource.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 from collections.abc import Mapping
 from typing import (
+    TYPE_CHECKING,
     Any,
     Generic,
     Literal,
@@ -17,6 +20,9 @@ from unique_sdk._util import (
     convert_to_unique_object,
     retry_on_error,
 )
+
+if TYPE_CHECKING:
+    from unique_sdk._client import _BaseClient
 
 T = TypeVar("T", bound=UniqueObject)
 
@@ -194,10 +200,11 @@ class APIResource(UniqueObject, Generic[T]):
         user_id: str | None = None,
         company_id: str | None = None,
         params=None,
+        client: "_BaseClient | None" = None,
     ):
         params = None if params is None else params.copy()
 
-        requestor = APIRequestor(user_id=user_id, company_id=company_id)
+        requestor = APIRequestor(user_id=user_id, company_id=company_id, client=client)
 
         response = requestor.request(method_, url_, params)
         return convert_to_unique_object(response, user_id, company_id, params)
@@ -213,10 +220,11 @@ class APIResource(UniqueObject, Generic[T]):
         user_id: str | None = None,
         company_id: str | None = None,
         params=None,
+        client: "_BaseClient | None" = None,
     ):
         params = None if params is None else params.copy()
 
-        requestor = APIRequestor(user_id=user_id, company_id=company_id)
+        requestor = APIRequestor(user_id=user_id, company_id=company_id, client=client)
 
         response = await requestor.request_async(method_, url_, params)
         return convert_to_unique_object(response, user_id, company_id, params)

--- a/unique_sdk/unique_sdk/_client.py
+++ b/unique_sdk/unique_sdk/_client.py
@@ -1,0 +1,2082 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from unique_sdk._http_client import HTTPClient
+
+
+class _BaseClient:
+    """Shared configuration for sync and async clients."""
+
+    api_key: str | None
+    app_id: str | None
+    api_base: str
+    api_version: str
+    additional_headers: dict[str, str]
+    _http_client: HTTPClient | None
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        app_id: str | None = None,
+        api_base: str | None = None,
+        api_version: str | None = None,
+        additional_headers: dict[str, str] | None = None,
+        http_client: HTTPClient | None = None,
+    ) -> None:
+        import unique_sdk
+
+        self.api_key = api_key if api_key is not None else unique_sdk.api_key
+        self.app_id = app_id if app_id is not None else unique_sdk.app_id
+        self.api_base = api_base if api_base is not None else unique_sdk.api_base
+        self.api_version = (
+            api_version if api_version is not None else unique_sdk.api_version
+        )
+        self.additional_headers = dict(additional_headers) if additional_headers else {}
+        self._http_client = http_client
+
+
+class UniqueClient(_BaseClient):
+    """Synchronous SDK client.
+
+    Initialise once with your credentials and optional extra headers, then
+    call any resource through the typed accessor properties::
+
+        client = UniqueClient(
+            api_key="ukey_...",
+            app_id="app_...",
+            additional_headers={"x-trace-id": "abc123"},
+        )
+        results = client.search.create(user_id, company_id, searchString="...")
+    """
+
+    @property
+    def acronyms(self) -> _SyncAcronymsAccessor:
+        return _SyncAcronymsAccessor(self)
+
+    @property
+    def analytics_order(self) -> _SyncAnalyticsOrderAccessor:
+        return _SyncAnalyticsOrderAccessor(self)
+
+    @property
+    def benchmarking(self) -> _SyncBenchmarkingAccessor:
+        return _SyncBenchmarkingAccessor(self)
+
+    @property
+    def briefing(self) -> _SyncBriefingAccessor:
+        return _SyncBriefingAccessor(self)
+
+    @property
+    def chat_completion(self) -> _SyncChatCompletionAccessor:
+        return _SyncChatCompletionAccessor(self)
+
+    @property
+    def content(self) -> _SyncContentAccessor:
+        return _SyncContentAccessor(self)
+
+    @property
+    def dynamic_frontend(self) -> _SyncDynamicFrontendAccessor:
+        return _SyncDynamicFrontendAccessor(self)
+
+    @property
+    def elicitation(self) -> _SyncElicitationAccessor:
+        return _SyncElicitationAccessor(self)
+
+    @property
+    def embeddings(self) -> _SyncEmbeddingsAccessor:
+        return _SyncEmbeddingsAccessor(self)
+
+    @property
+    def folder(self) -> _SyncFolderAccessor:
+        return _SyncFolderAccessor(self)
+
+    @property
+    def group(self) -> _SyncGroupAccessor:
+        return _SyncGroupAccessor(self)
+
+    @property
+    def integrated(self) -> _SyncIntegratedAccessor:
+        return _SyncIntegratedAccessor(self)
+
+    @property
+    def llm_models(self) -> _SyncLLMModelsAccessor:
+        return _SyncLLMModelsAccessor(self)
+
+    @property
+    def mcp(self) -> _SyncMCPAccessor:
+        return _SyncMCPAccessor(self)
+
+    @property
+    def message(self) -> _SyncMessageAccessor:
+        return _SyncMessageAccessor(self)
+
+    @property
+    def message_assessment(self) -> _SyncMessageAssessmentAccessor:
+        return _SyncMessageAssessmentAccessor(self)
+
+    @property
+    def message_execution(self) -> _SyncMessageExecutionAccessor:
+        return _SyncMessageExecutionAccessor(self)
+
+    @property
+    def message_log(self) -> _SyncMessageLogAccessor:
+        return _SyncMessageLogAccessor(self)
+
+    @property
+    def message_tool(self) -> _SyncMessageToolAccessor:
+        return _SyncMessageToolAccessor(self)
+
+    @property
+    def module(self) -> _SyncModuleAccessor:
+        return _SyncModuleAccessor(self)
+
+    @property
+    def scheduled_task(self) -> _SyncScheduledTaskAccessor:
+        return _SyncScheduledTaskAccessor(self)
+
+    @property
+    def search(self) -> _SyncSearchAccessor:
+        return _SyncSearchAccessor(self)
+
+    @property
+    def search_string(self) -> _SyncSearchStringAccessor:
+        return _SyncSearchStringAccessor(self)
+
+    @property
+    def short_term_memory(self) -> _SyncShortTermMemoryAccessor:
+        return _SyncShortTermMemoryAccessor(self)
+
+    @property
+    def space(self) -> _SyncSpaceAccessor:
+        return _SyncSpaceAccessor(self)
+
+    @property
+    def user(self) -> _SyncUserAccessor:
+        return _SyncUserAccessor(self)
+
+    @property
+    def web_search(self) -> _SyncWebSearchAccessor:
+        return _SyncWebSearchAccessor(self)
+
+    @property
+    def web_crawl(self) -> _SyncWebCrawlAccessor:
+        return _SyncWebCrawlAccessor(self)
+
+
+class AsyncUniqueClient(_BaseClient):
+    """Asynchronous SDK client.
+
+    Initialise once with your credentials and optional extra headers, then
+    await any resource through the typed accessor properties::
+
+        client = AsyncUniqueClient(
+            api_key="ukey_...",
+            app_id="app_...",
+            additional_headers={"x-trace-id": "abc123"},
+        )
+        results = await client.search.create(user_id, company_id, searchString="...")
+    """
+
+    @property
+    def acronyms(self) -> _AsyncAcronymsAccessor:
+        return _AsyncAcronymsAccessor(self)
+
+    @property
+    def agentic_table(self) -> _AsyncAgenticTableAccessor:
+        return _AsyncAgenticTableAccessor(self)
+
+    @property
+    def analytics_order(self) -> _AsyncAnalyticsOrderAccessor:
+        return _AsyncAnalyticsOrderAccessor(self)
+
+    @property
+    def benchmarking(self) -> _AsyncBenchmarkingAccessor:
+        return _AsyncBenchmarkingAccessor(self)
+
+    @property
+    def briefing(self) -> _AsyncBriefingAccessor:
+        return _AsyncBriefingAccessor(self)
+
+    @property
+    def chat_completion(self) -> _AsyncChatCompletionAccessor:
+        return _AsyncChatCompletionAccessor(self)
+
+    @property
+    def content(self) -> _AsyncContentAccessor:
+        return _AsyncContentAccessor(self)
+
+    @property
+    def elicitation(self) -> _AsyncElicitationAccessor:
+        return _AsyncElicitationAccessor(self)
+
+    @property
+    def embeddings(self) -> _AsyncEmbeddingsAccessor:
+        return _AsyncEmbeddingsAccessor(self)
+
+    @property
+    def folder(self) -> _AsyncFolderAccessor:
+        return _AsyncFolderAccessor(self)
+
+    @property
+    def group(self) -> _AsyncGroupAccessor:
+        return _AsyncGroupAccessor(self)
+
+    @property
+    def integrated(self) -> _AsyncIntegratedAccessor:
+        return _AsyncIntegratedAccessor(self)
+
+    @property
+    def llm_models(self) -> _AsyncLLMModelsAccessor:
+        return _AsyncLLMModelsAccessor(self)
+
+    @property
+    def mcp(self) -> _AsyncMCPAccessor:
+        return _AsyncMCPAccessor(self)
+
+    @property
+    def message(self) -> _AsyncMessageAccessor:
+        return _AsyncMessageAccessor(self)
+
+    @property
+    def message_assessment(self) -> _AsyncMessageAssessmentAccessor:
+        return _AsyncMessageAssessmentAccessor(self)
+
+    @property
+    def message_execution(self) -> _AsyncMessageExecutionAccessor:
+        return _AsyncMessageExecutionAccessor(self)
+
+    @property
+    def message_log(self) -> _AsyncMessageLogAccessor:
+        return _AsyncMessageLogAccessor(self)
+
+    @property
+    def message_tool(self) -> _AsyncMessageToolAccessor:
+        return _AsyncMessageToolAccessor(self)
+
+    @property
+    def module(self) -> _AsyncModuleAccessor:
+        return _AsyncModuleAccessor(self)
+
+    @property
+    def scheduled_task(self) -> _AsyncScheduledTaskAccessor:
+        return _AsyncScheduledTaskAccessor(self)
+
+    @property
+    def search(self) -> _AsyncSearchAccessor:
+        return _AsyncSearchAccessor(self)
+
+    @property
+    def search_string(self) -> _AsyncSearchStringAccessor:
+        return _AsyncSearchStringAccessor(self)
+
+    @property
+    def short_term_memory(self) -> _AsyncShortTermMemoryAccessor:
+        return _AsyncShortTermMemoryAccessor(self)
+
+    @property
+    def space(self) -> _AsyncSpaceAccessor:
+        return _AsyncSpaceAccessor(self)
+
+    @property
+    def user(self) -> _AsyncUserAccessor:
+        return _AsyncUserAccessor(self)
+
+    @property
+    def web_search(self) -> _AsyncWebSearchAccessor:
+        return _AsyncWebSearchAccessor(self)
+
+    @property
+    def web_crawl(self) -> _AsyncWebCrawlAccessor:
+        return _AsyncWebCrawlAccessor(self)
+
+
+# ---------------------------------------------------------------------------
+# Sync accessor classes — forward to the *non*-async resource classmethods.
+# ---------------------------------------------------------------------------
+
+
+class _SyncAcronymsAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: UniqueClient) -> None:
+        self._client = client
+
+    def get(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._acronyms import Acronyms
+
+        return Acronyms.get(user_id, company_id, client=self._client, **params)
+
+
+class _SyncAnalyticsOrderAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: UniqueClient) -> None:
+        self._client = client
+
+    def create(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._analytics_order import AnalyticsOrder
+
+        return AnalyticsOrder.create(user_id, company_id, client=self._client, **params)
+
+    def list(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._analytics_order import AnalyticsOrder
+
+        return AnalyticsOrder.list(user_id, company_id, client=self._client, **params)
+
+    def retrieve(self, user_id: str, company_id: str, order_id: str):
+        from unique_sdk.api_resources._analytics_order import AnalyticsOrder
+
+        return AnalyticsOrder.retrieve(
+            user_id, company_id, order_id, client=self._client
+        )
+
+    def delete(self, user_id: str, company_id: str, order_id: str):
+        from unique_sdk.api_resources._analytics_order import AnalyticsOrder
+
+        return AnalyticsOrder.delete(user_id, company_id, order_id, client=self._client)
+
+    def download(self, user_id: str, company_id: str, order_id: str):
+        from unique_sdk.api_resources._analytics_order import AnalyticsOrder
+
+        return AnalyticsOrder.download(
+            user_id, company_id, order_id, client=self._client
+        )
+
+
+class _SyncBenchmarkingAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: UniqueClient) -> None:
+        self._client = client
+
+    def process_upload(
+        self,
+        user_id: str,
+        company_id: str,
+        file: bytes,
+        filename: str,
+        force: bool | None = None,
+    ):
+        from unique_sdk.api_resources._benchmarking import Benchmarking
+
+        return Benchmarking.process_upload(
+            user_id, company_id, file, filename, force, client=self._client
+        )
+
+    def get_status(self, user_id: str, company_id: str):
+        from unique_sdk.api_resources._benchmarking import Benchmarking
+
+        return Benchmarking.get_status(user_id, company_id, client=self._client)
+
+    def download_processed(self, user_id: str, company_id: str):
+        from unique_sdk.api_resources._benchmarking import Benchmarking
+
+        return Benchmarking.download_processed(user_id, company_id, client=self._client)
+
+    def download_template(self, user_id: str, company_id: str):
+        from unique_sdk.api_resources._benchmarking import Benchmarking
+
+        return Benchmarking.download_template(user_id, company_id, client=self._client)
+
+
+class _SyncBriefingAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: UniqueClient) -> None:
+        self._client = client
+
+    def upsert_for_assistant(
+        self, *, user_id: str, company_id: str, assistant_id: str, **params
+    ):
+        from unique_sdk.api_resources._briefing import Briefing
+
+        return Briefing.upsert_for_assistant(
+            user_id=user_id,
+            company_id=company_id,
+            assistant_id=assistant_id,
+            client=self._client,
+            **params,
+        )
+
+
+class _SyncChatCompletionAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: UniqueClient) -> None:
+        self._client = client
+
+    def create(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._chat_completion import ChatCompletion
+
+        return ChatCompletion.create(user_id, company_id, client=self._client, **params)
+
+
+class _SyncContentAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: UniqueClient) -> None:
+        self._client = client
+
+    def search(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._content import Content
+
+        return Content.search(user_id, company_id, client=self._client, **params)
+
+    def get_info(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._content import Content
+
+        return Content.get_info(user_id, company_id, client=self._client, **params)
+
+    def get_infos(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._content import Content
+
+        return Content.get_infos(user_id, company_id, client=self._client, **params)
+
+    def upsert(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._content import Content
+
+        return Content.upsert(user_id, company_id, client=self._client, **params)
+
+    def versions(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._content import Content
+
+        return Content.versions(user_id, company_id, client=self._client, **params)
+
+    def version_download_url(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._content import Content
+
+        return Content.version_download_url(
+            user_id, company_id, client=self._client, **params
+        )
+
+    def restore_version(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._content import Content
+
+        return Content.restore_version(
+            user_id, company_id, client=self._client, **params
+        )
+
+    def ingest_magic_table_sheets(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._content import Content
+
+        return Content.ingest_magic_table_sheets(
+            user_id, company_id, client=self._client, **params
+        )
+
+    def update(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._content import Content
+
+        return Content.update(user_id, company_id, client=self._client, **params)
+
+    def update_ingestion_state(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._content import Content
+
+        return Content.update_ingestion_state(
+            user_id, company_id, client=self._client, **params
+        )
+
+    def delete(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._content import Content
+
+        return Content.delete(user_id, company_id, client=self._client, **params)
+
+    def resolve_content_id_from_file_path(
+        self, user_id: str, company_id: str, **params
+    ):
+        from unique_sdk.api_resources._content import Content
+
+        return Content.resolve_content_id_from_file_path(
+            user_id, company_id, client=self._client, **params
+        )
+
+
+class _SyncDynamicFrontendAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: UniqueClient) -> None:
+        self._client = client
+
+    def create(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._dynamic_frontend import DynamicFrontend
+
+        return DynamicFrontend.create(
+            user_id, company_id, client=self._client, **params
+        )
+
+    def modify(self, space_id: str, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._dynamic_frontend import DynamicFrontend
+
+        return DynamicFrontend.modify(
+            space_id, user_id, company_id, client=self._client, **params
+        )
+
+    def delete(self, space_id: str, user_id: str, company_id: str):
+        from unique_sdk.api_resources._dynamic_frontend import DynamicFrontend
+
+        return DynamicFrontend.delete(
+            space_id, user_id, company_id, client=self._client
+        )
+
+    def list(self, user_id: str, company_id: str):
+        from unique_sdk.api_resources._dynamic_frontend import DynamicFrontend
+
+        return DynamicFrontend.list(user_id, company_id, client=self._client)
+
+
+class _SyncElicitationAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: UniqueClient) -> None:
+        self._client = client
+
+    def create_elicitation(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._elicitation import Elicitation
+
+        return Elicitation.create_elicitation(
+            user_id, company_id, client=self._client, **params
+        )
+
+    def get_pending_elicitations(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._elicitation import Elicitation
+
+        return Elicitation.get_pending_elicitations(
+            user_id, company_id, client=self._client, **params
+        )
+
+    def get_elicitation(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._elicitation import Elicitation
+
+        return Elicitation.get_elicitation(
+            user_id, company_id, client=self._client, **params
+        )
+
+    def respond_to_elicitation(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._elicitation import Elicitation
+
+        return Elicitation.respond_to_elicitation(
+            user_id, company_id, client=self._client, **params
+        )
+
+
+class _SyncEmbeddingsAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: UniqueClient) -> None:
+        self._client = client
+
+    def create(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._embedding import Embeddings
+
+        return Embeddings.create(user_id, company_id, client=self._client, **params)
+
+
+class _SyncFolderAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: UniqueClient) -> None:
+        self._client = client
+
+    def get_folder_path(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._folder import Folder
+
+        return Folder.get_folder_path(
+            user_id, company_id, client=self._client, **params
+        )
+
+    def get_info(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._folder import Folder
+
+        return Folder.get_info(user_id, company_id, client=self._client, **params)
+
+    def get_infos(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._folder import Folder
+
+        return Folder.get_infos(user_id, company_id, client=self._client, **params)
+
+    def create_paths(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._folder import Folder
+
+        return Folder.create_paths(user_id, company_id, client=self._client, **params)
+
+    def update_ingestion_config(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._folder import Folder
+
+        return Folder.update_ingestion_config(
+            user_id, company_id, client=self._client, **params
+        )
+
+    def add_access(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._folder import Folder
+
+        return Folder.add_access(user_id, company_id, client=self._client, **params)
+
+    def remove_access(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._folder import Folder
+
+        return Folder.remove_access(user_id, company_id, client=self._client, **params)
+
+    def update(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._folder import Folder
+
+        return Folder.update(user_id, company_id, client=self._client, **params)
+
+    def move(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._folder import Folder
+
+        return Folder.move(user_id, company_id, client=self._client, **params)
+
+    def delete(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._folder import Folder
+
+        return Folder.delete(user_id, company_id, client=self._client, **params)
+
+    def resolve_scope_id_from_folder_path(
+        self, user_id: str, company_id: str, **params
+    ):
+        from unique_sdk.api_resources._folder import Folder
+
+        return Folder.resolve_scope_id_from_folder_path(
+            user_id, company_id, client=self._client, **params
+        )
+
+    def resolve_scope_id_from_folder_path_with_create(
+        self, user_id: str, company_id: str, **params
+    ):
+        from unique_sdk.api_resources._folder import Folder
+
+        return Folder.resolve_scope_id_from_folder_path_with_create(
+            user_id, company_id, client=self._client, **params
+        )
+
+
+class _SyncGroupAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: UniqueClient) -> None:
+        self._client = client
+
+    def create_group(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._group import Group
+
+        return Group.create_group(user_id, company_id, client=self._client, **params)
+
+    def get_groups(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._group import Group
+
+        return Group.get_groups(user_id, company_id, client=self._client, **params)
+
+    def delete_group(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._group import Group
+
+        return Group.delete_group(user_id, company_id, client=self._client, **params)
+
+    def update_group(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._group import Group
+
+        return Group.update_group(user_id, company_id, client=self._client, **params)
+
+    def add_users_to_group(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._group import Group
+
+        return Group.add_users_to_group(
+            user_id, company_id, client=self._client, **params
+        )
+
+    def remove_users_from_group(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._group import Group
+
+        return Group.remove_users_from_group(
+            user_id, company_id, client=self._client, **params
+        )
+
+    def update_group_configuration(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._group import Group
+
+        return Group.update_group_configuration(
+            user_id, company_id, client=self._client, **params
+        )
+
+
+class _SyncIntegratedAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: UniqueClient) -> None:
+        self._client = client
+
+    def chat_stream_completion(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._integrated import Integrated
+
+        return Integrated.chat_stream_completion(
+            user_id, company_id, client=self._client, **params
+        )
+
+
+class _SyncLLMModelsAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: UniqueClient) -> None:
+        self._client = client
+
+    def get_models(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._llm_models import LLMModels
+
+        return LLMModels.get_models(user_id, company_id, client=self._client, **params)
+
+
+class _SyncMCPAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: UniqueClient) -> None:
+        self._client = client
+
+    def call_tool(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._mcp import MCP
+
+        return MCP.call_tool(user_id, company_id, client=self._client, **params)
+
+
+class _SyncMessageAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: UniqueClient) -> None:
+        self._client = client
+
+    def list(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._message import Message
+
+        return Message.list(user_id, company_id, client=self._client, **params)
+
+    def retrieve(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._message import Message
+
+        return Message.retrieve(user_id, company_id, client=self._client, **params)
+
+    def create(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._message import Message
+
+        return Message.create(user_id, company_id, client=self._client, **params)
+
+    def modify(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._message import Message
+
+        return Message.modify(user_id, company_id, client=self._client, **params)
+
+
+class _SyncMessageAssessmentAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: UniqueClient) -> None:
+        self._client = client
+
+    def create(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._message_assessment import MessageAssessment
+
+        return MessageAssessment.create(
+            user_id, company_id, client=self._client, **params
+        )
+
+    def modify(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._message_assessment import MessageAssessment
+
+        return MessageAssessment.modify(
+            user_id, company_id, client=self._client, **params
+        )
+
+
+class _SyncMessageExecutionAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: UniqueClient) -> None:
+        self._client = client
+
+    def create(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._message_execution import MessageExecution
+
+        return MessageExecution.create(
+            user_id, company_id, client=self._client, **params
+        )
+
+    def get(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._message_execution import MessageExecution
+
+        return MessageExecution.get(user_id, company_id, client=self._client, **params)
+
+    def update(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._message_execution import MessageExecution
+
+        return MessageExecution.update(
+            user_id, company_id, client=self._client, **params
+        )
+
+
+class _SyncMessageLogAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: UniqueClient) -> None:
+        self._client = client
+
+    def create(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._message_log import MessageLog
+
+        return MessageLog.create(user_id, company_id, client=self._client, **params)
+
+    def update(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._message_log import MessageLog
+
+        return MessageLog.update(user_id, company_id, client=self._client, **params)
+
+
+class _SyncMessageToolAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: UniqueClient) -> None:
+        self._client = client
+
+    def create_many(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._message_tool import MessageTool
+
+        return MessageTool.create_many(
+            user_id, company_id, client=self._client, **params
+        )
+
+    def get_message_tools(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._message_tool import MessageTool
+
+        return MessageTool.get_message_tools(
+            user_id, company_id, client=self._client, **params
+        )
+
+
+class _SyncModuleAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: UniqueClient) -> None:
+        self._client = client
+
+    def list(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._module import Module
+
+        return Module.list(
+            user_id=user_id, company_id=company_id, client=self._client, **params
+        )
+
+    def retrieve(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._module import Module
+
+        return Module.retrieve(
+            user_id=user_id, company_id=company_id, client=self._client, **params
+        )
+
+    def create(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._module import Module
+
+        return Module.create(
+            user_id=user_id, company_id=company_id, client=self._client, **params
+        )
+
+    def modify(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._module import Module
+
+        return Module.modify(
+            user_id=user_id, company_id=company_id, client=self._client, **params
+        )
+
+    def delete(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._module import Module
+
+        return Module.delete(
+            user_id=user_id, company_id=company_id, client=self._client, **params
+        )
+
+
+class _SyncScheduledTaskAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: UniqueClient) -> None:
+        self._client = client
+
+    def create(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._scheduled_task import ScheduledTask
+
+        return ScheduledTask.create(user_id, company_id, client=self._client, **params)
+
+    def list(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._scheduled_task import ScheduledTask
+
+        return ScheduledTask.list(user_id, company_id, client=self._client, **params)
+
+    def retrieve(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._scheduled_task import ScheduledTask
+
+        return ScheduledTask.retrieve(
+            user_id, company_id, client=self._client, **params
+        )
+
+    def modify(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._scheduled_task import ScheduledTask
+
+        return ScheduledTask.modify(user_id, company_id, client=self._client, **params)
+
+    def delete(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._scheduled_task import ScheduledTask
+
+        return ScheduledTask.delete(user_id, company_id, client=self._client, **params)
+
+
+class _SyncSearchAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: UniqueClient) -> None:
+        self._client = client
+
+    def create(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._search import Search
+
+        return Search.create(user_id, company_id, client=self._client, **params)
+
+
+class _SyncSearchStringAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: UniqueClient) -> None:
+        self._client = client
+
+    def create(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._search_string import SearchString
+
+        return SearchString.create(user_id, company_id, client=self._client, **params)
+
+
+class _SyncShortTermMemoryAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: UniqueClient) -> None:
+        self._client = client
+
+    def create(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._short_term_memory import ShortTermMemory
+
+        return ShortTermMemory.create(
+            user_id, company_id, client=self._client, **params
+        )
+
+    def find_latest(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._short_term_memory import ShortTermMemory
+
+        return ShortTermMemory.find_latest(
+            user_id, company_id, client=self._client, **params
+        )
+
+
+class _SyncSpaceAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: UniqueClient) -> None:
+        self._client = client
+
+    def create_message(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._space import Space
+
+        return Space.create_message(user_id, company_id, client=self._client, **params)
+
+    def create_chat(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._space import Space
+
+        return Space.create_chat(user_id, company_id, client=self._client, **params)
+
+    def get_chat_messages(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._space import Space
+
+        return Space.get_chat_messages(
+            user_id, company_id, client=self._client, **params
+        )
+
+    def get_latest_message(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._space import Space
+
+        return Space.get_latest_message(
+            user_id, company_id, client=self._client, **params
+        )
+
+    def delete_chat(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._space import Space
+
+        return Space.delete_chat(user_id, company_id, client=self._client, **params)
+
+    def get_space(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._space import Space
+
+        return Space.get_space(user_id, company_id, client=self._client, **params)
+
+    def create_space(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._space import Space
+
+        return Space.create_space(user_id, company_id, client=self._client, **params)
+
+    def get_space_access(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._space import Space
+
+        return Space.get_space_access(
+            user_id, company_id, client=self._client, **params
+        )
+
+    def add_space_access(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._space import Space
+
+        return Space.add_space_access(
+            user_id, company_id, client=self._client, **params
+        )
+
+    def delete_space_access(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._space import Space
+
+        return Space.delete_space_access(
+            user_id, company_id, client=self._client, **params
+        )
+
+    def update_space(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._space import Space
+
+        return Space.update_space(user_id, company_id, client=self._client, **params)
+
+    def delete_space(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._space import Space
+
+        return Space.delete_space(user_id, company_id, client=self._client, **params)
+
+    def get_spaces(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._space import Space
+
+        return Space.get_spaces(user_id, company_id, client=self._client, **params)
+
+
+class _SyncUserAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: UniqueClient) -> None:
+        self._client = client
+
+    def get_users(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._user import User
+
+        return User.get_users(user_id, company_id, client=self._client, **params)
+
+    def update_user_configuration(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._user import User
+
+        return User.update_user_configuration(
+            user_id, company_id, client=self._client, **params
+        )
+
+    def get_by_id(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._user import User
+
+        return User.get_by_id(user_id, company_id, client=self._client, **params)
+
+    def get_user_groups(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._user import User
+
+        return User.get_user_groups(user_id, company_id, client=self._client, **params)
+
+
+class _SyncWebSearchAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: UniqueClient) -> None:
+        self._client = client
+
+    def search(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._web_search import WebSearch
+
+        return WebSearch.search(user_id, company_id, client=self._client, **params)
+
+
+class _SyncWebCrawlAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: UniqueClient) -> None:
+        self._client = client
+
+    def crawl(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._web_search import WebCrawl
+
+        return WebCrawl.crawl(user_id, company_id, client=self._client, **params)
+
+
+# ---------------------------------------------------------------------------
+# Async accessor classes — forward to the *_async resource classmethods,
+# using the same base method name (no _async suffix from the caller's POV).
+# ---------------------------------------------------------------------------
+
+
+class _AsyncAcronymsAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: AsyncUniqueClient) -> None:
+        self._client = client
+
+    async def get(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._acronyms import Acronyms
+
+        return await Acronyms.get_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+
+class _AsyncAgenticTableAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: AsyncUniqueClient) -> None:
+        self._client = client
+
+    async def set_cell(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._agentic_table import AgenticTable
+
+        return await AgenticTable.set_cell(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def get_cell(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._agentic_table import AgenticTable
+
+        return await AgenticTable.get_cell(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def set_activity(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._agentic_table import AgenticTable
+
+        return await AgenticTable.set_activity(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def set_artifact(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._agentic_table import AgenticTable
+
+        return await AgenticTable.set_artifact(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def update_sheet_state(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._agentic_table import AgenticTable
+
+        return await AgenticTable.update_sheet_state(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def set_column_metadata(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._agentic_table import AgenticTable
+
+        return await AgenticTable.set_column_metadata(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def get_sheet_data(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._agentic_table import AgenticTable
+
+        return await AgenticTable.get_sheet_data(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def get_sheet_state(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._agentic_table import AgenticTable
+
+        return await AgenticTable.get_sheet_state(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def set_cell_metadata(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._agentic_table import AgenticTable
+
+        return await AgenticTable.set_cell_metadata(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def set_multiple_cells(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._agentic_table import AgenticTable
+
+        return await AgenticTable.set_multiple_cells(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def bulk_update_status(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._agentic_table import AgenticTable
+
+        return await AgenticTable.bulk_update_status(
+            user_id, company_id, client=self._client, **params
+        )
+
+
+class _AsyncAnalyticsOrderAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: AsyncUniqueClient) -> None:
+        self._client = client
+
+    async def create(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._analytics_order import AnalyticsOrder
+
+        return await AnalyticsOrder.create_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def list(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._analytics_order import AnalyticsOrder
+
+        return await AnalyticsOrder.list_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def retrieve(self, user_id: str, company_id: str, order_id: str):
+        from unique_sdk.api_resources._analytics_order import AnalyticsOrder
+
+        return await AnalyticsOrder.retrieve_async(
+            user_id, company_id, order_id, client=self._client
+        )
+
+    async def delete(self, user_id: str, company_id: str, order_id: str):
+        from unique_sdk.api_resources._analytics_order import AnalyticsOrder
+
+        return await AnalyticsOrder.delete_async(
+            user_id, company_id, order_id, client=self._client
+        )
+
+    async def download(self, user_id: str, company_id: str, order_id: str):
+        from unique_sdk.api_resources._analytics_order import AnalyticsOrder
+
+        return await AnalyticsOrder.download_async(
+            user_id, company_id, order_id, client=self._client
+        )
+
+
+class _AsyncBenchmarkingAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: AsyncUniqueClient) -> None:
+        self._client = client
+
+    async def process_upload(
+        self,
+        user_id: str,
+        company_id: str,
+        file: bytes,
+        filename: str,
+        force: bool | None = None,
+    ):
+        from unique_sdk.api_resources._benchmarking import Benchmarking
+
+        return await Benchmarking.process_upload_async(
+            user_id, company_id, file, filename, force, client=self._client
+        )
+
+    async def get_status(self, user_id: str, company_id: str):
+        from unique_sdk.api_resources._benchmarking import Benchmarking
+
+        return await Benchmarking.get_status_async(
+            user_id, company_id, client=self._client
+        )
+
+    async def download_processed(self, user_id: str, company_id: str):
+        from unique_sdk.api_resources._benchmarking import Benchmarking
+
+        return await Benchmarking.download_processed_async(
+            user_id, company_id, client=self._client
+        )
+
+    async def download_template(self, user_id: str, company_id: str):
+        from unique_sdk.api_resources._benchmarking import Benchmarking
+
+        return await Benchmarking.download_template_async(
+            user_id, company_id, client=self._client
+        )
+
+
+class _AsyncBriefingAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: AsyncUniqueClient) -> None:
+        self._client = client
+
+    async def upsert_for_assistant(
+        self, *, user_id: str, company_id: str, assistant_id: str, **params
+    ):
+        from unique_sdk.api_resources._briefing import Briefing
+
+        return await Briefing.upsert_for_assistant_async(
+            user_id=user_id,
+            company_id=company_id,
+            assistant_id=assistant_id,
+            client=self._client,
+            **params,
+        )
+
+
+class _AsyncChatCompletionAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: AsyncUniqueClient) -> None:
+        self._client = client
+
+    async def create(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._chat_completion import ChatCompletion
+
+        return await ChatCompletion.create_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+
+class _AsyncContentAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: AsyncUniqueClient) -> None:
+        self._client = client
+
+    async def search(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._content import Content
+
+        return await Content.search_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def get_info(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._content import Content
+
+        return await Content.get_info_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def get_infos(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._content import Content
+
+        return await Content.get_infos_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def upsert(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._content import Content
+
+        return await Content.upsert_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def versions(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._content import Content
+
+        return await Content.versions_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def version_download_url(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._content import Content
+
+        return await Content.version_download_url_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def restore_version(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._content import Content
+
+        return await Content.restore_version_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def ingest_magic_table_sheets(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._content import Content
+
+        return await Content.ingest_magic_table_sheets_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def update(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._content import Content
+
+        return await Content.update_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def update_ingestion_state(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._content import Content
+
+        return await Content.update_ingestion_state_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def delete(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._content import Content
+
+        return await Content.delete_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def resolve_content_id_from_file_path(
+        self, user_id: str, company_id: str, **params
+    ):
+        from unique_sdk.api_resources._content import Content
+
+        return Content.resolve_content_id_from_file_path(
+            user_id, company_id, client=self._client, **params
+        )
+
+
+class _AsyncElicitationAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: AsyncUniqueClient) -> None:
+        self._client = client
+
+    async def create_elicitation(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._elicitation import Elicitation
+
+        return await Elicitation.create_elicitation_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def get_pending_elicitations(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._elicitation import Elicitation
+
+        return await Elicitation.get_pending_elicitations_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def get_elicitation(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._elicitation import Elicitation
+
+        return await Elicitation.get_elicitation_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def respond_to_elicitation(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._elicitation import Elicitation
+
+        return await Elicitation.respond_to_elicitation_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+
+class _AsyncEmbeddingsAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: AsyncUniqueClient) -> None:
+        self._client = client
+
+    async def create(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._embedding import Embeddings
+
+        return await Embeddings.create_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+
+class _AsyncFolderAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: AsyncUniqueClient) -> None:
+        self._client = client
+
+    async def get_folder_path(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._folder import Folder
+
+        return await Folder.get_folder_path_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def get_info(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._folder import Folder
+
+        return await Folder.get_info_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def get_infos(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._folder import Folder
+
+        return await Folder.get_infos_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def create_paths(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._folder import Folder
+
+        return await Folder.create_paths_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def update_ingestion_config(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._folder import Folder
+
+        return await Folder.update_ingestion_config_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def add_access(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._folder import Folder
+
+        return await Folder.add_access_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def remove_access(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._folder import Folder
+
+        return await Folder.remove_access_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def update(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._folder import Folder
+
+        return await Folder.update_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def move(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._folder import Folder
+
+        return await Folder.move_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def delete(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._folder import Folder
+
+        return await Folder.delete_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def resolve_scope_id_from_folder_path(
+        self, user_id: str, company_id: str, **params
+    ):
+        from unique_sdk.api_resources._folder import Folder
+
+        return await Folder.resolve_scope_id_from_folder_path_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def resolve_scope_id_from_folder_path_with_create(
+        self, user_id: str, company_id: str, **params
+    ):
+        from unique_sdk.api_resources._folder import Folder
+
+        return await Folder.resolve_scope_id_from_folder_path_with_create_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+
+class _AsyncGroupAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: AsyncUniqueClient) -> None:
+        self._client = client
+
+    async def create_group(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._group import Group
+
+        return await Group.create_group_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def get_groups(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._group import Group
+
+        return await Group.get_groups_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def delete_group(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._group import Group
+
+        return await Group.delete_group_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def update_group(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._group import Group
+
+        return await Group.update_group_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def add_users_to_group(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._group import Group
+
+        return await Group.add_users_to_group_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def remove_users_from_group(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._group import Group
+
+        return await Group.remove_users_from_group_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def update_group_configuration(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._group import Group
+
+        return await Group.update_group_configuration_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+
+class _AsyncIntegratedAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: AsyncUniqueClient) -> None:
+        self._client = client
+
+    async def chat_stream_completion(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._integrated import Integrated
+
+        return await Integrated.chat_stream_completion_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+
+class _AsyncLLMModelsAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: AsyncUniqueClient) -> None:
+        self._client = client
+
+    async def get_models(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._llm_models import LLMModels
+
+        return await LLMModels.get_models_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+
+class _AsyncMCPAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: AsyncUniqueClient) -> None:
+        self._client = client
+
+    async def call_tool(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._mcp import MCP
+
+        return await MCP.call_tool_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+
+class _AsyncMessageAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: AsyncUniqueClient) -> None:
+        self._client = client
+
+    async def list(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._message import Message
+
+        return await Message.list_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def retrieve(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._message import Message
+
+        return await Message.retrieve_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def create(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._message import Message
+
+        return await Message.create_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def modify(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._message import Message
+
+        return await Message.modify_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+
+class _AsyncMessageAssessmentAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: AsyncUniqueClient) -> None:
+        self._client = client
+
+    async def create(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._message_assessment import MessageAssessment
+
+        return await MessageAssessment.create_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def modify(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._message_assessment import MessageAssessment
+
+        return await MessageAssessment.modify_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+
+class _AsyncMessageExecutionAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: AsyncUniqueClient) -> None:
+        self._client = client
+
+    async def create(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._message_execution import MessageExecution
+
+        return await MessageExecution.create_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def get(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._message_execution import MessageExecution
+
+        return await MessageExecution.get_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def update(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._message_execution import MessageExecution
+
+        return await MessageExecution.update_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+
+class _AsyncMessageLogAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: AsyncUniqueClient) -> None:
+        self._client = client
+
+    async def create(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._message_log import MessageLog
+
+        return await MessageLog.create_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def update(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._message_log import MessageLog
+
+        return await MessageLog.update_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+
+class _AsyncMessageToolAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: AsyncUniqueClient) -> None:
+        self._client = client
+
+    async def create_many(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._message_tool import MessageTool
+
+        return await MessageTool.create_many_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def get_message_tools(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._message_tool import MessageTool
+
+        return await MessageTool.get_message_tools_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+
+class _AsyncModuleAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: AsyncUniqueClient) -> None:
+        self._client = client
+
+    async def list(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._module import Module
+
+        return await Module.list_async(
+            user_id=user_id, company_id=company_id, client=self._client, **params
+        )
+
+    async def retrieve(self, user_id: str, company_id: str, id: str, **params):
+        from unique_sdk.api_resources._module import Module
+
+        return await Module.retrieve_async(
+            user_id=user_id, company_id=company_id, id=id, client=self._client
+        )
+
+    async def create(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._module import Module
+
+        return await Module.create_async(
+            user_id=user_id, company_id=company_id, client=self._client, **params
+        )
+
+    async def modify(self, user_id: str, company_id: str, id: str, **params):
+        from unique_sdk.api_resources._module import Module
+
+        return await Module.modify_async(
+            user_id=user_id, company_id=company_id, id=id, client=self._client, **params
+        )
+
+    async def delete(self, user_id: str, company_id: str, id: str, **params):
+        from unique_sdk.api_resources._module import Module
+
+        return await Module.delete_async(
+            user_id=user_id, company_id=company_id, id=id, client=self._client
+        )
+
+
+class _AsyncScheduledTaskAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: AsyncUniqueClient) -> None:
+        self._client = client
+
+    async def create(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._scheduled_task import ScheduledTask
+
+        return await ScheduledTask.create_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def list(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._scheduled_task import ScheduledTask
+
+        return await ScheduledTask.list_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def retrieve(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._scheduled_task import ScheduledTask
+
+        return await ScheduledTask.retrieve_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def modify(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._scheduled_task import ScheduledTask
+
+        return await ScheduledTask.modify_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def delete(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._scheduled_task import ScheduledTask
+
+        return await ScheduledTask.delete_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+
+class _AsyncSearchAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: AsyncUniqueClient) -> None:
+        self._client = client
+
+    async def create(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._search import Search
+
+        return await Search.create_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+
+class _AsyncSearchStringAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: AsyncUniqueClient) -> None:
+        self._client = client
+
+    async def create(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._search_string import SearchString
+
+        return await SearchString.create_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+
+class _AsyncShortTermMemoryAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: AsyncUniqueClient) -> None:
+        self._client = client
+
+    async def create(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._short_term_memory import ShortTermMemory
+
+        return await ShortTermMemory.create_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def find_latest(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._short_term_memory import ShortTermMemory
+
+        return await ShortTermMemory.find_latest_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+
+class _AsyncSpaceAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: AsyncUniqueClient) -> None:
+        self._client = client
+
+    async def create_message(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._space import Space
+
+        return await Space.create_message_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def create_chat(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._space import Space
+
+        return await Space.create_chat_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def get_chat_messages(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._space import Space
+
+        return await Space.get_chat_messages_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def get_latest_message(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._space import Space
+
+        return await Space.get_latest_message_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def delete_chat(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._space import Space
+
+        return await Space.delete_chat_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def get_space(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._space import Space
+
+        return await Space.get_space_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def create_space(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._space import Space
+
+        return await Space.create_space_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def get_space_access(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._space import Space
+
+        return await Space.get_space_access_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def add_space_access(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._space import Space
+
+        return await Space.add_space_access_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def delete_space_access(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._space import Space
+
+        return await Space.delete_space_access_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def update_space(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._space import Space
+
+        return await Space.update_space_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def delete_space(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._space import Space
+
+        return await Space.delete_space_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def get_spaces(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._space import Space
+
+        return await Space.get_spaces_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+
+class _AsyncUserAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: AsyncUniqueClient) -> None:
+        self._client = client
+
+    async def get_users(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._user import User
+
+        return await User.get_users_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def update_user_configuration(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._user import User
+
+        return await User.update_user_configuration_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def get_by_id(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._user import User
+
+        return await User.get_by_id_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+    async def get_user_groups(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._user import User
+
+        return await User.get_user_groups_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+
+class _AsyncWebSearchAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: AsyncUniqueClient) -> None:
+        self._client = client
+
+    async def search(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._web_search import WebSearch
+
+        return await WebSearch.search_async(
+            user_id, company_id, client=self._client, **params
+        )
+
+
+class _AsyncWebCrawlAccessor:
+    __slots__ = ("_client",)
+
+    def __init__(self, client: AsyncUniqueClient) -> None:
+        self._client = client
+
+    async def crawl(self, user_id: str, company_id: str, **params):
+        from unique_sdk.api_resources._web_search import WebCrawl
+
+        return await WebCrawl.crawl_async(
+            user_id, company_id, client=self._client, **params
+        )

--- a/unique_sdk/unique_sdk/api_resources/_acronyms.py
+++ b/unique_sdk/unique_sdk/api_resources/_acronyms.py
@@ -1,7 +1,12 @@
-from typing import Literal, cast
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal, cast
 
 from unique_sdk._api_resource import APIResource
 from unique_sdk._util import classproperty
+
+if TYPE_CHECKING:
+    from unique_sdk._client import _BaseClient
 
 
 class Acronyms(APIResource["Acronyms"]):
@@ -12,7 +17,9 @@ class Acronyms(APIResource["Acronyms"]):
     Acronyms: list[list[float]]
 
     @classmethod
-    def get(cls, user_id: str, company_id: str) -> "Acronyms":  # pyright: ignore[reportIncompatibleMethodOverride]
+    def get(
+        cls, user_id: str, company_id: str, client: "_BaseClient | None" = None
+    ) -> "Acronyms":  # pyright: ignore[reportIncompatibleMethodOverride]
         return cast(
             "Acronyms",
             cls._static_request(
@@ -20,11 +27,14 @@ class Acronyms(APIResource["Acronyms"]):
                 "/company/acronyms",
                 user_id,
                 company_id=company_id,
+                client=client,
             ),
         )
 
     @classmethod
-    async def get_async(cls, user_id: str, company_id: str) -> "Acronyms":
+    async def get_async(
+        cls, user_id: str, company_id: str, client: "_BaseClient | None" = None
+    ) -> "Acronyms":
         return cast(
             "Acronyms",
             await cls._static_request_async(
@@ -32,5 +42,6 @@ class Acronyms(APIResource["Acronyms"]):
                 "/company/acronyms",
                 user_id,
                 company_id=company_id,
+                client=client,
             ),
         )

--- a/unique_sdk/unique_sdk/api_resources/_agentic_table.py
+++ b/unique_sdk/unique_sdk/api_resources/_agentic_table.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 from enum import StrEnum
 from typing import (
+    TYPE_CHECKING,
     Any,
     Literal,
     NotRequired,
@@ -8,6 +11,9 @@ from typing import (
 )
 
 from typing_extensions import Unpack
+
+if TYPE_CHECKING:
+    from unique_sdk._client import _BaseClient
 
 from unique_sdk._api_resource import APIResource
 from unique_sdk._request_options import RequestOptions
@@ -243,6 +249,7 @@ class AgenticTable(APIResource["AgenticTable"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["AgenticTable.SetCell"],
     ) -> "AgenticTableCell":
         """ """
@@ -255,6 +262,7 @@ class AgenticTable(APIResource["AgenticTable"]):
                 user_id,
                 company_id,
                 params,
+                client=client,
             ),
         )
 
@@ -263,6 +271,7 @@ class AgenticTable(APIResource["AgenticTable"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["AgenticTable.GetCell"],
     ) -> "AgenticTableCell":
         """ """
@@ -278,6 +287,7 @@ class AgenticTable(APIResource["AgenticTable"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -286,6 +296,7 @@ class AgenticTable(APIResource["AgenticTable"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["AgenticTable.SetActivityStatus"],
     ) -> MagicTableActivityResponse:
         url = f"/magic-table/{params['tableId']}/activity"
@@ -297,6 +308,7 @@ class AgenticTable(APIResource["AgenticTable"]):
                 user_id,
                 company_id,
                 params,
+                client=client,
             ),
         )
 
@@ -305,6 +317,7 @@ class AgenticTable(APIResource["AgenticTable"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["AgenticTable.SetArtifact"],
     ) -> ColumnMetadataUpdateStatus:
         url = f"/magic-table/{params['tableId']}/artifact"
@@ -316,6 +329,7 @@ class AgenticTable(APIResource["AgenticTable"]):
                 user_id,
                 company_id,
                 params,
+                client=client,
             ),
         )
 
@@ -324,12 +338,15 @@ class AgenticTable(APIResource["AgenticTable"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["AgenticTable.UpdateSheet"],
     ) -> "AgenticTable.UpdateSheetResponse":
         url = f"/magic-table/{params['tableId']}"
         return cast(
             "AgenticTable.UpdateSheetResponse",
-            await cls._static_request_async("post", url, user_id, company_id, params),
+            await cls._static_request_async(
+                "post", url, user_id, company_id, params, client=client
+            ),
         )
 
     @classmethod
@@ -337,13 +354,14 @@ class AgenticTable(APIResource["AgenticTable"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["AgenticTable.SetColumnMetadata"],
     ) -> ColumnMetadataUpdateStatus:
         url = f"/magic-table/{params['tableId']}/column/metadata"
         # Remove tableId from params
         params.pop("tableId")
         response = await cls._static_request_async(
-            "post", url, user_id, company_id, params
+            "post", url, user_id, company_id, params, client=client
         )
         return cast(
             ColumnMetadataUpdateStatus,
@@ -355,21 +373,29 @@ class AgenticTable(APIResource["AgenticTable"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["AgenticTable.GetSheetData"],
     ) -> AgenticTableSheet:
         url = f"/magic-table/{params['tableId']}"
         return cast(
             AgenticTableSheet,
-            await cls._static_request_async("get", url, user_id, company_id, params),
+            await cls._static_request_async(
+                "get", url, user_id, company_id, params, client=client
+            ),
         )
 
     @classmethod
     async def get_sheet_state(
-        cls, user_id: str, company_id: str, tableId: str
+        cls,
+        user_id: str,
+        company_id: str,
+        tableId: str,
+        client: "_BaseClient | None" = None,
     ) -> AgenticTableSheetState:
         sheet = await cls.get_sheet_data(
             user_id=user_id,
             company_id=company_id,
+            client=client,
             tableId=tableId,
             includeCells=False,
         )
@@ -380,12 +406,15 @@ class AgenticTable(APIResource["AgenticTable"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["AgenticTable.SetCellMetadata"],
     ) -> ColumnMetadataUpdateStatus:
         url = f"/magic-table/{params['tableId']}/cell/metadata"
         return cast(
             "ColumnMetadataUpdateStatus",
-            await cls._static_request_async("post", url, user_id, company_id, params),
+            await cls._static_request_async(
+                "post", url, user_id, company_id, params, client=client
+            ),
         )
 
     @classmethod
@@ -395,6 +424,7 @@ class AgenticTable(APIResource["AgenticTable"]):
         company_id: str,
         tableId: str,
         cells: list[AgenticTableCell],
+        client: "_BaseClient | None" = None,
     ) -> ColumnMetadataUpdateStatus:
         url = f"/magic-table/{tableId}/cells/bulk-upsert"
         try:
@@ -413,7 +443,7 @@ class AgenticTable(APIResource["AgenticTable"]):
         return cast(
             "ColumnMetadataUpdateStatus",
             await cls._static_request_async(
-                "post", url, user_id, company_id, params=params_api
+                "post", url, user_id, company_id, params=params_api, client=client
             ),
         )
 
@@ -422,6 +452,7 @@ class AgenticTable(APIResource["AgenticTable"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["AgenticTable.BulkUpdateStatus"],
     ) -> ColumnMetadataUpdateStatus:
         url = f"/magic-table/{params['tableId']}/rows/bulk-update-status"
@@ -433,5 +464,6 @@ class AgenticTable(APIResource["AgenticTable"]):
                 user_id,
                 company_id,
                 params,
+                client=client,
             ),
         )

--- a/unique_sdk/unique_sdk/api_resources/_analytics_order.py
+++ b/unique_sdk/unique_sdk/api_resources/_analytics_order.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import builtins
-from typing import Any, ClassVar, Literal, NotRequired, cast, get_args
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, NotRequired, cast, get_args
+
+if TYPE_CHECKING:
+    from unique_sdk._client import _BaseClient
 from urllib.parse import quote_plus
 
 from typing_extensions import Unpack
@@ -59,6 +62,7 @@ class AnalyticsOrder(APIResource["AnalyticsOrder"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["AnalyticsOrder.CreateParams"],
     ) -> "AnalyticsOrder":
         return cast(
@@ -69,6 +73,7 @@ class AnalyticsOrder(APIResource["AnalyticsOrder"]):
                 user_id,
                 company_id,
                 params,
+                client=client,
             ),
         )
 
@@ -77,6 +82,7 @@ class AnalyticsOrder(APIResource["AnalyticsOrder"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["AnalyticsOrder.CreateParams"],
     ) -> "AnalyticsOrder":
         return cast(
@@ -87,6 +93,7 @@ class AnalyticsOrder(APIResource["AnalyticsOrder"]):
                 user_id,
                 company_id,
                 params,
+                client=client,
             ),
         )
 
@@ -95,6 +102,7 @@ class AnalyticsOrder(APIResource["AnalyticsOrder"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["AnalyticsOrder.ListParams"],
     ) -> builtins.list["AnalyticsOrder"]:
         return cast(
@@ -105,6 +113,7 @@ class AnalyticsOrder(APIResource["AnalyticsOrder"]):
                 user_id,
                 company_id,
                 params,
+                client=client,
             ),
         )
 
@@ -113,6 +122,7 @@ class AnalyticsOrder(APIResource["AnalyticsOrder"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["AnalyticsOrder.ListParams"],
     ) -> builtins.list["AnalyticsOrder"]:
         return cast(
@@ -123,6 +133,7 @@ class AnalyticsOrder(APIResource["AnalyticsOrder"]):
                 user_id,
                 company_id,
                 params,
+                client=client,
             ),
         )
 
@@ -132,11 +143,12 @@ class AnalyticsOrder(APIResource["AnalyticsOrder"]):
         user_id: str,
         company_id: str,
         order_id: str,
+        client: "_BaseClient | None" = None,
     ) -> "AnalyticsOrder":
         url = f"{cls.RESOURCE_URL}/{quote_plus(order_id)}"
         return cast(
             "AnalyticsOrder",
-            cls._static_request("get", url, user_id, company_id),
+            cls._static_request("get", url, user_id, company_id, client=client),
         )
 
     @classmethod
@@ -145,11 +157,14 @@ class AnalyticsOrder(APIResource["AnalyticsOrder"]):
         user_id: str,
         company_id: str,
         order_id: str,
+        client: "_BaseClient | None" = None,
     ) -> "AnalyticsOrder":
         url = f"{cls.RESOURCE_URL}/{quote_plus(order_id)}"
         return cast(
             "AnalyticsOrder",
-            await cls._static_request_async("get", url, user_id, company_id),
+            await cls._static_request_async(
+                "get", url, user_id, company_id, client=client
+            ),
         )
 
     @classmethod
@@ -158,11 +173,12 @@ class AnalyticsOrder(APIResource["AnalyticsOrder"]):
         user_id: str,
         company_id: str,
         order_id: str,
+        client: "_BaseClient | None" = None,
     ) -> "AnalyticsOrder":
         url = f"{cls.RESOURCE_URL}/{quote_plus(order_id)}"
         return cast(
             "AnalyticsOrder",
-            cls._static_request("delete", url, user_id, company_id),
+            cls._static_request("delete", url, user_id, company_id, client=client),
         )
 
     @classmethod
@@ -171,11 +187,14 @@ class AnalyticsOrder(APIResource["AnalyticsOrder"]):
         user_id: str,
         company_id: str,
         order_id: str,
+        client: "_BaseClient | None" = None,
     ) -> "AnalyticsOrder":
         url = f"{cls.RESOURCE_URL}/{quote_plus(order_id)}"
         return cast(
             "AnalyticsOrder",
-            await cls._static_request_async("delete", url, user_id, company_id),
+            await cls._static_request_async(
+                "delete", url, user_id, company_id, client=client
+            ),
         )
 
     @classmethod
@@ -184,9 +203,10 @@ class AnalyticsOrder(APIResource["AnalyticsOrder"]):
         user_id: str,
         company_id: str,
         order_id: str,
+        client: "_BaseClient | None" = None,
     ) -> str:
         url = f"{cls.RESOURCE_URL}/{quote_plus(order_id)}/download"
-        requestor = APIRequestor(user_id=user_id, company_id=company_id)
+        requestor = APIRequestor(user_id=user_id, company_id=company_id, client=client)
         rbody, rcode, rheaders = requestor.request_raw("get", url)
         if not 200 <= rcode < 300:
             requestor.interpret_response(rbody, rcode, rheaders)
@@ -200,9 +220,10 @@ class AnalyticsOrder(APIResource["AnalyticsOrder"]):
         user_id: str,
         company_id: str,
         order_id: str,
+        client: "_BaseClient | None" = None,
     ) -> str:
         url = f"{cls.RESOURCE_URL}/{quote_plus(order_id)}/download"
-        requestor = APIRequestor(user_id=user_id, company_id=company_id)
+        requestor = APIRequestor(user_id=user_id, company_id=company_id, client=client)
         rbody, rcode, rheaders = await requestor.request_raw_async("get", url)
         if not 200 <= rcode < 300:
             requestor.interpret_response(rbody, rcode, rheaders)

--- a/unique_sdk/unique_sdk/api_resources/_benchmarking.py
+++ b/unique_sdk/unique_sdk/api_resources/_benchmarking.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 import asyncio
 import tempfile
 from pathlib import Path
 from typing import (
+    TYPE_CHECKING,
     Literal,
     NotRequired,
     TypedDict,
@@ -14,6 +17,9 @@ import unique_sdk
 from unique_sdk._api_requestor import APIRequestor
 from unique_sdk._api_resource import APIResource
 from unique_sdk._util import classproperty
+
+if TYPE_CHECKING:
+    from unique_sdk._client import _BaseClient
 
 _XLSX = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
 _TIMEOUT = 600.0
@@ -44,9 +50,9 @@ class Benchmarking(APIResource["Benchmarking"]):
 
     @classmethod
     def _requestor_and_headers(
-        cls, user_id: str, company_id: str
+        cls, user_id: str, company_id: str, client: "_BaseClient | None" = None
     ) -> tuple[APIRequestor, dict[str, str]]:
-        requestor = APIRequestor(user_id=user_id, company_id=company_id)
+        requestor = APIRequestor(user_id=user_id, company_id=company_id, client=client)
         api_key = requestor.api_key or unique_sdk.api_key
         app_id = requestor.app_id or unique_sdk.app_id
         headers = requestor.request_headers(api_key, app_id, "get")
@@ -60,9 +66,10 @@ class Benchmarking(APIResource["Benchmarking"]):
         file: bytes,
         filename: str,
         force: bool | None = None,
+        client: "_BaseClient | None" = None,
     ) -> "Benchmarking.ProcessUploadResponse":
         """Upload a benchmarking spreadsheet for processing."""
-        _, headers = cls._requestor_and_headers(user_id, company_id)
+        _, headers = cls._requestor_and_headers(user_id, company_id, client)
         resp = requests.post(
             f"{unique_sdk.api_base}{cls.RESOURCE_URL}",
             headers=headers,
@@ -87,14 +94,17 @@ class Benchmarking(APIResource["Benchmarking"]):
         file: bytes,
         filename: str,
         force: bool | None = None,
+        client: "_BaseClient | None" = None,
     ) -> "Benchmarking.ProcessUploadResponse":
         """Async upload a benchmarking spreadsheet for processing."""
         return await asyncio.to_thread(
-            cls.process_upload, user_id, company_id, file, filename, force
+            cls.process_upload, user_id, company_id, file, filename, force, client
         )
 
     @classmethod
-    def get_status(cls, user_id: str, company_id: str) -> "Benchmarking.StatusSnapshot":
+    def get_status(
+        cls, user_id: str, company_id: str, client: "_BaseClient | None" = None
+    ) -> "Benchmarking.StatusSnapshot":
         """Get the current benchmarking status for the company."""
         return cast(
             "Benchmarking.StatusSnapshot",
@@ -103,12 +113,13 @@ class Benchmarking(APIResource["Benchmarking"]):
                 f"{cls.RESOURCE_URL}/status",
                 user_id,
                 company_id,
+                client=client,
             ),
         )
 
     @classmethod
     async def get_status_async(
-        cls, user_id: str, company_id: str
+        cls, user_id: str, company_id: str, client: "_BaseClient | None" = None
     ) -> "Benchmarking.StatusSnapshot":
         """Async get the current benchmarking status for the company."""
         return cast(
@@ -118,6 +129,7 @@ class Benchmarking(APIResource["Benchmarking"]):
                 f"{cls.RESOURCE_URL}/status",
                 user_id,
                 company_id,
+                client=client,
             ),
         )
 
@@ -128,8 +140,9 @@ class Benchmarking(APIResource["Benchmarking"]):
         company_id: str,
         path: str,
         filename: str,
+        client: "_BaseClient | None" = None,
     ) -> Path:
-        _, headers = cls._requestor_and_headers(user_id, company_id)
+        _, headers = cls._requestor_and_headers(user_id, company_id, client)
         url = f"{unique_sdk.api_base}{path}"
         response = requests.get(
             url,
@@ -151,10 +164,11 @@ class Benchmarking(APIResource["Benchmarking"]):
         user_id: str,
         company_id: str,
         filename: str = "benchmarking_result.xlsx",
+        client: "_BaseClient | None" = None,
     ) -> Path:
         """Download the processed benchmarking workbook to a temp file and return its path."""
         return cls._download_to_tmp(
-            user_id, company_id, f"{cls.RESOURCE_URL}/action/download", filename
+            user_id, company_id, f"{cls.RESOURCE_URL}/action/download", filename, client
         )
 
     @classmethod
@@ -163,10 +177,11 @@ class Benchmarking(APIResource["Benchmarking"]):
         user_id: str,
         company_id: str,
         filename: str = "benchmarking_result.xlsx",
+        client: "_BaseClient | None" = None,
     ) -> Path:
         """Async download the processed benchmarking workbook."""
         return await asyncio.to_thread(
-            cls.download_processed, user_id, company_id, filename
+            cls.download_processed, user_id, company_id, filename, client
         )
 
     @classmethod
@@ -175,6 +190,7 @@ class Benchmarking(APIResource["Benchmarking"]):
         user_id: str,
         company_id: str,
         filename: str = "benchmarking_template.xlsx",
+        client: "_BaseClient | None" = None,
     ) -> Path:
         """Download the benchmarking input template to a temp file and return its path."""
         return cls._download_to_tmp(
@@ -182,6 +198,7 @@ class Benchmarking(APIResource["Benchmarking"]):
             company_id,
             f"{cls.RESOURCE_URL}/action/template-download",
             filename,
+            client,
         )
 
     @classmethod
@@ -190,8 +207,9 @@ class Benchmarking(APIResource["Benchmarking"]):
         user_id: str,
         company_id: str,
         filename: str = "benchmarking_template.xlsx",
+        client: "_BaseClient | None" = None,
     ) -> Path:
         """Async download the benchmarking input template."""
         return await asyncio.to_thread(
-            cls.download_template, user_id, company_id, filename
+            cls.download_template, user_id, company_id, filename, client
         )

--- a/unique_sdk/unique_sdk/api_resources/_briefing.py
+++ b/unique_sdk/unique_sdk/api_resources/_briefing.py
@@ -8,8 +8,11 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from datetime import UTC, datetime
-from typing import Any, Literal, NotRequired, TypedDict, Unpack, cast
+from typing import TYPE_CHECKING, Any, Literal, NotRequired, TypedDict, Unpack, cast
 from urllib.parse import quote_plus
+
+if TYPE_CHECKING:
+    from unique_sdk._client import _BaseClient
 
 from unique_sdk._api_resource import APIResource
 from unique_sdk._request_options import RequestOptions
@@ -170,6 +173,7 @@ class Briefing(APIResource["Briefing"]):
         user_id: str,
         company_id: str,
         assistant_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Briefing.UpsertForAssistantParams"],
     ) -> "Briefing":
         """Upsert the briefing for ``assistant_id`` (external id = assistant id).
@@ -181,7 +185,9 @@ class Briefing(APIResource["Briefing"]):
         payload = cls._wire_json_from_upsert_params(params)
         return cast(
             "Briefing",
-            cls._static_request("put", url, user_id, company_id, payload),
+            cls._static_request(
+                "put", url, user_id, company_id, payload, client=client
+            ),
         )
 
     @classmethod
@@ -191,6 +197,7 @@ class Briefing(APIResource["Briefing"]):
         user_id: str,
         company_id: str,
         assistant_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Briefing.UpsertForAssistantParams"],
     ) -> "Briefing":
         """Async variant of :meth:`upsert_for_assistant`."""
@@ -198,5 +205,7 @@ class Briefing(APIResource["Briefing"]):
         payload = cls._wire_json_from_upsert_params(params)
         return cast(
             "Briefing",
-            await cls._static_request_async("put", url, user_id, company_id, payload),
+            await cls._static_request_async(
+                "put", url, user_id, company_id, payload, client=client
+            ),
         )

--- a/unique_sdk/unique_sdk/api_resources/_chat_completion.py
+++ b/unique_sdk/unique_sdk/api_resources/_chat_completion.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from typing import (
+    TYPE_CHECKING,
     Any,
     Literal,
     NotRequired,
@@ -10,6 +13,9 @@ from typing import (
 from unique_sdk._api_resource import APIResource
 from unique_sdk._request_options import RequestOptions
 from unique_sdk._util import classproperty
+
+if TYPE_CHECKING:
+    from unique_sdk._client import _BaseClient
 
 
 class ChatCompletionRequestMessage(TypedDict, total=False):
@@ -57,6 +63,7 @@ class ChatCompletion(APIResource["ChatCompletion"]):
         cls,
         company_id: str,
         user_id: str | None = None,
+        client: "_BaseClient | None" = None,
         **params: Unpack["ChatCompletion.CreateParams"],
     ) -> "ChatCompletion":
         return cast(
@@ -67,6 +74,7 @@ class ChatCompletion(APIResource["ChatCompletion"]):
                 company_id=company_id,
                 user_id=user_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -75,6 +83,7 @@ class ChatCompletion(APIResource["ChatCompletion"]):
         cls,
         company_id: str,
         user_id: str | None = None,
+        client: "_BaseClient | None" = None,
         **params: Unpack["ChatCompletion.CreateParams"],
     ) -> "ChatCompletion":
         return cast(
@@ -85,5 +94,6 @@ class ChatCompletion(APIResource["ChatCompletion"]):
                 company_id=company_id,
                 user_id=user_id,
                 params=params,
+                client=client,
             ),
         )

--- a/unique_sdk/unique_sdk/api_resources/_content.py
+++ b/unique_sdk/unique_sdk/api_resources/_content.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 from enum import Enum
 from typing import (
+    TYPE_CHECKING,
     Any,
     Literal,
     TypedDict,
@@ -12,6 +15,9 @@ import unique_sdk
 from unique_sdk._api_resource import APIResource
 from unique_sdk._request_options import RequestOptions
 from unique_sdk._util import classproperty
+
+if TYPE_CHECKING:
+    from unique_sdk._client import _BaseClient
 
 
 class Content(APIResource["Content"]):
@@ -307,6 +313,7 @@ class Content(APIResource["Content"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Content.SearchParams"],
     ) -> list["Content"]:
         return cast(
@@ -317,6 +324,7 @@ class Content(APIResource["Content"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -325,6 +333,7 @@ class Content(APIResource["Content"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Content.SearchParams"],
     ) -> list["Content"]:
         return cast(
@@ -335,6 +344,7 @@ class Content(APIResource["Content"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -343,6 +353,7 @@ class Content(APIResource["Content"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Content.ContentInfoParams"],
     ) -> PaginatedContentInfo:
         return cast(
@@ -353,6 +364,7 @@ class Content(APIResource["Content"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -361,6 +373,7 @@ class Content(APIResource["Content"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Content.ContentInfoParams"],
     ) -> PaginatedContentInfo:
         return cast(
@@ -371,6 +384,7 @@ class Content(APIResource["Content"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -379,6 +393,7 @@ class Content(APIResource["Content"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Content.ContentInfosParams"],
     ) -> "Content.PaginatedContentInfos":
         parent_id = unique_sdk.Folder.resolve_scope_id_from_folder_path(
@@ -399,6 +414,7 @@ class Content(APIResource["Content"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -407,6 +423,7 @@ class Content(APIResource["Content"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Content.ContentInfosParams"],
     ) -> "Content.PaginatedContentInfos":
         parent_id = await unique_sdk.Folder.resolve_scope_id_from_folder_path_async(
@@ -427,6 +444,7 @@ class Content(APIResource["Content"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -435,6 +453,7 @@ class Content(APIResource["Content"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Content.UpsertParams"],
     ) -> "Content":
         """
@@ -466,6 +485,7 @@ class Content(APIResource["Content"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -474,6 +494,7 @@ class Content(APIResource["Content"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Content.UpsertParams"],
     ) -> "Content":
         """
@@ -509,6 +530,7 @@ class Content(APIResource["Content"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -517,6 +539,7 @@ class Content(APIResource["Content"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Content.VersionsParams"],
     ) -> "Content.PaginatedContentVersions":
         content_id = params.pop("contentId")
@@ -528,6 +551,7 @@ class Content(APIResource["Content"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -536,6 +560,7 @@ class Content(APIResource["Content"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Content.VersionsParams"],
     ) -> "Content.PaginatedContentVersions":
         content_id = params.pop("contentId")
@@ -547,6 +572,7 @@ class Content(APIResource["Content"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -555,6 +581,7 @@ class Content(APIResource["Content"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Content.VersionDownloadUrlParams"],
     ) -> "Content.ContentVersionDownloadUrl":
         content_version_id = params.pop("contentVersionId")
@@ -566,6 +593,7 @@ class Content(APIResource["Content"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -574,6 +602,7 @@ class Content(APIResource["Content"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Content.VersionDownloadUrlParams"],
     ) -> "Content.ContentVersionDownloadUrl":
         content_version_id = params.pop("contentVersionId")
@@ -585,6 +614,7 @@ class Content(APIResource["Content"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -593,6 +623,7 @@ class Content(APIResource["Content"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Content.RestoreVersionParams"],
     ) -> "Content.ContentInfo":
         content_version_id = params.pop("contentVersionId")
@@ -604,6 +635,7 @@ class Content(APIResource["Content"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -612,6 +644,7 @@ class Content(APIResource["Content"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Content.RestoreVersionParams"],
     ) -> "Content.ContentInfo":
         content_version_id = params.pop("contentVersionId")
@@ -623,6 +656,7 @@ class Content(APIResource["Content"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -631,6 +665,7 @@ class Content(APIResource["Content"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Content.MagicTableSheetIngestParams"],
     ) -> "Content.MagicTableSheetResponse":
         return cast(
@@ -641,6 +676,7 @@ class Content(APIResource["Content"]):
                 user_id,
                 company_id=company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -649,6 +685,7 @@ class Content(APIResource["Content"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Content.MagicTableSheetIngestParams"],
     ) -> "Content.MagicTableSheetResponse":
         return cast(
@@ -659,6 +696,7 @@ class Content(APIResource["Content"]):
                 user_id,
                 company_id=company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -667,6 +705,7 @@ class Content(APIResource["Content"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Content.UpdateParams"],
     ) -> "Content.ContentInfo":
         content_id = cls.resolve_content_id_from_file_path(
@@ -695,6 +734,7 @@ class Content(APIResource["Content"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -703,6 +743,7 @@ class Content(APIResource["Content"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Content.UpdateParams"],
     ) -> "Content.ContentInfo":
         content_id = cls.resolve_content_id_from_file_path(
@@ -731,6 +772,7 @@ class Content(APIResource["Content"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -739,6 +781,7 @@ class Content(APIResource["Content"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Content.UpdateIngestionStateParams"],
     ) -> "Content.ContentInfo":
         content_id = params.get("contentId")
@@ -752,6 +795,7 @@ class Content(APIResource["Content"]):
                 user_id,
                 company_id,
                 params={"ingestionState": ingestion_state},
+                client=client,
             ),
         )
 
@@ -760,6 +804,7 @@ class Content(APIResource["Content"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Content.UpdateIngestionStateParams"],
     ) -> "Content.ContentInfo":
         content_id = params.get("contentId")
@@ -773,6 +818,7 @@ class Content(APIResource["Content"]):
                 user_id,
                 company_id,
                 params={"ingestionState": ingestion_state},
+                client=client,
             ),
         )
 
@@ -781,6 +827,7 @@ class Content(APIResource["Content"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Content.DeleteParams"],
     ) -> "Content.DeleteResponse":
         """
@@ -803,6 +850,7 @@ class Content(APIResource["Content"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -811,6 +859,7 @@ class Content(APIResource["Content"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Content.DeleteParams"],
     ) -> "Content.DeleteResponse":
         """
@@ -833,6 +882,7 @@ class Content(APIResource["Content"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -843,6 +893,7 @@ class Content(APIResource["Content"]):
         company_id: str,
         content_id: str | None = None,
         file_path: str | None = None,
+        client: "_BaseClient | None" = None,
     ) -> str | None:
         """
         Returns the contentId to use: if content_id is provided, returns it;
@@ -858,6 +909,7 @@ class Content(APIResource["Content"]):
             file_info = cls.get_info(
                 user_id=user_id,
                 company_id=company_id,
+                client=client,
                 filePath=file_path,
             )
             content_infos = file_info.get("contentInfo")

--- a/unique_sdk/unique_sdk/api_resources/_dynamic_frontend.py
+++ b/unique_sdk/unique_sdk/api_resources/_dynamic_frontend.py
@@ -1,10 +1,15 @@
-from typing import Literal, cast
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal, cast
 
 from typing_extensions import NotRequired, Unpack
 
 from unique_sdk._api_resource import APIResource
 from unique_sdk._request_options import RequestOptions
 from unique_sdk._util import classproperty
+
+if TYPE_CHECKING:
+    from unique_sdk._client import _BaseClient
 
 
 class DynamicFrontend(APIResource["DynamicFrontend"]):
@@ -33,6 +38,7 @@ class DynamicFrontend(APIResource["DynamicFrontend"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["DynamicFrontend.CreateParams"],
     ) -> "DynamicFrontend":
         return cast(
@@ -43,6 +49,7 @@ class DynamicFrontend(APIResource["DynamicFrontend"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -52,6 +59,7 @@ class DynamicFrontend(APIResource["DynamicFrontend"]):
         space_id: str,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["DynamicFrontend.UpdateParams"],
     ) -> "DynamicFrontend":
         return cast(
@@ -62,6 +70,7 @@ class DynamicFrontend(APIResource["DynamicFrontend"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -71,6 +80,7 @@ class DynamicFrontend(APIResource["DynamicFrontend"]):
         space_id: str,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
     ) -> "DynamicFrontend":
         """Delete a deployed Dynamic Frontend space."""
         return cast(
@@ -80,6 +90,7 @@ class DynamicFrontend(APIResource["DynamicFrontend"]):
                 f"/dynamic-frontend/{space_id}",
                 user_id,
                 company_id,
+                client=client,
             ),
         )
 
@@ -88,12 +99,14 @@ class DynamicFrontend(APIResource["DynamicFrontend"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
     ) -> list["DynamicFrontend"]:
         response = cls._static_request(
             "get",
             "/dynamic-frontend",
             user_id,
             company_id,
+            client=client,
         )
         if isinstance(response, list):
             return cast(list[DynamicFrontend], response)

--- a/unique_sdk/unique_sdk/api_resources/_elicitation.py
+++ b/unique_sdk/unique_sdk/api_resources/_elicitation.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from typing import (
+    TYPE_CHECKING,
     Any,
     Literal,
     NotRequired,
@@ -10,6 +13,9 @@ from typing import (
 from unique_sdk._api_resource import APIResource
 from unique_sdk._request_options import RequestOptions
 from unique_sdk._util import classproperty
+
+if TYPE_CHECKING:
+    from unique_sdk._client import _BaseClient
 
 ACTION_TYPES = Literal["ACCEPT", "DECLINE", "CANCEL"]
 SOURCE_TYPES = Literal["INTERNAL_TOOL", "MCP_SERVER"]
@@ -93,6 +99,7 @@ class Elicitation(APIResource["Elicitation"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Elicitation.CreateParams"],
     ) -> "Elicitation.Elicitation":
         """
@@ -106,6 +113,7 @@ class Elicitation(APIResource["Elicitation"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -114,6 +122,7 @@ class Elicitation(APIResource["Elicitation"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Elicitation.CreateParams"],
     ) -> "Elicitation.Elicitation":
         """
@@ -127,6 +136,7 @@ class Elicitation(APIResource["Elicitation"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -135,6 +145,7 @@ class Elicitation(APIResource["Elicitation"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
     ) -> "Elicitation.Elicitations":
         """
         Get all pending elicitation requests for a user in a company.
@@ -146,6 +157,7 @@ class Elicitation(APIResource["Elicitation"]):
                 "/elicitation/pending",
                 user_id,
                 company_id,
+                client=client,
             ),
         )
 
@@ -154,6 +166,7 @@ class Elicitation(APIResource["Elicitation"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
     ) -> "Elicitation.Elicitations":
         """
         Async get all pending elicitation requests for a user in a company.
@@ -165,6 +178,7 @@ class Elicitation(APIResource["Elicitation"]):
                 "/elicitation/pending",
                 user_id,
                 company_id,
+                client=client,
             ),
         )
 
@@ -174,6 +188,7 @@ class Elicitation(APIResource["Elicitation"]):
         user_id: str,
         company_id: str,
         elicitation_id: str,
+        client: "_BaseClient | None" = None,
     ) -> "Elicitation.Elicitation":
         """
         Get an elicitation request by ID in a company.
@@ -185,6 +200,7 @@ class Elicitation(APIResource["Elicitation"]):
                 f"/elicitation/{elicitation_id}",
                 user_id,
                 company_id,
+                client=client,
             ),
         )
 
@@ -194,6 +210,7 @@ class Elicitation(APIResource["Elicitation"]):
         user_id: str,
         company_id: str,
         elicitation_id: str,
+        client: "_BaseClient | None" = None,
     ) -> "Elicitation.Elicitation":
         """
         Async get an elicitation request by ID in a company.
@@ -205,6 +222,7 @@ class Elicitation(APIResource["Elicitation"]):
                 f"/elicitation/{elicitation_id}",
                 user_id,
                 company_id,
+                client=client,
             ),
         )
 
@@ -213,6 +231,7 @@ class Elicitation(APIResource["Elicitation"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Elicitation.RespondParams"],
     ) -> "Elicitation.ElicitationResponseResult":
         """
@@ -226,6 +245,7 @@ class Elicitation(APIResource["Elicitation"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -234,6 +254,7 @@ class Elicitation(APIResource["Elicitation"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Elicitation.RespondParams"],
     ) -> "Elicitation.ElicitationResponseResult":
         """
@@ -247,5 +268,6 @@ class Elicitation(APIResource["Elicitation"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )

--- a/unique_sdk/unique_sdk/api_resources/_embedding.py
+++ b/unique_sdk/unique_sdk/api_resources/_embedding.py
@@ -1,10 +1,15 @@
-from typing import Literal, cast
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal, cast
 
 from typing_extensions import Unpack
 
 from unique_sdk._api_resource import APIResource
 from unique_sdk._request_options import RequestOptions
 from unique_sdk._util import classproperty
+
+if TYPE_CHECKING:
+    from unique_sdk._client import _BaseClient
 
 
 class Embeddings(APIResource["Embeddings"]):
@@ -19,7 +24,11 @@ class Embeddings(APIResource["Embeddings"]):
 
     @classmethod
     def create(
-        cls, user_id: str, company_id: str, **params: Unpack["Embeddings.CreateParams"]
+        cls,
+        user_id: str,
+        company_id: str,
+        client: "_BaseClient | None" = None,
+        **params: Unpack["Embeddings.CreateParams"],
     ) -> "Embeddings":
         return cast(
             "Embeddings",
@@ -29,6 +38,7 @@ class Embeddings(APIResource["Embeddings"]):
                 user_id,
                 company_id=company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -37,6 +47,7 @@ class Embeddings(APIResource["Embeddings"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Embeddings.CreateParams"],
     ) -> "Embeddings":
         return cast(
@@ -47,5 +58,6 @@ class Embeddings(APIResource["Embeddings"]):
                 user_id,
                 company_id=company_id,
                 params=params,
+                client=client,
             ),
         )

--- a/unique_sdk/unique_sdk/api_resources/_folder.py
+++ b/unique_sdk/unique_sdk/api_resources/_folder.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from typing import (
+    TYPE_CHECKING,
     Any,
     Literal,
     NotRequired,
@@ -10,6 +13,9 @@ from typing import (
 from unique_sdk._api_resource import APIResource
 from unique_sdk._request_options import RequestOptions
 from unique_sdk._util import classproperty
+
+if TYPE_CHECKING:
+    from unique_sdk._client import _BaseClient
 
 
 class Folder(APIResource["Folder"]):
@@ -208,6 +214,7 @@ class Folder(APIResource["Folder"]):
         user_id: str,
         company_id: str,
         scope_id: str,
+        client: "_BaseClient | None" = None,
     ) -> "Folder.FolderPathResponse":
         """
         Get the complete folder path for a given folder ID.
@@ -219,6 +226,7 @@ class Folder(APIResource["Folder"]):
                 f"/folder/{scope_id}/path",
                 user_id,
                 company_id,
+                client=client,
             ),
         )
 
@@ -228,6 +236,7 @@ class Folder(APIResource["Folder"]):
         user_id: str,
         company_id: str,
         scope_id: str,
+        client: "_BaseClient | None" = None,
     ) -> "Folder.FolderPathResponse":
         """
         Async get the complete folder path for a given folder ID.
@@ -239,12 +248,17 @@ class Folder(APIResource["Folder"]):
                 f"/folder/{scope_id}/path",
                 user_id,
                 company_id,
+                client=client,
             ),
         )
 
     @classmethod
     def get_info(
-        cls, user_id: str, company_id: str, **params: Unpack["Folder.GetParams"]
+        cls,
+        user_id: str,
+        company_id: str,
+        client: "_BaseClient | None" = None,
+        **params: Unpack["Folder.GetParams"],
     ) -> "Folder.FolderInfo":
         """
         Get a folder by its ID or path.
@@ -257,12 +271,17 @@ class Folder(APIResource["Folder"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
     @classmethod
     async def get_info_async(
-        cls, user_id: str, company_id: str, **params: Unpack["Folder.GetParams"]
+        cls,
+        user_id: str,
+        company_id: str,
+        client: "_BaseClient | None" = None,
+        **params: Unpack["Folder.GetParams"],
     ) -> "Folder.FolderInfo":
         """
         Async get a folder by its ID or path.
@@ -275,12 +294,17 @@ class Folder(APIResource["Folder"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
     @classmethod
     def get_infos(
-        cls, user_id: str, company_id: str, **params: Unpack["Folder.GetInfosParams"]
+        cls,
+        user_id: str,
+        company_id: str,
+        client: "_BaseClient | None" = None,
+        **params: Unpack["Folder.GetInfosParams"],
     ) -> "Folder.FolderInfos":
         """
         Get paginated folders based on parentId. If the parentId is not defined, the root folders will be returned.
@@ -303,12 +327,17 @@ class Folder(APIResource["Folder"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
     @classmethod
     async def get_infos_async(
-        cls, user_id: str, company_id: str, **params: Unpack["Folder.GetInfosParams"]
+        cls,
+        user_id: str,
+        company_id: str,
+        client: "_BaseClient | None" = None,
+        **params: Unpack["Folder.GetInfosParams"],
     ) -> "Folder.FolderInfos":
         """
         Async get paginated folders based on parentId. If the parentId is not defined, the root folders will be returned.
@@ -331,12 +360,17 @@ class Folder(APIResource["Folder"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
     @classmethod
     def create_paths(
-        cls, user_id: str, company_id: str, **params: Unpack["Folder.CreateParams"]
+        cls,
+        user_id: str,
+        company_id: str,
+        client: "_BaseClient | None" = None,
+        **params: Unpack["Folder.CreateParams"],
     ) -> "Folder.CreateFolderStructureResponse":
         return cast(
             "Folder.CreateFolderStructureResponse",
@@ -346,12 +380,17 @@ class Folder(APIResource["Folder"]):
                 user_id,
                 company_id=company_id,
                 params=params,
+                client=client,
             ),
         )
 
     @classmethod
     async def create_paths_async(
-        cls, user_id: str, company_id: str, **params: Unpack["Folder.CreateParams"]
+        cls,
+        user_id: str,
+        company_id: str,
+        client: "_BaseClient | None" = None,
+        **params: Unpack["Folder.CreateParams"],
     ) -> "Folder.CreateFolderStructureResponse":
         return cast(
             "Folder.CreateFolderStructureResponse",
@@ -361,6 +400,7 @@ class Folder(APIResource["Folder"]):
                 user_id,
                 company_id=company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -369,6 +409,7 @@ class Folder(APIResource["Folder"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Folder.UpdateIngestionConfigParams"],
     ) -> "Folder":
         """
@@ -382,6 +423,7 @@ class Folder(APIResource["Folder"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -390,6 +432,7 @@ class Folder(APIResource["Folder"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Folder.UpdateIngestionConfigParams"],
     ) -> "Folder":
         """
@@ -403,6 +446,7 @@ class Folder(APIResource["Folder"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -411,6 +455,7 @@ class Folder(APIResource["Folder"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Folder.AddAccessParams"],
     ) -> "Folder":
         """
@@ -424,6 +469,7 @@ class Folder(APIResource["Folder"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -432,6 +478,7 @@ class Folder(APIResource["Folder"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Folder.AddAccessParams"],
     ) -> "Folder":
         """
@@ -445,6 +492,7 @@ class Folder(APIResource["Folder"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -453,6 +501,7 @@ class Folder(APIResource["Folder"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Folder.RemoveAccessParams"],
     ) -> dict[str, Any]:
         """
@@ -466,6 +515,7 @@ class Folder(APIResource["Folder"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -474,6 +524,7 @@ class Folder(APIResource["Folder"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Folder.RemoveAccessParams"],
     ) -> "Folder":
         """
@@ -487,6 +538,7 @@ class Folder(APIResource["Folder"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -495,6 +547,7 @@ class Folder(APIResource["Folder"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Folder.UpdateParams"],
     ) -> "Folder.FolderInfo":
         """
@@ -526,6 +579,7 @@ class Folder(APIResource["Folder"]):
                 user_id,
                 company_id=company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -534,6 +588,7 @@ class Folder(APIResource["Folder"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Folder.UpdateParams"],
     ) -> "Folder.FolderInfo":
         """
@@ -565,6 +620,7 @@ class Folder(APIResource["Folder"]):
                 user_id,
                 company_id=company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -573,6 +629,7 @@ class Folder(APIResource["Folder"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Folder.MoveParams"],
     ) -> "Folder.MoveResult":
         folder_id = params.pop("folderId")
@@ -584,6 +641,7 @@ class Folder(APIResource["Folder"]):
                 user_id,
                 company_id=company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -592,6 +650,7 @@ class Folder(APIResource["Folder"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Folder.MoveParams"],
     ) -> "Folder.MoveResult":
         folder_id = params.pop("folderId")
@@ -603,6 +662,7 @@ class Folder(APIResource["Folder"]):
                 user_id,
                 company_id=company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -611,6 +671,7 @@ class Folder(APIResource["Folder"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Folder.DeleteFolderParams"],
     ) -> "Folder.DeleteResponse":
         """
@@ -631,6 +692,7 @@ class Folder(APIResource["Folder"]):
                 user_id,
                 company_id=company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -639,6 +701,7 @@ class Folder(APIResource["Folder"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Folder.DeleteFolderParams"],
     ) -> "Folder.DeleteResponse":
         """
@@ -658,6 +721,7 @@ class Folder(APIResource["Folder"]):
                 user_id,
                 company_id=company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -668,6 +732,7 @@ class Folder(APIResource["Folder"]):
         company_id: str,
         scope_id: str | None = None,
         folder_path: str | None = None,
+        client: "_BaseClient | None" = None,
     ) -> str | None:
         """
         Returns the scopeId to use: if scope_id is provided, returns it;
@@ -683,6 +748,7 @@ class Folder(APIResource["Folder"]):
             folder_info = cls.get_info(
                 user_id=user_id,
                 company_id=company_id,
+                client=client,
                 folderPath=folder_path,
             )
             resolved_id = folder_info.get("id")
@@ -701,6 +767,7 @@ class Folder(APIResource["Folder"]):
         scope_id: str | None = None,
         folder_path: str | None = None,
         create_if_not_exists: bool = True,
+        client: "_BaseClient | None" = None,
     ) -> str | None:
         if scope_id:
             return scope_id
@@ -709,6 +776,7 @@ class Folder(APIResource["Folder"]):
                 folder_info = cls.get_info(
                     user_id=user_id,
                     company_id=company_id,
+                    client=client,
                     folderPath=folder_path,
                 )
                 resolved_id = folder_info.get("id")
@@ -721,6 +789,7 @@ class Folder(APIResource["Folder"]):
                 result = cls.create_paths(
                     user_id=user_id,
                     company_id=company_id,
+                    client=client,
                     paths=[folder_path],
                 )
                 created_folders = result.get("createdFolders", [])
@@ -740,6 +809,7 @@ class Folder(APIResource["Folder"]):
         company_id: str,
         scope_id: str | None = None,
         folder_path: str | None = None,
+        client: "_BaseClient | None" = None,
     ) -> str | None:
         """
         Async version of resolve_scope_id_from_folder_path.
@@ -756,6 +826,7 @@ class Folder(APIResource["Folder"]):
             folder_info = await cls.get_info_async(
                 user_id=user_id,
                 company_id=company_id,
+                client=client,
                 folderPath=folder_path,
             )
             resolved_id = folder_info.get("id")
@@ -774,6 +845,7 @@ class Folder(APIResource["Folder"]):
         scope_id: str | None = None,
         folder_path: str | None = None,
         create_if_not_exists: bool = True,
+        client: "_BaseClient | None" = None,
     ) -> str | None:
         if scope_id:
             return scope_id
@@ -782,6 +854,7 @@ class Folder(APIResource["Folder"]):
                 folder_info = await cls.get_info_async(
                     user_id=user_id,
                     company_id=company_id,
+                    client=client,
                     folderPath=folder_path,
                 )
                 resolved_id = folder_info.get("id")
@@ -794,6 +867,7 @@ class Folder(APIResource["Folder"]):
                 result = await cls.create_paths_async(
                     user_id=user_id,
                     company_id=company_id,
+                    client=client,
                     paths=[folder_path],
                 )
                 created_folders = result.get("createdFolders", [])

--- a/unique_sdk/unique_sdk/api_resources/_group.py
+++ b/unique_sdk/unique_sdk/api_resources/_group.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from typing import (
+    TYPE_CHECKING,
     Any,
     Literal,
     NotRequired,
@@ -10,6 +13,9 @@ from typing import (
 from unique_sdk._api_resource import APIResource
 from unique_sdk._request_options import RequestOptions
 from unique_sdk._util import classproperty
+
+if TYPE_CHECKING:
+    from unique_sdk._client import _BaseClient
 
 
 class Group(APIResource["Group"]):
@@ -132,6 +138,7 @@ class Group(APIResource["Group"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Group.CreateParams"],
     ) -> "Group.Group":
         """
@@ -145,6 +152,7 @@ class Group(APIResource["Group"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -153,6 +161,7 @@ class Group(APIResource["Group"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Group.CreateParams"],
     ) -> "Group.Group":
         """
@@ -166,6 +175,7 @@ class Group(APIResource["Group"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -174,6 +184,7 @@ class Group(APIResource["Group"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Group.GetParams"],
     ) -> "Group.Groups":
         """
@@ -187,6 +198,7 @@ class Group(APIResource["Group"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -195,6 +207,7 @@ class Group(APIResource["Group"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Group.GetParams"],
     ) -> "Group.Groups":
         """
@@ -208,6 +221,7 @@ class Group(APIResource["Group"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -217,6 +231,7 @@ class Group(APIResource["Group"]):
         user_id: str,
         company_id: str,
         group_id: str,
+        client: "_BaseClient | None" = None,
     ) -> "Group.DeleteResponse":
         """
         Delete a group in a company.
@@ -228,6 +243,7 @@ class Group(APIResource["Group"]):
                 f"/groups/{group_id}",
                 user_id,
                 company_id,
+                client=client,
             ),
         )
 
@@ -237,6 +253,7 @@ class Group(APIResource["Group"]):
         user_id: str,
         company_id: str,
         group_id: str,
+        client: "_BaseClient | None" = None,
     ) -> "Group.DeleteResponse":
         """
         Async delete a group in a company.
@@ -248,6 +265,7 @@ class Group(APIResource["Group"]):
                 f"/groups/{group_id}",
                 user_id,
                 company_id,
+                client=client,
             ),
         )
 
@@ -257,6 +275,7 @@ class Group(APIResource["Group"]):
         user_id: str,
         company_id: str,
         group_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Group.UpdateParams"],
     ) -> "Group.Group":
         """
@@ -270,6 +289,7 @@ class Group(APIResource["Group"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -279,6 +299,7 @@ class Group(APIResource["Group"]):
         user_id: str,
         company_id: str,
         group_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Group.UpdateParams"],
     ) -> "Group.Group":
         """
@@ -292,6 +313,7 @@ class Group(APIResource["Group"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -301,6 +323,7 @@ class Group(APIResource["Group"]):
         user_id: str,
         company_id: str,
         group_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Group.AddUsersParams"],
     ) -> "Group.AddUsersToGroupResponse":
         """
@@ -314,6 +337,7 @@ class Group(APIResource["Group"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -323,6 +347,7 @@ class Group(APIResource["Group"]):
         user_id: str,
         company_id: str,
         group_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Group.AddUsersParams"],
     ) -> "Group.AddUsersToGroupResponse":
         """
@@ -336,6 +361,7 @@ class Group(APIResource["Group"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -345,6 +371,7 @@ class Group(APIResource["Group"]):
         user_id: str,
         company_id: str,
         group_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Group.RemoveUsersParams"],
     ) -> "Group.RemoveUsersFromGroupResponse":
         """
@@ -358,6 +385,7 @@ class Group(APIResource["Group"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -367,6 +395,7 @@ class Group(APIResource["Group"]):
         user_id: str,
         company_id: str,
         group_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Group.RemoveUsersParams"],
     ) -> "Group.RemoveUsersFromGroupResponse":
         """
@@ -380,6 +409,7 @@ class Group(APIResource["Group"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -389,6 +419,7 @@ class Group(APIResource["Group"]):
         user_id: str,
         company_id: str,
         group_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Group.UpdateGroupConfigurationParams"],
     ) -> "Group.GroupWithConfiguration":
         """
@@ -402,6 +433,7 @@ class Group(APIResource["Group"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -411,6 +443,7 @@ class Group(APIResource["Group"]):
         user_id: str,
         company_id: str,
         group_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Group.UpdateGroupConfigurationParams"],
     ) -> "Group.GroupWithConfiguration":
         """
@@ -424,5 +457,6 @@ class Group(APIResource["Group"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )

--- a/unique_sdk/unique_sdk/api_resources/_integrated.py
+++ b/unique_sdk/unique_sdk/api_resources/_integrated.py
@@ -24,6 +24,8 @@ if TYPE_CHECKING:
         Reasoning,
     )
 
+    from unique_sdk._client import _BaseClient
+
 from unique_sdk._api_resource import APIResource
 from unique_sdk._request_options import RequestOptions
 from unique_sdk._util import classproperty
@@ -113,6 +115,7 @@ class Integrated(APIResource["Integrated"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Integrated.CreateStream"],
     ) -> "Integrated.StreamCompletionResult":
         """
@@ -129,6 +132,7 @@ class Integrated(APIResource["Integrated"]):
                 user_id,
                 company_id,
                 params,
+                client=client,
             ),
         )
 
@@ -137,6 +141,7 @@ class Integrated(APIResource["Integrated"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Integrated.CreateStream"],
     ) -> "Integrated.StreamCompletionResult":
         """
@@ -153,6 +158,7 @@ class Integrated(APIResource["Integrated"]):
                 user_id,
                 company_id,
                 params,
+                client=client,
             ),
         )
 
@@ -161,6 +167,7 @@ class Integrated(APIResource["Integrated"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Integrated.CreateStreamResponsesParams"],
     ) -> "Integrated.ResponsesStreamResult":
         """
@@ -176,6 +183,7 @@ class Integrated(APIResource["Integrated"]):
                 user_id,
                 company_id,
                 params,
+                client=client,
             ),
         )
 
@@ -184,6 +192,7 @@ class Integrated(APIResource["Integrated"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Integrated.CreateStreamResponsesParams"],
     ) -> "Integrated.ResponsesStreamResult":
         """
@@ -199,5 +208,6 @@ class Integrated(APIResource["Integrated"]):
                 user_id,
                 company_id,
                 params,
+                client=client,
             ),
         )

--- a/unique_sdk/unique_sdk/api_resources/_llm_models.py
+++ b/unique_sdk/unique_sdk/api_resources/_llm_models.py
@@ -1,8 +1,13 @@
-from typing import Literal, NotRequired, TypedDict, Unpack, cast
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal, NotRequired, TypedDict, Unpack, cast
 
 from unique_sdk._api_resource import APIResource
 from unique_sdk._request_options import RequestOptions
 from unique_sdk._util import classproperty
+
+if TYPE_CHECKING:
+    from unique_sdk._client import _BaseClient
 
 
 class LLMModels(APIResource["LLMModels"]):
@@ -29,6 +34,7 @@ class LLMModels(APIResource["LLMModels"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["LLMModels.GetParams"],
     ) -> "LLMModels.LLMModelsResponse":
         """
@@ -42,6 +48,7 @@ class LLMModels(APIResource["LLMModels"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -50,6 +57,7 @@ class LLMModels(APIResource["LLMModels"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["LLMModels.GetParams"],
     ) -> "LLMModels.LLMModelsResponse":
         """
@@ -63,5 +71,6 @@ class LLMModels(APIResource["LLMModels"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )

--- a/unique_sdk/unique_sdk/api_resources/_mcp.py
+++ b/unique_sdk/unique_sdk/api_resources/_mcp.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from typing import (
+    TYPE_CHECKING,
     Any,
     Literal,
     TypedDict,
@@ -11,6 +14,9 @@ from typing_extensions import NotRequired
 from unique_sdk._api_resource import APIResource
 from unique_sdk._request_options import RequestOptions
 from unique_sdk._util import classproperty
+
+if TYPE_CHECKING:
+    from unique_sdk._client import _BaseClient
 
 
 class CallToolTextResourceDto(TypedDict):
@@ -76,6 +82,7 @@ class MCP(APIResource["MCP"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["MCP.CallToolParams"],
     ) -> "MCP":
         """
@@ -97,6 +104,7 @@ class MCP(APIResource["MCP"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -105,6 +113,7 @@ class MCP(APIResource["MCP"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["MCP.CallToolParams"],
     ) -> "MCP":
         """
@@ -126,5 +135,6 @@ class MCP(APIResource["MCP"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )

--- a/unique_sdk/unique_sdk/api_resources/_message.py
+++ b/unique_sdk/unique_sdk/api_resources/_message.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 from datetime import datetime
 from typing import (
+    TYPE_CHECKING,
     Any,
     Literal,
     NotRequired,
@@ -8,6 +11,9 @@ from typing import (
     cast,
     overload,
 )
+
+if TYPE_CHECKING:
+    from unique_sdk._client import _BaseClient
 from urllib.parse import quote_plus
 
 from unique_sdk._api_resource import APIResource
@@ -90,6 +96,7 @@ class Message(APIResource["Message"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Message.ListParams"],
     ) -> ListObject["Message"]:
         """
@@ -101,6 +108,7 @@ class Message(APIResource["Message"]):
             user_id,
             company_id,
             params=params,
+            client=client,
         )
 
         if not isinstance(result, ListObject):
@@ -115,6 +123,7 @@ class Message(APIResource["Message"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Message.ListParams"],
     ) -> ListObject["Message"]:
         """
@@ -126,6 +135,7 @@ class Message(APIResource["Message"]):
             user_id,
             company_id,
             params=params,
+            client=client,
         )
 
         if not isinstance(result, ListObject):
@@ -141,6 +151,7 @@ class Message(APIResource["Message"]):
         user_id: str,
         company_id: str,
         id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Message.RetrieveParams"],
     ) -> "Message":
         """
@@ -156,6 +167,7 @@ class Message(APIResource["Message"]):
         user_id: str,
         company_id: str,
         id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Message.RetrieveParams"],
     ) -> "Message":
         """
@@ -170,6 +182,7 @@ class Message(APIResource["Message"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Message.CreateParams"],
     ) -> "Message":
         """
@@ -189,6 +202,7 @@ class Message(APIResource["Message"]):
                 user_id,
                 company_id,
                 params,
+                client=client,
             ),
         )
 
@@ -197,6 +211,7 @@ class Message(APIResource["Message"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Message.CreateParams"],
     ) -> "Message":
         """
@@ -216,6 +231,7 @@ class Message(APIResource["Message"]):
                 user_id,
                 company_id,
                 params,
+                client=client,
             ),
         )
 
@@ -225,6 +241,7 @@ class Message(APIResource["Message"]):
         user_id: str,
         company_id: str,
         id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Message.ModifyParams"],
     ) -> "Message":
         """
@@ -245,6 +262,7 @@ class Message(APIResource["Message"]):
                 user_id,
                 company_id,
                 params,
+                client=client,
             ),
         )
 
@@ -254,6 +272,7 @@ class Message(APIResource["Message"]):
         user_id: str,
         company_id: str,
         id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Message.ModifyParams"],
     ) -> "Message":
         """
@@ -274,6 +293,7 @@ class Message(APIResource["Message"]):
                 user_id,
                 company_id,
                 params,
+                client=client,
             ),
         )
 
@@ -353,6 +373,7 @@ class Message(APIResource["Message"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Message.CreateEventParams"],
     ) -> "Message":
         """
@@ -374,6 +395,7 @@ class Message(APIResource["Message"]):
                 user_id,
                 company_id,
                 params,
+                client=client,
             ),
         )
 
@@ -382,6 +404,7 @@ class Message(APIResource["Message"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Message.CreateEventParams"],
     ) -> "Message":
         """
@@ -403,5 +426,6 @@ class Message(APIResource["Message"]):
                 user_id,
                 company_id,
                 params,
+                client=client,
             ),
         )

--- a/unique_sdk/unique_sdk/api_resources/_message_assessment.py
+++ b/unique_sdk/unique_sdk/api_resources/_message_assessment.py
@@ -1,8 +1,13 @@
-from typing import Literal, Unpack
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal, Unpack
 
 from unique_sdk._api_resource import APIResource
 from unique_sdk._request_options import RequestOptions
 from unique_sdk._util import classproperty
+
+if TYPE_CHECKING:
+    from unique_sdk._client import _BaseClient
 
 
 class MessageAssessment(APIResource["MessageAssessment"]):
@@ -34,10 +39,11 @@ class MessageAssessment(APIResource["MessageAssessment"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["MessageAssessment.CreateParams"],
     ) -> "MessageAssessment":
         return cls._static_request(
-            "post", cls.RESOURCE_URL, user_id, company_id, params=params
+            "post", cls.RESOURCE_URL, user_id, company_id, params=params, client=client
         )
 
     @classmethod
@@ -45,10 +51,11 @@ class MessageAssessment(APIResource["MessageAssessment"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["MessageAssessment.CreateParams"],
     ) -> "MessageAssessment":
         return await cls._static_request_async(
-            "post", cls.RESOURCE_URL, user_id, company_id, params=params
+            "post", cls.RESOURCE_URL, user_id, company_id, params=params, client=client
         )
 
     @classmethod
@@ -56,19 +63,23 @@ class MessageAssessment(APIResource["MessageAssessment"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["MessageAssessment.ModifyParams"],
     ) -> "MessageAssessment":
         url = f"{cls.RESOURCE_URL}/{params['messageId']}"
-        return cls._static_request("patch", url, user_id, company_id, params=params)
+        return cls._static_request(
+            "patch", url, user_id, company_id, params=params, client=client
+        )
 
     @classmethod
     async def modify_async(
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["MessageAssessment.ModifyParams"],
     ) -> "MessageAssessment":
         url = f"{cls.RESOURCE_URL}/{params['messageId']}"
         return await cls._static_request_async(
-            "patch", url, user_id, company_id, params=params
+            "patch", url, user_id, company_id, params=params, client=client
         )

--- a/unique_sdk/unique_sdk/api_resources/_message_execution.py
+++ b/unique_sdk/unique_sdk/api_resources/_message_execution.py
@@ -1,8 +1,13 @@
-from typing import Any, Literal, NotRequired, Unpack, cast
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Literal, NotRequired, Unpack, cast
 
 from unique_sdk._api_resource import APIResource
 from unique_sdk._request_options import RequestOptions
 from unique_sdk._util import classproperty
+
+if TYPE_CHECKING:
+    from unique_sdk._client import _BaseClient
 
 
 class MessageExecution(APIResource["MessageExecution"]):
@@ -64,6 +69,7 @@ class MessageExecution(APIResource["MessageExecution"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["MessageExecution.CreateMessageExecutionParams"],
     ) -> "MessageExecution":
         """
@@ -77,6 +83,7 @@ class MessageExecution(APIResource["MessageExecution"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -85,6 +92,7 @@ class MessageExecution(APIResource["MessageExecution"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["MessageExecution.CreateMessageExecutionParams"],
     ) -> "MessageExecution":
         """
@@ -98,6 +106,7 @@ class MessageExecution(APIResource["MessageExecution"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -106,6 +115,7 @@ class MessageExecution(APIResource["MessageExecution"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["MessageExecution.GetMessageExecutionParams"],
     ) -> "MessageExecution":
         """
@@ -114,7 +124,12 @@ class MessageExecution(APIResource["MessageExecution"]):
         return cast(
             "MessageExecution",
             cls._static_request(
-                "get", cls.RESOURCE_URL, user_id, company_id, params=params
+                "get",
+                cls.RESOURCE_URL,
+                user_id,
+                company_id,
+                params=params,
+                client=client,
             ),
         )
 
@@ -123,6 +138,7 @@ class MessageExecution(APIResource["MessageExecution"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["MessageExecution.GetMessageExecutionParams"],
     ) -> "MessageExecution":
         """
@@ -131,7 +147,12 @@ class MessageExecution(APIResource["MessageExecution"]):
         return cast(
             "MessageExecution",
             await cls._static_request_async(
-                "get", cls.RESOURCE_URL, user_id, company_id, params=params
+                "get",
+                cls.RESOURCE_URL,
+                user_id,
+                company_id,
+                params=params,
+                client=client,
             ),
         )
 
@@ -140,6 +161,7 @@ class MessageExecution(APIResource["MessageExecution"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["MessageExecution.UpdateMessageExecutionParams"],
     ) -> "MessageExecution":
         """
@@ -153,6 +175,7 @@ class MessageExecution(APIResource["MessageExecution"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -161,6 +184,7 @@ class MessageExecution(APIResource["MessageExecution"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["MessageExecution.UpdateMessageExecutionParams"],
     ) -> "MessageExecution":
         """
@@ -174,5 +198,6 @@ class MessageExecution(APIResource["MessageExecution"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )

--- a/unique_sdk/unique_sdk/api_resources/_message_log.py
+++ b/unique_sdk/unique_sdk/api_resources/_message_log.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from typing import (
+    TYPE_CHECKING,
     Any,
     Literal,
     NotRequired,
@@ -10,6 +13,9 @@ from typing import (
 from unique_sdk._api_resource import APIResource
 from unique_sdk._request_options import RequestOptions
 from unique_sdk._util import classproperty
+
+if TYPE_CHECKING:
+    from unique_sdk._client import _BaseClient
 
 
 class MessageLog(APIResource["MessageLog"]):
@@ -70,6 +76,7 @@ class MessageLog(APIResource["MessageLog"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["MessageLog.CreateMessageLogParams"],
     ) -> "MessageLog":
         """
@@ -89,6 +96,7 @@ class MessageLog(APIResource["MessageLog"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -97,6 +105,7 @@ class MessageLog(APIResource["MessageLog"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["MessageLog.CreateMessageLogParams"],
     ) -> "MessageLog":
         """
@@ -116,6 +125,7 @@ class MessageLog(APIResource["MessageLog"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -125,6 +135,7 @@ class MessageLog(APIResource["MessageLog"]):
         user_id: str,
         company_id: str,
         message_log_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["MessageLog.UpdateMessageLogParams"],
     ) -> "MessageLog":
         """
@@ -144,6 +155,7 @@ class MessageLog(APIResource["MessageLog"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -153,6 +165,7 @@ class MessageLog(APIResource["MessageLog"]):
         user_id: str,
         company_id: str,
         message_log_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["MessageLog.UpdateMessageLogParams"],
     ) -> "MessageLog":
         """
@@ -172,5 +185,6 @@ class MessageLog(APIResource["MessageLog"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )

--- a/unique_sdk/unique_sdk/api_resources/_message_tool.py
+++ b/unique_sdk/unique_sdk/api_resources/_message_tool.py
@@ -1,13 +1,19 @@
 """MessageTool persistence API. Backend stores tool data in a single table (MessageTool) with type + jsonb payload."""
 
+from __future__ import annotations
+
 import asyncio
 from typing import (
+    TYPE_CHECKING,
     Any,
     Literal,
     NotRequired,
     TypedDict,
     Unpack,
 )
+
+if TYPE_CHECKING:
+    from unique_sdk._client import _BaseClient
 
 from unique_sdk._api_resource import APIResource
 from unique_sdk._list_object import ListObject
@@ -109,6 +115,7 @@ class MessageTool(APIResource["MessageTool"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["MessageTool.CreateParams"],
     ) -> ListObject["MessageTool"]:
         return cls._validate_list_response(
@@ -118,6 +125,7 @@ class MessageTool(APIResource["MessageTool"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             )
         )
 
@@ -126,6 +134,7 @@ class MessageTool(APIResource["MessageTool"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["MessageTool.CreateParams"],
     ) -> ListObject["MessageTool"]:
         return cls._validate_list_response(
@@ -135,6 +144,7 @@ class MessageTool(APIResource["MessageTool"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             )
         )
 
@@ -143,6 +153,7 @@ class MessageTool(APIResource["MessageTool"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["MessageTool.GetMessageToolsParams"],
     ) -> ListObject["MessageTool"]:
         message_ids_str = params.get("messageIds") or ""
@@ -157,6 +168,7 @@ class MessageTool(APIResource["MessageTool"]):
                     user_id,
                     company_id,
                     params={**params, "messageIds": chunk},
+                    client=client,
                 )
             )
             for chunk in chunks
@@ -176,6 +188,7 @@ class MessageTool(APIResource["MessageTool"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["MessageTool.GetMessageToolsParams"],
     ) -> ListObject["MessageTool"]:
         message_ids_str = params.get("messageIds") or ""
@@ -190,6 +203,7 @@ class MessageTool(APIResource["MessageTool"]):
                     user_id,
                     company_id,
                     params={**params, "messageIds": chunks[0]},
+                    client=client,
                 )
             )
         results = await asyncio.gather(
@@ -200,6 +214,7 @@ class MessageTool(APIResource["MessageTool"]):
                     user_id,
                     company_id,
                     params={**params, "messageIds": chunk},
+                    client=client,
                 )
                 for chunk in chunks
             )

--- a/unique_sdk/unique_sdk/api_resources/_module.py
+++ b/unique_sdk/unique_sdk/api_resources/_module.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import builtins
-from typing import Any, Literal, NotRequired, TypedDict, Unpack, cast
+from typing import TYPE_CHECKING, Any, Literal, NotRequired, TypedDict, Unpack, cast
 from urllib.parse import quote_plus
+
+if TYPE_CHECKING:
+    from unique_sdk._client import _BaseClient
 
 from unique_sdk._api_resource import APIResource
 from unique_sdk._request_options import RequestOptions
@@ -74,6 +77,7 @@ class Module(APIResource["Module"]):
         *,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Module.ListParams"],
     ) -> builtins.list["Module"]:
         result = cls._static_request(
@@ -82,6 +86,7 @@ class Module(APIResource["Module"]):
             user_id,
             company_id,
             params or None,
+            client=client,
         )
         if isinstance(result, builtins.list):
             data = result
@@ -95,6 +100,7 @@ class Module(APIResource["Module"]):
         *,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Module.ListParams"],
     ) -> builtins.list["Module"]:
         result = await cls._static_request_async(
@@ -103,6 +109,7 @@ class Module(APIResource["Module"]):
             user_id,
             company_id,
             params or None,
+            client=client,
         )
         if isinstance(result, builtins.list):
             data = result
@@ -117,11 +124,12 @@ class Module(APIResource["Module"]):
         user_id: str,
         company_id: str,
         id: str,
+        client: "_BaseClient | None" = None,
     ) -> "Module":
         url = "%s/%s" % (cls.RESOURCE_URL, quote_plus(id))
         return cast(
             "Module",
-            cls._static_request("get", url, user_id, company_id),
+            cls._static_request("get", url, user_id, company_id, client=client),
         )
 
     @classmethod
@@ -131,11 +139,14 @@ class Module(APIResource["Module"]):
         user_id: str,
         company_id: str,
         id: str,
+        client: "_BaseClient | None" = None,
     ) -> "Module":
         url = "%s/%s" % (cls.RESOURCE_URL, quote_plus(id))
         return cast(
             "Module",
-            await cls._static_request_async("get", url, user_id, company_id),
+            await cls._static_request_async(
+                "get", url, user_id, company_id, client=client
+            ),
         )
 
     @classmethod
@@ -144,6 +155,7 @@ class Module(APIResource["Module"]):
         *,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Module.CreateParams"],
     ) -> "Module":
         return cast(
@@ -154,6 +166,7 @@ class Module(APIResource["Module"]):
                 user_id,
                 company_id,
                 params,
+                client=client,
             ),
         )
 
@@ -163,6 +176,7 @@ class Module(APIResource["Module"]):
         *,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Module.CreateParams"],
     ) -> "Module":
         return cast(
@@ -173,6 +187,7 @@ class Module(APIResource["Module"]):
                 user_id,
                 company_id,
                 params,
+                client=client,
             ),
         )
 
@@ -183,12 +198,15 @@ class Module(APIResource["Module"]):
         user_id: str,
         company_id: str,
         id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Module.ModifyParams"],
     ) -> "Module":
         url = "%s/%s" % (cls.RESOURCE_URL, quote_plus(id))
         return cast(
             "Module",
-            cls._static_request("patch", url, user_id, company_id, params),
+            cls._static_request(
+                "patch", url, user_id, company_id, params, client=client
+            ),
         )
 
     @classmethod
@@ -198,12 +216,15 @@ class Module(APIResource["Module"]):
         user_id: str,
         company_id: str,
         id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Module.ModifyParams"],
     ) -> "Module":
         url = "%s/%s" % (cls.RESOURCE_URL, quote_plus(id))
         return cast(
             "Module",
-            await cls._static_request_async("patch", url, user_id, company_id, params),
+            await cls._static_request_async(
+                "patch", url, user_id, company_id, params, client=client
+            ),
         )
 
     @classmethod
@@ -213,11 +234,12 @@ class Module(APIResource["Module"]):
         user_id: str,
         company_id: str,
         id: str,
+        client: "_BaseClient | None" = None,
     ) -> "Module.DeletedObject":
         url = "%s/%s" % (cls.RESOURCE_URL, quote_plus(id))
         return cast(
             "Module.DeletedObject",
-            cls._static_request("delete", url, user_id, company_id),
+            cls._static_request("delete", url, user_id, company_id, client=client),
         )
 
     @classmethod
@@ -227,9 +249,12 @@ class Module(APIResource["Module"]):
         user_id: str,
         company_id: str,
         id: str,
+        client: "_BaseClient | None" = None,
     ) -> "Module.DeletedObject":
         url = "%s/%s" % (cls.RESOURCE_URL, quote_plus(id))
         return cast(
             "Module.DeletedObject",
-            await cls._static_request_async("delete", url, user_id, company_id),
+            await cls._static_request_async(
+                "delete", url, user_id, company_id, client=client
+            ),
         )

--- a/unique_sdk/unique_sdk/api_resources/_scheduled_task.py
+++ b/unique_sdk/unique_sdk/api_resources/_scheduled_task.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import builtins
-from typing import Literal, NotRequired, TypedDict, Unpack, cast
+from typing import TYPE_CHECKING, Literal, NotRequired, TypedDict, Unpack, cast
 from urllib.parse import quote_plus
+
+if TYPE_CHECKING:
+    from unique_sdk._client import _BaseClient
 
 from unique_sdk._api_resource import APIResource
 from unique_sdk._request_options import RequestOptions
@@ -68,6 +71,7 @@ class ScheduledTask(APIResource["ScheduledTask"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["ScheduledTask.CreateParams"],
     ) -> "ScheduledTask":
         return cast(
@@ -78,6 +82,7 @@ class ScheduledTask(APIResource["ScheduledTask"]):
                 user_id,
                 company_id,
                 params,
+                client=client,
             ),
         )
 
@@ -86,12 +91,14 @@ class ScheduledTask(APIResource["ScheduledTask"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
     ) -> builtins.list[ScheduledTask]:
         result = cls._static_request(
             "get",
             cls.RESOURCE_URL,
             user_id,
             company_id,
+            client=client,
         )
         if isinstance(result, builtins.list):
             data = result
@@ -105,6 +112,7 @@ class ScheduledTask(APIResource["ScheduledTask"]):
         user_id: str,
         company_id: str,
         id: str,
+        client: "_BaseClient | None" = None,
     ) -> "ScheduledTask":
         url = "%s/%s" % (cls.RESOURCE_URL, quote_plus(id))
         return cast(
@@ -114,6 +122,7 @@ class ScheduledTask(APIResource["ScheduledTask"]):
                 url,
                 user_id,
                 company_id,
+                client=client,
             ),
         )
 
@@ -123,6 +132,7 @@ class ScheduledTask(APIResource["ScheduledTask"]):
         user_id: str,
         company_id: str,
         id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["ScheduledTask.ModifyParams"],
     ) -> "ScheduledTask":
         url = "%s/%s" % (cls.RESOURCE_URL, quote_plus(id))
@@ -134,6 +144,7 @@ class ScheduledTask(APIResource["ScheduledTask"]):
                 user_id,
                 company_id,
                 params,
+                client=client,
             ),
         )
 
@@ -143,6 +154,7 @@ class ScheduledTask(APIResource["ScheduledTask"]):
         user_id: str,
         company_id: str,
         id: str,
+        client: "_BaseClient | None" = None,
     ) -> "ScheduledTask.DeletedObject":
         url = "%s/%s" % (cls.RESOURCE_URL, quote_plus(id))
         return cast(
@@ -152,6 +164,7 @@ class ScheduledTask(APIResource["ScheduledTask"]):
                 url,
                 user_id,
                 company_id,
+                client=client,
             ),
         )
 
@@ -162,6 +175,7 @@ class ScheduledTask(APIResource["ScheduledTask"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["ScheduledTask.CreateParams"],
     ) -> "ScheduledTask":
         return cast(
@@ -172,6 +186,7 @@ class ScheduledTask(APIResource["ScheduledTask"]):
                 user_id,
                 company_id,
                 params,
+                client=client,
             ),
         )
 
@@ -180,12 +195,14 @@ class ScheduledTask(APIResource["ScheduledTask"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
     ) -> builtins.list[ScheduledTask]:
         result = await cls._static_request_async(
             "get",
             cls.RESOURCE_URL,
             user_id,
             company_id,
+            client=client,
         )
         if isinstance(result, builtins.list):
             data = result
@@ -199,6 +216,7 @@ class ScheduledTask(APIResource["ScheduledTask"]):
         user_id: str,
         company_id: str,
         id: str,
+        client: "_BaseClient | None" = None,
     ) -> "ScheduledTask":
         url = "%s/%s" % (cls.RESOURCE_URL, quote_plus(id))
         return cast(
@@ -208,6 +226,7 @@ class ScheduledTask(APIResource["ScheduledTask"]):
                 url,
                 user_id,
                 company_id,
+                client=client,
             ),
         )
 
@@ -217,6 +236,7 @@ class ScheduledTask(APIResource["ScheduledTask"]):
         user_id: str,
         company_id: str,
         id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["ScheduledTask.ModifyParams"],
     ) -> "ScheduledTask":
         url = "%s/%s" % (cls.RESOURCE_URL, quote_plus(id))
@@ -228,6 +248,7 @@ class ScheduledTask(APIResource["ScheduledTask"]):
                 user_id,
                 company_id,
                 params,
+                client=client,
             ),
         )
 
@@ -237,6 +258,7 @@ class ScheduledTask(APIResource["ScheduledTask"]):
         user_id: str,
         company_id: str,
         id: str,
+        client: "_BaseClient | None" = None,
     ) -> "ScheduledTask.DeletedObject":
         url = "%s/%s" % (cls.RESOURCE_URL, quote_plus(id))
         return cast(
@@ -246,5 +268,6 @@ class ScheduledTask(APIResource["ScheduledTask"]):
                 url,
                 user_id,
                 company_id,
+                client=client,
             ),
         )

--- a/unique_sdk/unique_sdk/api_resources/_search.py
+++ b/unique_sdk/unique_sdk/api_resources/_search.py
@@ -1,8 +1,13 @@
-from typing import Any, Literal, NotRequired, TypedDict, Unpack, cast
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Literal, NotRequired, TypedDict, Unpack, cast
 
 from unique_sdk._api_resource import APIResource
 from unique_sdk._request_options import RequestOptions
 from unique_sdk._util import classproperty
+
+if TYPE_CHECKING:
+    from unique_sdk._client import _BaseClient
 
 
 class Search(APIResource["Search"]):
@@ -51,7 +56,11 @@ class Search(APIResource["Search"]):
 
     @classmethod
     def create(
-        cls, user_id: str, company_id: str, **params: Unpack["Search.CreateParams"]
+        cls,
+        user_id: str,
+        company_id: str,
+        client: "_BaseClient | None" = None,
+        **params: Unpack["Search.CreateParams"],
     ) -> list["Search"]:
         return cast(
             list["Search"],
@@ -61,12 +70,17 @@ class Search(APIResource["Search"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
     @classmethod
     async def create_async(
-        cls, user_id: str, company_id: str, **params: Unpack["Search.CreateParams"]
+        cls,
+        user_id: str,
+        company_id: str,
+        client: "_BaseClient | None" = None,
+        **params: Unpack["Search.CreateParams"],
     ) -> list["Search"]:
         return cast(
             list["Search"],
@@ -76,5 +90,6 @@ class Search(APIResource["Search"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )

--- a/unique_sdk/unique_sdk/api_resources/_search_string.py
+++ b/unique_sdk/unique_sdk/api_resources/_search_string.py
@@ -1,10 +1,15 @@
-from typing import Literal, TypedDict, cast
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal, TypedDict, cast
 
 from typing_extensions import NotRequired, Unpack
 
 from unique_sdk._api_resource import APIResource
 from unique_sdk._request_options import RequestOptions
 from unique_sdk._util import classproperty
+
+if TYPE_CHECKING:
+    from unique_sdk._client import _BaseClient
 
 
 class HistoryMessage(TypedDict):
@@ -31,7 +36,11 @@ class SearchString(APIResource["SearchString"]):
 
     @classmethod
     def create(
-        cls, user_id, company_id, **params: Unpack["SearchString.CreateParams"]
+        cls,
+        user_id,
+        company_id,
+        client: "_BaseClient | None" = None,
+        **params: Unpack["SearchString.CreateParams"],
     ) -> "SearchString":
         return cast(
             "SearchString",
@@ -41,12 +50,17 @@ class SearchString(APIResource["SearchString"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
     @classmethod
     async def create_async(
-        cls, user_id, company_id, **params: Unpack["SearchString.CreateParams"]
+        cls,
+        user_id,
+        company_id,
+        client: "_BaseClient | None" = None,
+        **params: Unpack["SearchString.CreateParams"],
     ) -> "SearchString":
         return cast(
             "SearchString",
@@ -56,5 +70,6 @@ class SearchString(APIResource["SearchString"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )

--- a/unique_sdk/unique_sdk/api_resources/_short_term_memory.py
+++ b/unique_sdk/unique_sdk/api_resources/_short_term_memory.py
@@ -1,10 +1,15 @@
-from typing import Literal, cast
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal, cast
 
 from typing_extensions import NotRequired, Unpack
 
 from unique_sdk._api_resource import APIResource
 from unique_sdk._request_options import RequestOptions
 from unique_sdk._util import classproperty
+
+if TYPE_CHECKING:
+    from unique_sdk._client import _BaseClient
 
 
 class ShortTermMemory(APIResource["ShortTermMemory"]):
@@ -34,6 +39,7 @@ class ShortTermMemory(APIResource["ShortTermMemory"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["ShortTermMemory.CreateParams"],
     ) -> "ShortTermMemory":
         """
@@ -47,6 +53,7 @@ class ShortTermMemory(APIResource["ShortTermMemory"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -55,6 +62,7 @@ class ShortTermMemory(APIResource["ShortTermMemory"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["ShortTermMemory.CreateParams"],
     ) -> "ShortTermMemory":
         """
@@ -68,6 +76,7 @@ class ShortTermMemory(APIResource["ShortTermMemory"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -76,6 +85,7 @@ class ShortTermMemory(APIResource["ShortTermMemory"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["ShortTermMemory.FindParams"],
     ) -> "ShortTermMemory":
         """
@@ -89,6 +99,7 @@ class ShortTermMemory(APIResource["ShortTermMemory"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -97,6 +108,7 @@ class ShortTermMemory(APIResource["ShortTermMemory"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["ShortTermMemory.FindParams"],
     ) -> "ShortTermMemory":
         """
@@ -110,5 +122,6 @@ class ShortTermMemory(APIResource["ShortTermMemory"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )

--- a/unique_sdk/unique_sdk/api_resources/_space.py
+++ b/unique_sdk/unique_sdk/api_resources/_space.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from typing import (
+    TYPE_CHECKING,
     Any,
     Literal,
     NotRequired,
@@ -11,6 +14,9 @@ from typing import (
 from unique_sdk._api_resource import APIResource
 from unique_sdk._request_options import RequestOptions
 from unique_sdk._util import classproperty
+
+if TYPE_CHECKING:
+    from unique_sdk._client import _BaseClient
 
 
 class Space(APIResource["Space"]):
@@ -330,6 +336,7 @@ class Space(APIResource["Space"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Space.CreateMessageParams"],
     ) -> "Space.Message":
         """
@@ -345,6 +352,7 @@ class Space(APIResource["Space"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -353,6 +361,7 @@ class Space(APIResource["Space"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Space.CreateMessageParams"],
     ) -> "Space.Message":
         """
@@ -368,6 +377,7 @@ class Space(APIResource["Space"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -376,6 +386,7 @@ class Space(APIResource["Space"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Space.CreateChatParams"],
     ) -> "Space.ChatResult":
         return cast(
@@ -386,6 +397,7 @@ class Space(APIResource["Space"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -394,6 +406,7 @@ class Space(APIResource["Space"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Space.CreateChatParams"],
     ) -> "Space.ChatResult":
         return cast(
@@ -404,6 +417,7 @@ class Space(APIResource["Space"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -413,6 +427,7 @@ class Space(APIResource["Space"]):
         user_id: str,
         company_id: str,
         chat_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Space.GetChatMessagesParams"],
     ) -> "Space.GetAllMessagesResponse":
         """
@@ -426,6 +441,7 @@ class Space(APIResource["Space"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -435,6 +451,7 @@ class Space(APIResource["Space"]):
         user_id: str,
         company_id: str,
         chat_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Space.GetChatMessagesParams"],
     ) -> "Space.GetAllMessagesResponse":
         """
@@ -448,12 +465,17 @@ class Space(APIResource["Space"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
     @classmethod
     def get_latest_message(
-        cls, user_id: str, company_id: str, chat_id: str
+        cls,
+        user_id: str,
+        company_id: str,
+        chat_id: str,
+        client: "_BaseClient | None" = None,
     ) -> "Space.Message":
         """
         Get the latest message in a space.
@@ -465,12 +487,17 @@ class Space(APIResource["Space"]):
                 f"/space/{chat_id}/messages/latest",
                 user_id,
                 company_id,
+                client=client,
             ),
         )
 
     @classmethod
     async def get_latest_message_async(
-        cls, user_id: str, company_id: str, chat_id: str
+        cls,
+        user_id: str,
+        company_id: str,
+        chat_id: str,
+        client: "_BaseClient | None" = None,
     ) -> "Space.Message":
         """
         Async get the latest message in a space.
@@ -482,6 +509,7 @@ class Space(APIResource["Space"]):
                 f"/space/{chat_id}/messages/latest",
                 user_id,
                 company_id,
+                client=client,
             ),
         )
 
@@ -491,6 +519,7 @@ class Space(APIResource["Space"]):
         user_id: str,
         company_id: str,
         chat_id: str,
+        client: "_BaseClient | None" = None,
     ) -> "Space.DeleteChatResponse":
         """
         Delete a chat in a space.
@@ -502,6 +531,7 @@ class Space(APIResource["Space"]):
                 f"/space/chat/{chat_id}",
                 user_id,
                 company_id,
+                client=client,
             ),
         )
 
@@ -511,6 +541,7 @@ class Space(APIResource["Space"]):
         user_id: str,
         company_id: str,
         chat_id: str,
+        client: "_BaseClient | None" = None,
     ) -> "Space.DeleteChatResponse":
         """
         Async delete a chat in a space.
@@ -522,6 +553,7 @@ class Space(APIResource["Space"]):
                 f"/space/chat/{chat_id}",
                 user_id,
                 company_id,
+                client=client,
             ),
         )
 
@@ -531,6 +563,7 @@ class Space(APIResource["Space"]):
         user_id: str,
         company_id: str,
         space_id: str,
+        client: "_BaseClient | None" = None,
     ) -> "Space":
         """
         Get detailed information about a space (assistant).
@@ -542,6 +575,7 @@ class Space(APIResource["Space"]):
                 f"/space/{space_id}",
                 user_id,
                 company_id,
+                client=client,
             ),
         )
 
@@ -551,6 +585,7 @@ class Space(APIResource["Space"]):
         user_id: str,
         company_id: str,
         space_id: str,
+        client: "_BaseClient | None" = None,
     ) -> "Space":
         """
         Async get detailed information about a space (assistant).
@@ -562,6 +597,7 @@ class Space(APIResource["Space"]):
                 f"/space/{space_id}",
                 user_id,
                 company_id,
+                client=client,
             ),
         )
 
@@ -570,6 +606,7 @@ class Space(APIResource["Space"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Space.CreateSpaceParams"],
     ) -> "Space":
         return cast(
@@ -580,6 +617,7 @@ class Space(APIResource["Space"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -588,6 +626,7 @@ class Space(APIResource["Space"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Space.CreateSpaceParams"],
     ) -> "Space":
         return cast(
@@ -598,6 +637,7 @@ class Space(APIResource["Space"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -607,6 +647,7 @@ class Space(APIResource["Space"]):
         user_id: str,
         company_id: str,
         space_id: str,
+        client: "_BaseClient | None" = None,
     ) -> "Space.SpaceAccessResponse":
         return cast(
             "Space.SpaceAccessResponse",
@@ -615,6 +656,7 @@ class Space(APIResource["Space"]):
                 f"/space/{space_id}/access",
                 user_id,
                 company_id,
+                client=client,
             ),
         )
 
@@ -624,6 +666,7 @@ class Space(APIResource["Space"]):
         user_id: str,
         company_id: str,
         space_id: str,
+        client: "_BaseClient | None" = None,
     ) -> "Space.SpaceAccessResponse":
         return cast(
             "Space.SpaceAccessResponse",
@@ -632,6 +675,7 @@ class Space(APIResource["Space"]):
                 f"/space/{space_id}/access",
                 user_id,
                 company_id,
+                client=client,
             ),
         )
 
@@ -641,6 +685,7 @@ class Space(APIResource["Space"]):
         user_id: str,
         company_id: str,
         space_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Space.AddSpaceAccessParams"],
     ) -> "Space.SpaceAccessResponse":
         return cast(
@@ -651,6 +696,7 @@ class Space(APIResource["Space"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -660,6 +706,7 @@ class Space(APIResource["Space"]):
         user_id: str,
         company_id: str,
         space_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Space.AddSpaceAccessParams"],
     ) -> "Space.SpaceAccessResponse":
         return cast(
@@ -670,6 +717,7 @@ class Space(APIResource["Space"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -679,6 +727,7 @@ class Space(APIResource["Space"]):
         user_id: str,
         company_id: str,
         space_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Space.DeleteSpaceAccessParams"],
     ) -> "Space.DeleteSpaceAccessResponse":
         return cast(
@@ -689,6 +738,7 @@ class Space(APIResource["Space"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -698,6 +748,7 @@ class Space(APIResource["Space"]):
         user_id: str,
         company_id: str,
         space_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Space.DeleteSpaceAccessParams"],
     ) -> "Space.DeleteSpaceAccessResponse":
         return cast(
@@ -708,6 +759,7 @@ class Space(APIResource["Space"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -717,6 +769,7 @@ class Space(APIResource["Space"]):
         user_id: str,
         company_id: str,
         space_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Space.UpdateParams"],
     ) -> "Space":
         return cast(
@@ -727,6 +780,7 @@ class Space(APIResource["Space"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -736,6 +790,7 @@ class Space(APIResource["Space"]):
         user_id: str,
         company_id: str,
         space_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Space.UpdateParams"],
     ) -> "Space":
         return cast(
@@ -746,6 +801,7 @@ class Space(APIResource["Space"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -755,6 +811,7 @@ class Space(APIResource["Space"]):
         user_id: str,
         company_id: str,
         space_id: str,
+        client: "_BaseClient | None" = None,
     ) -> "Space.DeleteSpaceResponse":
         """
         Delete a space.
@@ -766,6 +823,7 @@ class Space(APIResource["Space"]):
                 f"/space/{space_id}",
                 user_id,
                 company_id,
+                client=client,
             ),
         )
 
@@ -775,6 +833,7 @@ class Space(APIResource["Space"]):
         user_id: str,
         company_id: str,
         space_id: str,
+        client: "_BaseClient | None" = None,
     ) -> "Space.DeleteSpaceResponse":
         """
         Async delete a space.
@@ -786,6 +845,7 @@ class Space(APIResource["Space"]):
                 f"/space/{space_id}",
                 user_id,
                 company_id,
+                client=client,
             ),
         )
 
@@ -794,6 +854,7 @@ class Space(APIResource["Space"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Space.GetSpacesParams"],
     ) -> "Space.Spaces":
         """
@@ -807,6 +868,7 @@ class Space(APIResource["Space"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -815,6 +877,7 @@ class Space(APIResource["Space"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["Space.GetSpacesParams"],
     ) -> "Space.Spaces":
         """
@@ -828,5 +891,6 @@ class Space(APIResource["Space"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )

--- a/unique_sdk/unique_sdk/api_resources/_user.py
+++ b/unique_sdk/unique_sdk/api_resources/_user.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from typing import (
+    TYPE_CHECKING,
     Any,
     Literal,
     NotRequired,
@@ -10,6 +13,9 @@ from typing import (
 from unique_sdk._api_resource import APIResource
 from unique_sdk._request_options import RequestOptions
 from unique_sdk._util import classproperty
+
+if TYPE_CHECKING:
+    from unique_sdk._client import _BaseClient
 
 
 class User(APIResource["User"]):
@@ -81,6 +87,7 @@ class User(APIResource["User"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["User.GetParams"],
     ) -> "User.Users":
         """
@@ -94,6 +101,7 @@ class User(APIResource["User"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -102,6 +110,7 @@ class User(APIResource["User"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["User.GetParams"],
     ) -> "User.Users":
         """
@@ -115,6 +124,7 @@ class User(APIResource["User"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -123,6 +133,7 @@ class User(APIResource["User"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["User.UpdateUserConfigurationParams"],
     ) -> "User.UserWithConfiguration":
         """
@@ -136,6 +147,7 @@ class User(APIResource["User"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -144,6 +156,7 @@ class User(APIResource["User"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["User.UpdateUserConfigurationParams"],
     ) -> "User.UserWithConfiguration":
         """
@@ -157,6 +170,7 @@ class User(APIResource["User"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -166,6 +180,7 @@ class User(APIResource["User"]):
         user_id: str,
         company_id: str,
         target_user_id: str,
+        client: "_BaseClient | None" = None,
     ) -> "User.User":
         """
         Get a user by their ID.
@@ -177,6 +192,7 @@ class User(APIResource["User"]):
                 f"/users/{target_user_id}",
                 user_id,
                 company_id,
+                client=client,
             ),
         )
 
@@ -186,6 +202,7 @@ class User(APIResource["User"]):
         user_id: str,
         company_id: str,
         target_user_id: str,
+        client: "_BaseClient | None" = None,
     ) -> "User.User":
         """
         Async get a user by their ID.
@@ -197,6 +214,7 @@ class User(APIResource["User"]):
                 f"/users/{target_user_id}",
                 user_id,
                 company_id,
+                client=client,
             ),
         )
 
@@ -206,6 +224,7 @@ class User(APIResource["User"]):
         user_id: str,
         company_id: str,
         target_user_id: str,
+        client: "_BaseClient | None" = None,
     ) -> "User.UserGroupsResponse":
         return cast(
             "User.UserGroupsResponse",
@@ -214,6 +233,7 @@ class User(APIResource["User"]):
                 f"/users/{target_user_id}/groups",
                 user_id,
                 company_id,
+                client=client,
             ),
         )
 
@@ -223,6 +243,7 @@ class User(APIResource["User"]):
         user_id: str,
         company_id: str,
         target_user_id: str,
+        client: "_BaseClient | None" = None,
     ) -> "User.UserGroupsResponse":
         return cast(
             "User.UserGroupsResponse",
@@ -231,5 +252,6 @@ class User(APIResource["User"]):
                 f"/users/{target_user_id}/groups",
                 user_id,
                 company_id,
+                client=client,
             ),
         )

--- a/unique_sdk/unique_sdk/api_resources/_web_search.py
+++ b/unique_sdk/unique_sdk/api_resources/_web_search.py
@@ -13,13 +13,18 @@ classes keeps the typed shape obvious at the call site and lets each one
 register its own ``OBJECT_NAME`` for response routing.
 """
 
-from typing import Any, Literal, TypedDict, cast
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Literal, TypedDict, cast
 
 from typing_extensions import NotRequired, Unpack
 
 from unique_sdk._api_resource import APIResource
 from unique_sdk._request_options import RequestOptions
 from unique_sdk._util import classproperty
+
+if TYPE_CHECKING:
+    from unique_sdk._client import _BaseClient
 
 
 class WebSearchResultItem(TypedDict):
@@ -69,6 +74,7 @@ class WebSearch(APIResource["WebSearch"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["WebSearch.SearchParams"],
     ) -> "WebSearch":
         return cast(
@@ -79,6 +85,7 @@ class WebSearch(APIResource["WebSearch"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -87,6 +94,7 @@ class WebSearch(APIResource["WebSearch"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["WebSearch.SearchParams"],
     ) -> "WebSearch":
         return cast(
@@ -97,6 +105,7 @@ class WebSearch(APIResource["WebSearch"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -140,6 +149,7 @@ class WebCrawl(APIResource["WebCrawl"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["WebCrawl.CrawlParams"],
     ) -> "WebCrawl":
         return cast(
@@ -150,6 +160,7 @@ class WebCrawl(APIResource["WebCrawl"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )
 
@@ -158,6 +169,7 @@ class WebCrawl(APIResource["WebCrawl"]):
         cls,
         user_id: str,
         company_id: str,
+        client: "_BaseClient | None" = None,
         **params: Unpack["WebCrawl.CrawlParams"],
     ) -> "WebCrawl":
         return cast(
@@ -168,5 +180,6 @@ class WebCrawl(APIResource["WebCrawl"]):
                 user_id,
                 company_id,
                 params=params,
+                client=client,
             ),
         )


### PR DESCRIPTION
## Summary

- Introduces `UniqueClient` (sync) and `AsyncUniqueClient` (async) — a proper client-based initialization pattern modeled after the OpenAI Python SDK, enabling the SDK to be used in multiple concurrent contexts without relying on global module variables
- Both clients accept `api_key`, `app_id`, `api_base`, `api_version`, and `additional_headers` at construction time; `additional_headers` are merged into every outgoing HTTP request made through that client instance
- Existing global-config usage (`unique_sdk.api_key = ...`) remains fully backwards-compatible — the client falls back to module-level values when not explicitly set

## Changes

- **`_client.py`** (new): `_BaseClient` shared config base, `UniqueClient` with 28 sync accessor properties, `AsyncUniqueClient` with 28 async accessor properties
- **`_api_requestor.py`**: accepts optional `client: _BaseClient | None`; reads credentials and `additional_headers` from client when provided
- **`_api_resource.py`**: threads `client` through `_static_request` / `_static_request_async`
- **All 28 `api_resources/` files**: `client: "_BaseClient | None" = None` added to every public classmethod
- **`__init__.py`**: exports `UniqueClient` and `AsyncUniqueClient`
- **Tests**: updated 9 assertions that mock `_static_request` to include `client=None`

## Usage

```python
from unique_sdk import UniqueClient, AsyncUniqueClient

# Sync
client = UniqueClient(
    api_key="ukey_...",
    app_id="app_...",
    additional_headers={"x-trace-id": "abc123"},
)
results = client.search.create(user_id, company_id, searchString="...")

# Async
client = AsyncUniqueClient(
    api_key="ukey_...",
    app_id="app_...",
    additional_headers={"x-tenant-id": "tenant_42"},
)
results = await client.search.create(user_id, company_id, searchString="...")
```

## Test plan

- [ ] `uv run poe typecheck` → 0 errors, 0 warnings, 0 notes
- [ ] `uv run poe test` → 968 passed, 39 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)