### PR TITLE
feat(uqadm): enable platform versioning on kb sync by default

### DIFF
--- a/uqadm/README.md
+++ b/uqadm/README.md
@@ -417,10 +417,18 @@ locally are **left untouched — `kb sync` never deletes remote files**. Require
 exactly one of ``--folder-path`` or ``--scope-id``. Without ``--recursive`` only
 top-level files are synced; with it, subdirectories are recreated as child folders.
 
+By default, replaced files **archive prior blobs** (restorable via
+``unique-cli versions`` / ``restore-version``). Content ids are unchanged on
+replace (upsert by filename key). Pass ``--no-version`` to skip archiving
+(legacy overwrite behavior). Once a content row has been versioned, the platform
+treats versioning as sticky — later uploads keep archiving even with
+``--no-version``.
+
 ```bash
 uqadm kb sync ./docs --folder-path /Dept/HR
 uqadm kb sync ./docs --folder-path /Dept/HR -r --dry-run
 uqadm kb sync ./docs --scope-id scope_abc -r --slot qa
+uqadm kb sync ./docs --scope-id scope_abc --no-version
 ```
 
 | Option | Description |
@@ -429,6 +437,7 @@ uqadm kb sync ./docs --scope-id scope_abc -r --slot qa
 | `--scope-id` | Target folder scope id (mutually exclusive with ``--folder-path``). |
 | `-r`, `--recursive` | Recurse into subdirectories, mirroring them as child KB folders. |
 | `--dry-run` | Show planned uploads without writing anything. |
+| `--no-version` | Upload without archiving prior blobs. |
 | `--slot SLOT` | Credential slot. |
 
 Extensions that the OS `mimetypes` database cannot resolve (common on macOS for

--- a/uqadm/tests/test_kb_cli.py
+++ b/uqadm/tests/test_kb_cli.py
@@ -73,6 +73,33 @@ def test_kb_sync_cli_invokes_helper(
     assert kw["scope_id"] is None
     assert kw["recursive"] is True
     assert kw["dry_run"] is True
+    assert kw["versioning"] is True
+
+
+@patch("uqadm.kb.cmd_sync")
+@patch("uqadm.kb.config_for_slot")
+@patch("uqadm.kb.resolve_slot", return_value="qa")
+def test_kb_sync_no_version_cli(
+    mock_resolve: MagicMock,
+    mock_cfg: MagicMock,
+    mock_sync: MagicMock,
+    tmp_path: Path,
+) -> None:
+    mock_cfg.return_value = MagicMock(user_id="u1", company_id="c1")
+    result = _runner().invoke(
+        app,
+        [
+            "kb",
+            "sync",
+            str(tmp_path),
+            "--folder-path",
+            "/X",
+            "--no-version",
+        ],
+    )
+    assert result.exit_code == 0
+    mock_sync.assert_called_once()
+    assert mock_sync.call_args.kwargs["versioning"] is False
 
 
 @patch("uqadm.kb.cmd_download")

--- a/uqadm/tests/test_kb_sync.py
+++ b/uqadm/tests/test_kb_sync.py
@@ -46,6 +46,7 @@ def test_new_file_uploaded(
     args, kwargs = upload.call_args
     assert args[3] == "a.txt"  # displayed_filename / key
     assert kwargs["scope_or_unique_path"] == "scope1"
+    assert kwargs["versioning_enabled"] is True
 
 
 @patch("uqadm.kb.sync.upload_file")
@@ -75,6 +76,34 @@ def test_existing_file_replaced(
 
     # Replaced files are still re-uploaded (upsert overwrites by key).
     upload.assert_called_once()
+    assert upload.call_args.kwargs["versioning_enabled"] is True
+
+
+@patch("uqadm.kb.sync.upload_file")
+@patch("uqadm.kb.sync.Content")
+@patch("uqadm.kb.sync.Folder")
+def test_no_version_passes_false(
+    folder: MagicMock,
+    content: MagicMock,
+    upload: MagicMock,
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "a.txt").write_text("hi", encoding="utf-8")
+    folder.resolve_scope_id_from_folder_path_with_create.return_value = "scope1"
+    content.get_infos.return_value = _no_remote()
+
+    cmd_sync(
+        _cfg(),
+        local_dir=tmp_path,
+        folder_path="/X",
+        scope_id=None,
+        recursive=False,
+        dry_run=False,
+        versioning=False,
+    )
+
+    upload.assert_called_once()
+    assert upload.call_args.kwargs["versioning_enabled"] is False
 
 
 @patch("uqadm.kb.sync.upload_file")
@@ -456,7 +485,7 @@ def test_dry_run_missing_folder_treats_files_as_new(
     upload.assert_not_called()
     content.get_infos.assert_not_called()
     folder.resolve_scope_id_from_folder_path_with_create.assert_not_called()
-    assert "[dry-run] new: a.txt" in capsys.readouterr().out
+    assert "[dry-run] new: a.txt (versioned)" in capsys.readouterr().out
 
 
 @patch("uqadm.kb.sync.upload_file")
@@ -491,4 +520,35 @@ def test_remote_keys_paginates(
     assert content.get_infos.call_args_list[0].kwargs["skip"] == 0
     assert content.get_infos.call_args_list[1].kwargs["skip"] == 1
     upload.assert_called_once()
-    assert "replaced: b.txt" in capsys.readouterr().out
+    assert "replaced: b.txt (versioned)" in capsys.readouterr().out
+
+
+@patch("uqadm.kb.sync.upload_file")
+@patch("uqadm.kb.sync.Content")
+@patch("uqadm.kb.sync.Folder")
+def test_dry_run_shows_no_version_label(
+    folder: MagicMock,
+    content: MagicMock,
+    upload: MagicMock,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    (tmp_path / "a.txt").write_text("hi", encoding="utf-8")
+    folder.resolve_scope_id_from_folder_path.return_value = "scope1"
+    content.get_infos.return_value = {
+        "contentInfos": [{"key": "a.txt"}],
+        "totalCount": 1,
+    }
+
+    cmd_sync(
+        _cfg(),
+        local_dir=tmp_path,
+        folder_path="/X",
+        scope_id=None,
+        recursive=False,
+        dry_run=True,
+        versioning=False,
+    )
+
+    upload.assert_not_called()
+    assert "[dry-run] replaced: a.txt (no-version)" in capsys.readouterr().out

--- a/uqadm/uqadm/kb/__init__.py
+++ b/uqadm/uqadm/kb/__init__.py
@@ -171,6 +171,13 @@ def kb_sync(
             help="Show planned uploads without writing anything.",
         ),
     ] = False,
+    no_version: Annotated[
+        bool,
+        typer.Option(
+            "--no-version",
+            help="Upload without archiving prior blobs.",
+        ),
+    ] = False,
 ) -> None:
     """Upload the contents of LOCAL_DIR into a knowledge-base folder.
 
@@ -181,11 +188,17 @@ def kb_sync(
     ``--recursive`` only top-level files are synced; with it, subdirectories are
     recreated as child folders under the target.
 
+    By default, replaced files archive prior blobs (restorable via
+    ``unique-cli versions`` / ``restore-version``). Pass ``--no-version`` to
+    skip archiving (legacy overwrite behavior). Content ids are unchanged on
+    replace (upsert by filename key).
+
     Examples:
 
       uqadm kb sync ./docs --folder-path /Dept/HR
       uqadm kb sync ./docs --folder-path /Dept/HR -r --dry-run
       uqadm kb sync ./docs --scope-id scope_abc -r --slot qa
+      uqadm kb sync ./docs --scope-id scope_abc --no-version
     """
     resolved_slot = _resolve(slot)
     cfg = _load_cfg(resolved_slot, _get_cwd(ctx))
@@ -196,6 +209,7 @@ def kb_sync(
         scope_id=scope_id,
         recursive=recursive,
         dry_run=dry_run,
+        versioning=not no_version,
     )
 
 

--- a/uqadm/uqadm/kb/sync.py
+++ b/uqadm/uqadm/kb/sync.py
@@ -90,6 +90,7 @@ def cmd_sync(
     scope_id: str | None,
     recursive: bool,
     dry_run: bool,
+    versioning: bool = True,
 ) -> None:
     if bool(folder_path) == bool(scope_id):
         typer.echo("Specify exactly one of --folder-path or --scope-id.", err=True)
@@ -152,8 +153,9 @@ def cmd_sync(
                 counts["failed"] += 1
                 continue
             action = "replaced" if path.name in existing else "new"
+            version_label = "(versioned)" if versioning else "(no-version)"
             if dry_run:
-                typer.echo(f"[dry-run] {action}: {display}")
+                typer.echo(f"[dry-run] {action}: {display} {version_label}")
                 counts[action] += 1
                 continue
             try:
@@ -164,13 +166,14 @@ def cmd_sync(
                     path.name,
                     mime,
                     scope_or_unique_path=target_scope,
+                    versioning_enabled=versioning,
                 )
             except Exception as exc:
                 typer.echo(f"failed: {display}: {exc}", err=True)
                 echo_credential_debug_if_auth_failure(cfg, exc, label="kb sync")
                 counts["failed"] += 1
                 continue
-            typer.echo(f"{action}: {display}")
+            typer.echo(f"{action}: {display} {version_label}")
             counts[action] += 1
 
     typer.echo(


### PR DESCRIPTION
## Summary
- `uqadm kb sync` now passes `versioning_enabled=True` by default so replaced files archive prior blobs (restorable via `unique-cli versions` / `restore-version`).
- Adds `--no-version` to opt out of archiving for legacy overwrite behavior.
- Dry-run and real sync output append `(versioned)` or `(no-version)` while keeping `new:` / `replaced:` prefixes unchanged.

## Changes
- `uqadm/uqadm/kb/__init__.py` — `--no-version` CLI flag; thread `versioning=not no_version` into `cmd_sync`.
- `uqadm/uqadm/kb/sync.py` — `versioning` parameter; explicit `versioning_enabled` on `upload_file`; output labels.
- `uqadm/tests/test_kb_sync.py` — default versioning, opt-out, and dry-run label tests.
- `uqadm/tests/test_kb_cli.py` — CLI wiring for `--no-version`.
- `uqadm/README.md` — document default versioned sync, opt-out, and sticky versioning caveat.

## Test plan
- [x] `uv run pytest uqadm/tests/test_kb_sync.py uqadm/tests/test_kb_cli.py -q` (29 passed)
- [ ] Manual QA smoke: sync with default versioning, confirm `unique-cli versions cont_<id>` shows archived prior blob; opt-out with `--no-version` on never-versioned content

## Risk / rollout
- Default behavior changes for `kb sync` replaces: prior blobs are now archived instead of overwritten in place.
- Platform versioning is sticky once enabled on a content row; `--no-version` only applies to content that has never been versioned.
- `unique-cli upload` is unchanged (still always versioned).

Made with [Cursor](https://cursor.com)