### PR TITLE
feat(mcp): config-driven reference mapping for MCP list-result citations

### DIFF
--- a/unique_sdk/tests/cli/test_mcp.py
+++ b/unique_sdk/tests/cli/test_mcp.py
@@ -113,8 +113,11 @@ def test_cmd_mcp_truncates_large_output(tmp_path: Path) -> None:
 # ── Refs manifest / citations (UN-21285) ─────────────────────────────────────
 #
 # One source per retrieved item — a *title* describing what was retrieved (no
-# URL). Titles come from resource_link names or a JSON-title heuristic; falls
-# back to a title-less tool chip when the result has no recognizable title.
+# URL). Titles come from (in order) a per-tool ``reference_mapping``, then
+# resource_link names, then a JSON-title heuristic over text blocks — the
+# heuristic tolerates a non-JSON preamble and unwraps a container key
+# (``{"issues": [...]}``) so each record becomes its own reference; falls back
+# to a title-less tool chip when the result has no recognizable title.
 
 
 def test_resource_link_item_has_title_no_url(tmp_path: Path) -> None:
@@ -209,6 +212,23 @@ def test_json_in_text_object_with_dict_container_key_stays_untitled(
             "details": None,
         }
     ]
+
+
+def test_json_in_text_titled_record_not_split_by_content_key(tmp_path: Path) -> None:
+    # A single page/document payload that carries its own top-level title plus a
+    # ``content`` body (an ambiguous container key) must keep the page title
+    # rather than being split into title-less inner blocks.
+    body = json.dumps(
+        {
+            "title": "Retrieval Design Doc",
+            "content": [{"block": "intro"}, {"block": "body"}],
+        }
+    )
+    response = _FakeMCPResponse(content=[{"type": "text", "text": body}])
+    _run("mcp__atlassian__getConfluencePage", response)
+
+    refs = _lines(tmp_path, _REFS_MANIFEST)
+    assert [r["title"] for r in refs] == ["Retrieval Design Doc"]
 
 
 # ── Reference enrichment / details line (UN-22310) ───────────────────────────
@@ -739,3 +759,37 @@ def test_reference_mapping_falls_back_to_heuristic_when_no_match(
     )
     refs = _unique_lines(unique_dir, "mcp-refs.jsonl")
     assert [r["title"] for r in refs] == ["Lonely Page"]
+
+
+def test_reference_mapping_title_from_text_does_not_block_list_heuristic(
+    tmp_path: Path,
+) -> None:
+    # A mapping that finds list records but resolves no per-record title must not
+    # fall through to titleFromText (a bogus single text chip). It should defer
+    # to the generic heuristic so each issue still becomes its own reference.
+    unique_dir = tmp_path / ".unique"
+    body = json.dumps(
+        {
+            "issues": [
+                {"key": "UN-1", "fields": {"summary": "First"}},
+                {"key": "UN-2", "fields": {"summary": "Second"}},
+            ]
+        }
+    )
+    response = _FakeMCPResponse(
+        content=[{"type": "text", "text": body}], mcp_server_id="atlassian"
+    )
+    record_mcp_citations(
+        response,
+        tool_name="searchJiraIssuesUsingJql",
+        server_name="atlassian",
+        unique_dir=unique_dir,
+        formatted_text=body,
+        reference_mapping={
+            "listPath": "issues",
+            "titlePath": "nonexistent",
+            "titleFromText": True,
+        },
+    )
+    refs = _unique_lines(unique_dir, "mcp-refs.jsonl")
+    assert {r["title"]: r["sourceNumber"] for r in refs} == {"UN-1": 1, "UN-2": 2}

--- a/unique_sdk/tests/cli/test_mcp.py
+++ b/unique_sdk/tests/cli/test_mcp.py
@@ -739,6 +739,61 @@ def test_reference_mapping_title_from_text_for_markdown_doc(tmp_path: Path) -> N
     ]
 
 
+def test_reference_mapping_list_of_plain_strings_titled_from_text(
+    tmp_path: Path,
+) -> None:
+    # A JSON array of plain-text documents: each item's title is its leading
+    # line (Markdown heading markers stripped, capped).
+    unique_dir = tmp_path / ".unique"
+    body = json.dumps({"docs": ["# Alpha Guide\nbody", "## Beta Notes\nmore"]})
+    response = _FakeMCPResponse(content=[{"type": "text", "text": body}])
+    record_mcp_citations(
+        response,
+        tool_name="list_docs",
+        server_name="docs",
+        unique_dir=unique_dir,
+        formatted_text=body,
+        reference_mapping={"listPath": "docs", "titleFromText": True},
+    )
+    refs = _lines(tmp_path, _REFS_MANIFEST)
+    assert [r["title"] for r in refs] == ["Alpha Guide", "Beta Notes"]
+
+
+def test_reference_mapping_list_of_objects_titled_from_text_field(
+    tmp_path: Path,
+) -> None:
+    # A JSON array of objects whose title comes from a text body field, with a
+    # separate details field per item.
+    unique_dir = tmp_path / ".unique"
+    body = json.dumps(
+        {
+            "results": [
+                {"content": "# Gamma\nx", "updated": "2026-01-01"},
+                {"content": "Delta\ny", "updated": "2026-02-02"},
+            ]
+        }
+    )
+    response = _FakeMCPResponse(content=[{"type": "text", "text": body}])
+    record_mcp_citations(
+        response,
+        tool_name="search_text_docs",
+        server_name="docs",
+        unique_dir=unique_dir,
+        formatted_text=body,
+        reference_mapping={
+            "listPath": "results",
+            "titleFromText": True,
+            "titleTextPath": "content",
+            "detailsPath": "updated",
+        },
+    )
+    refs = _lines(tmp_path, _REFS_MANIFEST)
+    assert {r["title"]: r["details"] for r in refs} == {
+        "Gamma": "2026-01-01",
+        "Delta": "2026-02-02",
+    }
+
+
 def test_reference_mapping_falls_back_to_heuristic_when_no_match(
     tmp_path: Path,
 ) -> None:

--- a/unique_sdk/tests/cli/test_mcp.py
+++ b/unique_sdk/tests/cli/test_mcp.py
@@ -154,6 +154,59 @@ def test_json_in_text_yields_title_no_url(tmp_path: Path) -> None:
     assert "url" not in refs[0]
 
 
+def test_json_in_text_unwraps_wrapped_array_into_items(tmp_path: Path) -> None:
+    # Atlassian JQL search: records wrapped under an "issues" key must each
+    # become their own reference (via the top-level "key"), not collapse into
+    # one title-less tool chip.
+    body = json.dumps(
+        {
+            "issues": [
+                {"key": "UN-1", "fields": {"summary": "First"}},
+                {"key": "UN-2", "fields": {"summary": "Second"}},
+            ]
+        }
+    )
+    response = _FakeMCPResponse(content=[{"type": "text", "text": body}])
+    _run("mcp__atlassian__searchJiraIssuesUsingJql", response)
+
+    refs = _lines(tmp_path, _REFS_MANIFEST)
+    assert {r["title"]: r["sourceNumber"] for r in refs} == {"UN-1": 1, "UN-2": 2}
+
+
+def test_json_in_text_tolerates_non_json_preamble(tmp_path: Path) -> None:
+    # Some servers (Atlassian) prefix a human-readable notice before the JSON;
+    # the whole string is not valid JSON, so the embedded body must be located.
+    body = json.dumps({"issues": [{"key": "UN-9", "fields": {"summary": "X"}}]})
+    text = f"[IMPORTANT: notice with a [bracket] inside]\n{body}"
+    response = _FakeMCPResponse(content=[{"type": "text", "text": text}])
+    _run("mcp__atlassian__searchJiraIssuesUsingJql", response)
+
+    refs = _lines(tmp_path, _REFS_MANIFEST)
+    assert [r["title"] for r in refs] == ["UN-9"]
+
+
+def test_json_in_text_object_with_dict_container_key_stays_untitled(
+    tmp_path: Path,
+) -> None:
+    # A container key whose value is a dict (not a list) must NOT be unwrapped;
+    # with no top-level title the result falls back to a single tool chip.
+    body = json.dumps({"data": {"users": {"users": []}}})
+    response = _FakeMCPResponse(content=[{"type": "text", "text": body}])
+    _run("mcp__atlassian__lookupJiraAccountId", response)
+
+    refs = _lines(tmp_path, _REFS_MANIFEST)
+    assert refs == [
+        {
+            "sourceNumber": 1,
+            "toolName": "mcp__atlassian__lookupJiraAccountId",
+            "serverName": "atlassian",
+            "title": None,
+            "snippet": None,
+            "details": None,
+        }
+    ]
+
+
 # ── Reference enrichment / details line (UN-22310) ───────────────────────────
 
 
@@ -570,3 +623,65 @@ def test_record_mcp_citations_concurrent_monotonic_numbers(
     # collisions despite concurrent writers (the per-turn flock serializes them).
     assert numbers == list(range(1, n + 1))
     assert len(_unique_lines(unique_dir, "mcp-output.jsonl")) == n
+
+
+# ── reference_mapping override (per-tool list destructuring) ──────────────────
+
+
+def test_reference_mapping_destructures_wrapped_list_with_template(
+    tmp_path: Path,
+) -> None:
+    # Atlassian-style: a non-JSON preamble wrapping issues under "issues", each
+    # issue's title composed from key + nested fields.summary via titleTemplate.
+    unique_dir = tmp_path / ".unique"
+    body = json.dumps(
+        {
+            "issues": [
+                {"key": "UN-1", "fields": {"summary": "First"}},
+                {"key": "UN-2", "fields": {"summary": "Second"}},
+            ]
+        }
+    )
+    response = _FakeMCPResponse(
+        content=[{"type": "text", "text": f"[IMPORTANT: notice]\n{body}"}],
+        mcp_server_id="atlassian",
+    )
+    footer = record_mcp_citations(
+        response,
+        tool_name="searchJiraIssuesUsingJql",
+        server_name="atlassian",
+        unique_dir=unique_dir,
+        formatted_text=body,
+        reference_mapping={
+            "listPath": "issues",
+            "titleTemplate": "{key} — {fields.summary}",
+        },
+    )
+    refs = _unique_lines(unique_dir, "mcp-refs.jsonl")
+    assert {r["title"]: r["sourceNumber"] for r in refs} == {
+        "UN-1 — First": 1,
+        "UN-2 — Second": 2,
+    }
+    assert "[mcpsource1] UN-1 — First" in footer
+
+
+def test_reference_mapping_falls_back_to_heuristic_when_no_match(
+    tmp_path: Path,
+) -> None:
+    # listPath points nowhere → mapping yields nothing → the generic JSON-title
+    # heuristic still extracts the top-level title.
+    unique_dir = tmp_path / ".unique"
+    body = json.dumps({"title": "Lonely Page"})
+    response = _FakeMCPResponse(
+        content=[{"type": "text", "text": body}], mcp_server_id="atlassian"
+    )
+    record_mcp_citations(
+        response,
+        tool_name="getConfluencePage",
+        server_name="atlassian",
+        unique_dir=unique_dir,
+        formatted_text=body,
+        reference_mapping={"listPath": "does_not_exist", "titlePath": "key"},
+    )
+    refs = _unique_lines(unique_dir, "mcp-refs.jsonl")
+    assert [r["title"] for r in refs] == ["Lonely Page"]

--- a/unique_sdk/tests/cli/test_mcp.py
+++ b/unique_sdk/tests/cli/test_mcp.py
@@ -793,3 +793,27 @@ def test_reference_mapping_title_from_text_does_not_block_list_heuristic(
     )
     refs = _unique_lines(unique_dir, "mcp-refs.jsonl")
     assert {r["title"]: r["sourceNumber"] for r in refs} == {"UN-1": 1, "UN-2": 2}
+
+
+def test_reference_mapping_empty_structured_content_still_titles_from_text(
+    tmp_path: Path,
+) -> None:
+    # An empty structuredContent object must not count as a located record: it
+    # carries no data, so titleFromText should still title the chip from the
+    # leading Markdown heading instead of falling back to the tool-name chip.
+    unique_dir = tmp_path / ".unique"
+    doc = "# Quarterly Planning Notes\n\nBody..."
+    response = _FakeMCPResponse(
+        content=[{"type": "text", "text": doc}], mcp_server_id="docs"
+    )
+    response.structured_content = {}
+    record_mcp_citations(
+        response,
+        tool_name="read_doc",
+        server_name="docs",
+        unique_dir=unique_dir,
+        formatted_text=doc,
+        reference_mapping={"titleFromText": True, "titleMaxChars": 80},
+    )
+    refs = _unique_lines(unique_dir, "mcp-refs.jsonl")
+    assert [r["title"] for r in refs] == ["Quarterly Planning Notes"]

--- a/unique_sdk/tests/cli/test_mcp.py
+++ b/unique_sdk/tests/cli/test_mcp.py
@@ -665,6 +665,34 @@ def test_reference_mapping_destructures_wrapped_list_with_template(
     assert "[mcpsource1] UN-1 — First" in footer
 
 
+def test_reference_mapping_writes_all_items_no_cap(tmp_path: Path) -> None:
+    # Every retrieved record must get its own reference — the extractor no
+    # longer caps the number of items per call.
+    unique_dir = tmp_path / ".unique"
+    n = 25
+    body = json.dumps(
+        {
+            "issues": [
+                {"key": f"UN-{i}", "fields": {"summary": f"s{i}"}} for i in range(n)
+            ]
+        }
+    )
+    response = _FakeMCPResponse(
+        content=[{"type": "text", "text": body}], mcp_server_id="atlassian"
+    )
+    record_mcp_citations(
+        response,
+        tool_name="searchJiraIssuesUsingJql",
+        server_name="atlassian",
+        unique_dir=unique_dir,
+        formatted_text=body,
+        reference_mapping={"listPath": "issues", "titlePath": "key"},
+    )
+    refs = _unique_lines(unique_dir, "mcp-refs.jsonl")
+    assert len(refs) == n
+    assert {r["sourceNumber"] for r in refs} == set(range(1, n + 1))
+
+
 def test_reference_mapping_falls_back_to_heuristic_when_no_match(
     tmp_path: Path,
 ) -> None:

--- a/unique_sdk/tests/cli/test_mcp.py
+++ b/unique_sdk/tests/cli/test_mcp.py
@@ -92,7 +92,11 @@ def test_cmd_mcp_writes_output_manifest(tmp_path: Path) -> None:
         _FakeMCPResponse(),
         formatted="ACME revenue: 1M",
     )
-    assert out.startswith("ACME revenue: 1M")
+    # Sources block leads so markers survive harness-side spilling of large
+    # results (UN-22309); the formatted tool output follows it.
+    assert out.startswith("Sources — MANDATORY")
+    assert "ACME revenue: 1M" in out
+    assert out.index("Sources — MANDATORY") < out.index("ACME revenue: 1M")
     entries = _lines(tmp_path, _OUTPUT_MANIFEST)
     assert entries[0]["toolName"] == "mcp__crm__get_account"
     assert entries[0]["serverName"] == "crm"
@@ -138,7 +142,7 @@ def test_resource_link_item_has_title_no_url(tmp_path: Path) -> None:
         }
     ]
     assert "[mcpsource1] RAG Retrieval Baseline" in out
-    assert "https://" not in out.split("result", 1)[1]  # no URL leaked into footer
+    assert "https://" not in out  # no URL leaked into the Sources block or body
 
 
 def test_json_in_text_yields_title_no_url(tmp_path: Path) -> None:
@@ -691,6 +695,28 @@ def test_reference_mapping_writes_all_items_no_cap(tmp_path: Path) -> None:
     refs = _unique_lines(unique_dir, "mcp-refs.jsonl")
     assert len(refs) == n
     assert {r["sourceNumber"] for r in refs} == set(range(1, n + 1))
+
+
+def test_reference_mapping_title_from_text_for_markdown_doc(tmp_path: Path) -> None:
+    # A fetched Markdown doc (non-JSON) titles its single chip from the leading
+    # heading line when titleFromText is set, instead of the tool-name fallback.
+    unique_dir = tmp_path / ".unique"
+    doc = "# Retrieval Performance and Scalability Evaluation\n\nhttps://docs.unique.ai/x\n\nBody..."
+    response = _FakeMCPResponse(
+        content=[{"type": "text", "text": doc}], mcp_server_id="docs"
+    )
+    record_mcp_citations(
+        response,
+        tool_name="read_doc",
+        server_name="docs",
+        unique_dir=unique_dir,
+        formatted_text=doc,
+        reference_mapping={"titleFromText": True, "titleMaxChars": 80},
+    )
+    refs = _unique_lines(unique_dir, "mcp-refs.jsonl")
+    assert [r["title"] for r in refs] == [
+        "Retrieval Performance and Scalability Evaluation"
+    ]
 
 
 def test_reference_mapping_falls_back_to_heuristic_when_no_match(

--- a/unique_sdk/unique_sdk/cli/commands/mcp.py
+++ b/unique_sdk/unique_sdk/cli/commands/mcp.py
@@ -28,8 +28,13 @@ _LOGGER = logging.getLogger(__name__)
 # (referencing is UN-21285, tracked separately).
 _MCP_OUTPUT_LOG_RELATIVE_PATH = Path(".unique") / "mcp-output.jsonl"
 # Writer-side cap so a single huge/raw tool result cannot bloat the manifest.
-# The evaluator applies its own per-source cap as well.
-_MCP_OUTPUT_TEXT_CHAR_LIMIT = 50_000
+# This manifest is the groundedness check's source of truth, so the cap is
+# sized against the eval model's context window rather than kept minimal:
+# GPT-4o's 128k-token input fits ~400k chars, and the runner bounds the
+# combined per-turn payload separately (UN-22309). At the previous 50k, a
+# large list result (e.g. a 115k-char Jira search) lost most of its items
+# before the judge saw them, flagging well-grounded answers as hallucinations.
+_MCP_OUTPUT_TEXT_CHAR_LIMIT = 200_000
 
 # Per-turn manifest of citable MCP sources, consumed by the runner to stitch
 # ``[mcpsourceN]`` markers into ``<sup>N</sup>`` footnotes + reference chips
@@ -300,17 +305,45 @@ def _mapped_records(response: Any, list_path: str | None) -> list[dict[str, Any]
     return []
 
 
+_MCP_TEXT_TITLE_DEFAULT_CHARS = 120
+
+
+def _first_text_title(response: Any, max_chars: int) -> str | None:
+    """Title from the first non-empty line of the first text block — for a
+    non-JSON result such as a fetched Markdown document (e.g. ``read_doc``),
+    whose first line is the doc's ``# heading``. Strips leading Markdown
+    heading/list markers and caps the length."""
+    for block in getattr(response, "content", None) or []:
+        if isinstance(block, dict) and block.get("type") == "text":
+            for line in (block.get("text") or "").splitlines():
+                stripped = line.strip().lstrip("#*->").strip()
+                if stripped:
+                    return stripped[:max_chars]
+    return None
+
+
 def _extract_with_reference_mapping(
     response: Any, mapping: dict[str, Any]
 ) -> list[dict[str, Any]]:
-    """Destructure a list result into ``{title, snippet, details}`` items using
-    an admin-configured reference mapping. Returns [] when the mapping locates
-    nothing, so the caller can fall back to the generic heuristic."""
+    """Destructure a result into ``{title, snippet, details}`` items using an
+    admin-configured reference mapping. For a list result, one item per record;
+    for a non-JSON text result with ``titleFromText`` set, a single item titled
+    from the leading text. Returns [] when the mapping locates nothing, so the
+    caller can fall back to the generic heuristic."""
     list_path = mapping.get("listPath") or mapping.get("list_path")
     title_path = mapping.get("titlePath") or mapping.get("title_path")
     title_template = mapping.get("titleTemplate") or mapping.get("title_template")
     details_path = mapping.get("detailsPath") or mapping.get("details_path")
     snippet_path = mapping.get("snippetPath") or mapping.get("snippet_path")
+    title_from_text = mapping.get("titleFromText") or mapping.get("title_from_text")
+    try:
+        title_max_chars = int(
+            mapping.get("titleMaxChars")
+            or mapping.get("title_max_chars")
+            or _MCP_TEXT_TITLE_DEFAULT_CHARS
+        )
+    except (TypeError, ValueError):
+        title_max_chars = _MCP_TEXT_TITLE_DEFAULT_CHARS
 
     items: list[dict[str, Any]] = []
     for record in _mapped_records(response, list_path):
@@ -332,6 +365,14 @@ def _extract_with_reference_mapping(
                 "details": str(details).strip() if details else None,
             }
         )
+    if items:
+        return items
+    # Non-list / non-JSON result (e.g. a fetched Markdown doc): title the single
+    # chip from the leading text when the tool opts in via ``titleFromText``.
+    if title_from_text:
+        title = _first_text_title(response, title_max_chars)
+        if title:
+            return [{"title": title, "snippet": None, "details": None}]
     return items
 
 
@@ -408,11 +449,11 @@ def _annotate_mcp_results_for_citations(
     reference_mapping: dict[str, Any] | None = None,
 ) -> list[tuple[int, dict[str, Any]]]:
     """Assign per-turn ``[mcpsourceN]`` numbers to each retrieved item and append
-    the refs manifest. Returns ``[(sourceNumber, item)]`` for the footer.
+    the refs manifest. Returns ``[(sourceNumber, item)]`` for the Sources block.
 
     Items dedup by title across the turn (same item keeps one number), or by
     tool for the title-less fallback. Best-effort — returns ``[]`` on any failure
-    (the tool result is unaffected; only the citation footer is skipped).
+    (the tool result is unaffected; only the citation Sources block is skipped).
     """
     refs_log_path = refs_log_path or (Path.cwd() / _MCP_REFS_LOG_RELATIVE_PATH)
     annotated: list[tuple[int, dict[str, Any]]] = []
@@ -490,15 +531,20 @@ def _annotate_mcp_results_for_citations(
     return annotated
 
 
-def _citation_footer(annotated: list[tuple[int, dict[str, Any]]]) -> str:
-    """Tell the agent which marker to cite each retrieved item with."""
+def _citation_sources_block(annotated: list[tuple[int, dict[str, Any]]]) -> str:
+    """Tell the agent which marker to cite each retrieved item with.
+
+    Rendered *before* the tool output (leading block, not a trailing footer):
+    the agent harness spills oversized tool results to a file wholesale, and a
+    partial or programmatic read of that file only reliably sees the head — a
+    trailing marker list would be exactly what such reads miss (UN-22309).
+    """
     if not annotated:
         return ""
     lines = [
-        "",
         "Sources — MANDATORY: every fact you take from this result MUST be "
-        "cited inline with its [mcpsourceN] marker below, or it will not be "
-        "referenced in the answer:",
+        "cited inline with its [mcpsourceN] marker from this list, or it "
+        "will not be referenced in the answer:",
     ]
     for source_number, item in annotated:
         label = item.get("title") or "this MCP tool result"
@@ -548,12 +594,15 @@ def record_mcp_citations(
     reference_mapping: dict[str, Any] | None = None,
 ) -> str:
     """Write both per-turn MCP manifests under ``unique_dir`` and return the
-    ``[mcpsourceN]`` citation footer for the agent.
+    ``[mcpsourceN]`` citation Sources block for the agent.
 
-    Shared by the ``unique-cli mcp`` skills flow (``cmd_mcp``) and the
-    in-process tools-mode proxy in assistants-core, so both write identical
-    manifests and footers. ``unique_dir`` is the workspace ``.unique`` directory
-    (its filenames are joined directly here — do not pass the workspace root).
+    Callers must place the block *before* the tool output (leading block, not
+    a trailing footer) so the markers survive harness-side spilling/truncation
+    of large results (UN-22309). Shared by the ``unique-cli mcp`` skills flow
+    (``cmd_mcp``) and the in-process tools-mode proxy in assistants-core, so
+    both write identical manifests and blocks. ``unique_dir`` is the workspace
+    ``.unique`` directory (its filenames are joined directly here — do not
+    pass the workspace root).
 
     - ``response`` is the raw ``unique_sdk.MCP`` result, used for citation
       extraction (titles from ``resource_link`` names / JSON bodies).
@@ -578,7 +627,7 @@ def record_mcp_citations(
         refs_log_path=unique_dir / _MCP_REFS_LOG_RELATIVE_PATH.name,
         reference_mapping=reference_mapping,
     )
-    return _citation_footer(annotated)
+    return _citation_sources_block(annotated)
 
 
 def _read_payload(
@@ -662,7 +711,7 @@ def cmd_mcp(
         formatted = f"mcp: formatter error ({fmt_exc}); raw response:\n{fallback}"
 
     server_name = _server_name_from_tool(name) or getattr(response, "mcpServerId", None)
-    footer = record_mcp_citations(
+    sources_block = record_mcp_citations(
         response,
         tool_name=name,
         server_name=server_name,
@@ -670,4 +719,8 @@ def cmd_mcp(
         formatted_text=formatted,
         reference_mapping=state.mcp_tool_reference_mappings.get(name),
     )
-    return formatted + footer
+    # Sources block FIRST: large outputs get spilled/truncated tail-first by
+    # the agent harness, and a trailing block is what partial reads miss.
+    if sources_block:
+        return sources_block + "\n\n" + formatted
+    return formatted

--- a/unique_sdk/unique_sdk/cli/commands/mcp.py
+++ b/unique_sdk/unique_sdk/cli/commands/mcp.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import sys
 from pathlib import Path
 from typing import Any
@@ -152,28 +153,186 @@ def _details_from_json(obj: dict[str, Any]) -> str | None:
     return " - ".join(parts)[:_MCP_DETAILS_CHAR_LIMIT]
 
 
-def _titles_from_json(text: str) -> list[dict[str, Any]]:
-    """Best-effort: pull a human title out of a JSON result (object or list of
-    objects), e.g. an Atlassian page/issue returned as JSON-in-text. Returns []
-    when the text is not JSON or carries no recognizable title.
+# Keys under which a JSON object commonly wraps the actual list of retrieved
+# records, e.g. Jira's ``{"issues": [...]}`` or a generic ``{"results": [...]}``.
+# When a result wraps its records this way, we iterate the list so each record
+# becomes its own reference instead of collapsing to one title-less chip.
+_CONTAINER_KEYS = (
+    "issues",
+    "results",
+    "items",
+    "values",
+    "data",
+    "hits",
+    "records",
+    "entries",
+    "elements",
+    "content",
+)
+
+
+def _loads_embedded_json(text: str) -> Any:
+    """Parse a JSON value from a tool-result string, tolerating a non-JSON
+    preamble.
+
+    Some MCP servers (e.g. Atlassian) prefix the JSON body with a human-readable
+    notice like ``[IMPORTANT: ...]\\n{...}``, so a direct ``json.loads`` of the
+    whole string fails. Try a direct parse first, then fall back to decoding the
+    first JSON object/array that appears. Returns ``None`` when no JSON is found.
     """
     try:
-        parsed = json.loads(text)
+        return json.loads(text)
     except (ValueError, TypeError):
+        pass
+    decoder = json.JSONDecoder()
+    for index, char in enumerate(text):
+        if char in "{[":
+            try:
+                value, _ = decoder.raw_decode(text, index)
+            except ValueError:
+                continue
+            return value
+    return None
+
+
+def _records_from_parsed(parsed: Any) -> list[dict[str, Any]]:
+    """Normalize a parsed JSON value to a flat list of record dicts, unwrapping
+    a single container key (``{"issues": [...]}``) when present."""
+    if isinstance(parsed, list):
+        return [entry for entry in parsed if isinstance(entry, dict)]
+    if isinstance(parsed, dict):
+        for key in _CONTAINER_KEYS:
+            value = parsed.get(key)
+            if isinstance(value, list):
+                records = [entry for entry in value if isinstance(entry, dict)]
+                if records:
+                    return records
+        return [parsed]
+    return []
+
+
+def _titles_from_json(text: str) -> list[dict[str, Any]]:
+    """Best-effort: pull a human title out of a JSON result, e.g. an Atlassian
+    page/issue returned as JSON-in-text. Tolerates a non-JSON preamble before
+    the JSON body and unwraps a container key (``{"issues": [...]}``) so each
+    retrieved record yields its own item. Returns [] when the text carries no
+    JSON or no record has a recognizable title.
+    """
+    parsed = _loads_embedded_json(text)
+    if parsed is None:
         return []
-    candidates = parsed if isinstance(parsed, list) else [parsed]
     items: list[dict[str, Any]] = []
-    for entry in candidates:
-        if isinstance(entry, dict):
-            title = _title_from_json(entry)
-            if title:
-                items.append(
-                    {
-                        "title": title,
-                        "snippet": None,
-                        "details": _details_from_json(entry),
-                    }
-                )
+    for entry in _records_from_parsed(parsed):
+        title = _title_from_json(entry)
+        if title:
+            items.append(
+                {
+                    "title": title,
+                    "snippet": None,
+                    "details": _details_from_json(entry),
+                }
+            )
+    return items
+
+
+def _get_by_dotted_path(obj: Any, path: str) -> Any:
+    """Walk a dotted path over dicts and lists (numeric segments index lists),
+    e.g. ``"issues"``, ``"fields.summary"``, ``"result.items.0.key"``. Returns
+    ``None`` when any segment is missing."""
+    current = obj
+    for segment in path.split("."):
+        if isinstance(current, dict):
+            current = current.get(segment)
+        elif isinstance(current, list) and segment.lstrip("-").isdigit():
+            index = int(segment)
+            try:
+                current = current[index]
+            except IndexError:
+                return None
+        else:
+            return None
+        if current is None:
+            return None
+    return current
+
+
+_TEMPLATE_TOKEN = re.compile(r"\{([^{}]+)\}")
+
+
+def _render_title_template(template: str, record: dict[str, Any]) -> str | None:
+    """Substitute ``{dotted.path}`` tokens from ``record`` into ``template``.
+    Missing tokens render empty; returns ``None`` if the result is blank."""
+
+    def _sub(match: re.Match[str]) -> str:
+        value = _get_by_dotted_path(record, match.group(1).strip())
+        return str(value).strip() if value is not None else ""
+
+    rendered = _TEMPLATE_TOKEN.sub(_sub, template).strip()
+    # Collapse artifacts left by empty tokens (e.g. a dangling " — ").
+    rendered = rendered.strip(" -—–|:").strip()
+    return rendered or None
+
+
+def _mapped_records(response: Any, list_path: str | None) -> list[dict[str, Any]]:
+    """Locate the record list a reference mapping applies to, preferring the
+    MCP-native ``structuredContent`` then any JSON-in-text block (preamble
+    tolerant). ``list_path`` (dotted) points at the array; when unset the parsed
+    value itself is used."""
+    sources: list[Any] = []
+    structured = getattr(response, "structuredContent", None) or getattr(
+        response, "structured_content", None
+    )
+    if structured is not None:
+        sources.append(structured)
+    for block in getattr(response, "content", None) or []:
+        if isinstance(block, dict) and block.get("type") == "text":
+            parsed = _loads_embedded_json(block.get("text") or "")
+            if parsed is not None:
+                sources.append(parsed)
+
+    for parsed in sources:
+        target = _get_by_dotted_path(parsed, list_path) if list_path else parsed
+        if isinstance(target, list):
+            records = [entry for entry in target if isinstance(entry, dict)]
+            if records:
+                return records
+        elif isinstance(target, dict):
+            return [target]
+    return []
+
+
+def _extract_with_reference_mapping(
+    response: Any, mapping: dict[str, Any]
+) -> list[dict[str, Any]]:
+    """Destructure a list result into ``{title, snippet, details}`` items using
+    an admin-configured reference mapping. Returns [] when the mapping locates
+    nothing, so the caller can fall back to the generic heuristic."""
+    list_path = mapping.get("listPath") or mapping.get("list_path")
+    title_path = mapping.get("titlePath") or mapping.get("title_path")
+    title_template = mapping.get("titleTemplate") or mapping.get("title_template")
+    details_path = mapping.get("detailsPath") or mapping.get("details_path")
+    snippet_path = mapping.get("snippetPath") or mapping.get("snippet_path")
+
+    items: list[dict[str, Any]] = []
+    for record in _mapped_records(response, list_path):
+        if title_template:
+            title = _render_title_template(title_template, record)
+        elif title_path:
+            value = _get_by_dotted_path(record, title_path)
+            title = str(value).strip() if isinstance(value, (str, int, float)) else None
+        else:
+            title = None
+        if not title:
+            continue
+        details = _get_by_dotted_path(record, details_path) if details_path else None
+        snippet = _get_by_dotted_path(record, snippet_path) if snippet_path else None
+        items.append(
+            {
+                "title": title,
+                "snippet": _snippet(snippet) if snippet is not None else None,
+                "details": str(details).strip() if details else None,
+            }
+        )
     return items
 
 
@@ -182,15 +341,23 @@ def _extract_mcp_citation_items(
     *,
     tool_name: str,
     server_name: str | None,
+    reference_mapping: dict[str, Any] | None = None,
 ) -> list[dict[str, Any]]:
     """Context for what the tool retrieved: ``{title, snippet}`` per item.
 
-    Titles come from MCP ``resource_link`` names (spec-native) or a best-effort
+    An optional admin ``reference_mapping`` is applied first (deterministic
+    destructuring of a list result); when it yields nothing we fall back to the
+    generic heuristic: MCP ``resource_link`` names (spec-native) or a best-effort
     JSON-title heuristic over text blocks (for tools like Atlassian that return
     JSON-in-text). No URLs are extracted — the chip is display-only. Falls back
     to a single title-less item (the runner names it after the tool) when the
     result carries no recognizable title.
     """
+    if reference_mapping:
+        mapped = _extract_with_reference_mapping(response, reference_mapping)
+        if mapped:
+            return mapped[:_MCP_MAX_ITEMS_PER_CALL]
+
     content = getattr(response, "content", None) or []
     items: list[dict[str, Any]] = []
 
@@ -239,6 +406,7 @@ def _annotate_mcp_results_for_citations(
     tool_name: str,
     server_name: str | None,
     refs_log_path: Path | None = None,
+    reference_mapping: dict[str, Any] | None = None,
 ) -> list[tuple[int, dict[str, Any]]]:
     """Assign per-turn ``[mcpsourceN]`` numbers to each retrieved item and append
     the refs manifest. Returns ``[(sourceNumber, item)]`` for the footer.
@@ -251,7 +419,10 @@ def _annotate_mcp_results_for_citations(
     annotated: list[tuple[int, dict[str, Any]]] = []
     try:
         items = _extract_mcp_citation_items(
-            response, tool_name=tool_name, server_name=server_name
+            response,
+            tool_name=tool_name,
+            server_name=server_name,
+            reference_mapping=reference_mapping,
         )
         with _locked_turn_refs_manifest(
             refs_log_path, lock_filename=_MCP_REFS_LOCK_FILENAME
@@ -375,6 +546,7 @@ def record_mcp_citations(
     server_name: str | None,
     unique_dir: Path,
     formatted_text: str,
+    reference_mapping: dict[str, Any] | None = None,
 ) -> str:
     """Write both per-turn MCP manifests under ``unique_dir`` and return the
     ``[mcpsourceN]`` citation footer for the agent.
@@ -405,6 +577,7 @@ def record_mcp_citations(
         tool_name=tool_name,
         server_name=server_name,
         refs_log_path=unique_dir / _MCP_REFS_LOG_RELATIVE_PATH.name,
+        reference_mapping=reference_mapping,
     )
     return _citation_footer(annotated)
 
@@ -496,5 +669,6 @@ def cmd_mcp(
         server_name=server_name,
         unique_dir=Path.cwd() / ".unique",
         formatted_text=formatted,
+        reference_mapping=state.mcp_tool_reference_mappings.get(name),
     )
     return formatted + footer

--- a/unique_sdk/unique_sdk/cli/commands/mcp.py
+++ b/unique_sdk/unique_sdk/cli/commands/mcp.py
@@ -294,7 +294,9 @@ def _mapped_records(response: Any, list_path: str | None) -> list[dict[str, Any]
     """Locate the record list a reference mapping applies to, preferring the
     MCP-native ``structuredContent`` then any JSON-in-text block (preamble
     tolerant). ``list_path`` (dotted) points at the array; when unset the parsed
-    value itself is used."""
+    value itself is used. An empty object/list is ignored (not treated as a
+    record) so the caller can still fall back to ``titleFromText`` / the generic
+    heuristic — e.g. an empty ``structuredContent`` alongside a Markdown doc."""
     sources: list[Any] = []
     structured = getattr(response, "structuredContent", None) or getattr(
         response, "structured_content", None
@@ -313,7 +315,7 @@ def _mapped_records(response: Any, list_path: str | None) -> list[dict[str, Any]
             records = [entry for entry in target if isinstance(entry, dict)]
             if records:
                 return records
-        elif isinstance(target, dict):
+        elif isinstance(target, dict) and target:
             return [target]
     return []
 

--- a/unique_sdk/unique_sdk/cli/commands/mcp.py
+++ b/unique_sdk/unique_sdk/cli/commands/mcp.py
@@ -40,7 +40,6 @@ _MCP_OUTPUT_TEXT_CHAR_LIMIT = 50_000
 _MCP_REFS_LOG_RELATIVE_PATH = Path(".unique") / "mcp-refs.jsonl"
 _MCP_REFS_LOCK_FILENAME = "mcp-refs.lock"
 _MCP_SNIPPET_CHAR_LIMIT = 300
-_MCP_MAX_ITEMS_PER_CALL = 8
 
 # Keys an MCP tool's JSON result commonly uses for a record's human title.
 _TITLE_KEYS = ("title", "name", "displayName", "subject", "summary", "key")
@@ -356,7 +355,7 @@ def _extract_mcp_citation_items(
     if reference_mapping:
         mapped = _extract_with_reference_mapping(response, reference_mapping)
         if mapped:
-            return mapped[:_MCP_MAX_ITEMS_PER_CALL]
+            return mapped
 
     content = getattr(response, "content", None) or []
     items: list[dict[str, Any]] = []
@@ -380,7 +379,7 @@ def _extract_mcp_citation_items(
         # No recognizable title — one chip named after the tool itself.
         items.append({"title": None, "snippet": None})
 
-    return items[:_MCP_MAX_ITEMS_PER_CALL]
+    return items
 
 
 def _next_mcp_source_number(entries: list[dict[str, Any]]) -> int:

--- a/unique_sdk/unique_sdk/cli/commands/mcp.py
+++ b/unique_sdk/unique_sdk/cli/commands/mcp.py
@@ -290,13 +290,15 @@ def _render_title_template(template: str, record: dict[str, Any]) -> str | None:
     return rendered or None
 
 
-def _mapped_records(response: Any, list_path: str | None) -> list[dict[str, Any]]:
-    """Locate the record list a reference mapping applies to, preferring the
+def _mapped_records(response: Any, list_path: str | None) -> list[Any]:
+    """Locate the records a reference mapping applies to, preferring the
     MCP-native ``structuredContent`` then any JSON-in-text block (preamble
     tolerant). ``list_path`` (dotted) points at the array; when unset the parsed
-    value itself is used. An empty object/list is ignored (not treated as a
-    record) so the caller can still fall back to ``titleFromText`` / the generic
-    heuristic — e.g. an empty ``structuredContent`` alongside a Markdown doc."""
+    value itself is used. List entries may be objects (field/template titles) or
+    plain strings (text titles), so both are kept; a single object is wrapped.
+    An empty object/list is ignored (not treated as a record) so the caller can
+    still fall back to ``titleFromText`` / the generic heuristic — e.g. an empty
+    ``structuredContent`` alongside a Markdown doc."""
     sources: list[Any] = []
     structured = getattr(response, "structuredContent", None) or getattr(
         response, "structured_content", None
@@ -312,7 +314,7 @@ def _mapped_records(response: Any, list_path: str | None) -> list[dict[str, Any]
     for parsed in sources:
         target = _get_by_dotted_path(parsed, list_path) if list_path else parsed
         if isinstance(target, list):
-            records = [entry for entry in target if isinstance(entry, dict)]
+            records = [entry for entry in target if isinstance(entry, (dict, str))]
             if records:
                 return records
         elif isinstance(target, dict) and target:
@@ -323,17 +325,28 @@ def _mapped_records(response: Any, list_path: str | None) -> list[dict[str, Any]
 _MCP_TEXT_TITLE_DEFAULT_CHARS = 120
 
 
+def _leading_title_line(text: str | None, max_chars: int) -> str | None:
+    """First non-empty line of ``text`` with leading Markdown heading/list
+    markers (``# * - >``) stripped, capped at ``max_chars``. Used to title a
+    plain-text document (or a plain-text list item) by its heading. ``None``
+    when ``text`` is not a non-empty string."""
+    if not isinstance(text, str):
+        return None
+    for line in text.splitlines():
+        stripped = line.strip().lstrip("#*->").strip()
+        if stripped:
+            return stripped[:max_chars]
+    return None
+
+
 def _first_text_title(response: Any, max_chars: int) -> str | None:
     """Title from the first non-empty line of the first text block — for a
-    non-JSON result such as a fetched Markdown document (e.g. ``read_doc``),
-    whose first line is the doc's ``# heading``. Strips leading Markdown
-    heading/list markers and caps the length."""
+    non-JSON result such as a fetched Markdown document (e.g. ``read_doc``)."""
     for block in getattr(response, "content", None) or []:
         if isinstance(block, dict) and block.get("type") == "text":
-            for line in (block.get("text") or "").splitlines():
-                stripped = line.strip().lstrip("#*->").strip()
-                if stripped:
-                    return stripped[:max_chars]
+            title = _leading_title_line(block.get("text"), max_chars)
+            if title:
+                return title
     return None
 
 
@@ -350,6 +363,10 @@ def _extract_with_reference_mapping(
     title_template = mapping.get("titleTemplate") or mapping.get("title_template")
     details_path = mapping.get("detailsPath") or mapping.get("details_path")
     title_from_text = mapping.get("titleFromText") or mapping.get("title_from_text")
+    # When titling from text and the list items are objects, this dotted path
+    # points at the text field within each item (e.g. ``content``); leave unset
+    # when each item is itself a plain string.
+    title_text_path = mapping.get("titleTextPath") or mapping.get("title_text_path")
     try:
         title_max_chars = int(
             mapping.get("titleMaxChars")
@@ -362,16 +379,31 @@ def _extract_with_reference_mapping(
     records = _mapped_records(response, list_path)
     items: list[dict[str, Any]] = []
     for record in records:
-        if title_template:
+        is_dict = isinstance(record, dict)
+        if title_from_text:
+            # Title from the item's text: the item itself when it's a plain
+            # string, else its ``title_text_path`` field.
+            if isinstance(record, str):
+                text = record
+            elif is_dict and title_text_path:
+                text = _get_by_dotted_path(record, title_text_path)
+            else:
+                text = None
+            title = _leading_title_line(text, title_max_chars)
+        elif title_template and is_dict:
             title = _render_title_template(title_template, record)
-        elif title_path:
+        elif title_path and is_dict:
             value = _get_by_dotted_path(record, title_path)
             title = str(value).strip() if isinstance(value, (str, int, float)) else None
         else:
             title = None
         if not title:
             continue
-        details = _get_by_dotted_path(record, details_path) if details_path else None
+        details = (
+            _get_by_dotted_path(record, details_path)
+            if details_path and is_dict
+            else None
+        )
         items.append(
             {
                 "title": title,

--- a/unique_sdk/unique_sdk/cli/commands/mcp.py
+++ b/unique_sdk/unique_sdk/cli/commands/mcp.py
@@ -334,7 +334,6 @@ def _extract_with_reference_mapping(
     title_path = mapping.get("titlePath") or mapping.get("title_path")
     title_template = mapping.get("titleTemplate") or mapping.get("title_template")
     details_path = mapping.get("detailsPath") or mapping.get("details_path")
-    snippet_path = mapping.get("snippetPath") or mapping.get("snippet_path")
     title_from_text = mapping.get("titleFromText") or mapping.get("title_from_text")
     try:
         title_max_chars = int(
@@ -357,11 +356,10 @@ def _extract_with_reference_mapping(
         if not title:
             continue
         details = _get_by_dotted_path(record, details_path) if details_path else None
-        snippet = _get_by_dotted_path(record, snippet_path) if snippet_path else None
         items.append(
             {
                 "title": title,
-                "snippet": _snippet(snippet) if snippet is not None else None,
+                "snippet": None,
                 "details": str(details).strip() if details else None,
             }
         )

--- a/unique_sdk/unique_sdk/cli/commands/mcp.py
+++ b/unique_sdk/unique_sdk/cli/commands/mcp.py
@@ -174,6 +174,13 @@ _CONTAINER_KEYS = (
     "content",
 )
 
+# Subset of ``_CONTAINER_KEYS`` that are also plausible fields of a *single*
+# titled record — e.g. a page/document payload ``{"title": ..., "content": [...]}``
+# whose ``content`` is the body, not a list of separate results. When one of
+# these matches on an object that carries its own top-level title, we keep the
+# object as one record rather than splitting it into title-less inner rows.
+_AMBIGUOUS_CONTAINER_KEYS = ("data", "content")
+
 
 def _loads_embedded_json(text: str) -> Any:
     """Parse a JSON value from a tool-result string, tolerating a non-JSON
@@ -210,6 +217,12 @@ def _records_from_parsed(parsed: Any) -> list[dict[str, Any]]:
             if isinstance(value, list):
                 records = [entry for entry in value if isinstance(entry, dict)]
                 if records:
+                    # A single titled record must not be split apart by an
+                    # incidental ambiguous key (a page body under ``content`` /
+                    # ``data``) — keep the object as one record so its title
+                    # survives instead of collapsing to a title-less chip.
+                    if key in _AMBIGUOUS_CONTAINER_KEYS and _title_from_json(parsed):
+                        return [parsed]
                     return records
         return [parsed]
     return []
@@ -344,8 +357,9 @@ def _extract_with_reference_mapping(
     except (TypeError, ValueError):
         title_max_chars = _MCP_TEXT_TITLE_DEFAULT_CHARS
 
+    records = _mapped_records(response, list_path)
     items: list[dict[str, Any]] = []
-    for record in _mapped_records(response, list_path):
+    for record in records:
         if title_template:
             title = _render_title_template(title_template, record)
         elif title_path:
@@ -367,7 +381,10 @@ def _extract_with_reference_mapping(
         return items
     # Non-list / non-JSON result (e.g. a fetched Markdown doc): title the single
     # chip from the leading text when the tool opts in via ``titleFromText``.
-    if title_from_text:
+    # Only when *no* records were located — if list records were found but
+    # yielded no usable title, defer to the generic heuristic (e.g. per-issue
+    # references) instead of a bogus text-derived chip.
+    if not records and title_from_text:
         title = _first_text_title(response, title_max_chars)
         if title:
             return [{"title": title, "snippet": None, "details": None}]

--- a/unique_sdk/unique_sdk/cli/state.py
+++ b/unique_sdk/unique_sdk/cli/state.py
@@ -13,6 +13,7 @@ from unique_sdk.cli.metadata_filter import MetadataFilter
 
 _SEARCH_CONFIG_FILENAME = ".unique-search.json"
 _UPLOADED_CONFIG_FILENAME = ".unique-uploaded.json"
+_MCP_TOOLS_CONFIG_FILENAME = ".unique-mcp-tools.json"
 _CHAT_FILES_MANIFEST_PATH = Path(".unique") / "chat-files.json"
 
 
@@ -46,6 +47,33 @@ def _load_uploaded_config() -> dict[str, Any]:
     except (json.JSONDecodeError, OSError):
         return {}
     return data if isinstance(data, dict) else {}
+
+
+def _load_mcp_tool_configs() -> dict[str, dict[str, Any]]:
+    """Load per-MCP-tool reference mappings from ``.unique-mcp-tools.json``.
+
+    Written by the Swappable Intelligence runner from each configured tool's
+    ``referenceMapping`` (a Unique admin override describing how to destructure
+    a list-returning result into individual citations). Shape:
+    ``{"toolConfigs": {<toolName>: {listPath, titlePath, titleTemplate, ...}}}``.
+    Keyed by the same namespaced tool name the agent passes to ``unique-cli
+    mcp``. Returns ``{}`` when absent or invalid.
+    """
+    config_path = Path.cwd() / _MCP_TOOLS_CONFIG_FILENAME
+    if not config_path.is_file():
+        return {}
+    try:
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}
+    configs = data.get("toolConfigs") if isinstance(data, dict) else None
+    if not isinstance(configs, dict):
+        return {}
+    return {
+        name: mapping
+        for name, mapping in configs.items()
+        if isinstance(name, str) and isinstance(mapping, dict)
+    }
 
 
 def _load_uploaded_content_ids(data: dict[str, Any]) -> list[str]:
@@ -144,6 +172,12 @@ class ShellState:
         )
         self.uploaded_search_content_ids: list[str] = _load_uploaded_content_ids(
             _uploaded_config
+        )
+        # Per-MCP-tool reference mappings (``.unique-mcp-tools.json``), keyed by
+        # the namespaced tool name the agent passes to ``unique-cli mcp``. Used
+        # by ``cmd_mcp`` to destructure list results into individual citations.
+        self.mcp_tool_reference_mappings: dict[str, dict[str, Any]] = (
+            _load_mcp_tool_configs()
         )
 
     @property

--- a/unique_toolkit/tests/agentic/tools/test_mcp_tool_wrapper.py
+++ b/unique_toolkit/tests/agentic/tools/test_mcp_tool_wrapper.py
@@ -248,6 +248,40 @@ class TestMCPToolWrapperToolDescription:
         assert "System prompt for test tool" in system_prompt
 
     @pytest.mark.ai
+    def test_tool_description_for_system_prompt__omits_none_system_prompt__AI(
+        self,
+        mock_mcp_server: McpServer,
+        mock_mcp_tool_config: MCPToolConfig,
+        mock_chat_event: ChatEvent,
+    ) -> None:
+        """
+        Purpose: Verify a missing per-tool system_prompt is not rendered as "None".
+        Why this matters: A literal "None" leaking into the system prompt is noise
+        that can mislead the model.
+        Setup summary: Create a tool without system_prompt, verify output is clean.
+        """
+        # Arrange
+        tool_no_system_prompt = McpTool(
+            name="tool_no_system",
+            input_schema={"type": "object"},
+            system_prompt=None,
+            is_connected=True,
+        )
+        wrapper = MCPToolWrapper(
+            mcp_server=mock_mcp_server,
+            mcp_tool=tool_no_system_prompt,
+            config=mock_mcp_tool_config,
+            event=mock_chat_event,
+        )
+
+        # Act
+        system_prompt = wrapper.tool_description_for_system_prompt()
+
+        # Assert
+        assert "None" not in system_prompt
+        assert "**Tool Name**: tool_no_system" in system_prompt
+
+    @pytest.mark.ai
     def test_tool_description_for_user_prompt__returns_user_prompt__AI(
         self,
         mcp_tool_wrapper: MCPToolWrapper,

--- a/unique_toolkit/unique_toolkit/agentic/tools/mcp/tool_wrapper.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/mcp/tool_wrapper.py
@@ -81,13 +81,14 @@ class MCPToolWrapper(Tool[MCPToolConfig]):
     def tool_description_for_system_prompt(self) -> str:
         """Return tool description for system prompt"""
         # Not using jinja here to keep it simple and not import new packages.
-        description = (
-            f"**MCP Server**: {self._mcp_server.name}\n"
-            f"**Tool Name**: {self.name}\n"
-            f"{self._mcp_tool.system_prompt}"
-        )
+        lines = [
+            f"**MCP Server**: {self._mcp_server.name}",
+            f"**Tool Name**: {self.name}",
+        ]
+        if self._mcp_tool.system_prompt:
+            lines.append(self._mcp_tool.system_prompt)
 
-        return description
+        return "\n".join(lines)
 
     def tool_description_for_user_prompt(self) -> str:
         return self._mcp_tool.user_prompt or ""

--- a/unique_toolkit/unique_toolkit/app/__init__.py
+++ b/unique_toolkit/unique_toolkit/app/__init__.py
@@ -41,6 +41,9 @@ from .schemas import (
     EventUserMessage as EventUserMessage,
 )
 from .schemas import (
+    McpReferenceMapping as McpReferenceMapping,
+)
+from .schemas import (
     McpServer as McpServer,
 )
 from .schemas import (

--- a/unique_toolkit/unique_toolkit/app/schemas.py
+++ b/unique_toolkit/unique_toolkit/app/schemas.py
@@ -114,10 +114,6 @@ class McpReferenceMapping(BaseModel):
         default=None,
         description="Optional dotted path to a details line for each record.",
     )
-    snippet_path: Optional[str] = Field(
-        default=None,
-        description="Optional dotted path to a snippet for each record.",
-    )
     title_from_text: Optional[bool] = Field(
         default=None,
         description="For a non-JSON text result (e.g. a fetched Markdown doc), title the single reference from the leading text line instead of the tool name.",

--- a/unique_toolkit/unique_toolkit/app/schemas.py
+++ b/unique_toolkit/unique_toolkit/app/schemas.py
@@ -89,6 +89,37 @@ class BaseEvent(BaseModel, Generic[FilterOptionsT]):
 ###
 
 
+class McpReferenceMapping(BaseModel):
+    """Optional per-tool rule for destructuring a list-returning MCP result into
+    individual citation references. A Unique-specific override; when unset the
+    generic citation heuristic is used. Paths are dotted (dict keys and numeric
+    list indices), e.g. ``"issues"`` or ``"fields.summary"``.
+    """
+
+    model_config = model_config
+
+    list_path: Optional[str] = Field(
+        default=None,
+        description="Dotted path to the array of records, e.g. 'issues' or 'result.items'.",
+    )
+    title_path: Optional[str] = Field(
+        default=None,
+        description="Dotted path to each record's title, e.g. 'key' or 'fields.summary'.",
+    )
+    title_template: Optional[str] = Field(
+        default=None,
+        description="Optional title template with {dotted.path} tokens, e.g. '{key} — {fields.summary}'. Takes precedence over title_path.",
+    )
+    details_path: Optional[str] = Field(
+        default=None,
+        description="Optional dotted path to a details line for each record.",
+    )
+    snippet_path: Optional[str] = Field(
+        default=None,
+        description="Optional dotted path to a snippet for each record.",
+    )
+
+
 class McpTool(BaseModel):
     model_config = model_config
 
@@ -116,6 +147,10 @@ class McpTool(BaseModel):
     tool_format_information: Optional[str] = Field(
         default=None,
         description="An optional tool format information. This is a Unique specific field.",
+    )
+    reference_mapping: Optional[McpReferenceMapping] = Field(
+        default=None,
+        description="Optional rule for destructuring a list-returning result into individual citation references. This is a Unique specific field.",
     )
     is_connected: bool = Field(
         description="Whether the tool is connected to the MCP server. This is a Unique specific field.",

--- a/unique_toolkit/unique_toolkit/app/schemas.py
+++ b/unique_toolkit/unique_toolkit/app/schemas.py
@@ -118,6 +118,14 @@ class McpReferenceMapping(BaseModel):
         default=None,
         description="Optional dotted path to a snippet for each record.",
     )
+    title_from_text: Optional[bool] = Field(
+        default=None,
+        description="For a non-JSON text result (e.g. a fetched Markdown doc), title the single reference from the leading text line instead of the tool name.",
+    )
+    title_max_chars: Optional[int] = Field(
+        default=None,
+        description="Max length of the title derived via title_from_text (default 120).",
+    )
 
 
 class McpTool(BaseModel):

--- a/unique_toolkit/unique_toolkit/app/schemas.py
+++ b/unique_toolkit/unique_toolkit/app/schemas.py
@@ -116,7 +116,11 @@ class McpReferenceMapping(BaseModel):
     )
     title_from_text: Optional[bool] = Field(
         default=None,
-        description="For a non-JSON text result (e.g. a fetched Markdown doc), title the single reference from the leading text line instead of the tool name.",
+        description="Title from the leading text line instead of a field/template: for a single plain-text document (e.g. a fetched Markdown doc) or each plain-text item of a list.",
+    )
+    title_text_path: Optional[str] = Field(
+        default=None,
+        description="When titling a list of objects from text, the dotted path to the text field within each item (e.g. 'content'); leave unset when each list item is itself a plain string.",
     )
     title_max_chars: Optional[int] = Field(
         default=None,


### PR DESCRIPTION
## What
Adds an optional per-MCP-tool **`reference_mapping`** so admins can declare how a list-returning tool result is destructured into individual citation references — deterministically, without extra tool round-trips.

Fields (dotted paths): `listPath`, `titlePath`, `titleTemplate` (`{key} — {fields.summary}`), `detailsPath`, `snippetPath`.

## Why
MCP tools that return a list (e.g. Atlassian `searchJiraIssuesUsingJql` → `{"issues":[…]}`) collapsed into a single, vaguely-named chip. The generic heuristic (preamble-strip + container-unwrap) handles common cases zero-config; `reference_mapping` is the explicit override for nested titles / unusual shapes.

## Changes (this repo)
- `unique_toolkit`: `McpReferenceMapping` model + `McpTool.reference_mapping`.
- `unique_sdk`: `record_mcp_citations(reference_mapping=…)` → `_extract_with_reference_mapping` + dotted-path/template helpers; **falls back to the heuristic** when the mapping matches nothing.
- **Skills mode**: `cmd_mcp` reads per-tool mappings from `.unique-mcp-tools.json` (`ShellState._load_mcp_tool_configs`).
- Also keeps a small fix: an unset `system_prompt` no longer renders a literal `"None"`.

## Companion (monorepo)
Runner writes `.unique-mcp-tools.json`; tools-mode proxy passes the mapping via `NormalizedMcpTool`; Prisma `referenceMapping Json?` + GraphQL + admin `EditToolModal` form. (Separate monorepo change.)

## Supersedes
Replaces #1984 (the tools-mode system-prompt nudge) with a deterministic, config-driven approach.

## Test plan
- [x] `unique_sdk`: `pytest tests/cli/test_mcp.py` — 29 passed (wrapped-array, preamble, mapping-with-template, heuristic-fallback)
- [x] `unique_toolkit`: `pytest tests/agentic/tools/test_mcp_tool_wrapper.py` — 39 passed
- [x] Verified against the real Atlassian payload: `titleTemplate` → per-issue chips (`UN-22309 — …`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)