### PR TITLE
fix(unique-toolkit): preserve concrete config for valid disabled tools [UN-17197]

### DIFF
--- a/unique_orchestrator/tests/test_unique_ai_builder_model_choice.py
+++ b/unique_orchestrator/tests/test_unique_ai_builder_model_choice.py
@@ -18,6 +18,7 @@ from unique_toolkit.agentic.tools.openai_builtin.base import OpenAIBuiltInToolNa
 from unique_toolkit.agentic.tools.openai_builtin.code_interpreter.config import (
     CodeInterpreterExtendedConfig,
 )
+from unique_toolkit.agentic.tools.schemas import BaseToolConfig
 from unique_toolkit.agentic.tools.tool import ToolBuildConfig
 from unique_toolkit.language_model.infos import (
     LanguageModelInfo,
@@ -447,3 +448,34 @@ def test_model_choice_refreshes_search_tool_token_limits() -> None:
         WebSearchTool.name: 4_000,
         RetrieveSearchScopeTool.name: 4_000,
     }
+
+
+@pytest.mark.ai
+def test_set_input_context_size_skips_disabled_search_tool_with_base_config() -> None:
+    """
+    Purpose: Verify a disabled search tool demoted to BaseToolConfig does not crash config load.
+    Why this matters: A search tool with an invalid stored config is demoted (is_enabled=False,
+    BaseToolConfig); set_input_context_size must skip it instead of raising AttributeError.
+    Setup summary: Provide a disabled WebSearch tool that demotes to BaseToolConfig; assert no crash.
+    """
+    web_search_tool = ToolBuildConfig(
+        name=WebSearchTool.name,
+        is_enabled=False,
+        configuration=BaseToolConfig(),
+    )
+    # The wrong config type for a WebSearch tool demotes it to disabled + BaseToolConfig.
+    assert web_search_tool.is_enabled is False
+    assert not hasattr(web_search_tool.configuration, "language_model_max_input_tokens")
+
+    config = UniqueAIConfig(
+        space=UniqueAISpaceConfig(
+            language_model=_make_model("default-model"),
+            tools=[web_search_tool],
+        )
+    )
+
+    disabled_tool = next(
+        tool for tool in config.space.tools if tool.name == WebSearchTool.name
+    )
+    assert disabled_tool.is_enabled is False
+    assert not hasattr(disabled_tool.configuration, "language_model_max_input_tokens")

--- a/unique_orchestrator/unique_orchestrator/config.py
+++ b/unique_orchestrator/unique_orchestrator/config.py
@@ -173,8 +173,6 @@ class SpaceConfigBase(BaseToolConfig, Generic[T]):
                 WebSearchTool.name,
                 RetrieveSearchScopeTool.name,
             ):
-                if not hasattr(tool.configuration, "language_model_max_input_tokens"):
-                    continue
                 tool.configuration.language_model_max_input_tokens = (  # type: ignore
                     info.data["language_model"].token_limits.token_limit_input
                 )

--- a/unique_orchestrator/unique_orchestrator/config.py
+++ b/unique_orchestrator/unique_orchestrator/config.py
@@ -166,11 +166,15 @@ class SpaceConfigBase(BaseToolConfig, Generic[T]):
         cls, tools: list[ToolBuildConfig], info: ValidationInfo
     ) -> list[ToolBuildConfig]:
         for tool in tools:
+            if not tool.is_enabled:
+                continue
             if tool.name in (
                 InternalSearchTool.name,
                 WebSearchTool.name,
                 RetrieveSearchScopeTool.name,
             ):
+                if not hasattr(tool.configuration, "language_model_max_input_tokens"):
+                    continue
                 tool.configuration.language_model_max_input_tokens = (  # type: ignore
                     info.data["language_model"].token_limits.token_limit_input
                 )

--- a/unique_toolkit/tests/agentic/tools/test_config.py
+++ b/unique_toolkit/tests/agentic/tools/test_config.py
@@ -1349,11 +1349,39 @@ def test_tool_build_config__disables_tool__with_wrong_config_type(
 
 
 @pytest.mark.ai
-def test_tool_build_config__skips_validation__when_disabled() -> None:
+def test_tool_build_config__resolves_config__when_disabled_but_valid(
+    register_simple_tool,
+) -> None:
     """
-    Purpose: Verify disabled tools skip config validation entirely.
-    Why this matters: Disabled tools should never crash due to invalid config.
-    Setup summary: Create config with is_enabled=False and unregistered name; assert no error.
+    Purpose: Verify a disabled tool with a valid config keeps its concrete config type.
+    Why this matters: Downstream validators key off the tool name and expect the
+    concrete config (e.g. to read language_model_max_input_tokens). A disabled tool
+    with a valid config must retain its resolved config, not a bare BaseToolConfig.
+    Setup summary: Create a disabled config for a registered tool; assert config resolved.
+    """
+    # Arrange — "test_tool" is registered to SimpleToolConfig by the fixture
+    config_data = {
+        "name": "test_tool",
+        "is_enabled": False,
+        "configuration": {"param_one": "kept", "param_two": 321},
+    }
+
+    # Act
+    config = ToolBuildConfig(**config_data)
+
+    # Assert — stays disabled, but the concrete config is preserved
+    assert config.is_enabled is False
+    assert isinstance(config.configuration, SimpleToolConfig)
+    assert config.configuration.param_one == "kept"
+    assert config.configuration.param_two == 321
+
+
+@pytest.mark.ai
+def test_tool_build_config__demotes_disabled_tool__with_invalid_config() -> None:
+    """
+    Purpose: Verify a disabled tool with an invalid config is demoted, not crashed.
+    Why this matters: Disabled tools may carry stale/garbage config; loading must not fail.
+    Setup summary: Create config with is_enabled=False and unregistered name; assert fallback.
     """
     # Arrange — tool name is not registered, config is garbage, but tool is disabled
     config_data = {
@@ -1372,13 +1400,11 @@ def test_tool_build_config__skips_validation__when_disabled() -> None:
 
 
 @pytest.mark.ai
-def test_tool_build_config__skips_validation__when_disabled_with_camel_case_key() -> (
-    None
-):
+def test_tool_build_config__demotes_disabled_tool__with_camel_case_key() -> None:
     """
-    Purpose: Verify disabled tools skip validation when isEnabled uses camelCase.
+    Purpose: Verify a disabled tool with an invalid config is demoted when isEnabled is camelCase.
     Why this matters: Backend payloads use alias_generator=to_camel keys.
-    Setup summary: Create config with isEnabled=False and invalid config; assert no error.
+    Setup summary: Create config with isEnabled=False and invalid config; assert fallback.
     """
     config_data = {
         "name": "nonexistent_tool_xyz",
@@ -1394,11 +1420,9 @@ def test_tool_build_config__skips_validation__when_disabled_with_camel_case_key(
 
 
 @pytest.mark.ai
-def test_tool_build_config__skips_validation__when_disabled_with_null_configuration() -> (
-    None
-):
+def test_tool_build_config__demotes_disabled_tool__with_null_configuration() -> None:
     """
-    Purpose: Verify disabled tools with null configuration do not crash validation.
+    Purpose: Verify a disabled tool with null configuration does not crash validation.
     Why this matters: Disabled tools may carry incomplete backend payloads.
     Setup summary: Create disabled config with configuration=null; assert BaseToolConfig fallback.
     """

--- a/unique_toolkit/unique_toolkit/agentic/tools/config.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/config.py
@@ -106,21 +106,13 @@ class ToolBuildConfig(BaseModel, Generic[T]):
     ) -> Any:
         """Validate and resolve tool configuration based on tool type and name.
 
-        Disabled tools skip validation entirely.
-        Enabled tools that fail validation are demoted to disabled.
+        Both enabled and disabled tools resolve to their concrete config type when
+        the stored configuration is valid, so downstream consumers that key off the
+        tool name keep seeing the expected config type regardless of the enabled
+        flag. A tool whose configuration is invalid is demoted to disabled with a
+        BaseToolConfig fallback instead of raising.
         """
         if not isinstance(value, dict):
-            return value
-
-        if "isEnabled" in value:
-            is_enabled = bool(value["isEnabled"])
-        elif "is_enabled" in value:
-            is_enabled = bool(value["is_enabled"])
-        else:
-            is_enabled = True
-
-        if not is_enabled:
-            _ensure_base_tool_config(value)
             return value
 
         is_mcp_tool = _is_mcp_tool_payload(value)


### PR DESCRIPTION
## Summary

Follow-up fix to the graceful tool initialization from #1076, which introduced a regression.

#1076 short-circuited **disabled** tools to a bare `BaseToolConfig` before resolving their concrete type. Combined with validators that dispatch on tool name (notably `unique_orchestrator`'s `set_input_context_size`), this crashed with:

```
AttributeError: 'BaseToolConfig' object has no field 'language_model_max_input_tokens'
```

Crucially, the trigger is not just a genuinely invalid stored config — it fires for **any space that simply toggles off** Web Search, Internal Search, or Retrieve Search Scope, because disabling the tool converted its config to `BaseToolConfig` while the tool kept its recognized name.

## Changes

- **`unique_toolkit` (`agentic/tools/config.py`)** — remove the `if not is_enabled` short-circuit in `initialize_config_based_on_tool_name`. Disabled tools now resolve through the same `try/except` path as enabled ones:
  - valid config (enabled *or* disabled) → resolves to its concrete type (keeps `language_model_max_input_tokens`);
  - invalid config → still demoted to `is_enabled=False` + `BaseToolConfig()` (graceful, no crash).
  - This restores the invariant "a named tool carries its concrete config unless genuinely broken", shrinking the blast radius back to genuinely-invalid configs only.
- **`unique_orchestrator` (`config.py`)** — guard `set_input_context_size` to skip `is_enabled=False` tools and any config lacking the field (`hasattr`). Covers the residual demoted cases and any future name-based accessor.

## Tests

- `unique_toolkit`: added `test_..._resolves_config__when_disabled_but_valid`; renamed the three `skips_validation__when_disabled` tests to `demotes_disabled_tool__*` to reflect the new resolve-else-demote semantics.
- `unique_orchestrator`: added `test_set_input_context_size_skips_disabled_search_tool_with_base_config` — direct regression test for the crash.

## Test plan

- [x] `uv run pytest unique_toolkit/tests/agentic/tools/test_config.py` — 49 passed
- [x] `uv run pytest unique_orchestrator/tests/test_unique_ai_builder_model_choice.py` — 12 passed (incl. new regression test)
- [x] `ruff check` / `ruff format` clean

Refs: UN-17197

AI assist: heavy

Made with [Cursor](https://cursor.com)