### PR TITLE
feat(cli): split uploaded-search into its own gated skill [UN-21780]

### DIFF
--- a/unique_sdk/tests/cli/test_skills.py
+++ b/unique_sdk/tests/cli/test_skills.py
@@ -1,0 +1,56 @@
+"""Guard tests for the bundled unique-cli skill docs.
+
+The runner on the Unique platform copies these ``SKILL.md`` files out of the
+installed ``unique_sdk`` wheel and feeds each skill's front-matter description
+to the agent so it knows which command to reach for. Two invariants matter for
+the uploaded-document search feature (UN-21780):
+
+1. ``unique-cli-uploaded-search`` is its **own** skill, so the monorepo can
+   gate it on the ``UploadedSearch`` synthetic tool and hide it entirely when a
+   space has no uploaded files / the feature is off.
+2. The always-on ``unique-cli-search`` skill must **not** mention
+   ``uploaded-search`` — otherwise the agent is told about the uploaded path
+   even when it is gated off, which defeats the clean off-switch.
+
+These are file-content assertions on purpose: the skills ship as data in the
+wheel, and a regression here is invisible to ordinary import/CLI tests.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import unique_sdk.cli
+
+_SKILLS_DIR = Path(unique_sdk.cli.__file__).parent / "skills"
+
+
+def _read_skill(name: str) -> str:
+    skill = _SKILLS_DIR / name / "SKILL.md"
+    assert skill.is_file(), f"missing skill: {skill}"
+    return skill.read_text(encoding="utf-8")
+
+
+def test_uploaded_search_skill_exists_and_is_named() -> None:
+    text = _read_skill("unique-cli-uploaded-search")
+    assert "name: unique-cli-uploaded-search" in text
+    # It must document the command it exists for and the shared citation rule.
+    assert "unique-cli uploaded-search" in text
+    assert "[sourceN]" in text
+
+
+def test_uploaded_search_skill_is_self_contained() -> None:
+    """The gated skill may be copied without the shared search skill (a space
+    can have uploads but no InternalSearch tool), so it must carry its own
+    citation contract rather than defer to unique-cli-search."""
+    text = _read_skill("unique-cli-uploaded-search")
+    assert "<sourceN>" in text
+    assert "web-search" in text  # namespace-separation rule is spelled out
+
+
+def test_search_skill_does_not_reference_uploaded_search() -> None:
+    """De-pointer guard: the always-on search skill must not advertise the
+    gated uploaded-search command (any casing/spelling of the token)."""
+    text = _read_skill("unique-cli-search").lower()
+    assert "uploaded-search" not in text
+    assert "searching uploaded documents" not in text

--- a/unique_sdk/tests/cli/test_state.py
+++ b/unique_sdk/tests/cli/test_state.py
@@ -741,6 +741,45 @@ class TestMetadataFilterContentGating:
             "cont_attached", allow_chat_files=False
         )
 
+    def test_uploaded_doc_exempt_from_filter(self) -> None:
+        # Per-row uploaded docs (.unique-uploaded.json) surfaced by
+        # `unique-cli uploaded-search` live outside the KB scope boundary, so the
+        # metadata filter would deny them. They are turn inputs and must stay
+        # readable so `read`/`ls`/`cite` can reach a doc uploaded-search returned.
+        # See UN-21780.
+        s = self._state_with_filter(
+            {"path": ["contentId"], "operator": "in", "value": ["cont_a"]}
+        )
+        s.uploaded_search_content_ids = ["cont_uploaded"]
+        assert s.is_content_within_workspace("cont_uploaded")
+        # A doc that is neither uploaded nor in the filter is still denied.
+        assert not s.is_content_within_workspace("cont_other")
+
+    def test_uploaded_doc_exemption_is_read_only(self) -> None:
+        # Same read-only guarantee as chat files: mutating ops (rm/mv) pass
+        # allow_chat_files=False and must not delete/rename an uploaded input.
+        s = self._state_with_filter(
+            {"path": ["contentId"], "operator": "in", "value": ["cont_a"]}
+        )
+        s.uploaded_search_content_ids = ["cont_uploaded"]
+        assert s.is_content_within_workspace("cont_uploaded", allow_chat_files=True)
+        assert not s.is_content_within_workspace(
+            "cont_uploaded", allow_chat_files=False
+        )
+
+    def test_uploaded_doc_exempt_under_static_scope_ids(self) -> None:
+        # The exemption must also apply when scoping is the static scopeIds
+        # boundary (no metadata filter): uploaded docs sit outside it too, and
+        # the check runs before any Content.get_info call.
+        s = ShellState(_config())
+        s.workspace_metadata_filter = None
+        s.workspace_scope_ids = ["scope_broad"]
+        s.uploaded_search_content_ids = ["cont_uploaded"]
+        assert s.is_content_within_workspace("cont_uploaded")
+        assert not s.is_content_within_workspace(
+            "cont_uploaded", allow_chat_files=False
+        )
+
     def test_filter_replaces_static_scope_ids(self) -> None:
         s = self._state_with_filter(
             {"path": ["contentId"], "operator": "in", "value": ["cont_a"]}

--- a/unique_sdk/unique_sdk/cli/skills/unique-cli-search/SKILL.md
+++ b/unique_sdk/unique_sdk/cli/skills/unique-cli-search/SKILL.md
@@ -7,10 +7,7 @@ description: >-
   platform. Use whenever the user asks to find, search, or query documents
   or content on Unique, including filtering by folder or metadata.
   Also covers `unique-cli read <cont_id>` for reading the full indexed text
-  of a document when its content ID is already known, and
-  `unique-cli uploaded-search "<query>"` for searching documents uploaded for
-  the current task/row, which are NOT in the knowledge-base scope and never
-  appear in `unique-cli search`.
+  of a document when its content ID is already known.
   NOTE: This search uses combined vector + full-text indexing. Excel
   (.xlsx/.xls), CSV (.csv), and image files are NOT full-text indexed,
   so they will not appear in search results. To locate these file types,
@@ -95,43 +92,10 @@ unique-cli search "audit" -m department=Legal -m year=2025
 unique-cli search "regulatory" -f /Legal -m year=2025 -l 50
 ```
 
-## Searching Uploaded Documents (`uploaded-search`)
-
-Documents **uploaded for the current task** (e.g. an Agentic Table row's
-attached files) are **not** part of the knowledge-base folder scope. They will
-**never** appear in `unique-cli search` results, no matter the folder or
-metadata filters — uploaded files are scoped to the chat, not to a KB folder.
-Use `uploaded-search` to retrieve them:
-
-```bash
-# Search the documents uploaded for this row/task
-unique-cli uploaded-search "target asset classes and investment strategy"
-
-# Limit results
-unique-cli uploaded-search "fee structure" --limit 50
-```
-
-When to use which:
-
-| You want to search… | Command |
-|---------------------|---------|
-| The knowledge base (folders the task scope grants) | `unique-cli search "<query>"` |
-| Documents uploaded for **this** row/task | `unique-cli uploaded-search "<query>"` |
-
-`uploaded-search` returns the same `<sourceN>...</sourceN>` blocks as `search`
-and shares the **same per-turn citation manifest**, so `[sourceN]` numbering is
-continuous across both commands within a turn — cite an uploaded-document fact
-exactly the same way (`[sourceN]`). If no documents were uploaded for the task,
-the command reports that and you should fall back to `unique-cli search`.
-
-> **Note:** there is no `--folder`/`--metadata` for `uploaded-search` — the set
-> of uploaded documents is fixed by what was attached to the task.
-
 ## Command Reference
 
 ```
 unique-cli search <query> [--folder <path|scope_id>] [--metadata <key=value>]... [--limit <N>]
-unique-cli uploaded-search <query> [--limit <N>]
 ```
 
 | Option | Short | Default | Description |

--- a/unique_sdk/unique_sdk/cli/skills/unique-cli-uploaded-search/SKILL.md
+++ b/unique_sdk/unique_sdk/cli/skills/unique-cli-uploaded-search/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: unique-cli-uploaded-search
+description: >-
+  Search the documents uploaded for the CURRENT task/row (e.g. an Agentic
+  Table row's attached files) via the `unique-cli uploaded-search "<query>"`
+  command, with the same per-turn citation tracking as `unique-cli search`
+  so cited facts render as `<sup>N</sup>` footnotes and clickable reference
+  chips on the Unique platform. ALWAYS use this skill when the user refers to
+  documents they uploaded/attached to this task, or when you need facts from
+  the task's own attached files. These uploaded files are scoped to the chat,
+  NOT to a knowledge-base folder, so they will NEVER appear in
+  `unique-cli search` results no matter the folder or metadata filters. Use
+  `unique-cli search` for the knowledge base and this command for the task's
+  uploaded documents; the two are complementary and citation numbering is
+  shared across them within a turn.
+---
+
+# Unique CLI -- Uploaded Document Search
+
+Documents **uploaded for the current task** (for example an Agentic Table
+row's attached files) are **not** part of the knowledge-base folder scope.
+They are scoped to the chat, so they will **never** appear in
+`unique-cli search` results — no folder or metadata filter can surface them.
+Use `unique-cli uploaded-search` to retrieve them.
+
+## Basic Usage
+
+```bash
+# Search the documents uploaded for this row/task
+unique-cli uploaded-search "target asset classes and investment strategy"
+
+# Limit results
+unique-cli uploaded-search "fee structure" --limit 50
+```
+
+There is **no** `--folder`/`--metadata` for `uploaded-search` — the set of
+uploaded documents is fixed by what was attached to the task.
+
+If no documents were uploaded for this task, the command reports that and you
+should fall back to `unique-cli search` for the knowledge base.
+
+## When to use which command
+
+| You want to search… | Command |
+|---------------------|---------|
+| The knowledge base (folders the task scope grants) | `unique-cli search "<query>"` |
+| Documents uploaded for **this** row/task | `unique-cli uploaded-search "<query>"` |
+
+## Output Format
+
+Each result is rendered as a `<sourceN>...</sourceN>` block, identical to
+`unique-cli search`. `N` is **1-based** and **shared with `unique-cli search`
+within the same turn** — both commands append to the same per-turn citation
+manifest, so numbering stays continuous across them (a `search` call that
+emitted `<source1>`–`<source3>` is followed by an `uploaded-search` call whose
+first result is `<source4>`).
+
+```
+Found 1 result(s):
+
+<source1>
+<|document|>investment-mandate.pdf</|document|>
+<|page|>2</|page|>
+<|info|>cont_abc123</|info|>
+...the mandate targets EMEA equities with a 5% cap per issuer...
+</source1>
+```
+
+## Citation Rules
+
+Cite a fact from `uploaded-search` results with `[sourceN]`, **exactly** as you
+would for `unique-cli search` — the two share the same namespace and manifest.
+The Unique platform converts each `[sourceN]` marker in your final answer into a
+`<sup>N</sup>` footnote and a clickable reference chip.
+
+```
+The uploaded mandate caps single-issuer exposure at 5% [source1].
+```
+
+**Rules** (enforced by the platform's reference post-processor):
+
+1. **`[sourceN]` is for KB and uploaded-document results.** Web results from
+   `unique-cli web-search` use `[websourceN]` — never mix the two namespaces.
+2. Only cite numbers you saw in the **current** turn's `search` /
+   `uploaded-search` output. Numbers from previous turns are stale and will be
+   silently dropped.
+3. Write `source` in singular form with the number in digits: `[source1]`,
+   `[source2]` — not `[Source 1]` or `[source one]`.
+4. Prefer citing each fact with a single, most-relevant source.
+5. Do not invent source numbers for remembered or inferred facts.
+
+## Command Reference
+
+```
+unique-cli uploaded-search <query> [--limit <N>]
+```
+
+| Option | Short | Default | Description |
+|--------|-------|---------|-------------|
+| `--limit` | `-l` | 200 | Max results |
+
+## Prerequisites
+
+Requires these environment variables:
+
+```bash
+UNIQUE_USER_ID    # User ID (required)
+UNIQUE_COMPANY_ID # Company ID (required)
+UNIQUE_API_KEY    # API key — optional on localhost / secured cluster
+UNIQUE_APP_ID     # App ID — optional on localhost / secured cluster
+```
+
+Install: `pip install unique-sdk`

--- a/unique_sdk/unique_sdk/cli/state.py
+++ b/unique_sdk/unique_sdk/cli/state.py
@@ -229,6 +229,14 @@ class ShellState:
         """Return True if *content_id* is in the current workspace scope.
 
         Precedence (UN-21780):
+        0. Per-row uploaded documents (``.unique-uploaded.json``) surfaced by
+           ``unique-cli uploaded-search`` are task inputs that live *outside* the
+           KB scope boundary by design, so neither the metadata filter nor the
+           static ``scopeIds`` path below would admit them. Exempt them for
+           non-destructive access so the agent can ``read``/``ls``/``cite`` a doc
+           it just found via uploaded-search — mirroring the chat-file exemption.
+           Mutating ops (``rm``/``mv``) pass ``allow_chat_files=False`` and stay
+           denied, so an uploaded input can't be deleted or renamed this way.
         1. A per-message UniqueQL ``metaDataFilter`` (e.g. an Agentic Table
            column's ``scope_rules``) is the authority for this turn and
            *replaces* the static ``scopeIds`` for content access. Files the
@@ -241,6 +249,8 @@ class ShellState:
            ``is_folder_target_within_workspace``).
         3. With neither configured, everything is in scope.
         """
+        if allow_chat_files and content_id in self.uploaded_search_content_ids:
+            return True
         if self.workspace_metadata_filter is not None:
             if allow_chat_files and content_id in self._chat_file_content_ids():
                 return True


### PR DESCRIPTION
## Summary

Splits the uploaded-document search guidance out of the always-on `unique-cli-search` skill into a dedicated, self-contained **`unique-cli-uploaded-search`** skill.

This is the SDK half of the "cleanly turn off uploaded-document search" work (monorepo #25993). Today the `uploaded-search` instructions live inside `unique-cli-search/SKILL.md`, which is always copied to the agent — so even when a space has no uploaded files (or the feature flag is off) the agent is still told the command exists. Moving the guidance into its own skill lets the monorepo runner **gate** it on a synthetic `UploadedSearch` tool and hide it entirely when it isn't applicable — a clean off-switch at the *awareness* layer, not just the data layer.

## Changes

- **New** `unique-cli-uploaded-search/SKILL.md` — self-contained: when-to-use, usage, output format, and the shared `[sourceN]` citation contract (a space can have uploads but no InternalSearch tool, so this skill can't defer to `unique-cli-search`).
- **De-pointered** `unique-cli-search/SKILL.md` — removes the "Searching Uploaded Documents" section, the frontmatter mention, and the `uploaded-search` command-reference line. The shared skill no longer advertises the gated path.
- **Guard test** `tests/cli/test_skills.py` — asserts the dedicated skill exists/is named and self-contained, and that the shared skill no longer references `uploaded-search`.

## Why a test for a docs move

The skills ship as data inside the wheel, and dev-publish change-detection excludes `*.md`-only diffs (`!unique_sdk/**/*.md`). The guard test is both real anti-drift coverage and the non-markdown change that lets the dev wheel rebuild and carry the relocated skills to PyPI, so the monorepo can pin a dev that actually contains them.

## Downstream

Monorepo #25993 will register `unique-cli-uploaded-search` in `_TOOL_GATED_SKILL_DIRS` (gated on `UploadedSearch`), inject the synthetic tool when uploaded-search is active for the turn, and repin `unique-sdk` to the dev cut produced by this PR.

## Test plan

- [x] `pytest unique_sdk/tests/cli/test_skills.py` (3 passed)
- [x] `pytest unique_sdk/tests/cli/test_search.py tests/cli/test_commands.py` (205 passed — no regression)
- [x] `ruff check` / `ruff format --check` clean

Made with [Cursor](https://cursor.com)