### PR TITLE
fix(unique-toolkit): retarget stop polling to active assistant segment [UN-22747]

### DIFF
--- a/unique_toolkit/tests/chat/test_cancellation.py
+++ b/unique_toolkit/tests/chat/test_cancellation.py
@@ -25,6 +25,42 @@ class TestProperties:
         w = _make_watcher()
         assert w.on_cancellation is w._bus
 
+    def test_assistant_message_id__returns_initial_value(self):
+        w = _make_watcher()
+        assert w.assistant_message_id == "msg1"
+
+
+class TestSetAssistantMessageId:
+    def test_updates_polled_message_id(self):
+        w = _make_watcher()
+        w.set_assistant_message_id("msg2")
+        assert w.assistant_message_id == "msg2"
+
+    def test_no_op_after_cancelled(self):
+        w = _make_watcher()
+        w._cancelled = True
+        w.set_assistant_message_id("msg2")
+        assert w.assistant_message_id == "msg1"
+
+    @pytest.mark.asyncio
+    @patch("unique_sdk.Message.retrieve_async", new_callable=AsyncMock)
+    async def test_check_uses_retargeted_message_id(self, mock_retrieve):
+        mock_retrieve.return_value = SimpleNamespace(
+            userAbortedAt="2025-01-01T00:00:00Z"
+        )
+        w = _make_watcher()
+        w.set_assistant_message_id("msg2")
+
+        result = await w.check_cancellation_async()
+
+        assert result is True
+        mock_retrieve.assert_awaited_once_with(
+            user_id="u1",
+            company_id="c1",
+            id="msg2",
+            chatId="chat1",
+        )
+
 
 class TestCheckCancellationAsync:
     @pytest.mark.asyncio

--- a/unique_toolkit/tests/services/test_chat_service.py
+++ b/unique_toolkit/tests/services/test_chat_service.py
@@ -1,5 +1,7 @@
 """Unit tests for ChatService.from_settings."""
 
+from unittest.mock import AsyncMock, patch
+
 import pytest
 from pydantic import SecretStr
 
@@ -226,3 +228,31 @@ class TestChatServiceFromContext:
         )
         with pytest.raises(ValueError):
             ChatService.from_context(UniqueContext(auth=auth, chat=chat_no_user_msg))
+
+
+class TestAssistantMessageIdRetargeting:
+    @pytest.mark.ai
+    @patch(
+        "unique_toolkit.services.chat_service.create_message_async",
+        new_callable=AsyncMock,
+    )
+    @pytest.mark.asyncio
+    async def test_create_assistant_message_async__retargets_cancellation_watcher(
+        self,
+        mock_create_message_async: AsyncMock,
+        context: UniqueContext,
+    ) -> None:
+        from unique_toolkit.chat.schemas import ChatMessage, ChatMessageRole
+
+        mock_create_message_async.return_value = ChatMessage(
+            id="segment-2",
+            role=ChatMessageRole.ASSISTANT,
+            content="",
+            chat_id="chat-1",
+        )
+        svc = ChatService.from_context(context)
+
+        await svc.create_assistant_message_async(content="")
+
+        assert svc._assistant_message_id == "segment-2"
+        assert svc._cancellation_watcher.assistant_message_id == "segment-2"

--- a/unique_toolkit/unique_toolkit/chat/cancellation.py
+++ b/unique_toolkit/unique_toolkit/chat/cancellation.py
@@ -57,6 +57,16 @@ class CancellationWatcher:
     def on_cancellation(self) -> TypedEventBus[CancellationEvent]:
         return self._bus
 
+    @property
+    def assistant_message_id(self) -> str:
+        return self._assistant_message_id
+
+    def set_assistant_message_id(self, message_id: str) -> None:
+        """Retarget polling to the active assistant segment."""
+        if self._cancelled:
+            return
+        self._assistant_message_id = message_id
+
     async def check_cancellation_async(self) -> bool:
         """Poll the DB once.  Returns ``True`` if the message was cancelled.
 

--- a/unique_toolkit/unique_toolkit/services/chat_service.py
+++ b/unique_toolkit/unique_toolkit/services/chat_service.py
@@ -200,6 +200,11 @@ class ChatService(ChatServiceDeprecated):
         """Cancellation watcher for this chat session."""
         return self._cancellation_watcher
 
+    def _set_assistant_message_id(self, message_id: str) -> None:
+        """Point active assistant operations and cancellation polling at *message_id*."""
+        self._assistant_message_id = message_id
+        self._cancellation_watcher.set_assistant_message_id(message_id)
+
     @property
     def elicitation(self) -> ElicitationService:
         """Get the ElicitationService for this chat session."""
@@ -515,8 +520,7 @@ class ChatService(ChatServiceDeprecated):
             response_turn_id=response_turn_id,
             segment_index=segment_index,
         )
-        # Update the assistant message id
-        self._assistant_message_id = chat_message.id or "unknown"
+        self._set_assistant_message_id(chat_message.id or "unknown")
         return chat_message
 
     async def create_assistant_message_async(
@@ -564,8 +568,7 @@ class ChatService(ChatServiceDeprecated):
             response_turn_id=response_turn_id,
             segment_index=segment_index,
         )
-        # Update the assistant message id
-        self._assistant_message_id = chat_message.id or "unknown"
+        self._set_assistant_message_id(chat_message.id or "unknown")
         return chat_message
 
     def create_user_message(


### PR DESCRIPTION
## Summary

- Retarget `CancellationWatcher` to the active assistant segment whenever `ChatService` creates a new multi-segment message, so conduct stop-button polling observes `userAbortedAt` on the same message the UI aborts.
- Add `_set_assistant_message_id()` helper to keep `_assistant_message_id` and the watcher in sync.
- Add regression tests for watcher retargeting and `create_assistant_message_async` integration.

Refs: UN-22747

## Test plan

- [x] `uv run pytest unique_toolkit/tests/chat/test_cancellation.py unique_toolkit/tests/services/test_chat_service.py::TestAssistantMessageIdRetargeting -q`
- [ ] After unique-toolkit release, verify on QA conduct: start a tool-using turn, click Stop, confirm sandbox logs show `user cancellation detected` → `interrupted live client turn`

## AI assist

light

Made with [Cursor](https://cursor.com)