### PR TITLE
feat(uqadm): add kb rm to delete KB folders and files (UN-22561)

### DIFF
--- a/uqadm/README.md
+++ b/uqadm/README.md
@@ -3,7 +3,7 @@
 Admin CLI for the Unique platform. It groups these command families:
 
 - **`space`** — list, export, diff, migrate, upsert, access grants, ingestion settings, and delete assistant spaces.
-- **`kb`** — knowledge-base folders: create paths, sync/download files, grant group access, set folder ingestion config.
+- **`kb`** — knowledge-base folders: create paths, sync/download/remove files and folders, grant group access, set folder ingestion config.
 - **`chat`** — send messages to an assistant and inspect chat history.
 - **`env`** — manage named credential slots stored in `~/.uqadm/envs/`.
 - **`install`** — one-time bootstrap: create directories, install shell completion, set up your first slot.
@@ -379,7 +379,9 @@ uqadm space delete space_old123 --dry-run
 
 ## `uqadm kb`
 
-Manage **knowledge-base folder** paths and metadata via ``unique_sdk.Folder``.
+Manage **knowledge-base folders**: create paths, sync/download/remove files and
+folders, grant group access, and set folder ingestion config (via
+``unique_sdk.Folder`` and ``Content.delete`` for targeted file removal).
 
 ```bash
 uqadm kb --help

--- a/uqadm/README.md
+++ b/uqadm/README.md
@@ -453,6 +453,32 @@ uqadm kb download ./out --scope-id scope_abc -r --slot qa
 | `--dry-run` | Show planned downloads without writing anything. |
 | `--slot SLOT` | Credential slot. |
 
+### `kb rm`
+
+Delete a KB folder or specific files within it, using ``Folder.delete`` /
+``Content.delete``. Requires exactly one of ``--folder-path`` or ``--scope-id``.
+With one or more ``--file`` options (matched by key, repeatable) only those
+files are deleted; otherwise the whole folder is removed. Deleting a **non-empty
+folder requires ``--recursive``** (it refuses otherwise). Unless ``--yes`` is
+given you are **prompted to confirm**; ``--dry-run`` prints the plan without
+deleting anything.
+
+```bash
+uqadm kb rm --folder-path /Dept/HR --file old.pdf
+uqadm kb rm --scope-id scope_abc -r --dry-run
+uqadm kb rm --scope-id scope_abc -r --slot qa -y
+```
+
+| Option | Description |
+|--------|-------------|
+| `--folder-path` | Target KB folder path (mutually exclusive with ``--scope-id``). |
+| `--scope-id` | Target folder scope id (mutually exclusive with ``--folder-path``). |
+| `--file` | Delete only this file (matched by key) in the scope; repeatable. |
+| `-r`, `--recursive` | Delete a non-empty folder and everything under it. |
+| `--dry-run` | Show what would be deleted without deleting anything. |
+| `-y`, `--yes` | Skip the interactive confirmation prompt. |
+| `--slot SLOT` | Credential slot. |
+
 ### `kb access grant`
 
 Grant **group** ``READ`` or ``WRITE`` on a folder. By default the change **applies to subfolders** (``applyToSubScopes``); pass ``--no-subfolders`` for this folder only.

--- a/uqadm/tests/test_kb_cli.py
+++ b/uqadm/tests/test_kb_cli.py
@@ -119,6 +119,30 @@ def test_kb_download_rejects_existing_file_target(
     mock_download.assert_not_called()
 
 
+@patch("uqadm.kb.cmd_rm")
+@patch("uqadm.kb.config_for_slot")
+@patch("uqadm.kb.resolve_slot", return_value="qa")
+def test_kb_rm_cli_invokes_helper(
+    mock_resolve: MagicMock,
+    mock_cfg: MagicMock,
+    mock_rm: MagicMock,
+) -> None:
+    mock_cfg.return_value = MagicMock(user_id="u1", company_id="c1")
+    result = _runner().invoke(
+        app,
+        ["kb", "rm", "--scope-id", "scope_x", "-r", "--dry-run", "--file", "a.txt"],
+    )
+    assert result.exit_code == 0
+    mock_rm.assert_called_once()
+    kw = mock_rm.call_args.kwargs
+    assert kw["folder_path"] is None
+    assert kw["scope_id"] == "scope_x"
+    assert kw["files"] == ("a.txt",)
+    assert kw["recursive"] is True
+    assert kw["dry_run"] is True
+    assert kw["assume_yes"] is False
+
+
 @patch("uqadm.kb.cmd_access_grant")
 @patch("uqadm.kb.config_for_slot")
 @patch("uqadm.kb.resolve_slot", return_value="qa")

--- a/uqadm/tests/test_kb_rm.py
+++ b/uqadm/tests/test_kb_rm.py
@@ -229,14 +229,27 @@ def test_dry_run_folder_deletes_nothing(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     folder.resolve_scope_id_from_folder_path.return_value = "scope1"
-    content.get_infos.return_value = {
-        "contentInfos": [{"id": "c1", "key": "a.txt"}],
-        "totalCount": 1,
-    }
-    folder.get_infos.return_value = {
-        "folderInfos": [{"id": "scope_sub", "name": "sub"}],
-        "totalCount": 1,
-    }
+
+    def content_side_effect(
+        user_id: str, company_id: str, **kwargs: object
+    ) -> dict[str, object]:
+        if kwargs.get("parentId") == "scope1":
+            return {"contentInfos": [{"id": "c1", "key": "a.txt"}], "totalCount": 1}
+        return _no_content()
+
+    content.get_infos.side_effect = content_side_effect
+
+    def folder_side_effect(
+        user_id: str, company_id: str, **kwargs: object
+    ) -> dict[str, object]:
+        if kwargs.get("parentId") == "scope1":
+            return {
+                "folderInfos": [{"id": "scope_sub", "name": "sub"}],
+                "totalCount": 1,
+            }
+        return _no_folders()
+
+    folder.get_infos.side_effect = folder_side_effect
 
     cmd_rm(
         _cfg(),
@@ -252,6 +265,65 @@ def test_dry_run_folder_deletes_nothing(
     content.delete.assert_not_called()
     out = capsys.readouterr().out
     assert "[dry-run] deleted file: a.txt" in out
+    assert "[dry-run] deleted subfolder: sub" in out
+    assert "[dry-run] deleted folder: /X" in out
+
+
+@patch("uqadm.kb.rm.Content")
+@patch("uqadm.kb.rm.Folder")
+def test_dry_run_recursive_walks_nested_subtree(
+    folder: MagicMock,
+    content: MagicMock,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # A recursive dry-run must list files nested in child scopes, since
+    # Folder.delete(recursive=True) removes the whole subtree.
+    folder.resolve_scope_id_from_folder_path.return_value = "scope1"
+
+    def content_side_effect(
+        user_id: str, company_id: str, **kwargs: object
+    ) -> dict[str, object]:
+        parent = kwargs.get("parentId")
+        if parent == "scope1":
+            return {
+                "contentInfos": [{"id": "c_top", "key": "top.txt"}],
+                "totalCount": 1,
+            }
+        if parent == "scope_sub":
+            return {
+                "contentInfos": [{"id": "c_nested", "key": "nested.txt"}],
+                "totalCount": 1,
+            }
+        return _no_content()
+
+    content.get_infos.side_effect = content_side_effect
+
+    def folder_side_effect(
+        user_id: str, company_id: str, **kwargs: object
+    ) -> dict[str, object]:
+        if kwargs.get("parentId") == "scope1":
+            return {
+                "folderInfos": [{"id": "scope_sub", "name": "sub"}],
+                "totalCount": 1,
+            }
+        return _no_folders()
+
+    folder.get_infos.side_effect = folder_side_effect
+
+    cmd_rm(
+        _cfg(),
+        folder_path="/X",
+        scope_id=None,
+        files=(),
+        recursive=True,
+        dry_run=True,
+        assume_yes=True,
+    )
+
+    folder.delete.assert_not_called()
+    out = capsys.readouterr().out
+    assert "[dry-run] deleted file: top.txt" in out
+    assert "[dry-run] deleted file: sub/nested.txt" in out
     assert "[dry-run] deleted subfolder: sub" in out
     assert "[dry-run] deleted folder: /X" in out
 

--- a/uqadm/tests/test_kb_rm.py
+++ b/uqadm/tests/test_kb_rm.py
@@ -137,6 +137,33 @@ def test_single_file_delete(
 
 @patch("uqadm.kb.rm.Content")
 @patch("uqadm.kb.rm.Folder")
+def test_repeated_file_flag_deletes_once(
+    folder: MagicMock,
+    content: MagicMock,
+) -> None:
+    # The same --file value passed twice must not call Content.delete again.
+    folder.resolve_scope_id_from_folder_path.return_value = "scope1"
+    content.get_infos.return_value = {
+        "contentInfos": [{"id": "c_del", "key": "gone.txt"}],
+        "totalCount": 1,
+    }
+
+    cmd_rm(
+        _cfg(),
+        folder_path="/X",
+        scope_id=None,
+        files=("gone.txt", "gone.txt"),
+        recursive=False,
+        dry_run=False,
+        assume_yes=True,
+    )
+
+    content.delete.assert_called_once()
+    assert content.delete.call_args.kwargs["contentId"] == "c_del"
+
+
+@patch("uqadm.kb.rm.Content")
+@patch("uqadm.kb.rm.Folder")
 def test_file_delete_deletes_all_matching_keys(
     folder: MagicMock,
     content: MagicMock,

--- a/uqadm/tests/test_kb_rm.py
+++ b/uqadm/tests/test_kb_rm.py
@@ -1,0 +1,485 @@
+"""Unit tests for ``uqadm kb rm`` (``cmd_rm``)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from uqadm.kb.rm import cmd_rm
+
+
+def _cfg() -> SimpleNamespace:
+    return SimpleNamespace(user_id="u1", company_id="c1")
+
+
+def _no_content() -> dict[str, object]:
+    return {"contentInfos": [], "totalCount": 0}
+
+
+def _no_folders() -> dict[str, object]:
+    return {"folderInfos": [], "totalCount": 0}
+
+
+@patch("uqadm.kb.rm.Content")
+@patch("uqadm.kb.rm.Folder")
+def test_recursive_folder_delete(
+    folder: MagicMock,
+    content: MagicMock,
+) -> None:
+    folder.resolve_scope_id_from_folder_path.return_value = "scope1"
+    content.get_infos.return_value = {
+        "contentInfos": [{"id": "c1", "key": "a.txt"}],
+        "totalCount": 1,
+    }
+    folder.get_infos.return_value = _no_folders()
+
+    cmd_rm(
+        _cfg(),
+        folder_path="/X",
+        scope_id=None,
+        files=(),
+        recursive=True,
+        dry_run=False,
+        assume_yes=True,
+    )
+
+    folder.delete.assert_called_once()
+    kwargs = folder.delete.call_args.kwargs
+    assert kwargs["scopeId"] == "scope1"
+    assert kwargs["recursive"] is True
+    content.delete.assert_not_called()
+
+
+@patch("uqadm.kb.rm.Content")
+@patch("uqadm.kb.rm.Folder")
+def test_non_empty_without_recursive_refuses(
+    folder: MagicMock,
+    content: MagicMock,
+) -> None:
+    folder.resolve_scope_id_from_folder_path.return_value = "scope1"
+    content.get_infos.return_value = {
+        "contentInfos": [{"id": "c1", "key": "a.txt"}],
+        "totalCount": 1,
+    }
+    folder.get_infos.return_value = _no_folders()
+
+    with pytest.raises(SystemExit) as exc:
+        cmd_rm(
+            _cfg(),
+            folder_path="/X",
+            scope_id=None,
+            files=(),
+            recursive=False,
+            dry_run=False,
+            assume_yes=True,
+        )
+
+    assert exc.value.code == 2
+    folder.delete.assert_not_called()
+
+
+@patch("uqadm.kb.rm.Content")
+@patch("uqadm.kb.rm.Folder")
+def test_empty_folder_delete_without_recursive(
+    folder: MagicMock,
+    content: MagicMock,
+) -> None:
+    # An empty folder can be removed without --recursive.
+    folder.resolve_scope_id_from_folder_path.return_value = "scope1"
+    content.get_infos.return_value = _no_content()
+    folder.get_infos.return_value = _no_folders()
+
+    cmd_rm(
+        _cfg(),
+        folder_path="/X",
+        scope_id=None,
+        files=(),
+        recursive=False,
+        dry_run=False,
+        assume_yes=True,
+    )
+
+    folder.delete.assert_called_once()
+    assert folder.delete.call_args.kwargs["recursive"] is False
+
+
+@patch("uqadm.kb.rm.Content")
+@patch("uqadm.kb.rm.Folder")
+def test_single_file_delete(
+    folder: MagicMock,
+    content: MagicMock,
+) -> None:
+    folder.resolve_scope_id_from_folder_path.return_value = "scope1"
+    content.get_infos.return_value = {
+        "contentInfos": [
+            {"id": "c_keep", "key": "keep.txt"},
+            {"id": "c_del", "key": "gone.txt"},
+        ],
+        "totalCount": 2,
+    }
+
+    cmd_rm(
+        _cfg(),
+        folder_path="/X",
+        scope_id=None,
+        files=("gone.txt",),
+        recursive=False,
+        dry_run=False,
+        assume_yes=True,
+    )
+
+    content.delete.assert_called_once()
+    assert content.delete.call_args.kwargs["contentId"] == "c_del"
+    folder.delete.assert_not_called()
+
+
+@patch("uqadm.kb.rm.Content")
+@patch("uqadm.kb.rm.Folder")
+def test_file_delete_deletes_all_matching_keys(
+    folder: MagicMock,
+    content: MagicMock,
+) -> None:
+    # Duplicate keys in a scope are all removed.
+    folder.resolve_scope_id_from_folder_path.return_value = "scope1"
+    content.get_infos.return_value = {
+        "contentInfos": [
+            {"id": "c_1", "key": "dup.txt"},
+            {"id": "c_2", "key": "dup.txt"},
+        ],
+        "totalCount": 2,
+    }
+
+    cmd_rm(
+        _cfg(),
+        folder_path="/X",
+        scope_id=None,
+        files=("dup.txt",),
+        recursive=False,
+        dry_run=False,
+        assume_yes=True,
+    )
+
+    assert content.delete.call_count == 2
+    deleted_ids = {call.kwargs["contentId"] for call in content.delete.call_args_list}
+    assert deleted_ids == {"c_1", "c_2"}
+
+
+@patch("uqadm.kb.rm.Content")
+@patch("uqadm.kb.rm.Folder")
+def test_missing_file_reports_and_exits_1(
+    folder: MagicMock,
+    content: MagicMock,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    folder.resolve_scope_id_from_folder_path.return_value = "scope1"
+    content.get_infos.return_value = _no_content()
+
+    with pytest.raises(SystemExit) as exc:
+        cmd_rm(
+            _cfg(),
+            folder_path="/X",
+            scope_id=None,
+            files=("nope.txt",),
+            recursive=False,
+            dry_run=False,
+            assume_yes=True,
+        )
+
+    assert exc.value.code == 1
+    content.delete.assert_not_called()
+    assert "not found: nope.txt" in capsys.readouterr().out
+
+
+@patch("uqadm.kb.rm.Content")
+@patch("uqadm.kb.rm.Folder")
+def test_dry_run_folder_deletes_nothing(
+    folder: MagicMock,
+    content: MagicMock,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    folder.resolve_scope_id_from_folder_path.return_value = "scope1"
+    content.get_infos.return_value = {
+        "contentInfos": [{"id": "c1", "key": "a.txt"}],
+        "totalCount": 1,
+    }
+    folder.get_infos.return_value = {
+        "folderInfos": [{"id": "scope_sub", "name": "sub"}],
+        "totalCount": 1,
+    }
+
+    cmd_rm(
+        _cfg(),
+        folder_path="/X",
+        scope_id=None,
+        files=(),
+        recursive=True,
+        dry_run=True,
+        assume_yes=True,
+    )
+
+    folder.delete.assert_not_called()
+    content.delete.assert_not_called()
+    out = capsys.readouterr().out
+    assert "[dry-run] deleted file: a.txt" in out
+    assert "[dry-run] deleted subfolder: sub" in out
+    assert "[dry-run] deleted folder: /X" in out
+
+
+@patch("uqadm.kb.rm.Content")
+@patch("uqadm.kb.rm.Folder")
+def test_dry_run_file_deletes_nothing(
+    folder: MagicMock,
+    content: MagicMock,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    folder.resolve_scope_id_from_folder_path.return_value = "scope1"
+    content.get_infos.return_value = {
+        "contentInfos": [{"id": "c_del", "key": "gone.txt"}],
+        "totalCount": 1,
+    }
+
+    cmd_rm(
+        _cfg(),
+        folder_path="/X",
+        scope_id=None,
+        files=("gone.txt", "missing.txt"),
+        recursive=False,
+        dry_run=True,
+        assume_yes=True,
+    )
+
+    content.delete.assert_not_called()
+    folder.delete.assert_not_called()
+    out = capsys.readouterr().out
+    assert "[dry-run] deleted: gone.txt" in out
+    assert "not found: missing.txt" in out
+
+
+@patch("uqadm.kb.rm.Content")
+@patch("uqadm.kb.rm.Folder")
+def test_scope_id_entry_point(
+    folder: MagicMock,
+    content: MagicMock,
+) -> None:
+    content.get_infos.return_value = _no_content()
+    folder.get_infos.return_value = _no_folders()
+
+    cmd_rm(
+        _cfg(),
+        folder_path=None,
+        scope_id="scope_abc",
+        files=(),
+        recursive=True,
+        dry_run=False,
+        assume_yes=True,
+    )
+
+    folder.resolve_scope_id_from_folder_path.assert_not_called()
+    folder.get_folder_path.assert_called_once()
+    folder.delete.assert_called_once()
+    assert folder.delete.call_args.kwargs["scopeId"] == "scope_abc"
+
+
+def test_requires_exactly_one_target() -> None:
+    with pytest.raises(SystemExit) as exc:
+        cmd_rm(
+            _cfg(),
+            folder_path="/X",
+            scope_id="scope_abc",
+            files=(),
+            recursive=False,
+            dry_run=False,
+            assume_yes=True,
+        )
+    assert exc.value.code == 2
+
+
+def test_requires_at_least_one_target() -> None:
+    with pytest.raises(SystemExit) as exc:
+        cmd_rm(
+            _cfg(),
+            folder_path=None,
+            scope_id=None,
+            files=(),
+            recursive=False,
+            dry_run=False,
+            assume_yes=True,
+        )
+    assert exc.value.code == 2
+
+
+def test_relative_folder_path_exits_2() -> None:
+    with pytest.raises(SystemExit) as exc:
+        cmd_rm(
+            _cfg(),
+            folder_path="relative/path",
+            scope_id=None,
+            files=(),
+            recursive=False,
+            dry_run=False,
+            assume_yes=True,
+        )
+    assert exc.value.code == 2
+
+
+@patch("uqadm.kb.rm.Content")
+@patch("uqadm.kb.rm.Folder")
+def test_unresolvable_folder_path_exits_1(
+    folder: MagicMock,
+    content: MagicMock,
+) -> None:
+    folder.resolve_scope_id_from_folder_path.return_value = None
+
+    with pytest.raises(SystemExit) as exc:
+        cmd_rm(
+            _cfg(),
+            folder_path="/missing",
+            scope_id=None,
+            files=(),
+            recursive=True,
+            dry_run=False,
+            assume_yes=True,
+        )
+
+    assert exc.value.code == 1
+    folder.delete.assert_not_called()
+
+
+@patch("uqadm.kb.rm.echo_credential_debug_if_auth_failure")
+@patch("uqadm.kb.rm.Content")
+@patch("uqadm.kb.rm.Folder")
+def test_invalid_scope_id_exits_1(
+    folder: MagicMock,
+    content: MagicMock,
+    _debug: MagicMock,
+) -> None:
+    folder.get_folder_path.side_effect = Exception("not found")
+
+    with pytest.raises(SystemExit) as exc:
+        cmd_rm(
+            _cfg(),
+            folder_path=None,
+            scope_id="scope_missing",
+            files=(),
+            recursive=True,
+            dry_run=False,
+            assume_yes=True,
+        )
+
+    assert exc.value.code == 1
+    content.get_infos.assert_not_called()
+    folder.delete.assert_not_called()
+
+
+@patch("uqadm.kb.rm.echo_credential_debug_if_auth_failure")
+@patch("uqadm.kb.rm.Content")
+@patch("uqadm.kb.rm.Folder")
+def test_file_delete_failure_exits_1(
+    folder: MagicMock,
+    content: MagicMock,
+    debug: MagicMock,
+) -> None:
+    folder.resolve_scope_id_from_folder_path.return_value = "scope1"
+    content.get_infos.return_value = {
+        "contentInfos": [{"id": "c_del", "key": "gone.txt"}],
+        "totalCount": 1,
+    }
+    content.delete.side_effect = RuntimeError("boom")
+
+    with pytest.raises(SystemExit) as exc:
+        cmd_rm(
+            _cfg(),
+            folder_path="/X",
+            scope_id=None,
+            files=("gone.txt",),
+            recursive=False,
+            dry_run=False,
+            assume_yes=True,
+        )
+
+    assert exc.value.code == 1
+    content.delete.assert_called_once()
+    debug.assert_called_once()
+
+
+@patch("uqadm.kb.rm.typer.confirm", return_value=False)
+@patch("uqadm.kb.rm.Content")
+@patch("uqadm.kb.rm.Folder")
+def test_confirmation_declined_aborts(
+    folder: MagicMock,
+    content: MagicMock,
+    _confirm: MagicMock,
+) -> None:
+    folder.resolve_scope_id_from_folder_path.return_value = "scope1"
+    content.get_infos.return_value = _no_content()
+    folder.get_infos.return_value = _no_folders()
+
+    with pytest.raises(SystemExit) as exc:
+        cmd_rm(
+            _cfg(),
+            folder_path="/X",
+            scope_id=None,
+            files=(),
+            recursive=True,
+            dry_run=False,
+            assume_yes=False,
+        )
+
+    assert exc.value.code == 1
+    folder.delete.assert_not_called()
+
+
+@patch("uqadm.kb.rm.typer.confirm", return_value=True)
+@patch("uqadm.kb.rm.Content")
+@patch("uqadm.kb.rm.Folder")
+def test_confirmation_accepted_deletes(
+    folder: MagicMock,
+    content: MagicMock,
+    confirm: MagicMock,
+) -> None:
+    folder.resolve_scope_id_from_folder_path.return_value = "scope1"
+    content.get_infos.return_value = _no_content()
+    folder.get_infos.return_value = _no_folders()
+
+    cmd_rm(
+        _cfg(),
+        folder_path="/X",
+        scope_id=None,
+        files=(),
+        recursive=True,
+        dry_run=False,
+        assume_yes=False,
+    )
+
+    confirm.assert_called_once()
+    folder.delete.assert_called_once()
+
+
+@patch("uqadm.kb.rm.Content")
+@patch("uqadm.kb.rm.Folder")
+def test_content_pagination(
+    folder: MagicMock,
+    content: MagicMock,
+) -> None:
+    # The file matched only on the second page is still found and deleted.
+    folder.resolve_scope_id_from_folder_path.return_value = "scope1"
+    content.get_infos.side_effect = [
+        {"contentInfos": [{"id": "c_other", "key": "other.txt"}], "totalCount": 2},
+        {"contentInfos": [{"id": "c_target", "key": "target.txt"}], "totalCount": 2},
+    ]
+
+    cmd_rm(
+        _cfg(),
+        folder_path="/X",
+        scope_id=None,
+        files=("target.txt",),
+        recursive=False,
+        dry_run=False,
+        assume_yes=True,
+    )
+
+    assert content.get_infos.call_count == 2
+    content.delete.assert_called_once()
+    assert content.delete.call_args.kwargs["contentId"] == "c_target"

--- a/uqadm/tests/test_kb_rm.py
+++ b/uqadm/tests/test_kb_rm.py
@@ -194,6 +194,35 @@ def test_missing_file_reports_and_exits_1(
 
 @patch("uqadm.kb.rm.Content")
 @patch("uqadm.kb.rm.Folder")
+def test_dry_run_all_missing_files_exits_1(
+    folder: MagicMock,
+    content: MagicMock,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # A dry run that matches nothing must fail like a real run, so automation
+    # using --dry-run to validate targets doesn't treat a fully missing set as
+    # success.
+    folder.resolve_scope_id_from_folder_path.return_value = "scope1"
+    content.get_infos.return_value = _no_content()
+
+    with pytest.raises(SystemExit) as exc:
+        cmd_rm(
+            _cfg(),
+            folder_path="/X",
+            scope_id=None,
+            files=("nope.txt",),
+            recursive=False,
+            dry_run=True,
+            assume_yes=True,
+        )
+
+    assert exc.value.code == 1
+    content.delete.assert_not_called()
+    assert "not found: nope.txt" in capsys.readouterr().out
+
+
+@patch("uqadm.kb.rm.Content")
+@patch("uqadm.kb.rm.Folder")
 def test_dry_run_folder_deletes_nothing(
     folder: MagicMock,
     content: MagicMock,

--- a/uqadm/uqadm/kb/__init__.py
+++ b/uqadm/uqadm/kb/__init__.py
@@ -13,13 +13,15 @@ from uqadm.kb.access import cmd_access_grant
 from uqadm.kb.download import cmd_download
 from uqadm.kb.ingestion import cmd_ingestion_set
 from uqadm.kb.mkdir import cmd_mkdir
+from uqadm.kb.rm import cmd_rm
 from uqadm.kb.sync import cmd_sync
 
 kb_app = typer.Typer(
     name="kb",
     help=(
         "Knowledge-base folder administration: create paths (Folder.create_paths), "
-        "sync/download files, grant group access (Folder.add_access), set ingestion "
+        "sync/download files, remove folders/files (Folder.delete, Content.delete), "
+        "grant group access (Folder.add_access), set ingestion "
         "(Folder.update_ingestion_config)."
     ),
     no_args_is_help=True,
@@ -262,6 +264,83 @@ def kb_download(
         scope_id=scope_id,
         recursive=recursive,
         dry_run=dry_run,
+    )
+
+
+@kb_app.command("rm", short_help="Delete KB folders or individual files.")
+def kb_rm(
+    ctx: typer.Context,
+    slot: Annotated[Optional[str], typer.Option("--slot", help=_SLOT_HELP)] = None,
+    folder_path: Annotated[
+        Optional[str],
+        typer.Option(
+            "--folder-path",
+            help="Target KB folder path (mutually exclusive with --scope-id).",
+        ),
+    ] = None,
+    scope_id: Annotated[
+        Optional[str],
+        typer.Option(
+            "--scope-id",
+            help="Target folder scope id (mutually exclusive with --folder-path).",
+        ),
+    ] = None,
+    file: Annotated[
+        Optional[list[str]],
+        typer.Option(
+            "--file",
+            help="Delete only this file (matched by key) in the scope; repeatable.",
+        ),
+    ] = None,
+    recursive: Annotated[
+        bool,
+        typer.Option(
+            "--recursive",
+            "-r",
+            help="Delete a non-empty folder and everything under it.",
+        ),
+    ] = False,
+    dry_run: Annotated[
+        bool,
+        typer.Option(
+            "--dry-run",
+            help="Show what would be deleted without deleting anything.",
+        ),
+    ] = False,
+    assume_yes: Annotated[
+        bool,
+        typer.Option(
+            "--yes",
+            "-y",
+            help="Skip the interactive confirmation prompt.",
+        ),
+    ] = False,
+) -> None:
+    """Delete a knowledge-base folder or specific files within it.
+
+    Requires exactly one of ``--folder-path`` or ``--scope-id`` to name the
+    target scope. With one or more ``--file`` options only those files are
+    deleted (Content.delete); otherwise the whole folder is deleted
+    (Folder.delete). Deleting a non-empty folder requires ``--recursive``.
+    Unless ``--yes`` is given you are prompted to confirm; ``--dry-run`` prints
+    the plan without deleting.
+
+    Examples:
+
+      uqadm kb rm --folder-path /Dept/HR --file old.pdf
+      uqadm kb rm --scope-id scope_abc -r --dry-run
+      uqadm kb rm --scope-id scope_abc -r --slot qa -y
+    """
+    resolved_slot = _resolve(slot)
+    cfg = _load_cfg(resolved_slot, _get_cwd(ctx))
+    cmd_rm(
+        cfg,
+        folder_path=folder_path,
+        scope_id=scope_id,
+        files=tuple(file or []),
+        recursive=recursive,
+        dry_run=dry_run,
+        assume_yes=assume_yes,
     )
 
 

--- a/uqadm/uqadm/kb/rm.py
+++ b/uqadm/uqadm/kb/rm.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sys
+from collections import deque
 
 import typer
 from unique_sdk import Content, Folder
@@ -51,6 +52,28 @@ def _list_child_folders(cfg: Config, scope_id: str) -> list[Folder.FolderInfo]:
         if not batch or skip >= page.get("totalCount", 0):
             break
     return folders
+
+
+def _collect_subtree(cfg: Config, scope_id: str) -> tuple[list[str], list[str]]:
+    """Return ``(file_paths, folder_paths)`` for the whole subtree under a scope.
+
+    Both lists hold display paths relative to the root scope (the root folder
+    itself is excluded). Used to render an accurate ``--recursive`` delete plan,
+    since ``Folder.delete(recursive=True)`` removes the entire subtree, not just
+    the top level.
+    """
+    files: list[str] = []
+    folders: list[str] = []
+    queue: deque[tuple[str, str]] = deque([(scope_id, "")])
+    while queue:
+        current_scope_id, rel = queue.popleft()
+        for info in _list_content_infos(cfg, current_scope_id):
+            files.append(f"{rel}/{info['key']}" if rel else info["key"])
+        for folder_info in _list_child_folders(cfg, current_scope_id):
+            child_rel = f"{rel}/{folder_info['name']}" if rel else folder_info["name"]
+            folders.append(child_rel)
+            queue.append((folder_info["id"], child_rel))
+    return files, folders
 
 
 def _report(counts: dict[str, int]) -> None:
@@ -168,10 +191,24 @@ def _rm_folder(
         sys.exit(2)
 
     if dry_run:
-        for info in contents:
-            typer.echo(f"[dry-run] deleted file: {info['key']}")
-        for folder_info in child_folders:
-            typer.echo(f"[dry-run] deleted subfolder: {folder_info['name']}")
+        if recursive:
+            # Walk the full subtree so the plan reflects everything
+            # Folder.delete(recursive=True) will remove, not just the top level.
+            try:
+                files, subfolders = _collect_subtree(cfg, scope_id)
+            except Exception as exc:
+                typer.echo(
+                    f"failed to inspect folder {target_label!r}: {exc}", err=True
+                )
+                echo_credential_debug_if_auth_failure(cfg, exc, label="kb rm")
+                sys.exit(1)
+        else:
+            files = [info["key"] for info in contents]
+            subfolders = [folder_info["name"] for folder_info in child_folders]
+        for display in files:
+            typer.echo(f"[dry-run] deleted file: {display}")
+        for display in subfolders:
+            typer.echo(f"[dry-run] deleted subfolder: {display}")
         typer.echo(f"[dry-run] deleted folder: {target_label}")
         return
 

--- a/uqadm/uqadm/kb/rm.py
+++ b/uqadm/uqadm/kb/rm.py
@@ -86,6 +86,15 @@ def _rm_files(
 
     matched = [name for name in files if name in by_key]
 
+    # None of the requested files exist: report and fail regardless of dry-run,
+    # so automation validating targets with --dry-run sees the same exit code as
+    # a real run.
+    if not matched:
+        for name in files:
+            typer.echo(f"not found: {name}")
+        typer.echo("No matching files to delete.")
+        sys.exit(1)
+
     if dry_run:
         counts = {"deleted": 0, "not_found": 0, "failed": 0}
         for name in files:
@@ -99,12 +108,6 @@ def _rm_files(
                 counts["deleted"] += 1
         _report(counts)
         return
-
-    if not matched:
-        for name in files:
-            typer.echo(f"not found: {name}")
-        typer.echo("No matching files to delete.")
-        sys.exit(1)
 
     if not assume_yes:
         total = sum(len(by_key[name]) for name in matched)

--- a/uqadm/uqadm/kb/rm.py
+++ b/uqadm/uqadm/kb/rm.py
@@ -94,6 +94,10 @@ def _rm_files(
     dry_run: bool,
     assume_yes: bool,
 ) -> None:
+    # Repeated --file flags for the same key should not trigger a second delete
+    # attempt (Content.delete would fail on already-removed IDs).
+    files = list(dict.fromkeys(files))
+
     try:
         infos = _list_content_infos(cfg, scope_id)
     except Exception as exc:

--- a/uqadm/uqadm/kb/rm.py
+++ b/uqadm/uqadm/kb/rm.py
@@ -1,0 +1,261 @@
+"""Delete knowledge-base folders or individual files from a scope."""
+
+from __future__ import annotations
+
+import sys
+
+import typer
+from unique_sdk import Content, Folder
+from unique_sdk.cli.config import Config
+
+from uqadm.core.auth_debug import echo_credential_debug_if_auth_failure
+
+_PAGE_SIZE = 100
+
+
+def _list_content_infos(cfg: Config, scope_id: str) -> list[Content.ContentInfo]:
+    """Return all content infos in a folder scope (paginated)."""
+    infos: list[Content.ContentInfo] = []
+    skip = 0
+    while True:
+        page = Content.get_infos(
+            cfg.user_id,
+            cfg.company_id,
+            parentId=scope_id,
+            skip=skip,
+            take=_PAGE_SIZE,
+        )
+        batch = page.get("contentInfos") or []
+        infos.extend(batch)
+        skip += len(batch)
+        if not batch or skip >= page.get("totalCount", 0):
+            break
+    return infos
+
+
+def _list_child_folders(cfg: Config, scope_id: str) -> list[Folder.FolderInfo]:
+    """Return all child folder infos under a scope (paginated)."""
+    folders: list[Folder.FolderInfo] = []
+    skip = 0
+    while True:
+        page = Folder.get_infos(
+            cfg.user_id,
+            cfg.company_id,
+            parentId=scope_id,
+            skip=skip,
+            take=_PAGE_SIZE,
+        )
+        batch = page.get("folderInfos") or []
+        folders.extend(batch)
+        skip += len(batch)
+        if not batch or skip >= page.get("totalCount", 0):
+            break
+    return folders
+
+
+def _report(counts: dict[str, int]) -> None:
+    typer.echo(
+        f"Done: {counts['deleted']} deleted, {counts['not_found']} not found, "
+        f"{counts['failed']} failed."
+    )
+    if counts["failed"]:
+        sys.exit(1)
+
+
+def _rm_files(
+    cfg: Config,
+    scope_id: str,
+    target_label: str,
+    files: list[str],
+    *,
+    dry_run: bool,
+    assume_yes: bool,
+) -> None:
+    try:
+        infos = _list_content_infos(cfg, scope_id)
+    except Exception as exc:
+        typer.echo(f"failed to list contents of {target_label!r}: {exc}", err=True)
+        echo_credential_debug_if_auth_failure(cfg, exc, label="kb rm")
+        sys.exit(1)
+
+    # A folder may legitimately hold several files with the same key; delete all
+    # matches so a targeted removal doesn't leave duplicates behind.
+    by_key: dict[str, list[str]] = {}
+    for info in infos:
+        by_key.setdefault(info["key"], []).append(info["id"])
+
+    matched = [name for name in files if name in by_key]
+
+    if dry_run:
+        counts = {"deleted": 0, "not_found": 0, "failed": 0}
+        for name in files:
+            ids = by_key.get(name)
+            if not ids:
+                typer.echo(f"not found: {name}")
+                counts["not_found"] += 1
+                continue
+            for _cid in ids:
+                typer.echo(f"[dry-run] deleted: {name}")
+                counts["deleted"] += 1
+        _report(counts)
+        return
+
+    if not matched:
+        for name in files:
+            typer.echo(f"not found: {name}")
+        typer.echo("No matching files to delete.")
+        sys.exit(1)
+
+    if not assume_yes:
+        total = sum(len(by_key[name]) for name in matched)
+        typer.echo(f"About to delete {total} file(s) from {target_label}:")
+        for name in matched:
+            typer.echo(f"  {name}")
+        if not typer.confirm("Proceed?"):
+            typer.echo("Aborted.")
+            sys.exit(1)
+
+    counts = {"deleted": 0, "not_found": 0, "failed": 0}
+    for name in files:
+        ids = by_key.get(name)
+        if not ids:
+            typer.echo(f"not found: {name}")
+            counts["not_found"] += 1
+            continue
+        for content_id in ids:
+            try:
+                Content.delete(cfg.user_id, cfg.company_id, contentId=content_id)
+            except Exception as exc:
+                typer.echo(f"failed: {name}: {exc}", err=True)
+                echo_credential_debug_if_auth_failure(cfg, exc, label="kb rm")
+                counts["failed"] += 1
+                continue
+            typer.echo(f"deleted: {name}")
+            counts["deleted"] += 1
+
+    _report(counts)
+
+
+def _rm_folder(
+    cfg: Config,
+    scope_id: str,
+    target_label: str,
+    *,
+    recursive: bool,
+    dry_run: bool,
+    assume_yes: bool,
+) -> None:
+    try:
+        contents = _list_content_infos(cfg, scope_id)
+        child_folders = _list_child_folders(cfg, scope_id)
+    except Exception as exc:
+        typer.echo(f"failed to inspect folder {target_label!r}: {exc}", err=True)
+        echo_credential_debug_if_auth_failure(cfg, exc, label="kb rm")
+        sys.exit(1)
+
+    # A non-empty folder is only removable with --recursive; refuse otherwise so
+    # a stray `kb rm` can't wipe a populated folder by surprise.
+    if (contents or child_folders) and not recursive:
+        typer.echo(
+            f"refusing to delete non-empty folder {target_label!r} "
+            f"({len(contents)} file(s), {len(child_folders)} subfolder(s)); "
+            f"pass --recursive/-r to delete it and everything under it.",
+            err=True,
+        )
+        sys.exit(2)
+
+    if dry_run:
+        for info in contents:
+            typer.echo(f"[dry-run] deleted file: {info['key']}")
+        for folder_info in child_folders:
+            typer.echo(f"[dry-run] deleted subfolder: {folder_info['name']}")
+        typer.echo(f"[dry-run] deleted folder: {target_label}")
+        return
+
+    if not assume_yes:
+        prompt = (
+            f"Delete folder {target_label} and everything under it?"
+            if recursive
+            else f"Delete folder {target_label}?"
+        )
+        if not typer.confirm(prompt):
+            typer.echo("Aborted.")
+            sys.exit(1)
+
+    try:
+        Folder.delete(
+            cfg.user_id, cfg.company_id, scopeId=scope_id, recursive=recursive
+        )
+    except Exception as exc:
+        typer.echo(f"failed to delete folder {target_label!r}: {exc}", err=True)
+        echo_credential_debug_if_auth_failure(cfg, exc, label="kb rm")
+        sys.exit(1)
+
+    typer.echo(f"deleted folder: {target_label}")
+
+
+def cmd_rm(
+    cfg: Config,
+    *,
+    folder_path: str | None,
+    scope_id: str | None,
+    files: tuple[str, ...],
+    recursive: bool,
+    dry_run: bool,
+    assume_yes: bool,
+) -> None:
+    if bool(folder_path) == bool(scope_id):
+        typer.echo("Specify exactly one of --folder-path or --scope-id.", err=True)
+        sys.exit(2)
+
+    if folder_path and not folder_path.startswith("/"):
+        typer.echo(
+            f"--folder-path must be an absolute path (start with '/'): {folder_path}",
+            err=True,
+        )
+        sys.exit(2)
+
+    # Reduce both entry points to a scope id plus a human-readable label.
+    if folder_path:
+        try:
+            resolved_scope_id = Folder.resolve_scope_id_from_folder_path(
+                cfg.user_id, cfg.company_id, folder_path=folder_path
+            )
+        except Exception as exc:
+            typer.echo(f"failed to resolve folder {folder_path!r}: {exc}", err=True)
+            echo_credential_debug_if_auth_failure(cfg, exc, label="kb rm")
+            sys.exit(1)
+        if resolved_scope_id is None:
+            typer.echo(f"failed to resolve folder {folder_path!r}: not found", err=True)
+            sys.exit(1)
+        base_scope_id = resolved_scope_id
+        target_label = folder_path
+    else:
+        assert scope_id is not None
+        try:
+            _ = Folder.get_folder_path(cfg.user_id, cfg.company_id, scope_id)
+        except Exception as exc:
+            typer.echo(f"failed to resolve scope {scope_id!r}: {exc}", err=True)
+            echo_credential_debug_if_auth_failure(cfg, exc, label="kb rm")
+            sys.exit(1)
+        base_scope_id = scope_id
+        target_label = scope_id
+
+    if files:
+        _rm_files(
+            cfg,
+            base_scope_id,
+            target_label,
+            list(files),
+            dry_run=dry_run,
+            assume_yes=assume_yes,
+        )
+    else:
+        _rm_folder(
+            cfg,
+            base_scope_id,
+            target_label,
+            recursive=recursive,
+            dry_run=dry_run,
+            assume_yes=assume_yes,
+        )


### PR DESCRIPTION
## Summary

Adds a new `uqadm kb rm` command that wraps the SDK's `Folder.delete` / `Content.delete`, giving the CLI a way to remove KB folders and files (previously it could only `mkdir`, `sync`, and `download`).

- Requires exactly one of `--folder-path` / `--scope-id` to name the target scope (same guard/absolute-path check as `kb download`).
- `--file NAME` (repeatable): deletes only the matching file(s) by key via `Content.delete`; reports `deleted:` / `not found:` per file.
- Without `--file`: deletes the whole folder via `Folder.delete`. A non-empty folder is refused (exit 2) unless `--recursive`/`-r` is passed.
- `--dry-run`: prints the plan (files + subfolders) without calling delete.
- Confirmation prompt via `typer.confirm` unless `--yes`/`-y` is given.
- Reuses `echo_credential_debug_if_auth_failure` for auth errors, matching the other `kb` commands.

Jira: UN-22561

## Test plan

- [x] `pytest` for the `uqadm` package (225 passed), including new `tests/test_kb_rm.py` and a `kb rm` CLI-registration case in `tests/test_kb_cli.py`.
- [x] `ruff check` + `ruff format` clean on the changed files (also enforced by pre-commit).
- [x] `uqadm kb rm --help` renders; mutual-exclusion / absolute-path guards exit 2.

Made with [Cursor](https://cursor.com)