### PR TITLE
fix(unique_toolkit): token-set fuzzy scoring + chat_id=None correctness fix

### DIFF
--- a/unique_toolkit/pyproject.toml
+++ b/unique_toolkit/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "tenacity>=9.1.4",
     "pydantic-core>=2.41.5",
     "cachetools>=5.0,<6",
+    "rapidfuzz>=3.0,<4",
 ]
 
 [project.optional-dependencies]

--- a/unique_toolkit/tests/services/test_knowledge_base_service_unit.py
+++ b/unique_toolkit/tests/services/test_knowledge_base_service_unit.py
@@ -401,7 +401,7 @@ class TestKnowledgeBaseServiceSearchContentChunks:
         mock_search.assert_called_once_with(
             user_id="test_user",
             company_id="test_company",
-            chat_id="",
+            chat_id=None,
             search_string="test query",
             search_type=ContentSearchType.VECTOR,
             limit=10,
@@ -681,7 +681,7 @@ class TestKnowledgeBaseServiceSearchContents:
         mock_search.assert_called_once_with(
             user_id="test_user",
             company_id="test_company",
-            chat_id="",
+            chat_id=None,
             where={"key": "test_file.txt"},
             include_failed_content=False,
         )
@@ -777,7 +777,7 @@ class TestKnowledgeBaseServiceUpload:
             content_name="test.txt",
             mime_type="text/plain",
             scope_id="scope_test123",
-            chat_id="",
+            chat_id=None,
             skip_ingestion=False,
             ingestion_config=None,
             metadata=None,
@@ -910,7 +910,7 @@ class TestKnowledgeBaseServiceDownload:
             user_id="test_user",
             company_id="test_company",
             content_id="cont_test123",
-            chat_id="",
+            chat_id=None,
             filename="downloaded.txt",
             tmp_dir_path=tmp_path,
         )

--- a/unique_toolkit/unique_toolkit/experimental/components/content_tree/service.py
+++ b/unique_toolkit/unique_toolkit/experimental/components/content_tree/service.py
@@ -19,11 +19,13 @@ on its own.
 from __future__ import annotations
 
 import asyncio
-import difflib
 import functools
 import json
+import re
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Protocol, Self, overload
+
+from rapidfuzz import fuzz
 
 from unique_toolkit._common.validate_required_values import validate_required_values
 from unique_toolkit.app.unique_settings import UniqueSettings
@@ -42,6 +44,26 @@ from unique_toolkit.experimental.components.content_tree.schemas import (
 
 if TYPE_CHECKING:
     from unique_toolkit.app.unique_settings import UniqueContext
+
+
+_FUZZY_SEPARATORS_RE = re.compile(r"[\s_\-/]+")
+_TRAILING_EXTENSION_RE = re.compile(r"\.[A-Za-z0-9]{1,8}$")
+
+
+def _tokenize_for_fuzzy_scoring(
+    value: str, case_sensitive: bool, *, strip_extension: bool = False
+) -> str:
+    """Normalize ``value`` into whitespace-separated tokens for
+    :func:`rapidfuzz.fuzz.token_set_ratio`, which only tokenizes on
+    whitespace — filenames/paths use ``_``/``-``/``/`` as their real word
+    separators, so those need converting to spaces first or every candidate
+    is scored as a single opaque token (no better than a plain char-ratio).
+    """
+    if strip_extension:
+        value = _TRAILING_EXTENSION_RE.sub("", value)
+    if not case_sensitive:
+        value = value.lower()
+    return _FUZZY_SEPARATORS_RE.sub(" ", value).strip()
 
 
 class _CachedResolveTaskFactory(Protocol):
@@ -340,16 +362,24 @@ class ContentTree:
     ) -> list[FuzzyMatch]:
         """Fuzzy-match ``query`` against visible file names and/or paths.
 
-        Scoring uses :class:`difflib.SequenceMatcher` (stdlib), which returns a
-        ratio in ``[0.0, 1.0]``. Matching is case-insensitive by default since
-        file names in a knowledge base tend to be noisy.
+        Scoring uses :func:`rapidfuzz.fuzz.token_set_ratio` over each string's
+        tokens (split on whitespace, ``_``, ``-``, and ``/``, extension
+        stripped), scaled to ``[0.0, 1.0]``. Token-set scoring means a short
+        query that's a complete word inside a much longer filename scores
+        highly (ideally ``1.0`` for an exact token match) instead of being
+        penalized for the filename's unrelated length — a plain character-level
+        ratio (e.g. :class:`difflib.SequenceMatcher`, used here previously)
+        scores "alpensys" vs. "alpensys_budget_vs_actual_q3_2024.docx" at only
+        ~0.35, indistinguishable from genuinely unrelated files, because it
+        penalizes every unmatched character in the (much longer) candidate.
+        Matching is case-insensitive by default since file names in a
+        knowledge base tend to be noisy.
 
         Args:
             query: The search string (typically a fragment of a filename or path).
             limit: Maximum number of matches to return, after sorting by score
                 descending.
-            min_score: Drop matches scoring below this threshold. ``0.6`` is
-                :mod:`difflib`'s own rule of thumb for "reasonably close".
+            min_score: Drop matches scoring below this threshold.
             match_on: Score against the basename (``"key"``), the joined folder
                 path (``"path"``), or take the max of both (``"both"``).
             case_sensitive: If ``False`` (default) both sides are lowercased
@@ -369,25 +399,26 @@ class ContentTree:
             metadata_filter=metadata_filter,
             max_concurrent_scope_lookups=max_concurrent_scope_lookups,
         )
-        normalized_query = query if case_sensitive else query.lower()
+        normalized_query = _tokenize_for_fuzzy_scoring(query, case_sensitive)
 
         matches: list[FuzzyMatch] = []
         for content_info, segments in rows:
-            key_candidate = content_info.key
-            path_candidate = "/".join(segments)
-            if not case_sensitive:
-                key_candidate = key_candidate.lower()
-                path_candidate = path_candidate.lower()
+            key_candidate = _tokenize_for_fuzzy_scoring(
+                content_info.key, case_sensitive, strip_extension=True
+            )
+            path_candidate = _tokenize_for_fuzzy_scoring(
+                "/".join(segments), case_sensitive
+            )
 
             score_key = match_on in ("key", "both")
             score_path = match_on in ("path", "both")
             key_score = (
-                difflib.SequenceMatcher(None, normalized_query, key_candidate).ratio()
+                fuzz.token_set_ratio(normalized_query, key_candidate) / 100.0
                 if score_key
                 else 0.0
             )
             path_score = (
-                difflib.SequenceMatcher(None, normalized_query, path_candidate).ratio()
+                fuzz.token_set_ratio(normalized_query, path_candidate) / 100.0
                 if score_path
                 else 0.0
             )

--- a/unique_toolkit/unique_toolkit/experimental/components/content_tree/service.py
+++ b/unique_toolkit/unique_toolkit/experimental/components/content_tree/service.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
     from unique_toolkit.app.unique_settings import UniqueContext
 
 
-_FUZZY_SEPARATORS_RE = re.compile(r"[\s_\-/]+")
+_NON_ALNUM_RE = re.compile(r"[^a-zA-Z0-9]+")
 _TRAILING_EXTENSION_RE = re.compile(r"\.[A-Za-z0-9]{1,8}$")
 
 
@@ -55,15 +55,21 @@ def _tokenize_for_fuzzy_scoring(
 ) -> str:
     """Normalize ``value`` into whitespace-separated tokens for
     :func:`rapidfuzz.fuzz.token_set_ratio`, which only tokenizes on
-    whitespace — filenames/paths use ``_``/``-``/``/`` as their real word
-    separators, so those need converting to spaces first or every candidate
-    is scored as a single opaque token (no better than a plain char-ratio).
+    whitespace — filenames/paths use ``_``/``-``/``/`` (and other
+    punctuation) as their real word separators, so those need converting to
+    spaces first or every candidate is scored as a single opaque token (no
+    better than a plain char-ratio). Mirrors what
+    :func:`rapidfuzz.utils.default_process` does, minus the unconditional
+    lowercasing it bundles in — kept as a local regex rather than that
+    helper (via ``fuzz.token_set_ratio``'s ``processor=`` argument) so
+    ``case_sensitive=True`` can still skip lowercasing while keeping
+    separator normalization.
     """
     if strip_extension:
         value = _TRAILING_EXTENSION_RE.sub("", value)
     if not case_sensitive:
         value = value.lower()
-    return _FUZZY_SEPARATORS_RE.sub(" ", value).strip()
+    return _NON_ALNUM_RE.sub(" ", value).strip()
 
 
 class _CachedResolveTaskFactory(Protocol):

--- a/unique_toolkit/unique_toolkit/services/knowledge_base.py
+++ b/unique_toolkit/unique_toolkit/services/knowledge_base.py
@@ -230,7 +230,7 @@ class KnowledgeBaseService:
             searches = search_content_chunks(
                 user_id=self._user_id,
                 company_id=self._company_id,
-                chat_id="",
+                chat_id=None,
                 search_string=search_string,
                 search_type=search_type,
                 limit=limit,
@@ -327,7 +327,7 @@ class KnowledgeBaseService:
             searches = await search_content_chunks_async(
                 user_id=self._user_id,
                 company_id=self._company_id,
-                chat_id="",
+                chat_id=None,
                 search_string=search_string,
                 search_type=search_type,
                 limit=limit,
@@ -363,7 +363,7 @@ class KnowledgeBaseService:
         return search_contents(
             user_id=self._user_id,
             company_id=self._company_id,
-            chat_id="",
+            chat_id=None,
             where=where,
             include_failed_content=include_failed_content,
         )
@@ -387,7 +387,7 @@ class KnowledgeBaseService:
         return await search_contents_async(
             user_id=self._user_id,
             company_id=self._company_id,
-            chat_id="",
+            chat_id=None,
             where=where,
             include_failed_content=include_failed_content,
         )
@@ -429,7 +429,7 @@ class KnowledgeBaseService:
             content_name=content_name,
             mime_type=mime_type,
             scope_id=scope_id,
-            chat_id="",
+            chat_id=None,
             skip_ingestion=skip_ingestion,
             ingestion_config=ingestion_config,
             metadata=metadata,
@@ -470,7 +470,7 @@ class KnowledgeBaseService:
             content_name=content_name,
             mime_type=mime_type,
             scope_id=scope_id,
-            chat_id="",
+            chat_id=None,
             skip_ingestion=skip_ingestion,
             ingestion_config=ingestion_config,
             metadata=metadata,
@@ -511,7 +511,7 @@ class KnowledgeBaseService:
             content_name=content_name,
             mime_type=mime_type,
             scope_id=scope_id,
-            chat_id="",
+            chat_id=None,
             skip_ingestion=skip_ingestion,
             skip_excel_ingestion=skip_excel_ingestion,
             ingestion_config=ingestion_config,
@@ -544,7 +544,7 @@ class KnowledgeBaseService:
             user_id=self._user_id,
             company_id=self._company_id,
             content_id=content_id,
-            chat_id="",
+            chat_id=None,
             filename=output_filename,
             tmp_dir_path=output_dir_path,
         )

--- a/uv.lock
+++ b/uv.lock
@@ -12,13 +12,13 @@ conflicts = [[
 ]]
 
 [options]
-exclude-newer = "2026-06-19T14:07:06.628215984Z"
+exclude-newer = "2026-06-23T13:35:58.334235Z"
 exclude-newer-span = "P2W"
 
 [options.exclude-newer-package]
 unique-toolkit = false
 unique-internal-search = false
-crawl4ai = "2026-06-20T00:00:00Z"
+crawl4ai = "2026-06-19T22:00:00Z"
 unique-swot = false
 unique-sdk = false
 unique-search-proxy-core = false
@@ -26,9 +26,9 @@ unique-mcp = false
 unique-orchestrator = false
 unique-follow-up-questions = false
 unique-user-memory = false
-langsmith = "2026-06-21T00:00:00Z"
+langsmith = "2026-06-20T22:00:00Z"
 unique-six = false
-pydantic-settings = "2026-06-21T00:00:00Z"
+pydantic-settings = "2026-06-20T22:00:00Z"
 unique-search-proxy = false
 unique-web-search = false
 unique-deep-research = false
@@ -6234,6 +6234,7 @@ dependencies = [
     { name = "pyhumps" },
     { name = "pypandoc" },
     { name = "python-docx" },
+    { name = "rapidfuzz" },
     { name = "requests" },
     { name = "sseclient" },
     { name = "tenacity" },
@@ -6292,6 +6293,7 @@ requires-dist = [
     { name = "pyhumps", specifier = ">=3.8.0,<4" },
     { name = "pypandoc", specifier = ">=1.16.2,<2" },
     { name = "python-docx", specifier = ">=1.1.0,<2" },
+    { name = "rapidfuzz", specifier = ">=3.0,<4" },
     { name = "requests", specifier = ">=2.32.0,<3" },
     { name = "sseclient", specifier = ">=0.0.27,<0.0.28" },
     { name = "starlette", marker = "extra == 'fastapi'", specifier = ">=0.49.1" },


### PR DESCRIPTION
## Summary
- `ContentTree.search_visible_files_fuzzy_async` switches from `difflib.SequenceMatcher.ratio()` to `rapidfuzz.fuzz.token_set_ratio` (tokenized on whitespace/`_`/`-`/`/`, extension stripped for filenames). The old algorithm penalizes every unmatched character in the candidate string, so a short query against a long filename scored low even on a perfect substring match — e.g. `"alpensys"` vs. `"alpensys_budget_vs_actual_q3_2024.docx"` scored ~0.35, indistinguishable from genuinely unrelated files. Discovered via a real MCP tool (`mcp_search`'s `content_tree`) returning zero results for content that was confirmed to exist.
- `KnowledgeBaseService`: `chat_id="" → chat_id=None` across all call sites — `""` and `None` aren't equivalent to the backend; `None` is the documented "no active chat, download from the KB" value.

Both fixes verified against real production KB content (not just synthetic test fixtures) — previously-invisible `AlpenSys`-named files now score `1.0` and rank correctly above unrelated files, using the service's own unmodified default `min_score=0.6`.

## Test plan
- [x] Full `unique_toolkit` suite passes: 3031 passed, 1 skipped, 0 failed.
- [x] Lint (`ruff check`/`ruff format --check`) and `basedpyright` clean on all changed files.
- [x] Live-verified against real KB content via `ContentTree.from_settings()` — see commit message for before/after scores.