### PR TITLE
fix(sdk): send explicit scopeIds null for unscoped CLI search [UN-22753]

### DIFF
--- a/unique_sdk/tests/cli/test_search.py
+++ b/unique_sdk/tests/cli/test_search.py
@@ -437,6 +437,23 @@ class TestCmdSearchCallShapes:
         assert mock.call_args[1]["scopeIds"] == ["scope_r"]
 
     @patch("unique_sdk.Search.create")
+    def test_unscoped_search_sends_explicit_null_scope_ids(
+        self, mock: MagicMock
+    ) -> None:
+        """An unscoped (entire-KB) search must SEND ``scopeIds=None`` — a JSON
+        ``null`` on the wire — never omit the key. An omitted key reaches
+        node-ingestion as ``undefined`` and is destructure-defaulted to ``[]``,
+        which getScopes treats as "restrict to zero scopes", so entire-KB
+        search returns nothing on companies without file-based access. The
+        null-vs-omitted distinction is load-bearing; do not "simplify" this
+        back to a conditional key. See UN-22753.
+        """
+        mock.return_value = []
+        cmd_search(_state(), "q")
+        assert "scopeIds" in mock.call_args[1]
+        assert mock.call_args[1]["scopeIds"] is None
+
+    @patch("unique_sdk.Search.create")
     def test_uses_workspace_scope_ids_when_no_folder(self, mock: MagicMock) -> None:
         mock.return_value = []
         s = _state()
@@ -456,7 +473,7 @@ class TestCmdSearchCallShapes:
         s.workspace_metadata_filter = rule
         cmd_search(s, "q")
         assert mock.call_args[1]["metaDataFilter"] == rule
-        assert "scopeIds" not in mock.call_args[1]
+        assert mock.call_args[1]["scopeIds"] is None
 
     @patch("unique_sdk.Search.create")
     def test_workspace_metadata_filter_overrides_workspace_scope_ids(
@@ -474,7 +491,7 @@ class TestCmdSearchCallShapes:
         s.workspace_metadata_filter = rule
         cmd_search(s, "q")
         assert mock.call_args[1]["metaDataFilter"] == rule
-        assert "scopeIds" not in mock.call_args[1]
+        assert mock.call_args[1]["scopeIds"] is None
 
     @patch("unique_sdk.Search.create")
     def test_explicit_metadata_arg_is_anded_with_workspace_filter(
@@ -514,7 +531,7 @@ class TestCmdSearchCallShapes:
         }
         s.workspace_metadata_filter = wmf
         cmd_search(s, "q")
-        assert "scopeIds" not in mock.call_args[1]
+        assert mock.call_args[1]["scopeIds"] is None
         assert mock.call_args[1]["metaDataFilter"] == wmf
 
     @patch("unique_sdk.Search.create")

--- a/unique_sdk/unique_sdk/cli/commands/search.py
+++ b/unique_sdk/unique_sdk/cli/commands/search.py
@@ -261,9 +261,16 @@ def cmd_search(
             "searchString": query,
             "searchType": "COMBINED",
             "limit": limit,
+            # An unscoped search must send an explicit ``scopeIds: null``,
+            # never omit the key. An absent key reaches node-ingestion as
+            # ``undefined`` and is destructure-defaulted to ``[]``, which
+            # getScopes treats as "restrict to zero scopes" — an entire-KB
+            # search then returns nothing on companies without file-based
+            # access. A JSON ``null`` bypasses both the default and the
+            # truthy check, matching what unique_toolkit's
+            # search_content_chunks sends. See UN-22753.
+            "scopeIds": scope_ids or None,
         }
-        if scope_ids:
-            search_params["scopeIds"] = scope_ids
         if metadata_filter:
             search_params["metaDataFilter"] = metadata_filter
 


### PR DESCRIPTION
## Summary

An unscoped (entire-KB) `unique-cli search` currently **omits** the `scopeIds` key from `Search.create`. The absent key reaches node-ingestion as `undefined`, where the search adapters destructure-default it to `[]`, and `getScopes` treats `[]` as "restrict to zero scopes" — so entire-KB search returns **no results** on companies without file-based access ([UN-22753](https://unique-ch.atlassian.net/browse/UN-22753)).

This PR makes the CLI always send the key — as an explicit JSON `null` when unscoped:

- `null` bypasses the `scopeIds = []` destructuring default (which only fires on `undefined`) and `getScopes`' truthy check, restoring "all readable scopes" semantics.
- This mirrors what `unique_toolkit`'s `search_content_chunks` already sends (`scope_ids=None` passed unconditionally to `unique_sdk.Search.create`) — which is exactly why classic UniqueAI unscoped search is **not** affected by the same backend behavior, while conduct is.
- Chosen over the backend fix (Unique-AG/monorepo#26392, reverted due to regression concerns in shared `getScopes`): this change's blast radius is limited to CLI-driven searches and only changes the case that returns zero results today.

## Wire-chain verification (null survives end to end)

- `unique_sdk`: POST bodies are `json.dumps(params)` — the `None`-stripping `_api_encode` applies only to GET/DELETE query strings.
- node-chat public `/search` and node-ingestion `/v1/search` DTOs are `@IsOptional()` (skips validation for `null`), controllers/services pass through without re-defaulting.
- All three search adapters (qdrant / FTS / similarity) and the chunk/content facades guard with falsy checks (`if (!scopeIds)`, `Boolean(scopeIds && scopeIds.length > 0)`).

## Note for reviewers

The null-vs-omitted distinction is **load-bearing** — please don't simplify back to a conditional key. A dedicated regression test (`test_unscoped_search_sends_explicit_null_scope_ids`) pins this down, and three existing tests were flipped from asserting key absence to asserting explicit `None`.

`cmd_uploaded_search` is deliberately untouched (chat-only search, `scopeIds` never applies).

## Test plan

- [x] `pytest tests/cli` — 872 passed, 1 skipped
- [x] ruff check + format clean
- [ ] Verify on QA once a dev build of unique_sdk is picked up by the sandbox image: conduct space with no configured scope returns KB results on a non-file-access company

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[UN-22753]: https://unique-ch.atlassian.net/browse/UN-22753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ