### PR TITLE
fix(toolkit): inject shared ChatService into tools at construction

### DIFF
--- a/tool_packages/unique_deep_research/unique_deep_research/service.py
+++ b/tool_packages/unique_deep_research/unique_deep_research/service.py
@@ -290,7 +290,7 @@ class DeepResearchTool(Tool[DeepResearchToolConfig]):
         if await self.is_followup_question_answer() and not self.is_message_execution():
             _LOGGER.info("This is a follow-up question answer")
             self.chat_service.create_message_execution(
-                message_id=self.event.payload.assistant_message.id,
+                message_id=self.chat_service.assistant_message_id,
                 type=MessageExecutionType.DEEP_RESEARCH,
             )
             self.write_message_log_text_message(
@@ -347,7 +347,7 @@ class DeepResearchTool(Tool[DeepResearchToolConfig]):
 
         # put message in short term memory to remember that we asked the followup questions
         await self.memory_service.save_async(
-            MemorySchema(message_id=self.event.payload.assistant_message.id),
+            MemorySchema(message_id=self.chat_service.assistant_message_id),
         )
         return ToolCallResponse(
             id=tool_call.id or "",
@@ -369,7 +369,7 @@ class DeepResearchTool(Tool[DeepResearchToolConfig]):
             percentage = 100 if status == MessageExecutionUpdateStatus.COMPLETED else 0
 
         await self.chat_service.update_message_execution_async(
-            message_id=self.event.payload.assistant_message.id,
+            message_id=self.chat_service.assistant_message_id,
             status=status,
             percentage_completed=percentage,
         )
@@ -405,7 +405,7 @@ class DeepResearchTool(Tool[DeepResearchToolConfig]):
     def write_message_log_text_message(self, text: str):
         create_message_log_entry(
             self.chat_service,
-            self.event.payload.assistant_message.id,
+            self.chat_service.assistant_message_id,
             text,
             MessageLogStatus.COMPLETED,
             details=MessageLogDetails(data=[]),
@@ -468,7 +468,7 @@ class DeepResearchTool(Tool[DeepResearchToolConfig]):
             "notes": [],
             "final_report": "",
             "chat_service": self.chat_service,
-            "message_id": self.event.payload.assistant_message.id,
+            "message_id": self.chat_service.assistant_message_id,
         }
 
         # Prepare configuration for LangGraph
@@ -486,7 +486,7 @@ class DeepResearchTool(Tool[DeepResearchToolConfig]):
                 "openai_client": self.client,
                 "chat_service": self.chat_service,
                 "content_service": self.content_service,
-                "message_id": self.event.payload.assistant_message.id,
+                "message_id": self.chat_service.assistant_message_id,
                 "citation_manager": citation_manager,
                 "additional_openai_proxy_headers": additional_openai_proxy_headers,
             },
@@ -652,11 +652,11 @@ class DeepResearchTool(Tool[DeepResearchToolConfig]):
                         if isinstance(event.item, ResponseReasoningItem):
                             for summary in event.item.summary:
                                 self.chat_service.create_message_log(
-                                    message_id=self.event.payload.assistant_message.id,
+                                    message_id=self.chat_service.assistant_message_id,
                                     text=summary.text,
                                     status=MessageLogStatus.COMPLETED,
                                     order=get_next_message_order(
-                                        self.event.payload.assistant_message.id
+                                        self.chat_service.assistant_message_id
                                     ),
                                     uncited_references=MessageLogUncitedReferences(
                                         data=[],
@@ -671,11 +671,11 @@ class DeepResearchTool(Tool[DeepResearchToolConfig]):
                             ) and isinstance(event.item.action.query, str):
                                 _LOGGER.info("OpenAI web search")
                                 self.chat_service.create_message_log(
-                                    message_id=self.event.payload.assistant_message.id,
+                                    message_id=self.chat_service.assistant_message_id,
                                     text="**Searching the web**",
                                     status=MessageLogStatus.COMPLETED,
                                     order=get_next_message_order(
-                                        self.event.payload.assistant_message.id
+                                        self.chat_service.assistant_message_id
                                     ),
                                     uncited_references=MessageLogUncitedReferences(
                                         data=[],
@@ -718,11 +718,11 @@ class DeepResearchTool(Tool[DeepResearchToolConfig]):
                                     )
                                     continue
                                 self.chat_service.create_message_log(
-                                    message_id=self.event.payload.assistant_message.id,
+                                    message_id=self.chat_service.assistant_message_id,
                                     text="**Reading website**",
                                     status=MessageLogStatus.COMPLETED,
                                     order=get_next_message_order(
-                                        self.event.payload.assistant_message.id
+                                        self.chat_service.assistant_message_id
                                     ),
                                     uncited_references=MessageLogUncitedReferences(
                                         data=[
@@ -745,11 +745,11 @@ class DeepResearchTool(Tool[DeepResearchToolConfig]):
                                 )
                     case "response.failed":
                         self.chat_service.create_message_log(
-                            message_id=self.event.payload.assistant_message.id,
+                            message_id=self.chat_service.assistant_message_id,
                             text=f"Failed to complete research: {event.response.error}",
                             status=MessageLogStatus.FAILED,
                             order=get_next_message_order(
-                                self.event.payload.assistant_message.id
+                                self.chat_service.assistant_message_id
                             ),
                             uncited_references=MessageLogUncitedReferences(
                                 data=[],

--- a/tool_packages/unique_deep_research/unique_deep_research/service.py
+++ b/tool_packages/unique_deep_research/unique_deep_research/service.py
@@ -28,6 +28,7 @@ from unique_toolkit.agentic.tools.agent_chunks_hanlder import AgentChunksHandler
 from unique_toolkit.agentic.tools.factory import ToolFactory
 from unique_toolkit.agentic.tools.schemas import ToolCallResponse
 from unique_toolkit.agentic.tools.tool import Tool
+from unique_toolkit.agentic.tools.tool_progress_reporter import ToolProgressReporter
 from unique_toolkit.app.schemas import ChatEvent
 from unique_toolkit.chat.cancellation import CancellationEvent
 from unique_toolkit.chat.schemas import (
@@ -38,10 +39,11 @@ from unique_toolkit.chat.schemas import (
     MessageLogStatus,
     MessageLogUncitedReferences,
 )
-from unique_toolkit.chat.service import LanguageModelToolDescription
+from unique_toolkit.chat.service import ChatService, LanguageModelToolDescription
 from unique_toolkit.content.schemas import ContentReference
 from unique_toolkit.content.service import ContentService
 from unique_toolkit.framework_utilities.openai.client import get_async_openai_client
+from unique_toolkit.language_model import LanguageModelService
 from unique_toolkit.language_model.schemas import (
     LanguageModelFunction,
     LanguageModelMessage,
@@ -107,9 +109,21 @@ class DeepResearchTool(Tool[DeepResearchToolConfig]):
         self,
         configuration: DeepResearchToolConfig,
         event: ChatEvent,
-        tool_progress_reporter,
+        tool_progress_reporter: ToolProgressReporter | None = None,
+        *,
+        chat_service: ChatService | None = None,
+        language_model_service: LanguageModelService | None = None,
     ):
-        super().__init__(configuration, event, tool_progress_reporter)
+        if chat_service is not None and language_model_service is not None:
+            super().__init__(
+                configuration,
+                event,
+                tool_progress_reporter,
+                chat_service=chat_service,
+                language_model_service=language_model_service,
+            )
+        else:
+            super().__init__(configuration, event, tool_progress_reporter)
         self.chat_id = event.payload.chat_id
         self.company_id = event.company_id
         self.user_id = event.user_id

--- a/unique_orchestrator/unique_orchestrator/unique_ai_builder.py
+++ b/unique_orchestrator/unique_orchestrator/unique_ai_builder.py
@@ -319,11 +319,15 @@ async def _build_common(
         mcp_servers=event.payload.mcp_servers,
         event=event,
         tool_progress_reporter=tool_progress_reporter,
+        chat_service=chat_service,
+        language_model_service=llm_service,
     )
     a2a_manager = A2AManager(
         logger=logger,
         tool_progress_reporter=tool_progress_reporter,
         response_watcher=response_watcher,
+        chat_service=chat_service,
+        language_model_service=llm_service,
     )
 
     tool_manager_config = ToolManagerConfig(
@@ -528,6 +532,8 @@ async def _build_responses(
         mcp_manager=common_components.mcp_manager,
         a2a_manager=common_components.a2a_manager,
         builtin_tool_manager=builtin_tool_manager,
+        chat_service=common_components.chat_service,
+        language_model_service=common_components.llm_service,
     )
     if (
         not config.agent.experimental.open_file_tool_config.enabled
@@ -629,6 +635,8 @@ async def _build_completions(
         tool_progress_reporter=common_components.tool_progress_reporter,
         mcp_manager=common_components.mcp_manager,
         a2a_manager=common_components.a2a_manager,
+        chat_service=common_components.chat_service,
+        language_model_service=common_components.llm_service,
     )
     if force_uploaded_search:
         tool_manager.add_forced_tool(UploadedSearchTool.name)

--- a/unique_toolkit/docs/agentic_framework/tool.md
+++ b/unique_toolkit/docs/agentic_framework/tool.md
@@ -67,26 +67,69 @@ This method is the heart of the tool's functionality and must be tailored to the
 
 ### 🧩 Initialization
 
-The base `Tool` class is initialized with **configuration only**. The base class is decoupled from chat-frontend concerns (ChatEvent, ChatService, LanguageModelService, ToolProgressReporter).
+The base `Tool` class supports three initialization paths. Which one runs depends on who constructs the tool.
 
-Tools that need runtime context (event, chat_service, language_model_service, tool_progress_reporter) should accept them in their own `__init__` and create the services they need.
+#### Orchestrator path (preferred)
 
-#### Base Constructor:
+When tools run inside the agent loop, the orchestrator owns a single `ChatService` and `LanguageModelService` for the turn. `ToolManager` (and the MCP/A2A managers) inject that shared pair into every tool at construction time. All tools therefore share the same live `assistant_message_id` across multi-turn loops.
+
+Do **not** create a separate `ChatService(event)` inside a tool when the orchestrator injects services — a second instance freezes state from init time and produces stale message IDs.
+
+#### Constructor overloads
+
 ```{.python #tool-init}
-def __init__(self, config: ConfigType) -> None:
-    """Initialize the tool with configuration only."""
-    self.settings = ToolBuildConfig(
-        name=self.name,
-        configuration=config,
-    )
-    self.config = config
-    self.logger = getLogger(f"{module_name}.{__name__}")
-    self.debug_info: dict = {}
+# Config only — standalone / tests
+Tool(config)
+
+# Legacy — bootstraps its own ChatService + LanguageModelService from event
+Tool(config, event, tool_progress_reporter)
+
+# Orchestrator — reuses the shared services injected by ToolManager
+Tool(
+    config,
+    event,
+    tool_progress_reporter,
+    chat_service=chat_service,
+    language_model_service=language_model_service,
+)
 ```
+
+When `chat_service` and `language_model_service` are supplied, the base class stores them directly. When only `event` is supplied, it creates `ChatService(event)` and `LanguageModelService.from_event(event)` for backward compatibility with SDK and legacy callers.
+
+Both services must be injected together; supplying only one raises `ValueError`.
+
+#### Custom `__init__` in tool subclasses
+
+Tools with their own constructor must accept the optional injected services and forward them to `super().__init__`. `ToolManager` passes these kwargs when building tools from configuration.
+
+```{.python #tool-subclass-init}
+def __init__(
+    self,
+    configuration: MyToolConfig,
+    event: ChatEvent,
+    tool_progress_reporter: ToolProgressReporter | None = None,
+    *,
+    chat_service: ChatService | None = None,
+    language_model_service: LanguageModelService | None = None,
+) -> None:
+    if chat_service is not None and language_model_service is not None:
+        super().__init__(
+            configuration,
+            event,
+            tool_progress_reporter,
+            chat_service=chat_service,
+            language_model_service=language_model_service,
+        )
+    else:
+        super().__init__(configuration, event, tool_progress_reporter)
+    # tool-specific setup using event fields ...
+```
+
+Use `self.chat_service.assistant_message_id` (via the inherited property) for the current assistant message — not `event.payload.assistant_message.id`, which is frozen at event creation.
 
 #### 🔄 Progress Reporting
 
-Tools that need progress reporting should accept `tool_progress_reporter` in their `__init__` (passed by ToolManager) and store it. Progress updates are typically sent before any streaming begins, ensuring users are aware of the tool's current state.
+Tools that need progress reporting accept `tool_progress_reporter` in their `__init__` (passed by `ToolManager`) and store it via the base class. Progress updates are typically sent before any streaming begins, ensuring users are aware of the tool's current state.
 
 ---
 

--- a/unique_toolkit/tests/agentic/tools/test_shared_chat_service_injection.py
+++ b/unique_toolkit/tests/agentic/tools/test_shared_chat_service_injection.py
@@ -1,0 +1,329 @@
+"""Regression tests for shared ChatService injection into tools (UN-19148)."""
+
+from typing import overload
+from unittest.mock import Mock
+
+import pytest
+from typing_extensions import deprecated
+
+from unique_toolkit.agentic.evaluation.schemas import EvaluationMetricName
+from unique_toolkit.agentic.tools.a2a import A2AManager
+from unique_toolkit.agentic.tools.a2a.response_watcher import SubAgentResponseWatcher
+from unique_toolkit.agentic.tools.config import (
+    ToolBuildConfig,
+    ToolIcon,
+    ToolSelectionPolicy,
+)
+from unique_toolkit.agentic.tools.mcp.manager import MCPManager
+from unique_toolkit.agentic.tools.mcp.models import MCPToolConfig
+from unique_toolkit.agentic.tools.mcp.tool_wrapper import MCPToolWrapper
+from unique_toolkit.agentic.tools.schemas import BaseToolConfig
+from unique_toolkit.agentic.tools.tool import Tool
+from unique_toolkit.agentic.tools.tool_manager import ToolManager, ToolManagerConfig
+from unique_toolkit.agentic.tools.tool_progress_reporter import ToolProgressReporter
+from unique_toolkit.app.schemas import ChatEvent, McpServer, McpTool
+from unique_toolkit.chat.service import ChatService
+from unique_toolkit.language_model import LanguageModelService
+from unique_toolkit.language_model.schemas import (
+    LanguageModelFunction,
+    LanguageModelToolDescription,
+)
+
+
+class _SharedServiceToolConfig(BaseToolConfig):
+    pass
+
+
+class _SharedServiceTool(Tool[_SharedServiceToolConfig]):
+    name = "shared_service_tool"
+
+    def __init__(self, configuration: _SharedServiceToolConfig, *args, **kwargs):
+        super().__init__(configuration, *args, **kwargs)
+
+    def tool_description(self) -> LanguageModelToolDescription:
+        return LanguageModelToolDescription(
+            name=self.name,
+            description="test",
+            parameters=dict,
+        )
+
+    async def run(self, tool_call: LanguageModelFunction):
+        raise NotImplementedError
+
+    def evaluation_check_list(self) -> list[EvaluationMetricName]:
+        return []
+
+    def get_evaluation_checks_based_on_tool_response(self, tool_response):
+        return []
+
+
+class _FixedInitToolConfig(BaseToolConfig):
+    pass
+
+
+class _FixedInitTool(Tool[_FixedInitToolConfig]):
+    """Mirrors production tools (e.g. AskUser) with service-injection support."""
+
+    name = "fixed_init_tool"
+
+    @overload
+    def __init__(
+        self,
+        config: _FixedInitToolConfig,
+        *,
+        chat_service: ChatService,
+        language_model_service: LanguageModelService,
+        tool_progress_reporter: ToolProgressReporter | None = ...,
+        event: ChatEvent | None = ...,
+    ) -> None: ...
+
+    @overload
+    @deprecated(
+        "Passing event is deprecated. Inject chat_service and language_model_service."
+    )
+    def __init__(
+        self,
+        config: _FixedInitToolConfig,
+        event: ChatEvent,
+        tool_progress_reporter: ToolProgressReporter | None = ...,
+    ) -> None: ...
+
+    def __init__(
+        self,
+        config: _FixedInitToolConfig,
+        event: ChatEvent | None = None,
+        tool_progress_reporter: ToolProgressReporter | None = None,
+        *,
+        chat_service: ChatService | None = None,
+        language_model_service: LanguageModelService | None = None,
+    ) -> None:
+        if chat_service is not None and language_model_service is not None:
+            super().__init__(
+                config,
+                event,
+                tool_progress_reporter=tool_progress_reporter,
+                chat_service=chat_service,
+                language_model_service=language_model_service,
+            )
+        elif event is not None:
+            super().__init__(config, event, tool_progress_reporter)
+        else:
+            raise ValueError(
+                "_FixedInitTool requires event or injected chat_service and "
+                "language_model_service"
+            )
+
+    def tool_description(self) -> LanguageModelToolDescription:
+        return LanguageModelToolDescription(
+            name=self.name,
+            description="test",
+            parameters=dict,
+        )
+
+    async def run(self, tool_call: LanguageModelFunction):
+        raise NotImplementedError
+
+    def evaluation_check_list(self) -> list[EvaluationMetricName]:
+        return []
+
+    def get_evaluation_checks_based_on_tool_response(self, tool_response):
+        return []
+
+
+@pytest.fixture
+def chat_event() -> ChatEvent:
+    event = Mock(spec=ChatEvent)
+    event.company_id = "company-1"
+    event.user_id = "user-1"
+    event.payload = Mock()
+    event.payload.chat_id = "chat-1"
+    event.payload.assistant_message = Mock()
+    event.payload.assistant_message.id = "assistant-msg-initial"
+    event.payload.tool_choices = ["shared_service_tool"]
+    event.payload.disabled_tools = []
+    event.payload.mcp_servers = []
+    return event
+
+
+@pytest.fixture
+def shared_chat_service(chat_event: ChatEvent) -> ChatService:
+    return ChatService(chat_event)
+
+
+@pytest.fixture
+def shared_llm_service(chat_event: ChatEvent) -> LanguageModelService:
+    return LanguageModelService.from_event(chat_event)
+
+
+def test_tool_init_with_injected_services_shares_chat_service_instance(
+    chat_event: ChatEvent,
+    shared_chat_service: ChatService,
+    shared_llm_service: LanguageModelService,
+) -> None:
+    tool = _SharedServiceTool(
+        _SharedServiceToolConfig(),
+        chat_event,
+        chat_service=shared_chat_service,
+        language_model_service=shared_llm_service,
+    )
+
+    assert tool._chat_service is shared_chat_service
+    assert tool.event is chat_event
+
+
+def test_tool_manager_passes_shared_chat_service_to_internal_tools(
+    chat_event: ChatEvent,
+    shared_chat_service: ChatService,
+    shared_llm_service: LanguageModelService,
+) -> None:
+    from unique_toolkit.agentic.tools.factory import ToolFactory
+
+    ToolFactory.register_tool(_SharedServiceTool, _SharedServiceToolConfig)
+
+    try:
+        tool_manager = ToolManager(
+            logger=Mock(),
+            config=ToolManagerConfig(
+                tools=[
+                    ToolBuildConfig(
+                        name=_SharedServiceTool.name,
+                        configuration=_SharedServiceToolConfig(),
+                        display_name="Shared Service Tool",
+                        is_exclusive=False,
+                        is_enabled=True,
+                        icon=ToolIcon.BOOK,
+                        selection_policy=ToolSelectionPolicy.BY_USER,
+                    )
+                ]
+            ),
+            event=chat_event,
+            tool_progress_reporter=Mock(spec=ToolProgressReporter),
+            mcp_manager=MCPManager(
+                mcp_servers=[],
+                event=chat_event,
+                tool_progress_reporter=Mock(spec=ToolProgressReporter),
+                chat_service=shared_chat_service,
+                language_model_service=shared_llm_service,
+            ),
+            a2a_manager=A2AManager(
+                logger=Mock(),
+                tool_progress_reporter=Mock(spec=ToolProgressReporter),
+                response_watcher=SubAgentResponseWatcher(),
+            ),
+            chat_service=shared_chat_service,
+            language_model_service=shared_llm_service,
+        )
+
+        internal_tool = tool_manager.get_tool_by_name(_SharedServiceTool.name)
+        assert internal_tool is not None
+        assert internal_tool._chat_service is shared_chat_service
+    finally:
+        ToolFactory.tool_map.pop(_SharedServiceTool.name, None)
+        ToolFactory.tool_config_map.pop(_SharedServiceTool.name, None)
+
+
+def test_tool_manager_injects_shared_services_into_custom_init_tools(
+    chat_event: ChatEvent,
+    shared_chat_service: ChatService,
+    shared_llm_service: LanguageModelService,
+) -> None:
+    from unique_toolkit.agentic.tools.factory import ToolFactory
+
+    ToolFactory.register_tool(_FixedInitTool, _FixedInitToolConfig)
+    chat_event.payload.tool_choices = [_FixedInitTool.name]
+
+    try:
+        tool_manager = ToolManager(
+            logger=Mock(),
+            config=ToolManagerConfig(
+                tools=[
+                    ToolBuildConfig(
+                        name=_FixedInitTool.name,
+                        configuration=_FixedInitToolConfig(),
+                        display_name="Fixed Init Tool",
+                        is_exclusive=False,
+                        is_enabled=True,
+                        icon=ToolIcon.BOOK,
+                        selection_policy=ToolSelectionPolicy.BY_USER,
+                    )
+                ]
+            ),
+            event=chat_event,
+            tool_progress_reporter=Mock(spec=ToolProgressReporter),
+            mcp_manager=MCPManager(
+                mcp_servers=[],
+                event=chat_event,
+                tool_progress_reporter=Mock(spec=ToolProgressReporter),
+            ),
+            a2a_manager=A2AManager(
+                logger=Mock(),
+                tool_progress_reporter=Mock(spec=ToolProgressReporter),
+                response_watcher=SubAgentResponseWatcher(),
+            ),
+            chat_service=shared_chat_service,
+            language_model_service=shared_llm_service,
+        )
+
+        fixed_init_tool = tool_manager.get_tool_by_name(_FixedInitTool.name)
+        assert fixed_init_tool is not None
+        assert fixed_init_tool._chat_service is shared_chat_service
+    finally:
+        ToolFactory.tool_map.pop(_FixedInitTool.name, None)
+        ToolFactory.tool_config_map.pop(_FixedInitTool.name, None)
+
+
+def test_mcp_tool_wrapper_uses_live_assistant_message_id_for_sdk_call(
+    chat_event: ChatEvent,
+    shared_chat_service: ChatService,
+    shared_llm_service: LanguageModelService,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mcp_tool = McpTool(
+        id="mcp-tool-id",
+        name="mcp_tool",
+        title="MCP Tool",
+        description="desc",
+        input_schema={"type": "object", "properties": {}},
+        is_connected=True,
+    )
+    mcp_server = McpServer(
+        id="server-1",
+        name="test-server",
+        description="test",
+        tools=[mcp_tool],
+        system_prompt="sys",
+        user_prompt="user",
+        is_connected=True,
+    )
+    wrapper = MCPToolWrapper(
+        mcp_server=mcp_server,
+        mcp_tool=mcp_server.tools[0],
+        config=MCPToolConfig(
+            server_id=mcp_server.id,
+            server_name=mcp_server.name,
+            server_system_prompt=mcp_server.system_prompt,
+            server_user_prompt=mcp_server.user_prompt,
+            mcp_source_id=mcp_server.id,
+        ),
+        event=chat_event,
+        chat_service=shared_chat_service,
+        language_model_service=shared_llm_service,
+    )
+
+    shared_chat_service._assistant_message_id = "assistant-msg-updated"
+    captured: dict[str, str] = {}
+
+    async def fake_call_tool_async(**kwargs):
+        captured["messageId"] = kwargs["messageId"]
+        return {}
+
+    monkeypatch.setattr(
+        "unique_toolkit.agentic.tools.mcp.tool_wrapper.unique_sdk.MCP.call_tool_async",
+        fake_call_tool_async,
+    )
+
+    import asyncio
+
+    asyncio.run(wrapper._call_mcp_tool_via_sdk({}))
+
+    assert captured["messageId"] == "assistant-msg-updated"

--- a/unique_toolkit/unique_toolkit/agentic/tools/a2a/manager.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/a2a/manager.py
@@ -52,23 +52,33 @@ class A2AManager:
             sub_agent_tool_config = tool_config.configuration
 
             try:
-                sub_agent_kwargs: dict[str, object] = {
-                    "configuration": sub_agent_tool_config,
-                    "event": event,
-                    "tool_progress_reporter": self._tool_progress_reporter,
-                    "name": tool_config.name,
-                    "display_name": tool_config.display_name,
-                    "response_watcher": self._response_watcher,
-                }
                 if (
                     self._chat_service is not None
                     and self._language_model_service is not None
                 ):
-                    sub_agent_kwargs["chat_service"] = self._chat_service
-                    sub_agent_kwargs["language_model_service"] = (
-                        self._language_model_service
+                    sub_agents.append(
+                        SubAgentTool(
+                            configuration=sub_agent_tool_config,
+                            event=event,
+                            tool_progress_reporter=self._tool_progress_reporter,
+                            name=tool_config.name,
+                            display_name=tool_config.display_name,
+                            response_watcher=self._response_watcher,
+                            chat_service=self._chat_service,
+                            language_model_service=self._language_model_service,
+                        )
                     )
-                sub_agents.append(SubAgentTool(**sub_agent_kwargs))
+                else:
+                    sub_agents.append(
+                        SubAgentTool(
+                            configuration=sub_agent_tool_config,
+                            event=event,
+                            tool_progress_reporter=self._tool_progress_reporter,
+                            name=tool_config.name,
+                            display_name=tool_config.display_name,
+                            response_watcher=self._response_watcher,
+                        )
+                    )
             except Exception:
                 self._logger.warning(
                     "Skipping sub-agent '%s' due to initialization failure.",

--- a/unique_toolkit/unique_toolkit/agentic/tools/a2a/manager.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/a2a/manager.py
@@ -5,6 +5,8 @@ from unique_toolkit.agentic.tools.a2a.tool import SubAgentTool, SubAgentToolConf
 from unique_toolkit.agentic.tools.config import ToolBuildConfig
 from unique_toolkit.agentic.tools.tool_progress_reporter import ToolProgressReporter
 from unique_toolkit.app.schemas import ChatEvent
+from unique_toolkit.chat.service import ChatService
+from unique_toolkit.language_model import LanguageModelService
 
 
 class A2AManager:
@@ -13,10 +15,15 @@ class A2AManager:
         logger: Logger,
         tool_progress_reporter: ToolProgressReporter,
         response_watcher: SubAgentResponseWatcher,
+        *,
+        chat_service: ChatService | None = None,
+        language_model_service: LanguageModelService | None = None,
     ):
         self._logger = logger
         self._tool_progress_reporter = tool_progress_reporter
         self._response_watcher = response_watcher
+        self._chat_service = chat_service
+        self._language_model_service = language_model_service
 
     def get_all_sub_agents(
         self,
@@ -45,16 +52,23 @@ class A2AManager:
             sub_agent_tool_config = tool_config.configuration
 
             try:
-                sub_agents.append(
-                    SubAgentTool(
-                        configuration=sub_agent_tool_config,
-                        event=event,
-                        tool_progress_reporter=self._tool_progress_reporter,
-                        name=tool_config.name,
-                        display_name=tool_config.display_name,
-                        response_watcher=self._response_watcher,
+                sub_agent_kwargs: dict[str, object] = {
+                    "configuration": sub_agent_tool_config,
+                    "event": event,
+                    "tool_progress_reporter": self._tool_progress_reporter,
+                    "name": tool_config.name,
+                    "display_name": tool_config.display_name,
+                    "response_watcher": self._response_watcher,
+                }
+                if (
+                    self._chat_service is not None
+                    and self._language_model_service is not None
+                ):
+                    sub_agent_kwargs["chat_service"] = self._chat_service
+                    sub_agent_kwargs["language_model_service"] = (
+                        self._language_model_service
                     )
-                )
+                sub_agents.append(SubAgentTool(**sub_agent_kwargs))
             except Exception:
                 self._logger.warning(
                     "Skipping sub-agent '%s' due to initialization failure.",

--- a/unique_toolkit/unique_toolkit/agentic/tools/a2a/tool/service.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/a2a/tool/service.py
@@ -20,7 +20,6 @@ from unique_toolkit._common.referencing import (
 from unique_toolkit._common.utils.jinja.render import render_template
 from unique_toolkit.agentic.evaluation.schemas import EvaluationMetricName
 from unique_toolkit.agentic.feature_flags import feature_flags
-from unique_toolkit.agentic.message_log_manager.service import MessageStepLogger
 from unique_toolkit.agentic.tools.a2a.response_watcher import SubAgentResponseWatcher
 from unique_toolkit.agentic.tools.a2a.tool._memory import (
     get_sub_agent_short_term_memory_manager,
@@ -53,6 +52,7 @@ from unique_toolkit.chat.service import ChatService
 from unique_toolkit.content import ContentChunk, ContentReference
 from unique_toolkit.language_model import (
     LanguageModelFunction,
+    LanguageModelService,
     LanguageModelToolDescription,
 )
 
@@ -72,12 +72,17 @@ class SubAgentTool(Tool[SubAgentToolConfig]):
         name: str = "SubAgentTool",
         display_name: str = "SubAgentTool",
         response_watcher: SubAgentResponseWatcher | None = None,
+        *,
+        chat_service: ChatService | None = None,
+        language_model_service: LanguageModelService | None = None,
     ) -> None:
-        super().__init__(configuration)
-        self._event = event
-        self._tool_progress_reporter = tool_progress_reporter
-        self._chat_service = ChatService(event)
-        self._message_step_logger = MessageStepLogger(chat_service=self._chat_service)
+        init_kwargs: dict[str, object] = {
+            "tool_progress_reporter": tool_progress_reporter,
+        }
+        if chat_service is not None and language_model_service is not None:
+            init_kwargs["chat_service"] = chat_service
+            init_kwargs["language_model_service"] = language_model_service
+        super().__init__(configuration, event, **init_kwargs)
         self._user_id = event.user_id
         self._company_id = event.company_id
 

--- a/unique_toolkit/unique_toolkit/agentic/tools/a2a/tool/service.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/a2a/tool/service.py
@@ -76,13 +76,16 @@ class SubAgentTool(Tool[SubAgentToolConfig]):
         chat_service: ChatService | None = None,
         language_model_service: LanguageModelService | None = None,
     ) -> None:
-        init_kwargs: dict[str, object] = {
-            "tool_progress_reporter": tool_progress_reporter,
-        }
         if chat_service is not None and language_model_service is not None:
-            init_kwargs["chat_service"] = chat_service
-            init_kwargs["language_model_service"] = language_model_service
-        super().__init__(configuration, event, **init_kwargs)
+            super().__init__(
+                configuration,
+                event,
+                tool_progress_reporter=tool_progress_reporter,
+                chat_service=chat_service,
+                language_model_service=language_model_service,
+            )
+        else:
+            super().__init__(configuration, event, tool_progress_reporter)
         self._user_id = event.user_id
         self._company_id = event.company_id
 

--- a/unique_toolkit/unique_toolkit/agentic/tools/experimental/ask_user_tool/tool.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/experimental/ask_user_tool/tool.py
@@ -13,12 +13,14 @@ from unique_toolkit.agentic.tools.schemas import ToolCallResponse
 from unique_toolkit.agentic.tools.tool import Tool
 from unique_toolkit.agentic.tools.tool_progress_reporter import ToolProgressReporter
 from unique_toolkit.app.schemas import ChatEvent
+from unique_toolkit.chat.service import ChatService
 from unique_toolkit.elicitation import (
     ElicitationCancelledException,
     ElicitationDeclinedException,
     ElicitationExpiredException,
     ElicitationMode,
 )
+from unique_toolkit.language_model import LanguageModelService
 from unique_toolkit.language_model.schemas import (
     LanguageModelFunction,
     LanguageModelToolDescription,
@@ -44,10 +46,24 @@ class AskUserTool(Tool[AskUserToolConfig]):
         config: AskUserToolConfig,
         event: ChatEvent,
         tool_progress_reporter: ToolProgressReporter | None = None,
+        *,
+        chat_service: ChatService | None = None,
+        language_model_service: LanguageModelService | None = None,
     ) -> None:
-        super().__init__(
-            config=config, event=event, tool_progress_reporter=tool_progress_reporter
-        )
+        if chat_service is not None and language_model_service is not None:
+            super().__init__(
+                config=config,
+                event=event,
+                tool_progress_reporter=tool_progress_reporter,
+                chat_service=chat_service,
+                language_model_service=language_model_service,
+            )
+        else:
+            super().__init__(
+                config=config,
+                event=event,
+                tool_progress_reporter=tool_progress_reporter,
+            )
         self._lock = asyncio.Lock()
 
     @override

--- a/unique_toolkit/unique_toolkit/agentic/tools/experimental/todo/service.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/experimental/todo/service.py
@@ -20,7 +20,11 @@ from unique_toolkit.agentic.tools.tool import Tool
 from unique_toolkit.agentic.tools.tool_progress_reporter import ToolProgressReporter
 from unique_toolkit.app.schemas import ChatEvent
 from unique_toolkit.chat.schemas import MessageLog, MessageLogStatus
-from unique_toolkit.language_model import LanguageModelToolDescription
+from unique_toolkit.chat.service import ChatService
+from unique_toolkit.language_model import (
+    LanguageModelService,
+    LanguageModelToolDescription,
+)
 from unique_toolkit.language_model.schemas import LanguageModelFunction
 from unique_toolkit.short_term_memory.service import ShortTermMemoryService
 
@@ -45,8 +49,20 @@ class TodoWriteTool(Tool[TodoConfig]):
         config: TodoConfig,
         event: ChatEvent,
         tool_progress_reporter: ToolProgressReporter | None = None,
+        *,
+        chat_service: ChatService | None = None,
+        language_model_service: LanguageModelService | None = None,
     ) -> None:
-        super().__init__(config, event, tool_progress_reporter)
+        if chat_service is not None and language_model_service is not None:
+            super().__init__(
+                config,
+                event,
+                tool_progress_reporter,
+                chat_service=chat_service,
+                language_model_service=language_model_service,
+            )
+        else:
+            super().__init__(config, event, tool_progress_reporter)
         stm_service = ShortTermMemoryService(
             company_id=event.company_id,
             user_id=event.user_id,

--- a/unique_toolkit/unique_toolkit/agentic/tools/mcp/manager.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/mcp/manager.py
@@ -11,6 +11,8 @@ from unique_toolkit.agentic.tools.schemas import BaseToolConfig
 from unique_toolkit.agentic.tools.tool import Tool
 from unique_toolkit.agentic.tools.tool_progress_reporter import ToolProgressReporter
 from unique_toolkit.app.schemas import ChatEvent, McpServer
+from unique_toolkit.chat.service import ChatService
+from unique_toolkit.language_model import LanguageModelService
 
 
 class MCPManager:
@@ -19,10 +21,15 @@ class MCPManager:
         mcp_servers: list[McpServer],
         event: ChatEvent,
         tool_progress_reporter: ToolProgressReporter,
-    ):
+        *,
+        chat_service: ChatService | None = None,
+        language_model_service: LanguageModelService | None = None,
+    ) -> None:
         self._mcp_servers = mcp_servers
         self._event = event
         self._tool_progress_reporter = tool_progress_reporter
+        self._chat_service = chat_service
+        self._language_model_service = language_model_service
 
     def get_mcp_servers(self):
         return self._mcp_servers
@@ -47,13 +54,22 @@ class MCPManager:
                         server_user_prompt=server.user_prompt,
                         mcp_source_id=server.id,
                     )
-                    wrapper = MCPToolWrapper(
-                        mcp_server=server,
-                        mcp_tool=tool,
-                        config=config,
-                        event=self._event,
-                        tool_progress_reporter=self._tool_progress_reporter,
-                    )
+                    wrapper_kwargs: dict[str, object] = {
+                        "mcp_server": server,
+                        "mcp_tool": tool,
+                        "config": config,
+                        "event": self._event,
+                        "tool_progress_reporter": self._tool_progress_reporter,
+                    }
+                    if (
+                        self._chat_service is not None
+                        and self._language_model_service is not None
+                    ):
+                        wrapper_kwargs["chat_service"] = self._chat_service
+                        wrapper_kwargs["language_model_service"] = (
+                            self._language_model_service
+                        )
+                    wrapper = MCPToolWrapper(**wrapper_kwargs)
                     wrapper.settings = ToolBuildConfig(  # TODO: this must be refactored to behave like the other tools.
                         name=tool.name,
                         configuration=config,

--- a/unique_toolkit/unique_toolkit/agentic/tools/mcp/manager.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/mcp/manager.py
@@ -54,22 +54,27 @@ class MCPManager:
                         server_user_prompt=server.user_prompt,
                         mcp_source_id=server.id,
                     )
-                    wrapper_kwargs: dict[str, object] = {
-                        "mcp_server": server,
-                        "mcp_tool": tool,
-                        "config": config,
-                        "event": self._event,
-                        "tool_progress_reporter": self._tool_progress_reporter,
-                    }
                     if (
                         self._chat_service is not None
                         and self._language_model_service is not None
                     ):
-                        wrapper_kwargs["chat_service"] = self._chat_service
-                        wrapper_kwargs["language_model_service"] = (
-                            self._language_model_service
+                        wrapper = MCPToolWrapper(
+                            mcp_server=server,
+                            mcp_tool=tool,
+                            config=config,
+                            event=self._event,
+                            tool_progress_reporter=self._tool_progress_reporter,
+                            chat_service=self._chat_service,
+                            language_model_service=self._language_model_service,
                         )
-                    wrapper = MCPToolWrapper(**wrapper_kwargs)
+                    else:
+                        wrapper = MCPToolWrapper(
+                            mcp_server=server,
+                            mcp_tool=tool,
+                            config=config,
+                            event=self._event,
+                            tool_progress_reporter=self._tool_progress_reporter,
+                        )
                     wrapper.settings = ToolBuildConfig(  # TODO: this must be refactored to behave like the other tools.
                         name=tool.name,
                         configuration=config,

--- a/unique_toolkit/unique_toolkit/agentic/tools/mcp/tool_wrapper.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/mcp/tool_wrapper.py
@@ -10,7 +10,6 @@ import unique_sdk
 
 from unique_toolkit.agentic.evaluation.schemas import EvaluationMetricName
 from unique_toolkit.agentic.feature_flags import feature_flags
-from unique_toolkit.agentic.message_log_manager.service import MessageStepLogger
 from unique_toolkit.agentic.tools.mcp.models import MCPToolConfig
 from unique_toolkit.agentic.tools.schemas import ToolCallResponse
 from unique_toolkit.agentic.tools.tool import Tool
@@ -22,6 +21,7 @@ from unique_toolkit.app.schemas import ChatEvent, McpServer, McpTool
 from unique_toolkit.chat.schemas import MessageLog, MessageLogStatus
 from unique_toolkit.chat.service import ChatService
 from unique_toolkit.content.functions import upload_content_from_bytes
+from unique_toolkit.language_model import LanguageModelService
 from unique_toolkit.language_model.schemas import (
     LanguageModelFunction,
     LanguageModelToolDescription,
@@ -40,13 +40,18 @@ class MCPToolWrapper(Tool[MCPToolConfig]):
         config: MCPToolConfig,
         event: ChatEvent,
         tool_progress_reporter: ToolProgressReporter | None = None,
+        *,
+        chat_service: ChatService | None = None,
+        language_model_service: LanguageModelService | None = None,
     ) -> None:
         self.name = mcp_tool.name
-        super().__init__(config)
-        self._event = event
-        self._tool_progress_reporter = tool_progress_reporter
-        self._chat_service = ChatService(event)
-        self._message_step_logger = MessageStepLogger(chat_service=self._chat_service)
+        init_kwargs: dict[str, object] = {
+            "tool_progress_reporter": tool_progress_reporter,
+        }
+        if chat_service is not None and language_model_service is not None:
+            init_kwargs["chat_service"] = chat_service
+            init_kwargs["language_model_service"] = language_model_service
+        super().__init__(config, event, **init_kwargs)
         self._mcp_tool = mcp_tool
         self._mcp_server = mcp_server
 
@@ -384,7 +389,7 @@ class MCPToolWrapper(Tool[MCPToolConfig]):
                 user_id=self._event.user_id,
                 company_id=self._event.company_id,
                 name=self.name,
-                messageId=self._event.payload.assistant_message.id,
+                messageId=self._chat_service._assistant_message_id,
                 chatId=self._event.payload.chat_id,
                 arguments=arguments,
             )

--- a/unique_toolkit/unique_toolkit/agentic/tools/mcp/tool_wrapper.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/mcp/tool_wrapper.py
@@ -392,7 +392,7 @@ class MCPToolWrapper(Tool[MCPToolConfig]):
                 user_id=self._event.user_id,
                 company_id=self._event.company_id,
                 name=self.name,
-                messageId=self._chat_service._assistant_message_id,
+                messageId=self._chat_service.assistant_message_id,
                 chatId=self._event.payload.chat_id,
                 arguments=arguments,
             )

--- a/unique_toolkit/unique_toolkit/agentic/tools/mcp/tool_wrapper.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/mcp/tool_wrapper.py
@@ -45,13 +45,16 @@ class MCPToolWrapper(Tool[MCPToolConfig]):
         language_model_service: LanguageModelService | None = None,
     ) -> None:
         self.name = mcp_tool.name
-        init_kwargs: dict[str, object] = {
-            "tool_progress_reporter": tool_progress_reporter,
-        }
         if chat_service is not None and language_model_service is not None:
-            init_kwargs["chat_service"] = chat_service
-            init_kwargs["language_model_service"] = language_model_service
-        super().__init__(config, event, **init_kwargs)
+            super().__init__(
+                config,
+                event,
+                tool_progress_reporter=tool_progress_reporter,
+                chat_service=chat_service,
+                language_model_service=language_model_service,
+            )
+        else:
+            super().__init__(config, event, tool_progress_reporter)
         self._mcp_tool = mcp_tool
         self._mcp_server = mcp_server
 

--- a/unique_toolkit/unique_toolkit/agentic/tools/tool.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/tool.py
@@ -230,6 +230,8 @@ class Tool(ABC, Generic[ConfigType]):
                 MessageStepLogger,
             )
 
+            if event is not None:
+                self._event = event
             self._tool_progress_reporter = tool_progress_reporter
             self._chat_service = chat_service
             self._language_model_service = language_model_service

--- a/unique_toolkit/unique_toolkit/agentic/tools/tool.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/tool.py
@@ -184,6 +184,17 @@ class Tool(ABC, Generic[ConfigType]):
     def __init__(
         self,
         config: ConfigType,
+        event: ChatEvent,
+        tool_progress_reporter: ToolProgressReporter | None = ...,
+        *,
+        chat_service: ChatService,
+        language_model_service: LanguageModelService,
+    ) -> None: ...
+
+    @overload
+    def __init__(
+        self,
+        config: ConfigType,
         *,
         chat_service: ChatService,
         language_model_service: LanguageModelService,

--- a/unique_toolkit/unique_toolkit/agentic/tools/tool_manager.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/tool_manager.py
@@ -232,23 +232,29 @@ class _ToolManager(Generic[_ApiMode]):
                     t.name,
                 )
                 continue
-            build_kwargs: dict[str, object] = {
-                "tool_progress_reporter": self._tool_progress_reporter,
-            }
             if (
                 self._chat_service is not None
                 and self._language_model_service is not None
             ):
-                build_kwargs["chat_service"] = self._chat_service
-                build_kwargs["language_model_service"] = self._language_model_service
-            result = safe_executor.execute(
-                ToolFactory.build_tool_with_settings,
-                t.name,
-                t,
-                t.configuration,
-                tool_init_event,
-                **build_kwargs,
-            )
+                result = safe_executor.execute(
+                    ToolFactory.build_tool_with_settings,
+                    t.name,
+                    t,
+                    t.configuration,
+                    tool_init_event,
+                    tool_progress_reporter=self._tool_progress_reporter,
+                    chat_service=self._chat_service,
+                    language_model_service=self._language_model_service,
+                )
+            else:
+                result = safe_executor.execute(
+                    ToolFactory.build_tool_with_settings,
+                    t.name,
+                    t,
+                    t.configuration,
+                    tool_init_event,
+                    tool_progress_reporter=self._tool_progress_reporter,
+                )
             if result.success:
                 self._internal_tools.append(result.unpack())
             else:
@@ -735,6 +741,8 @@ class ToolManager(_ToolManager[Literal["completions"]]):
         a2a_manager: A2AManager,
         api_mode: Literal["completions"] = "completions",
         builtin_tool_manager: OpenAIBuiltInToolManager | None = None,
+        chat_service: ChatService | None = None,
+        language_model_service: LanguageModelService | None = None,
     ) -> Self:
         return super().from_run_context(
             logger=logger,
@@ -745,6 +753,8 @@ class ToolManager(_ToolManager[Literal["completions"]]):
             a2a_manager=a2a_manager,
             api_mode=api_mode,
             builtin_tool_manager=builtin_tool_manager,
+            chat_service=chat_service,
+            language_model_service=language_model_service,
         )
 
 
@@ -787,6 +797,8 @@ class ResponsesApiToolManager(_ToolManager[Literal["responses"]]):
         a2a_manager: A2AManager,
         api_mode: Literal["responses"] = "responses",
         builtin_tool_manager: OpenAIBuiltInToolManager | None = None,
+        chat_service: ChatService | None = None,
+        language_model_service: LanguageModelService | None = None,
     ) -> Self:
         if builtin_tool_manager is None:
             msg = "builtin_tool_manager is required for ResponsesApiToolManager"
@@ -800,6 +812,8 @@ class ResponsesApiToolManager(_ToolManager[Literal["responses"]]):
             a2a_manager=a2a_manager,
             api_mode=api_mode,
             builtin_tool_manager=builtin_tool_manager,
+            chat_service=chat_service,
+            language_model_service=language_model_service,
         )
 
     def get_required_include_params(self) -> list[ResponseIncludable]:

--- a/unique_toolkit/unique_toolkit/agentic/tools/tool_manager.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/tool_manager.py
@@ -37,6 +37,8 @@ from unique_toolkit.agentic.tools.schemas import ToolCallResponse, ToolPrompts
 from unique_toolkit.agentic.tools.tool import Tool
 from unique_toolkit.agentic.tools.tool_progress_reporter import ToolProgressReporter
 from unique_toolkit.app.schemas import ChatEvent
+from unique_toolkit.chat.service import ChatService
+from unique_toolkit.language_model import LanguageModelService
 from unique_toolkit.language_model.schemas import (
     LanguageModelFunction,
     LanguageModelToolDescription,
@@ -90,6 +92,8 @@ class _ToolManager(Generic[_ApiMode]):
         a2a_manager: A2AManager,
         api_mode: _ApiMode,
         builtin_tool_manager: OpenAIBuiltInToolManager | None = None,
+        chat_service: ChatService | None = None,
+        language_model_service: LanguageModelService | None = None,
     ) -> None:
         self._setup(
             logger=logger,
@@ -100,6 +104,8 @@ class _ToolManager(Generic[_ApiMode]):
             a2a_manager=a2a_manager,
             api_mode=api_mode,
             builtin_tool_manager=builtin_tool_manager,
+            chat_service=chat_service,
+            language_model_service=language_model_service,
         )
 
     @classmethod
@@ -114,6 +120,8 @@ class _ToolManager(Generic[_ApiMode]):
         a2a_manager: A2AManager,
         api_mode: _ApiMode,
         builtin_tool_manager: OpenAIBuiltInToolManager | None = None,
+        chat_service: ChatService | None = None,
+        language_model_service: LanguageModelService | None = None,
     ) -> Self:
         instance = cls.__new__(cls)
         instance._setup(
@@ -125,6 +133,8 @@ class _ToolManager(Generic[_ApiMode]):
             a2a_manager=a2a_manager,
             api_mode=api_mode,
             builtin_tool_manager=builtin_tool_manager,
+            chat_service=chat_service,
+            language_model_service=language_model_service,
         )
         return instance
 
@@ -139,10 +149,14 @@ class _ToolManager(Generic[_ApiMode]):
         a2a_manager: A2AManager,
         api_mode: _ApiMode,
         builtin_tool_manager: OpenAIBuiltInToolManager | None,
+        chat_service: ChatService | None = None,
+        language_model_service: LanguageModelService | None = None,
     ) -> None:
         self._logger = logger
         self._config = config
         self._tool_progress_reporter = tool_progress_reporter
+        self._chat_service = chat_service
+        self._language_model_service = language_model_service
         self._tools: list[Tool[Any] | OpenAIBuiltInTool[Any]] = []
         self._tool_choices = run_context.tool_choices
         self._disabled_tools = run_context.disabled_tools
@@ -218,13 +232,22 @@ class _ToolManager(Generic[_ApiMode]):
                     t.name,
                 )
                 continue
+            build_kwargs: dict[str, object] = {
+                "tool_progress_reporter": self._tool_progress_reporter,
+            }
+            if (
+                self._chat_service is not None
+                and self._language_model_service is not None
+            ):
+                build_kwargs["chat_service"] = self._chat_service
+                build_kwargs["language_model_service"] = self._language_model_service
             result = safe_executor.execute(
                 ToolFactory.build_tool_with_settings,
                 t.name,
                 t,
                 t.configuration,
                 tool_init_event,
-                tool_progress_reporter=self._tool_progress_reporter,
+                **build_kwargs,
             )
             if result.success:
                 self._internal_tools.append(result.unpack())
@@ -684,6 +707,8 @@ class ToolManager(_ToolManager[Literal["completions"]]):
         tool_progress_reporter: ToolProgressReporter,
         mcp_manager: MCPManager,
         a2a_manager: A2AManager,
+        chat_service: ChatService | None = None,
+        language_model_service: LanguageModelService | None = None,
     ) -> None:
         super().__init__(
             logger=logger,
@@ -694,6 +719,8 @@ class ToolManager(_ToolManager[Literal["completions"]]):
             a2a_manager=a2a_manager,
             api_mode="completions",
             builtin_tool_manager=None,
+            chat_service=chat_service,
+            language_model_service=language_model_service,
         )
 
     @classmethod
@@ -731,6 +758,8 @@ class ResponsesApiToolManager(_ToolManager[Literal["responses"]]):
         mcp_manager: MCPManager,
         a2a_manager: A2AManager,
         builtin_tool_manager: OpenAIBuiltInToolManager,
+        chat_service: ChatService | None = None,
+        language_model_service: LanguageModelService | None = None,
     ) -> None:
         self._builtin_tool_manager = builtin_tool_manager
         super().__init__(
@@ -742,6 +771,8 @@ class ResponsesApiToolManager(_ToolManager[Literal["responses"]]):
             a2a_manager=a2a_manager,
             api_mode="responses",
             builtin_tool_manager=builtin_tool_manager,
+            chat_service=chat_service,
+            language_model_service=language_model_service,
         )
 
     @classmethod

--- a/uv.lock
+++ b/uv.lock
@@ -12,13 +12,13 @@ conflicts = [[
 ]]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-06-17T07:12:11.715996909Z"
 exclude-newer-span = "P2W"
 
 [options.exclude-newer-package]
 unique-toolkit = false
 unique-internal-search = false
-crawl4ai = "2026-06-19T22:00:00Z"
+crawl4ai = "2026-06-20T00:00:00Z"
 unique-swot = false
 unique-sdk = false
 unique-search-proxy-core = false
@@ -26,9 +26,9 @@ unique-mcp = false
 unique-orchestrator = false
 unique-follow-up-questions = false
 unique-user-memory = false
-langsmith = "2026-06-20T22:00:00Z"
+langsmith = "2026-06-21T00:00:00Z"
 unique-six = false
-pydantic-settings = "2026-06-20T22:00:00Z"
+pydantic-settings = "2026-06-21T00:00:00Z"
 unique-search-proxy = false
 unique-web-search = false
 unique-deep-research = false

--- a/uv.lock
+++ b/uv.lock
@@ -12,13 +12,13 @@ conflicts = [[
 ]]
 
 [options]
-exclude-newer = "2026-06-17T07:12:11.715996909Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P2W"
 
 [options.exclude-newer-package]
 unique-toolkit = false
 unique-internal-search = false
-crawl4ai = "2026-06-20T00:00:00Z"
+crawl4ai = "2026-06-19T22:00:00Z"
 unique-swot = false
 unique-sdk = false
 unique-search-proxy-core = false
@@ -26,9 +26,9 @@ unique-mcp = false
 unique-orchestrator = false
 unique-follow-up-questions = false
 unique-user-memory = false
-langsmith = "2026-06-21T00:00:00Z"
+langsmith = "2026-06-20T22:00:00Z"
 unique-six = false
-pydantic-settings = "2026-06-21T00:00:00Z"
+pydantic-settings = "2026-06-20T22:00:00Z"
 unique-search-proxy = false
 unique-web-search = false
 unique-deep-research = false


### PR DESCRIPTION
## Summary

Fixes stale `assistant_message_id` in multi-turn agent loops by injecting the orchestrator's live `ChatService` and `LanguageModelService` into tool construction instead of each tool bootstrapping its own `ChatService(event)` at init time.

- Add `resolve_tool_services()` and extend `ToolRunContext` with per-turn snapshot fields
- Wire shared services through `ToolManager`, `MCPManager`, `A2AManager`, and `unique_ai_builder`
- Update in-repo tools (DeepResearch, InternalSearch, UploadedSearch, WebSearch, SWOT, MCP/A2A wrappers, experimental tools) to prefer injected services
- **`Tool(config, event, tool_progress_reporter)` remains supported (deprecated)** for SDK/legacy callers
- **`Tool.run(tool_call)` signature unchanged** — no breaking API change

AI assist: **heavy**

Refs: UN-19148

## Test plan

- [x] `uv run pytest unique_toolkit/tests/agentic/tools/test_shared_chat_service_injection.py`
- [x] `uv run pytest unique_toolkit/tests/agentic/tools/test_service_resolution.py`
- [x] `uv run pytest unique_toolkit/tests/agentic/tools/test_run_context.py`
- [x] `uv run pytest unique_orchestrator/tests/test_unique_ai_builder_uploaded_search.py`
- [x] `uv run pytest tool_packages/unique_web_search/tests/test_service.py`
- [x] `uv run pytest tool_packages/unique_swot/unique_swot/tests/test_swot_analysis_tool.py`
- [x] `uv run pytest tool_packages/unique_internal_search/tests/test_service.py` (init-path tests)

Made with [Cursor](https://cursor.com)