### PR TITLE
feat(toolkit): nudge agent to fetch MCP list items individually for referencing

### DIFF
--- a/unique_toolkit/tests/agentic/tools/test_mcp_tool_wrapper.py
+++ b/unique_toolkit/tests/agentic/tools/test_mcp_tool_wrapper.py
@@ -248,6 +248,62 @@ class TestMCPToolWrapperToolDescription:
         assert "System prompt for test tool" in system_prompt
 
     @pytest.mark.ai
+    def test_tool_description_for_system_prompt__includes_list_item_guidance__AI(
+        self,
+        mcp_tool_wrapper: MCPToolWrapper,
+    ) -> None:
+        """
+        Purpose: Verify the default list-item retrieval guidance is always appended.
+        Why this matters: Nudging the agent to fetch list items individually yields
+        a distinct, properly-titled reference per item instead of one tool-named chip.
+        Setup summary: Call method, verify the guidance phrase is present.
+        """
+        # Act
+        system_prompt = mcp_tool_wrapper.tool_description_for_system_prompt()
+
+        # Assert
+        assert "retrieve detailed information for each individual list item" in (
+            system_prompt
+        )
+
+    @pytest.mark.ai
+    def test_tool_description_for_system_prompt__omits_none_system_prompt__AI(
+        self,
+        mock_mcp_server: McpServer,
+        mock_mcp_tool_config: MCPToolConfig,
+        mock_chat_event: ChatEvent,
+    ) -> None:
+        """
+        Purpose: Verify a missing per-tool system_prompt is not rendered as "None".
+        Why this matters: A literal "None" leaking into the system prompt is noise
+        that can mislead the model; the guidance should still be present.
+        Setup summary: Create a tool without system_prompt, verify output is clean.
+        """
+        # Arrange
+        tool_no_system_prompt = McpTool(
+            name="tool_no_system",
+            input_schema={"type": "object"},
+            system_prompt=None,
+            is_connected=True,
+        )
+        wrapper = MCPToolWrapper(
+            mcp_server=mock_mcp_server,
+            mcp_tool=tool_no_system_prompt,
+            config=mock_mcp_tool_config,
+            event=mock_chat_event,
+        )
+
+        # Act
+        system_prompt = wrapper.tool_description_for_system_prompt()
+
+        # Assert
+        assert "None" not in system_prompt
+        assert "**Tool Name**: tool_no_system" in system_prompt
+        assert "retrieve detailed information for each individual list item" in (
+            system_prompt
+        )
+
+    @pytest.mark.ai
     def test_tool_description_for_user_prompt__returns_user_prompt__AI(
         self,
         mcp_tool_wrapper: MCPToolWrapper,

--- a/unique_toolkit/unique_toolkit/agentic/tools/mcp/tool_wrapper.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/mcp/tool_wrapper.py
@@ -29,6 +29,16 @@ from unique_toolkit.language_model.schemas import (
 
 logger = logging.getLogger(__name__)
 
+# Default guidance appended to every MCP tool's system prompt. Tools that return
+# a list often surface only a single, tool-named reference (e.g. "search_..."),
+# because the list result carries no per-item title. Nudging the agent to fetch
+# each item individually yields a distinct, properly-titled reference per item.
+_LIST_ITEM_RETRIEVAL_GUIDANCE = (
+    "When using a tool that returns a list of items, try to retrieve detailed "
+    "information for each individual list item where possible (e.g. via a "
+    "get-by-id tool) instead of relying on the list result alone."
+)
+
 
 class MCPToolWrapper(Tool[MCPToolConfig]):
     """Wrapper class for MCP tools that implements the Tool interface"""
@@ -81,13 +91,15 @@ class MCPToolWrapper(Tool[MCPToolConfig]):
     def tool_description_for_system_prompt(self) -> str:
         """Return tool description for system prompt"""
         # Not using jinja here to keep it simple and not import new packages.
-        description = (
-            f"**MCP Server**: {self._mcp_server.name}\n"
-            f"**Tool Name**: {self.name}\n"
-            f"{self._mcp_tool.system_prompt}"
-        )
+        lines = [
+            f"**MCP Server**: {self._mcp_server.name}",
+            f"**Tool Name**: {self.name}",
+        ]
+        if self._mcp_tool.system_prompt:
+            lines.append(self._mcp_tool.system_prompt)
+        lines.append(_LIST_ITEM_RETRIEVAL_GUIDANCE)
 
-        return description
+        return "\n".join(lines)
 
     def tool_description_for_user_prompt(self) -> str:
         return self._mcp_tool.user_prompt or ""


### PR DESCRIPTION
## What

Appends a default guidance line to every MCP tool's system prompt, nudging the agent to retrieve detailed information for each individual list item (e.g. via a get-by-id tool) instead of relying on a list result alone.

## Why

MCP tools that return a list of objects currently surface only a **single, tool-named reference** (e.g. `search_...`) in citations, because the list result carries no per-item title. The reference pipeline (`record_mcp_citations`) can only break a result into per-item chips when each item has a recognizable title — which a raw list rarely provides.

Rather than trying to parse every possible list shape server-side, this takes the pragmatic route: instruct the agent to fetch items individually, so each retrieved object comes back as its own titled result and gets its own citation chip.

## Changes

- `unique_toolkit/agentic/tools/mcp/tool_wrapper.py`
  - New module-level `_LIST_ITEM_RETRIEVAL_GUIDANCE` appended to every MCP tool's system prompt in `tool_description_for_system_prompt()`.
  - Fixed a latent bug: a tool with no `system_prompt` previously rendered a literal `"None"` into the system prompt; it's now omitted when unset.
- Tests: guidance is always present; a `None` per-tool prompt is no longer leaked.

## Notes

- Applies to the in-process **tools-mode** path (reaches the agent via `ToolPrompts` → orchestrator system prompt).
- This is a nudge, not a guarantee — the guidance is generic and also applies to servers with no get-by-id companion. Deterministic citation quality still ultimately depends on the parser in `record_mcp_citations`.

## Test plan

- [x] `pytest tests/agentic/tools/test_mcp_tool_wrapper.py` — 40 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)