### PR TITLE
fix(unique_toolkit): resolve async feature-flag checks before sync use sites

### DIFF
--- a/unique_toolkit/tests/agentic/test_loop_token_reducer.py
+++ b/unique_toolkit/tests/agentic/test_loop_token_reducer.py
@@ -107,6 +107,20 @@ def language_model_info() -> LanguageModelInfo:
     return LanguageModelInfo.from_name(LanguageModelName.AZURE_GPT_4o_2024_0513)
 
 
+@pytest.fixture(autouse=True)
+def _default_selected_uploaded_files_ff_off():
+    """`get_history_from_db` now awaits the selected-uploaded-files flag lazily
+    (previously the coroutine was silently dropped — see UN-19522 bugbot fix).
+    Default it to disabled so tests that don't care about this flag don't need
+    live `CONFIGURATION_BACKEND_URL` / `FEATURE_FLAG_SERVICE_ID` env vars.
+    """
+    with patch(
+        "unique_toolkit.agentic.history_manager.utils.is_flag_enabled",
+        AsyncMock(return_value=False),
+    ):
+        yield
+
+
 @pytest.fixture
 def loop_token_reducer(
     mock_logger: Logger,

--- a/unique_toolkit/tests/agentic/tools/test_code_interpreter_postprocessors_code_display.py
+++ b/unique_toolkit/tests/agentic/tools/test_code_interpreter_postprocessors_code_display.py
@@ -201,7 +201,7 @@ async def test_show_executed_code_postprocessor__run__no_op__when_fence_ff_on() 
     config = ShowExecutedCodePostprocessorConfig()
 
     with (
-        patch(CODE_DISPLAY_FF, AsyncMock(return_value=False)),
+        patch(CODE_DISPLAY_FF, AsyncMock(return_value=True)),
         patch.object(asyncio, "sleep") as mock_sleep,
     ):
         postprocessor = ShowExecutedCodePostprocessor(

--- a/unique_toolkit/tests/agentic/tools/test_code_interpreter_postprocessors_code_display.py
+++ b/unique_toolkit/tests/agentic/tools/test_code_interpreter_postprocessors_code_display.py
@@ -1,7 +1,7 @@
 """Tests for code interpreter ShowExecutedCode postprocessor (config and behavior)."""
 
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -19,9 +19,16 @@ def _build_code_display_postprocessor(
     *,
     is_flag_enabled_return: bool = True,
 ) -> ShowExecutedCodePostprocessor:
-    """Patch ``is_flag_enabled`` with a sync bool (production assigns its return value to ``_is_enabled``)."""
-    with patch(CODE_DISPLAY_FF, MagicMock(return_value=is_flag_enabled_return)):
-        return ShowExecutedCodePostprocessor(config=config, company_id=company_id)
+    """Build a postprocessor with `_is_enabled` pre-seeded, as `run()` would set it.
+
+    Production resolves the flag asynchronously in `run()` (always awaited by
+    `PostprocessorManager` before `apply_postprocessing_to_response`), so unit
+    tests exercising `apply_postprocessing_to_response` directly seed the
+    post-`run()` state instead of re-patching `is_flag_enabled` per call.
+    """
+    postprocessor = ShowExecutedCodePostprocessor(config=config, company_id=company_id)
+    postprocessor._is_enabled = is_flag_enabled_return
+    return postprocessor
 
 
 @pytest.mark.ai
@@ -194,7 +201,7 @@ async def test_show_executed_code_postprocessor__run__no_op__when_fence_ff_on() 
     config = ShowExecutedCodePostprocessorConfig()
 
     with (
-        patch(CODE_DISPLAY_FF, MagicMock(return_value=False)),
+        patch(CODE_DISPLAY_FF, AsyncMock(return_value=False)),
         patch.object(asyncio, "sleep") as mock_sleep,
     ):
         postprocessor = ShowExecutedCodePostprocessor(
@@ -248,12 +255,13 @@ async def test_show_executed_code_postprocessor__run__no_op__when_enable_false()
     import asyncio
 
     config = ShowExecutedCodePostprocessorConfig(enable=False)
-    postprocessor = _build_code_display_postprocessor(
-        config=config, is_flag_enabled_return=False
-    )
+    postprocessor = ShowExecutedCodePostprocessor(config=config)
     loop_response = SimpleNamespace(code_interpreter_calls=[])
 
-    with patch.object(asyncio, "sleep") as mock_sleep:
+    with (
+        patch(CODE_DISPLAY_FF, AsyncMock(return_value=False)),
+        patch.object(asyncio, "sleep") as mock_sleep,
+    ):
         await postprocessor.run(loop_response)
 
     mock_sleep.assert_not_called()

--- a/unique_toolkit/tests/agentic/tools/test_code_interpreter_postprocessors_generated_files.py
+++ b/unique_toolkit/tests/agentic/tools/test_code_interpreter_postprocessors_generated_files.py
@@ -3,7 +3,7 @@
 import logging
 import time
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from openai.types.responses import ResponseCodeInterpreterToolCall
@@ -38,25 +38,21 @@ from unique_toolkit.chat.schemas import ChatMessage, ChatMessageRole
 from unique_toolkit.content.schemas import ContentReference
 from unique_toolkit.language_model.schemas import ResponsesLanguageModelStreamResponse
 
-GEN_FILES_FF = (
-    "unique_toolkit.agentic.tools.openai_builtin.code_interpreter."
-    "postprocessors.generated_files.is_flag_enabled"
-)
 
-
-def _patch_gen_files_feature_flags(
+def _set_gen_files_feature_flags(
+    proc: DisplayCodeInterpreterFilesPostProcessor,
     *,
     fence_ff_on: bool = False,
     html_fence_ff_on: bool = False,
-):
-    def side_effect(flag: str, *, company_id: str) -> bool:
-        if "17972" in flag:
-            return fence_ff_on
-        if "17927" in flag:
-            return html_fence_ff_on
-        return False
+) -> None:
+    """Seed flag state on the instance, as `run()` would after awaiting it.
 
-    return patch(GEN_FILES_FF, MagicMock(side_effect=side_effect))
+    Production resolves both flags asynchronously in `run()` (always awaited
+    before `apply_postprocessing_to_response`), so unit tests exercising
+    `apply_postprocessing_to_response` directly seed the post-`run()` state.
+    """
+    proc._fence_ff_on = fence_ff_on
+    proc._html_fence_ff_on = html_fence_ff_on
 
 
 class _MockStreamResponse:
@@ -1777,8 +1773,8 @@ def test_apply_postprocessing__normalizes_none_message_text__to_empty_string() -
         references=[],
     )
     loop = ResponsesLanguageModelStreamResponse(message=msg, output=[])
-    with _patch_gen_files_feature_flags():
-        proc.apply_postprocessing_to_response(loop)
+    _set_gen_files_feature_flags(proc)
+    proc.apply_postprocessing_to_response(loop)
     assert msg.text == ""
 
 
@@ -1810,8 +1806,8 @@ def test_apply_postprocessing__ff_on__does_not_append_reference_for_non_image_fi
         container_files=[],
         code_interpreter_calls=[],
     )
-    with _patch_gen_files_feature_flags(fence_ff_on=True):
-        proc.apply_postprocessing_to_response(loop_response)
+    _set_gen_files_feature_flags(proc, fence_ff_on=True)
+    proc.apply_postprocessing_to_response(loop_response)
     assert message.references == []
 
 
@@ -1840,8 +1836,8 @@ def test_apply_postprocessing__ff_off__appends_reference_for_non_image_file() ->
         container_files=[],
         code_interpreter_calls=[],
     )
-    with _patch_gen_files_feature_flags():
-        proc.apply_postprocessing_to_response(loop_response)
+    _set_gen_files_feature_flags(proc)
+    proc.apply_postprocessing_to_response(loop_response)
     assert len(message.references) == 1
     ref = message.references[0]
     assert ref.source_id == "cid-pdf-1"
@@ -1882,8 +1878,8 @@ def test_apply_postprocessing__ff_off__existing_citation_refs_preserved() -> Non
         container_files=[],
         code_interpreter_calls=[],
     )
-    with _patch_gen_files_feature_flags():
-        proc.apply_postprocessing_to_response(loop_response)
+    _set_gen_files_feature_flags(proc)
+    proc.apply_postprocessing_to_response(loop_response)
     assert len(message.references) == 2
     source_ids = {r.source_id for r in message.references}
     assert "existing-sid" in source_ids
@@ -1913,8 +1909,8 @@ def test_apply_postprocessing_to_response__html_uses_HtmlRendering__when_fence_f
         code_interpreter_calls=[],
     )
 
-    with _patch_gen_files_feature_flags():
-        changed = proc.apply_postprocessing_to_response(loop_response)
+    _set_gen_files_feature_flags(proc)
+    changed = proc.apply_postprocessing_to_response(loop_response)
 
     assert changed is True
     assert "HtmlRendering" in message.text
@@ -1948,8 +1944,8 @@ def test_apply_postprocessing_to_response__html_uses_HtmlRendering__when_fence_f
         code_interpreter_calls=[call],
     )
 
-    with _patch_gen_files_feature_flags(fence_ff_on=True):
-        changed = proc.apply_postprocessing_to_response(loop_response)
+    _set_gen_files_feature_flags(proc, fence_ff_on=True)
+    changed = proc.apply_postprocessing_to_response(loop_response)
 
     assert changed is True
     assert len(refs) == 0
@@ -1983,8 +1979,8 @@ def test_apply_postprocessing_to_response__html_uses_htmlWithSource__when_both_f
         code_interpreter_calls=[call],
     )
 
-    with _patch_gen_files_feature_flags(fence_ff_on=True, html_fence_ff_on=True):
-        changed = proc.apply_postprocessing_to_response(loop_response)
+    _set_gen_files_feature_flags(proc, fence_ff_on=True, html_fence_ff_on=True)
+    changed = proc.apply_postprocessing_to_response(loop_response)
 
     assert changed is True
     assert len(refs) == 0

--- a/unique_toolkit/tests/agentic/tools/test_code_interpreter_service.py
+++ b/unique_toolkit/tests/agentic/tools/test_code_interpreter_service.py
@@ -32,7 +32,7 @@ def _mock_is_flag_enabled_in_build_tool_tests(request: pytest.FixtureRequest):
     if "build_tool" not in request.node.name:
         yield
         return
-    with patch(f"{_SERVICE_MOD}.is_flag_enabled", MagicMock(return_value=False)):
+    with patch(f"{_SERVICE_MOD}.is_flag_enabled", AsyncMock(return_value=False)):
         yield
 
 
@@ -121,14 +121,22 @@ def test_get_debug_info__reflects_call_fields__for_different_calls(
 # ============================================================================
 
 
-def _make_tool(company_id: str = "company-1") -> OpenAICodeInterpreterTool:
-    """Construct a minimal OpenAICodeInterpreterTool instance (auto container, no container_id needed)."""
+def _make_tool(
+    company_id: str = "company-1", *, fence_enabled: bool = False
+) -> OpenAICodeInterpreterTool:
+    """Construct a minimal OpenAICodeInterpreterTool instance (auto container, no container_id needed).
+
+    `fence_enabled` mirrors what `build_tool` resolves once (async) and passes
+    into `__init__`, since flag evaluation is async but this instance is read
+    from sync call-sites (`get_required_include_params`).
+    """
     config = MagicMock()
     config.use_auto_container = True
     return OpenAICodeInterpreterTool(
         config=config,
         container_id=None,
         company_id=company_id,
+        fence_enabled=fence_enabled,
     )
 
 
@@ -154,9 +162,8 @@ def test_get_required_include_params__returns_code_interpreter_outputs__when_ff_
     Why this matters: The include param is what causes OpenAI to attach execution logs to the
     response; without it the postprocessor falls back to source code only.
     """
-    tool = _make_tool(company_id="company-ff-on")
-    with patch(f"{_SERVICE_MOD}.is_flag_enabled", MagicMock(return_value=True)):
-        result = tool.get_required_include_params()
+    tool = _make_tool(company_id="company-ff-on", fence_enabled=True)
+    result = tool.get_required_include_params()
 
     assert result == ["code_interpreter_call.outputs"]
 
@@ -250,9 +257,8 @@ def test_get_required_include_params__returns_empty_list__when_ff_off() -> None:
     Why this matters: When FF is off, no extra include should be forwarded to the Responses API,
     preserving legacy behaviour exactly.
     """
-    tool = _make_tool(company_id="company-ff-off")
-    with patch(f"{_SERVICE_MOD}.is_flag_enabled", MagicMock(return_value=False)):
-        result = tool.get_required_include_params()
+    tool = _make_tool(company_id="company-ff-off", fence_enabled=False)
+    result = tool.get_required_include_params()
 
     assert result == []
 

--- a/unique_toolkit/unique_toolkit/agentic/feature_flags/__init__.py
+++ b/unique_toolkit/unique_toolkit/agentic/feature_flags/__init__.py
@@ -1,6 +1,7 @@
 from unique_toolkit.agentic.feature_flags.feature_flags import (
+    FeatureFlagNames,
     FeatureFlags,
     feature_flags,
 )
 
-__all__ = ["FeatureFlags", "feature_flags"]
+__all__ = ["FeatureFlagNames", "FeatureFlags", "feature_flags"]

--- a/unique_toolkit/unique_toolkit/agentic/feature_flags/feature_flags.py
+++ b/unique_toolkit/unique_toolkit/agentic/feature_flags/feature_flags.py
@@ -1,9 +1,35 @@
+from enum import StrEnum
 from typing import Any
 
 from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from unique_toolkit._common.config_checker import register_config
+
+
+class FeatureFlagNames(StrEnum):
+    """Flag name constants used by unique_toolkit's own agentic features.
+
+    Values match both the env-var fallback names (``FeatureFlags`` below) and
+    the configuration-backend registry keys used by
+    ``unique_toolkit.experimental.resources.feature_flags.FeatureFlagClient``.
+    """
+
+    enable_selected_uploaded_files_un_18215 = (
+        "FEATURE_FLAG_ENABLE_SELECTED_UPLOADED_FILES_UN_18215"
+    )
+    enable_mcp_metadata_fallback_un_19145 = (
+        "FEATURE_FLAG_ENABLE_MCP_METADATA_FALLBACK_UN_19145"
+    )
+    enable_html_rendering_un_15131 = "FEATURE_FLAG_ENABLE_HTML_RENDERING_UN_15131"
+    enable_code_execution_fence_un_17972 = (
+        "FEATURE_FLAG_ENABLE_CODE_EXECUTION_FENCE_UN_17972"
+    )
+    enable_html_with_fence_un_17927 = "FEATURE_FLAG_ENABLE_HTML_WITH_FENCE_UN_17927"
+    enable_web_search_argument_screening_un_18741 = (
+        "FEATURE_FLAG_ENABLE_WEB_SEARCH_ARGUMENT_SCREENING_UN_18741"
+    )
+    enable_new_answers_ui_un_14411 = "FEATURE_FLAG_ENABLE_NEW_ANSWERS_UI_UN_14411"
 
 
 class FeatureFlag:

--- a/unique_toolkit/unique_toolkit/agentic/history_manager/loop_token_reducer.py
+++ b/unique_toolkit/unique_toolkit/agentic/history_manager/loop_token_reducer.py
@@ -78,7 +78,21 @@ class LoopTokenReducer:
         self._max_db_source_number: int = -1
         self._db_source_map: dict[int, ContentChunk] = {}
         self._enable_tool_call_persistence = enable_tool_call_persistence
-        self._selected_content_ids = get_selected_uploaded_content_ids(event)
+        self._event = event
+        # Resolved lazily on first async use (`get_history_from_db`) since
+        # evaluating the underlying feature flag is async; `_resolved` tracks
+        # whether resolution has happened yet, distinct from a resolved `None`
+        # (flag off — include all uploaded content).
+        self._selected_content_ids: set[str] | None = None
+        self._selected_content_ids_resolved = False
+
+    async def _get_selected_content_ids(self) -> set[str] | None:
+        if not self._selected_content_ids_resolved:
+            self._selected_content_ids = await get_selected_uploaded_content_ids(
+                self._event
+            )
+            self._selected_content_ids_resolved = True
+        return self._selected_content_ids
 
     @property
     def max_db_source_number(self) -> int:
@@ -314,6 +328,7 @@ class LoopTokenReducer:
             if self._has_uploaded_content_config
             else FileContentSerialization.FILE_NAME
         )
+        selected_content_ids = await self._get_selected_content_ids()
         if self._enable_tool_call_persistence:
             (
                 full_history,
@@ -325,7 +340,7 @@ class LoopTokenReducer:
                 chat_service=self._chat_service,
                 content_service=self._content_service,
                 file_content_serialization_type=file_content_serialization_type,
-                selected_content_ids=self._selected_content_ids,
+                selected_content_ids=selected_content_ids,
             )
             self._max_db_source_number = max_src
             self._db_source_map = src_map
@@ -336,7 +351,7 @@ class LoopTokenReducer:
                 chat_service=self._chat_service,
                 content_service=self._content_service,
                 file_content_serialization_type=file_content_serialization_type,
-                selected_content_ids=self._selected_content_ids,
+                selected_content_ids=selected_content_ids,
             )
 
         if remove_from_text is not None:

--- a/unique_toolkit/unique_toolkit/agentic/history_manager/utils.py
+++ b/unique_toolkit/unique_toolkit/agentic/history_manager/utils.py
@@ -3,13 +3,11 @@ import logging
 from copy import deepcopy
 from typing import Any
 
+from unique_toolkit.agentic.feature_flags import FeatureFlagNames
 from unique_toolkit.agentic.tools.schemas import Source
 from unique_toolkit.app.schemas import ChatEvent
 from unique_toolkit.content.schemas import ContentChunk
-from unique_toolkit.experimental.resources.feature_flags import (
-    FeatureFlagNames,
-    is_flag_enabled,
-)
+from unique_toolkit.experimental.resources.feature_flags import is_flag_enabled
 from unique_toolkit.language_model.schemas import (
     LanguageModelAssistantMessage,
     LanguageModelMessage,

--- a/unique_toolkit/unique_toolkit/agentic/tools/a2a/tool/service.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/a2a/tool/service.py
@@ -19,6 +19,7 @@ from unique_toolkit._common.referencing import (
 )
 from unique_toolkit._common.utils.jinja.render import render_template
 from unique_toolkit.agentic.evaluation.schemas import EvaluationMetricName
+from unique_toolkit.agentic.feature_flags import FeatureFlagNames
 from unique_toolkit.agentic.message_log_manager.service import MessageStepLogger
 from unique_toolkit.agentic.tools.a2a.response_watcher import SubAgentResponseWatcher
 from unique_toolkit.agentic.tools.a2a.tool._memory import (
@@ -50,10 +51,7 @@ from unique_toolkit.chat.schemas import (
 )
 from unique_toolkit.chat.service import ChatService
 from unique_toolkit.content import ContentChunk, ContentReference
-from unique_toolkit.experimental.resources.feature_flags import (
-    FeatureFlagNames,
-    is_flag_enabled,
-)
+from unique_toolkit.experimental.resources.feature_flags import is_flag_enabled
 from unique_toolkit.language_model import (
     LanguageModelFunction,
     LanguageModelToolDescription,

--- a/unique_toolkit/unique_toolkit/agentic/tools/mcp/tool_wrapper.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/mcp/tool_wrapper.py
@@ -9,6 +9,7 @@ from typing import Any, Dict
 import unique_sdk
 
 from unique_toolkit.agentic.evaluation.schemas import EvaluationMetricName
+from unique_toolkit.agentic.feature_flags import FeatureFlagNames
 from unique_toolkit.agentic.message_log_manager.service import MessageStepLogger
 from unique_toolkit.agentic.tools.mcp.models import MCPToolConfig
 from unique_toolkit.agentic.tools.schemas import ToolCallResponse
@@ -21,10 +22,7 @@ from unique_toolkit.app.schemas import ChatEvent, McpServer, McpTool
 from unique_toolkit.chat.schemas import MessageLog, MessageLogStatus
 from unique_toolkit.chat.service import ChatService
 from unique_toolkit.content.functions import upload_content_from_bytes
-from unique_toolkit.experimental.resources.feature_flags import (
-    FeatureFlagNames,
-    is_flag_enabled,
-)
+from unique_toolkit.experimental.resources.feature_flags import is_flag_enabled
 from unique_toolkit.language_model.schemas import (
     LanguageModelFunction,
     LanguageModelToolDescription,

--- a/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/postprocessors/code_display.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/postprocessors/code_display.py
@@ -63,7 +63,7 @@ class ShowExecutedCodePostprocessor(ResponsesApiPostprocessor):
 
     @override
     async def run(self, loop_response: ResponsesLanguageModelStreamResponse) -> None:
-        self._is_enabled = await is_flag_enabled(
+        self._is_enabled = self._config.enable and not await is_flag_enabled(
             FeatureFlagNames.enable_code_execution_fence_un_17972,
             company_id=self._company_id or "",
         )

--- a/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/postprocessors/code_display.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/postprocessors/code_display.py
@@ -6,14 +6,12 @@ from typing import override
 from pydantic import BaseModel, Field
 from pydantic.json_schema import SkipJsonSchema
 
+from unique_toolkit.agentic.feature_flags import FeatureFlagNames
 from unique_toolkit.agentic.postprocessor.postprocessor_manager import (
     ResponsesApiPostprocessor,
 )
 from unique_toolkit.agentic.tools.config import get_configuration_dict
-from unique_toolkit.experimental.resources.feature_flags import (
-    FeatureFlagNames,
-    is_flag_enabled,
-)
+from unique_toolkit.experimental.resources.feature_flags import is_flag_enabled
 from unique_toolkit.language_model.schemas import ResponsesLanguageModelStreamResponse
 
 _TEMPLATE = """
@@ -59,13 +57,16 @@ class ShowExecutedCodePostprocessor(ResponsesApiPostprocessor):
         super().__init__(self.__class__.__name__)
         self._config = config
         self._company_id = company_id
-        self._is_enabled = is_flag_enabled(
-            FeatureFlagNames.enable_code_execution_fence_un_17972,
-            company_id=self._company_id or "",
-        )
+        # Resolved in `run()` (awaited by PostprocessorManager before
+        # `apply_postprocessing_to_response`) since flag evaluation is async.
+        self._is_enabled = False
 
     @override
     async def run(self, loop_response: ResponsesLanguageModelStreamResponse) -> None:
+        self._is_enabled = await is_flag_enabled(
+            FeatureFlagNames.enable_code_execution_fence_un_17972,
+            company_id=self._company_id or "",
+        )
         if self._is_enabled:
             await asyncio.sleep(self._config.sleep_time_before_display)
 

--- a/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/postprocessors/generated_files.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/postprocessors/generated_files.py
@@ -21,6 +21,7 @@ from tenacity import (
 
 from unique_toolkit import ChatService
 from unique_toolkit._common.execution import failsafe_async
+from unique_toolkit.agentic.feature_flags import FeatureFlagNames
 from unique_toolkit.agentic.postprocessor.postprocessor_manager import (
     ResponsesApiPostprocessor,
 )
@@ -38,10 +39,7 @@ from unique_toolkit.agentic.tools.openai_builtin.code_interpreter.schemas import
 )
 from unique_toolkit.content.schemas import ContentReference
 from unique_toolkit.content.service import ContentService
-from unique_toolkit.experimental.resources.feature_flags import (
-    FeatureFlagNames,
-    is_flag_enabled,
-)
+from unique_toolkit.experimental.resources.feature_flags import is_flag_enabled
 from unique_toolkit.language_model.schemas import ResponsesLanguageModelStreamResponse
 from unique_toolkit.services.knowledge_base import KnowledgeBaseService
 from unique_toolkit.short_term_memory.service import ShortTermMemoryService
@@ -371,6 +369,11 @@ class DisplayCodeInterpreterFilesPostProcessor(
                 chat_id=chat_id,
             )
 
+        # Resolved in `run()` (awaited by PostprocessorManager before
+        # `apply_postprocessing_to_response`) since flag evaluation is async.
+        self._fence_ff_on = False
+        self._html_fence_ff_on = False
+
     def _build_retry(self) -> AsyncRetrying:
         """Build a tenacity retry policy from the current config.
 
@@ -388,6 +391,18 @@ class DisplayCodeInterpreterFilesPostProcessor(
     async def run(self, loop_response: ResponsesLanguageModelStreamResponse) -> None:
         run_t0 = time.monotonic()
         self._log.info("run() started — fetching and uploading code interpreter files")
+
+        self._fence_ff_on = await is_flag_enabled(
+            FeatureFlagNames.enable_code_execution_fence_un_17972,
+            company_id=self._company_id or "",
+        )
+        # HTML uses htmlWithSource only when BOTH the code-execution fence FF AND the
+        # dedicated HTML-fence FF are on. Default (FF off) keeps HtmlRendering so
+        # existing deployments are unaffected.
+        self._html_fence_ff_on = await is_flag_enabled(
+            FeatureFlagNames.enable_html_with_fence_un_17927,
+            company_id=self._company_id or "",
+        )
 
         container_files = loop_response.container_files
         self._log.info(
@@ -491,10 +506,7 @@ class DisplayCodeInterpreterFilesPostProcessor(
         self._log.info(
             "apply_postprocessing started — %d file(s) in content_map, fence_ff=%s",
             len(self._content_map),
-            is_flag_enabled(
-                FeatureFlagNames.enable_code_execution_fence_un_17972,
-                company_id=self._company_id or "",
-            ),
+            self._fence_ff_on,
         )
 
         if loop_response.message.references is None:
@@ -504,17 +516,6 @@ class DisplayCodeInterpreterFilesPostProcessor(
 
         ref_number = _get_next_ref_number(loop_response.message.references)
         changed = False
-        fence_ff_on = is_flag_enabled(
-            FeatureFlagNames.enable_code_execution_fence_un_17972,
-            company_id=self._company_id or "",
-        )
-        # HTML uses htmlWithSource only when BOTH the code-execution fence FF AND the
-        # dedicated HTML-fence FF are on. Default (FF off) keeps HtmlRendering so
-        # existing deployments are unaffected.
-        html_fence_ff_on = is_flag_enabled(
-            FeatureFlagNames.enable_html_with_fence_un_17927,
-            company_id=self._company_id or "",
-        )
 
         replaced_files: list[str] = []
         missed_files: list[str] = []
@@ -548,7 +549,7 @@ class DisplayCodeInterpreterFilesPostProcessor(
 
             # HTML rendered as HtmlRendering block unless the dedicated html-fence FF
             # is on (enable_html_with_fence_un_17927). Default keeps HtmlRendering.
-            elif is_html and not html_fence_ff_on:
+            elif is_html and not self._html_fence_ff_on:
                 loop_response.message.text, replaced = _replace_container_html_citation(
                     text=loop_response.message.text or "",
                     filename=filename,
@@ -556,7 +557,7 @@ class DisplayCodeInterpreterFilesPostProcessor(
                 )
                 changed |= replaced
 
-            # Non-HTML files, or HTML when html_fence_ff_on → inline content link for
+            # Non-HTML files, or HTML when self._html_fence_ff_on → inline content link for
             # subsequent fence injection (htmlWithSource / imgWithSource / fileWithSource)
             else:
                 loop_response.message.text, replaced = _replace_container_file_citation(
@@ -564,7 +565,7 @@ class DisplayCodeInterpreterFilesPostProcessor(
                     filename=filename,
                     content_id=content_id,
                     ref_number=ref_number,
-                    use_content_link=fence_ff_on,
+                    use_content_link=self._fence_ff_on,
                 )
                 changed |= replaced
 
@@ -581,7 +582,7 @@ class DisplayCodeInterpreterFilesPostProcessor(
 
             # HtmlRendering and htmlWithSource both embed contentId directly — no ContentReference needed
             is_html_rendered = is_html
-            if replaced and not (is_image or is_html_rendered or fence_ff_on):
+            if replaced and not (is_image or is_html_rendered or self._fence_ff_on):
                 loop_response.message.references.append(
                     ContentReference(
                         sequence_number=ref_number,
@@ -600,9 +601,9 @@ class DisplayCodeInterpreterFilesPostProcessor(
             error_files,
         )
 
-        if fence_ff_on:
+        if self._fence_ff_on:
             code_blocks = _build_code_blocks(
-                loop_response, self._content_map, include_html=html_fence_ff_on
+                loop_response, self._content_map, include_html=self._html_fence_ff_on
             )
             self._log.info(
                 "Fence injection — %d code block(s), files: %s",
@@ -610,7 +611,7 @@ class DisplayCodeInterpreterFilesPostProcessor(
                 [f.filename for b in code_blocks for f in b.files],
             )
             _warn_unmatched_code_blocks(
-                self._content_map, code_blocks, include_html=html_fence_ff_on
+                self._content_map, code_blocks, include_html=self._html_fence_ff_on
             )
             text_before = loop_response.message.text
             loop_response.message.text = _inject_code_execution_fences(

--- a/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/service.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/service.py
@@ -24,6 +24,7 @@ from unique_toolkit._common.execution import (
     failsafe_async,
 )
 from unique_toolkit._common.utils.jinja.render import render_template
+from unique_toolkit.agentic.feature_flags import FeatureFlagNames
 from unique_toolkit.agentic.short_term_memory_manager.persistent_short_term_memory_manager import (
     PersistentShortMemoryManager,
 )
@@ -41,10 +42,7 @@ from unique_toolkit.agentic.tools.schemas import ToolPrompts
 from unique_toolkit.content.schemas import (
     Content,
 )
-from unique_toolkit.experimental.resources.feature_flags import (
-    FeatureFlagNames,
-    is_flag_enabled,
-)
+from unique_toolkit.experimental.resources.feature_flags import is_flag_enabled
 
 logger = logging.getLogger(__name__)
 
@@ -261,6 +259,7 @@ class OpenAICodeInterpreterTool(OpenAIBuiltInTool[CodeInterpreter]):
         user_uploaded_files: list[str] | None = None,
         kb_uploaded_files: list[str] | None = None,
         code_execution_files: list[str] | None = None,
+        fence_enabled: bool = False,
     ) -> None:
         self._config = config
 
@@ -274,6 +273,9 @@ class OpenAICodeInterpreterTool(OpenAIBuiltInTool[CodeInterpreter]):
         self._user_uploaded_files = user_uploaded_files
         self._kb_uploaded_files = kb_uploaded_files
         self._code_interpreter_artifacts = code_execution_files
+        # Resolved once in `build_tool` (async) since flag evaluation is async
+        # but this instance is used from sync call-sites (get_required_include_params).
+        self._fence_enabled = fence_enabled
 
     @property
     @override
@@ -325,6 +327,11 @@ class OpenAICodeInterpreterTool(OpenAIBuiltInTool[CodeInterpreter]):
         if force_auto_container:
             config = config.model_copy(update={"use_auto_container": True})
 
+        fence_enabled = await is_flag_enabled(
+            FeatureFlagNames.enable_code_execution_fence_un_17972,
+            company_id=company_id,
+        )
+
         if config.use_auto_container:
             logger.info("Using `auto` container setting")
             return cls(
@@ -332,6 +339,7 @@ class OpenAICodeInterpreterTool(OpenAIBuiltInTool[CodeInterpreter]):
                 container_id=None,
                 company_id=company_id,
                 is_exclusive=is_exclusive,
+                fence_enabled=fence_enabled,
             )
 
         memory_manager = _get_container_code_execution_short_term_memory_manager(
@@ -410,6 +418,7 @@ class OpenAICodeInterpreterTool(OpenAIBuiltInTool[CodeInterpreter]):
             user_uploaded_files=_extract_paths(user_uploaded_files),
             kb_uploaded_files=_extract_paths(kb_files),
             code_execution_files=_extract_paths(code_execution_files),
+            fence_enabled=fence_enabled,
         )
 
     @override
@@ -437,10 +446,7 @@ class OpenAICodeInterpreterTool(OpenAIBuiltInTool[CodeInterpreter]):
 
     @override
     def get_required_include_params(self) -> list[ResponseIncludable]:
-        if is_flag_enabled(
-            FeatureFlagNames.enable_code_execution_fence_un_17972,
-            company_id=self._company_id or "",
-        ):
+        if self._fence_enabled:
             return ["code_interpreter_call.outputs"]
         return []
 

--- a/unique_toolkit/unique_toolkit/experimental/resources/feature_flags/__init__.py
+++ b/unique_toolkit/unique_toolkit/experimental/resources/feature_flags/__init__.py
@@ -14,12 +14,13 @@ Quick start — explicit IDs::
 
     from unique_toolkit.experimental.resources.feature_flags import FeatureFlagClient, is_flag_enabled
 
-    # Tries remote client; falls back to FeatureFlags settings when not configured.
+    # Requires CONFIGURATION_BACKEND_URL / FEATURE_FLAG_SERVICE_ID to be set;
+    # falls back to the env-var value (or stale cache) on transport errors.
     enabled = await is_flag_enabled("FEATURE_FLAG_ENABLE_X", company_id=company_id)
 
-    # Or manage the singleton directly (returns None when not configured):
+    # Or manage the singleton directly:
     client = FeatureFlagClient.from_settings()  # raises if URL/service_id absent
-    client = get_feature_flag_client()           # returns None instead of raising
+    client = get_feature_flag_client()          # same — thin passthrough to from_settings()
 
 Per-request binding (when you have UniqueSettings / AuthContext)::
 
@@ -38,7 +39,6 @@ See README.md for the full evaluation-order diagram and adoption steps.
 from .client import (
     BoundFeatureFlagClient,
     FeatureFlagClient,
-    FeatureFlagNames,
     get_feature_flag_client,
     is_flag_enabled,
 )
@@ -46,7 +46,6 @@ from .schemas import FlagEvaluation
 from .settings import FeatureFlagSettings
 
 __all__ = [
-    "FeatureFlagNames",
     "BoundFeatureFlagClient",
     "FeatureFlagClient",
     "FlagEvaluation",

--- a/unique_toolkit/unique_toolkit/experimental/resources/feature_flags/client.py
+++ b/unique_toolkit/unique_toolkit/experimental/resources/feature_flags/client.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 import logging
 import os
-from enum import StrEnum
 from typing import ClassVar
 
 import httpx
 from tenacity import retry, retry_if_exception, stop_after_attempt
 
+from unique_toolkit.agentic.feature_flags.feature_flags import FeatureFlags
 from unique_toolkit.app.unique_settings import AuthContextProtocol, UniqueSettings
 
 from ._graphql_client import evaluate_flag
@@ -16,24 +16,6 @@ from .schemas import FlagEvaluation
 from .settings import FeatureFlagSettings
 
 logger = logging.getLogger(__name__)
-
-
-class FeatureFlagNames(StrEnum):
-    enable_selected_uploaded_files_un_18215 = (
-        "FEATURE_FLAG_ENABLE_SELECTED_UPLOADED_FILES_UN_18215"
-    )
-    enable_mcp_metadata_fallback_un_19145 = (
-        "FEATURE_FLAG_ENABLE_MCP_METADATA_FALLBACK_UN_19145"
-    )
-    enable_html_rendering_un_15131 = "FEATURE_FLAG_ENABLE_HTML_RENDERING_UN_15131"
-    enable_code_execution_fence_un_17972 = (
-        "FEATURE_FLAG_ENABLE_CODE_EXECUTION_FENCE_UN_17972"
-    )
-    enable_html_with_fence_un_17927 = "FEATURE_FLAG_ENABLE_HTML_WITH_FENCE_UN_17927"
-    enable_web_search_argument_screening_un_18741 = (
-        "FEATURE_FLAG_ENABLE_WEB_SEARCH_ARGUMENT_SCREENING_UN_18741"
-    )
-    enable_new_answers_ui_un_14411 = "FEATURE_FLAG_ENABLE_NEW_ANSWERS_UI_UN_14411"
 
 
 class FeatureFlagClient:
@@ -198,19 +180,13 @@ class FeatureFlagClient:
     def _env_fallback(flag: str, company_id: str | None = None) -> bool:
         """Read *flag* from env vars using the same semantics as ``FeatureFlag``.
 
-        Supports both plain booleans (``"true"`` / ``"false"``) and
-        comma-separated company-ID allowlists (``"company1,company2"``),
-        consistent with ``unique_toolkit.agentic.feature_flags.FeatureFlags``.
+        Delegates parsing to ``FeatureFlags.parse_feature_flag`` (plain booleans
+        or comma-separated company-ID allowlists) so the two env-var fallback
+        paths — this client and ``unique_toolkit.agentic.feature_flags`` —
+        can't drift apart.
         """
-        raw = os.getenv(flag, "false").strip()
-        raw_lower = raw.lower()
-        if raw_lower in ("true", "1", "yes"):
-            return True
-        if raw_lower in ("false", "0", "no", ""):
-            return False
-        # Comma-separated company-ID allowlist
-        allowed = {part.strip() for part in raw.split(",") if part.strip()}
-        return company_id in allowed if company_id else False
+        raw = os.getenv(flag, "false")
+        return FeatureFlags.parse_feature_flag(raw).is_enabled(company_id)
 
 
 class BoundFeatureFlagClient:
@@ -237,9 +213,10 @@ class BoundFeatureFlagClient:
 def get_feature_flag_client() -> FeatureFlagClient:
     """Return the process-level :class:`FeatureFlagClient` singleton.
 
-    Built lazily via :meth:`FeatureFlagClient.from_settings` which reads
-    ``CONFIGURATION_BACKEND_URL`` and ``FEATURE_FLAG_SERVICE_ID`` from env.
-    Falls back to env-var defaults on missing config or transport errors.
+    Built lazily via :meth:`FeatureFlagClient.from_settings`, which reads
+    ``CONFIGURATION_BACKEND_URL`` and ``FEATURE_FLAG_SERVICE_ID`` from env and
+    raises :class:`ValueError` if either is missing. Evaluations fall back to
+    env-var defaults (or a stale cached value) only on *transport* errors.
     """
     return FeatureFlagClient.from_settings()
 

--- a/unique_toolkit/unique_toolkit/services/chat_service.py
+++ b/unique_toolkit/unique_toolkit/services/chat_service.py
@@ -22,6 +22,7 @@ from unique_toolkit._common.metadata_filter_scope import (
     merge_scope_clause_into_metadata_filter,
 )
 from unique_toolkit._common.utils.files import is_file_content, is_image_content
+from unique_toolkit.agentic.feature_flags import FeatureFlagNames
 from unique_toolkit.agentic.message_log_order import next_message_log_order
 from unique_toolkit.app.unique_settings import UniqueContext, UniqueSettings
 from unique_toolkit.chat.cancellation import CancellationWatcher
@@ -99,10 +100,7 @@ from unique_toolkit.content.schemas import (
     ContentSearchType,
 )
 from unique_toolkit.elicitation.service import ElicitationService
-from unique_toolkit.experimental.resources.feature_flags import (
-    FeatureFlagNames,
-    is_flag_enabled,
-)
+from unique_toolkit.experimental.resources.feature_flags import is_flag_enabled
 from unique_toolkit.language_model.constants import (
     DEFAULT_COMPLETE_TEMPERATURE,
     DEFAULT_COMPLETE_TIMEOUT,


### PR DESCRIPTION
## Summary
Follow-up to #1970 addressing Bugbot findings and review comments:

- Fixed several call sites that assigned/compared the coroutine returned by async `is_flag_enabled()` / `get_selected_uploaded_content_ids()` directly in sync code (`ShowExecutedCodePostprocessor.__init__`, `DisplayCodeInterpreterFilesPostProcessor.apply_postprocessing_to_response`, `OpenAICodeInterpreterTool.get_required_include_params`, `LoopTokenReducer.__init__`) — flags were always truthy or silently skipped. Each is now resolved once at the nearest async touchpoint already on the call path (`run()`, `build_tool()`, or lazily on first async use) and cached for sync readers downstream.
- `FeatureFlagClient._env_fallback` now delegates its bool/allowlist parsing to `FeatureFlags.parse_feature_flag` instead of re-implementing it, so the two env-var fallback paths can't drift apart.
- Fixed stale docstrings claiming `get_feature_flag_client()` returns `None` when unconfigured (it raises `ValueError`, same as `from_settings()`).
- Moved `FeatureFlagNames` out of the generic `experimental.resources.feature_flags` client into `agentic.feature_flags`, alongside `FeatureFlag`/`FeatureFlags` — the client now only exposes `is_flag_enabled`/`get_feature_flag_client` (plain strings), matching the pattern of service-owned flag classes (e.g. assistants-core's `AssistantsCoreFlags`) that consume it.

## Test plan
- [x] `pytest unique_toolkit/tests` — 2584 passed, 12 skipped
- [x] `ruff check` — clean
- [x] `basedpyright` — 0 errors