### PR TITLE
feat(sdk, toolkit): allow segment_kind on message modify (UN-22153)

### DIFF
--- a/unique_sdk/unique_sdk/api_resources/_message.py
+++ b/unique_sdk/unique_sdk/api_resources/_message.py
@@ -64,6 +64,9 @@ class Message(APIResource["Message"]):
         startedStreamingAt: NotRequired[datetime | None]
         stoppedStreamingAt: NotRequired[datetime | None]
         completedAt: NotRequired[datetime | None]
+        segmentKind: NotRequired[
+            Literal["PROCESS", "PREFACE", "ELICITATION", "ANSWER"] | None
+        ]
 
     class DeleteParams(RequestOptions):
         chatId: str

--- a/unique_toolkit/tests/chat/test_chat_functions_unit.py
+++ b/unique_toolkit/tests/chat/test_chat_functions_unit.py
@@ -229,6 +229,51 @@ def test_modify_message_with_references(mock_sdk, sample_message_data):
     assert isinstance(call_kwargs["references"], list)
 
 
+def test_modify_message_with_segment_kind(mock_sdk, sample_message_data):
+    # Setup
+    mock_sdk.Message.modify.return_value = sample_message_data
+
+    # Execute
+    result = modify_message(
+        user_id="user123",
+        company_id="company123",
+        assistant_message_id="asst123",
+        chat_id="chat123",
+        user_message_id="user123",
+        user_message_text="Hello",
+        assistant=True,
+        content="",
+        segment_kind="PREFACE",
+    )
+
+    # Assert
+    assert isinstance(result, ChatMessage)
+    mock_sdk.Message.modify.assert_called_once()
+    call_kwargs = mock_sdk.Message.modify.call_args[1]
+    assert call_kwargs["segmentKind"] == "PREFACE"
+
+
+def test_modify_message_without_segment_kind_omits_key(mock_sdk, sample_message_data):
+    # Setup
+    mock_sdk.Message.modify.return_value = sample_message_data
+
+    # Execute
+    modify_message(
+        user_id="user123",
+        company_id="company123",
+        assistant_message_id="asst123",
+        chat_id="chat123",
+        user_message_id="user123",
+        user_message_text="Hello",
+        assistant=True,
+        content="Modified content",
+    )
+
+    # Assert
+    call_kwargs = mock_sdk.Message.modify.call_args[1]
+    assert "segmentKind" not in call_kwargs
+
+
 @pytest.mark.asyncio
 async def test_create_message_async(mock_sdk, sample_message_data):
     # Setup

--- a/unique_toolkit/tests/chat/test_chat_service_unit.py
+++ b/unique_toolkit/tests/chat/test_chat_service_unit.py
@@ -216,6 +216,39 @@ class TestChatServiceUnit:
         ]
         mock_modify.assert_has_calls(expected_calls)
 
+    @patch.object(unique_sdk.Message, "modify", autospec=True)
+    def test_modify_assistant_message_with_segment_kind(self, mock_modify):
+        mock_modify.return_value = {
+            "id": "test_message",
+            "chatId": "chatId123",
+            "content": "",
+            "role": "assistant",
+        }
+
+        result = self.service.modify_assistant_message(
+            content="",
+            message_id="test_assistant_message",
+            segment_kind="PREFACE",
+        )
+
+        assert isinstance(result, ChatMessage)
+
+        expected_calls = [
+            mock.call(
+                user_id="test_user",
+                company_id="test_company",
+                id="test_assistant_message",
+                chatId="test_chat",
+                text="",
+                originalText=None,
+                references=[],
+                debugInfo=None,
+                completedAt=None,
+                segmentKind="PREFACE",
+            )
+        ]
+        mock_modify.assert_has_calls(expected_calls)
+
     @patch.object(unique_sdk.Message, "list", autospec=True)
     def test_get_history(self, mock_list):
         mock_list.return_value = {

--- a/unique_toolkit/unique_toolkit/chat/functions.py
+++ b/unique_toolkit/unique_toolkit/chat/functions.py
@@ -66,6 +66,7 @@ def modify_message(
     debug_info: dict[str, Any] | None = None,
     message_id: str | None = None,
     set_completed_at: bool = False,
+    segment_kind: str | None = None,
 ) -> ChatMessage:
     """Modifies a chat message synchronously.
 
@@ -83,6 +84,7 @@ def modify_message(
         references (list[ContentReference]): list of ContentReference objects. Defaults to None.
         debug_info (dict[str, Any]], optional): Debug information. Defaults to None.
         set_completed_at (bool, optional): Whether to set the completedAt field with the current date time. Defaults to False.
+        segment_kind (str, optional): The segment kind (e.g. "PROCESS", "PREFACE", "ELICITATION", "ANSWER") to relabel the segment to in place. Defaults to None (kind unchanged).
 
     Returns:
         ChatMessage: The modified message.
@@ -106,6 +108,7 @@ def modify_message(
             debug_info=debug_info,
             message_id=message_id,
             set_completed_at=set_completed_at,
+            segment_kind=segment_kind,
         )
         message = unique_sdk.Message.modify(**params)
         return ChatMessage(**message)
@@ -128,6 +131,7 @@ async def modify_message_async(
     debug_info: dict[str, Any] | None = None,
     message_id: str | None = None,
     set_completed_at: bool = False,
+    segment_kind: str | None = None,
 ) -> ChatMessage:
     """Modifies a chat message asynchronously.
 
@@ -145,6 +149,7 @@ async def modify_message_async(
         references (list[ContentReference]): list of ContentReference objects. Defaults to None.
         debug_info (dict[str, Any]], optional): Debug information. Defaults to None.
         set_completed_at (bool, optional): Whether to set the completedAt field with the current date time. Defaults to False.
+        segment_kind (str, optional): The segment kind (e.g. "PROCESS", "PREFACE", "ELICITATION", "ANSWER") to relabel the segment to in place. Defaults to None (kind unchanged).
 
     Returns:
         ChatMessage: The modified message.
@@ -168,6 +173,7 @@ async def modify_message_async(
             debug_info=debug_info,
             message_id=message_id,
             set_completed_at=set_completed_at,
+            segment_kind=segment_kind,
         )
         message = await unique_sdk.Message.modify_async(**params)
         return ChatMessage(**message)
@@ -225,6 +231,7 @@ def _construct_message_modify_params(
     debug_info: dict[str, Any] | None = None,
     message_id: str | None = None,
     set_completed_at: bool = False,
+    segment_kind: str | None = None,
 ) -> dict[str, Any]:
     completed_at_datetime = None
 
@@ -242,7 +249,7 @@ def _construct_message_modify_params(
     if set_completed_at:
         completed_at_datetime = _time_utils.get_datetime_now()
 
-    params = {
+    params: dict[str, Any] = {
         "user_id": user_id,
         "company_id": company_id,
         "id": message_id,
@@ -253,6 +260,8 @@ def _construct_message_modify_params(
         "debugInfo": debug_info,
         "completedAt": completed_at_datetime,
     }
+    if segment_kind is not None:
+        params["segmentKind"] = segment_kind
     return params
 
 

--- a/unique_toolkit/unique_toolkit/services/chat_service.py
+++ b/unique_toolkit/unique_toolkit/services/chat_service.py
@@ -387,6 +387,7 @@ class ChatService(ChatServiceDeprecated):
         debug_info: dict[str, Any] | None = None,
         message_id: str | None = None,
         set_completed_at: bool | None = None,
+        segment_kind: str | None = None,
     ) -> ChatMessage:
         """Modifies a message in the chat session synchronously if parameter is not specified the corresponding field will remain as is.
 
@@ -397,6 +398,7 @@ class ChatService(ChatServiceDeprecated):
             debug_info (dict[str, Any]]]): Debug information. Defaults to {}.
             message_id (Optional[str]): The message ID. Defaults to None.
             set_completed_at (Optional[bool]): Whether to set the completedAt field with the current date time. Defaults to False.
+            segment_kind (str, optional): The segment kind (e.g. "PROCESS", "PREFACE", "ELICITATION", "ANSWER") to relabel the segment to in place, e.g. relabeling M0 from PROCESS to PREFACE once content is set. Defaults to None (kind unchanged).
 
         Returns:
             ChatMessage: The modified message.
@@ -420,6 +422,7 @@ class ChatService(ChatServiceDeprecated):
             debug_info=debug_info,
             message_id=message_id,
             set_completed_at=set_completed_at or False,
+            segment_kind=segment_kind,
         )
 
     async def modify_assistant_message_async(
@@ -430,6 +433,7 @@ class ChatService(ChatServiceDeprecated):
         debug_info: dict[str, Any] | None = None,
         message_id: str | None = None,
         set_completed_at: bool | None = False,
+        segment_kind: str | None = None,
     ) -> ChatMessage:
         """Modifies a message in the chat session asynchronously.
 
@@ -440,6 +444,7 @@ class ChatService(ChatServiceDeprecated):
             references (list[ContentReference]): list of ContentReference objects. Defaults to None.
             debug_info (dict[str, Any]], optional): Debug information. Defaults to None.
             set_completed_at (bool, optional): Whether to set the completedAt field with the current date time. Defaults to False.
+            segment_kind (str, optional): The segment kind (e.g. "PROCESS", "PREFACE", "ELICITATION", "ANSWER") to relabel the segment to in place, e.g. relabeling M0 from PROCESS to PREFACE once content is set. Defaults to None (kind unchanged).
 
         Returns:
             ChatMessage: The modified message.
@@ -462,6 +467,7 @@ class ChatService(ChatServiceDeprecated):
             debug_info=debug_info,
             message_id=message_id,
             set_completed_at=set_completed_at or False,
+            segment_kind=segment_kind,
         )
 
     def create_assistant_message(


### PR DESCRIPTION
## Summary
- Adds `segmentKind` to `unique_sdk`'s `Message.ModifyParams` and a matching `segment_kind` param through `unique_toolkit`'s `modify_message(_async)` / `ChatService.modify_assistant_message(_async)`, mirroring the existing create-path pattern.
- Lets a caller relabel an existing segment's kind in place via `modify` (previously only possible via `create`) — fixes the M0 "ghost bubble": M0 is auto-created by node-chat as `segmentKind=PROCESS` before the Python strategy runs, and `SegmentItem.tsx` hides empty segments unless `segmentKind === 'PROCESS'`, so an emptied `PROCESS` M0 was never hidden.
- Purely additive: new params default to `None` and are only forwarded when explicitly set, so all existing callers are unaffected (covered by tests).

## Changes
- `unique_sdk/unique_sdk/api_resources/_message.py`: add `segmentKind` to `Message.ModifyParams`.
- `unique_toolkit/unique_toolkit/chat/functions.py`: add `segment_kind` to `_construct_message_modify_params`, `modify_message`, `modify_message_async`.
- `unique_toolkit/unique_toolkit/services/chat_service.py`: add `segment_kind` to `ChatService.modify_assistant_message(_async)`, update docstrings.
- Tests: new unit tests asserting `segmentKind` is forwarded when set and omitted when not, in both `unique_toolkit/tests/chat/test_chat_functions_unit.py` and `test_chat_service_unit.py`.

## Monorepo follow-up (new UI streaming for swappable intelligence)
No node-chat change needed — `MessageUpdateInput` already accepts `segmentKind` and `message.service.ts` forwards it with no guards. Once this is published, the monorepo side of the swappable-intelligence streaming work will:
- Bump `unique-toolkit`/`unique-sdk` floors in `python/assistants/bundles/core/src/pyproject.toml` (+ `uv.lock`).
- Bump the exact pins in `conduct/sbx/runtime/images/unique-polyagent/001/requirements.in` (+ lock).
- Let `runner.py`'s `_report_setup_status()` use `segment_kind="PREFACE"` on its first `modify_assistant_message_async` call per turn (already guarded + has a `TypeError` fallback to a content-only call, so it's a safe no-op until the floor bump lands).

## Test plan
- [x] `ruff check` / `ruff format` clean on both packages
- [x] `unique_toolkit` chat unit tests pass, including new `segment_kind` coverage (pre-existing, unrelated sandbox/network test failures in tiktoken-dependent tests excluded)
- [ ] Manual verification of M0 relabeling end-to-end (pending monorepo-side floor bump — tracked separately)

## Risk / rollout
- Backward compatible, additive-only change; no behavior change for existing callers that don't pass `segment_kind`.
- No changelog/version bump included — release-please handles that from these commits' `feat(sdk):`/`feat(toolkit):` scopes on the standing Release PR.

Refs: UN-22153

Made with [Cursor](https://cursor.com)