### PR TITLE
feat(sdk): record per-item text in MCP refs manifest for citation grounding [UN-22762]

### DIFF
--- a/unique_sdk/tests/cli/test_mcp.py
+++ b/unique_sdk/tests/cli/test_mcp.py
@@ -142,6 +142,7 @@ def test_resource_link_item_has_title_no_url(tmp_path: Path) -> None:
             "title": "RAG Retrieval Baseline",
             "snippet": "Why retrieval fails",
             "details": None,
+            "text": "Why retrieval fails",
         }
     ]
     assert "[mcpsource1] RAG Retrieval Baseline" in out
@@ -210,6 +211,9 @@ def test_json_in_text_object_with_dict_container_key_stays_untitled(
             "title": None,
             "snippet": None,
             "details": None,
+            # Title-less fallback grounds on the whole formatted output
+            # (`_run` formats every response as "result").
+            "text": "result",
         }
     ]
 
@@ -347,6 +351,164 @@ def test_dedup_does_not_clobber_existing_details(tmp_path: Path) -> None:
     refs = _lines(tmp_path, _REFS_MANIFEST)
     assert len(refs) == 1
     assert refs[0]["details"] == "01/01/2026"
+
+
+# ── Per-item text ground truth (UN-22762) ────────────────────────────────────
+#
+# Each refs-manifest entry records the cited item's underlying ``text`` so the
+# runner's hallucination check grounds every ``[mcpsourceN]`` on what was
+# actually retrieved, instead of only the head-truncated flat output manifest.
+
+
+def test_json_in_text_records_serialized_record_as_text(tmp_path: Path) -> None:
+    # JSON-title heuristic: each record's text is the serialized record — the
+    # titled field plus all metadata the agent may cite.
+    record = {"key": "UN-1", "fields": {"summary": "First"}}
+    body = json.dumps({"issues": [record]})
+    response = _FakeMCPResponse(content=[{"type": "text", "text": body}])
+    _run("mcp__atlassian__searchJiraIssuesUsingJql", response)
+
+    refs = _lines(tmp_path, _REFS_MANIFEST)
+    assert json.loads(refs[0]["text"]) == record
+
+
+def test_reference_mapping_record_text_is_serialized_record(tmp_path: Path) -> None:
+    unique_dir = tmp_path / ".unique"
+    record = {"key": "UN-7", "fields": {"summary": "Deep"}, "status": "Done"}
+    body = json.dumps({"issues": [record]})
+    response = _FakeMCPResponse(content=[{"type": "text", "text": body}])
+    record_mcp_citations(
+        response,
+        tool_name="searchJiraIssuesUsingJql",
+        server_name="atlassian",
+        unique_dir=unique_dir,
+        formatted_text=body,
+        reference_mapping={"listPath": "issues", "titlePath": "key"},
+    )
+    refs = _unique_lines(unique_dir, "mcp-refs.jsonl")
+    assert json.loads(refs[0]["text"]) == record
+
+
+def test_reference_mapping_plain_string_record_text_is_the_string(
+    tmp_path: Path,
+) -> None:
+    unique_dir = tmp_path / ".unique"
+    doc = "# Alpha Guide\nbody with the cited fact"
+    body = json.dumps({"docs": [doc]})
+    response = _FakeMCPResponse(content=[{"type": "text", "text": body}])
+    record_mcp_citations(
+        response,
+        tool_name="list_docs",
+        server_name="docs",
+        unique_dir=unique_dir,
+        formatted_text=body,
+        reference_mapping={"listPath": "docs", "titleFromText": True},
+    )
+    refs = _unique_lines(unique_dir, "mcp-refs.jsonl")
+    assert refs[0]["text"] == doc
+
+
+def test_reference_mapping_text_doc_records_full_text(tmp_path: Path) -> None:
+    # titleFromText on a fetched Markdown doc: the chip's text is the whole
+    # document body, not just the heading line used for the title.
+    unique_dir = tmp_path / ".unique"
+    doc = "# Retrieval Evaluation\n\n" + "Deep fact far into the document. " * 50
+    response = _FakeMCPResponse(
+        content=[{"type": "text", "text": doc}], mcp_server_id="docs"
+    )
+    record_mcp_citations(
+        response,
+        tool_name="read_doc",
+        server_name="docs",
+        unique_dir=unique_dir,
+        formatted_text=doc,
+        reference_mapping={"titleFromText": True},
+    )
+    refs = _unique_lines(unique_dir, "mcp-refs.jsonl")
+    assert refs[0]["text"] == doc
+
+
+def test_titleless_fallback_records_formatted_text(tmp_path: Path) -> None:
+    # The title-less tool chip grounds on the whole formatted output the agent
+    # saw, so citing it still reaches the hallucination check with real text.
+    unique_dir = tmp_path / ".unique"
+    response = _FakeMCPResponse(content=[{"type": "text", "text": "status: ok"}])
+    record_mcp_citations(
+        response,
+        tool_name="update",
+        server_name="crm",
+        unique_dir=unique_dir,
+        formatted_text="status: ok — record 42 updated",
+    )
+    refs = _unique_lines(unique_dir, "mcp-refs.jsonl")
+    assert refs[0]["title"] is None
+    assert refs[0]["text"] == "status: ok — record 42 updated"
+
+
+def test_resource_link_text_is_none_when_no_description(tmp_path: Path) -> None:
+    response = _FakeMCPResponse(
+        content=[{"type": "resource_link", "uri": "https://e/a", "name": "Doc A"}]
+    )
+    _run("mcp__kb__fetch", response)
+    refs = _lines(tmp_path, _REFS_MANIFEST)
+    assert refs[0]["text"] is None
+
+
+def test_ref_text_truncated_to_writer_cap(tmp_path: Path) -> None:
+    unique_dir = tmp_path / ".unique"
+    doc = "# Big Doc\n" + "x" * (mcp_cmd._MCP_REF_TEXT_CHAR_LIMIT + 500)
+    response = _FakeMCPResponse(content=[{"type": "text", "text": doc}])
+    record_mcp_citations(
+        response,
+        tool_name="read_doc",
+        server_name="docs",
+        unique_dir=unique_dir,
+        formatted_text=doc,
+        reference_mapping={"titleFromText": True},
+    )
+    refs = _unique_lines(unique_dir, "mcp-refs.jsonl")
+    assert len(refs[0]["text"]) == mcp_cmd._MCP_REF_TEXT_CHAR_LIMIT
+
+
+def test_dedup_backfills_longer_text_from_later_call(tmp_path: Path) -> None:
+    # Search first (small serialized record), then a full fetch of the same
+    # titled item: the dedup reuses source 1 and upgrades its text to the
+    # longer capture — the richer ground truth for the hallucination check.
+    search_body = json.dumps({"results": [{"title": "Doc A"}]})
+    first = _FakeMCPResponse(content=[{"type": "text", "text": search_body}])
+    _run("mcp__kb__search", first, formatted=search_body)
+    short_text = _lines(tmp_path, _REFS_MANIFEST)[0]["text"]
+
+    full_record = {"title": "Doc A", "body": "Full page body. " * 100}
+    second = _FakeMCPResponse(
+        content=[{"type": "text", "text": json.dumps(full_record)}]
+    )
+    _run("mcp__kb__search", second, formatted=json.dumps(full_record))
+
+    refs = _lines(tmp_path, _REFS_MANIFEST)
+    assert len(refs) == 1  # still deduped — one entry, one source number
+    assert refs[0]["sourceNumber"] == 1
+    assert len(refs[0]["text"]) > len(short_text)
+    assert json.loads(refs[0]["text"]) == full_record
+
+
+def test_dedup_keeps_longer_existing_text(tmp_path: Path) -> None:
+    # A later, poorer capture of the same item must not downgrade the stored
+    # text (prefer-longer, never clobber with shorter).
+    full_record = {"title": "Doc A", "body": "Full page body. " * 100}
+    first = _FakeMCPResponse(
+        content=[{"type": "text", "text": json.dumps(full_record)}]
+    )
+    _run("mcp__kb__search", first, formatted=json.dumps(full_record))
+
+    second = _FakeMCPResponse(
+        content=[{"type": "text", "text": json.dumps({"title": "Doc A"})}]
+    )
+    _run("mcp__kb__search", second)
+
+    refs = _lines(tmp_path, _REFS_MANIFEST)
+    assert len(refs) == 1
+    assert json.loads(refs[0]["text"]) == full_record
 
 
 def test_different_tools_same_title_get_distinct_numbers(tmp_path: Path) -> None:
@@ -570,6 +732,7 @@ def test_record_mcp_citations_writes_both_manifests_under_unique_dir(
             "title": "RAG Retrieval Baseline",
             "snippet": "Why retrieval fails",
             "details": None,
+            "text": "Why retrieval fails",
         }
     ]
     assert output == [

--- a/unique_sdk/unique_sdk/cli/commands/mcp.py
+++ b/unique_sdk/unique_sdk/cli/commands/mcp.py
@@ -45,6 +45,13 @@ _MCP_OUTPUT_TEXT_CHAR_LIMIT = 200_000
 _MCP_REFS_LOG_RELATIVE_PATH = Path(".unique") / "mcp-refs.jsonl"
 _MCP_REFS_LOCK_FILENAME = "mcp-refs.lock"
 _MCP_SNIPPET_CHAR_LIMIT = 300
+# Writer-side cap on the per-item ``text`` recorded in the refs manifest — the
+# cited item's underlying text, consumed by the runner's hallucination check to
+# ground each ``[mcpsourceN]`` citation on what was actually retrieved
+# (UN-22762). Half the flat-output cap (``_MCP_OUTPUT_TEXT_CHAR_LIMIT``): one
+# cited item (a page, an issue record) rarely exceeds it, and the eval side
+# bounds the combined cited-text payload separately.
+_MCP_REF_TEXT_CHAR_LIMIT = 100_000
 
 # Keys an MCP tool's JSON result commonly uses for a record's human title.
 _TITLE_KEYS = ("title", "name", "displayName", "subject", "summary", "key")
@@ -247,6 +254,7 @@ def _titles_from_json(text: str) -> list[dict[str, Any]]:
                     "title": title,
                     "snippet": None,
                     "details": _details_from_json(entry),
+                    "text": _record_text(entry),
                 }
             )
     return items
@@ -350,6 +358,32 @@ def _first_text_title(response: Any, max_chars: int) -> str | None:
     return None
 
 
+def _all_text_blocks(response: Any) -> str | None:
+    """Concatenation of every text block — the underlying text of a single-item
+    result (e.g. a fetched document) recorded as that item's ground truth."""
+    texts = [
+        block.get("text")
+        for block in getattr(response, "content", None) or []
+        if isinstance(block, dict)
+        and block.get("type") == "text"
+        and isinstance(block.get("text"), str)
+        and block.get("text").strip()
+    ]
+    return "\n\n".join(texts) or None
+
+
+def _record_text(record: Any) -> str | None:
+    """A record's underlying text for citation grounding: the record itself
+    when it is a plain string, else the serialized record — which carries the
+    titled field plus all metadata the agent may cite."""
+    if isinstance(record, str):
+        return record or None
+    try:
+        return json.dumps(record, ensure_ascii=False, default=str)
+    except (TypeError, ValueError):
+        return None
+
+
 def _extract_with_reference_mapping(
     response: Any, mapping: dict[str, Any]
 ) -> list[dict[str, Any]]:
@@ -409,6 +443,7 @@ def _extract_with_reference_mapping(
                 "title": title,
                 "snippet": None,
                 "details": str(details).strip() if details else None,
+                "text": _record_text(record),
             }
         )
     if items:
@@ -421,7 +456,14 @@ def _extract_with_reference_mapping(
     if not records and title_from_text:
         title = _first_text_title(response, title_max_chars)
         if title:
-            return [{"title": title, "snippet": None, "details": None}]
+            return [
+                {
+                    "title": title,
+                    "snippet": None,
+                    "details": None,
+                    "text": _all_text_blocks(response),
+                }
+            ]
     return items
 
 
@@ -431,8 +473,9 @@ def _extract_mcp_citation_items(
     tool_name: str,
     server_name: str | None,
     reference_mapping: dict[str, Any] | None = None,
+    fallback_text: str | None = None,
 ) -> list[dict[str, Any]]:
-    """Context for what the tool retrieved: ``{title, snippet}`` per item.
+    """Context for what the tool retrieved: ``{title, snippet, text}`` per item.
 
     An optional admin ``reference_mapping`` is applied first (deterministic
     destructuring of a list result); when it yields nothing we fall back to the
@@ -441,6 +484,12 @@ def _extract_mcp_citation_items(
     JSON-in-text). No URLs are extracted — the chip is display-only. Falls back
     to a single title-less item (the runner names it after the tool) when the
     result carries no recognizable title.
+
+    ``text`` is the item's underlying retrieved text (the serialized record, a
+    fetched document body, or — for the title-less fallback — ``fallback_text``,
+    the whole formatted output). The runner grounds the hallucination check for
+    each cited ``[mcpsourceN]`` on it. A ``resource_link`` carries no body, so
+    its ``text`` is the link description only.
     """
     if reference_mapping:
         mapped = _extract_with_reference_mapping(response, reference_mapping)
@@ -457,7 +506,11 @@ def _extract_mcp_citation_items(
             name = (block.get("name") or "").strip()
             if name:
                 items.append(
-                    {"title": name, "snippet": _snippet(block.get("description"))}
+                    {
+                        "title": name,
+                        "snippet": _snippet(block.get("description")),
+                        "text": block.get("description") or None,
+                    }
                 )
 
     if not items:
@@ -467,7 +520,7 @@ def _extract_mcp_citation_items(
 
     if not items:
         # No recognizable title — one chip named after the tool itself.
-        items.append({"title": None, "snippet": None})
+        items.append({"title": None, "snippet": None, "text": fallback_text})
 
     return items
 
@@ -489,6 +542,16 @@ def _item_dedup_key(tool_name: str, item: dict[str, Any]) -> str:
     return f"tool:{tool_name}"
 
 
+def _ref_text(item: dict[str, Any]) -> str | None:
+    """The item's underlying text for the manifest, capped at
+    ``_MCP_REF_TEXT_CHAR_LIMIT`` (single write-side cap shared by all
+    extraction modes)."""
+    text = item.get("text")
+    if not isinstance(text, str) or not text:
+        return None
+    return text[:_MCP_REF_TEXT_CHAR_LIMIT]
+
+
 def _annotate_mcp_results_for_citations(
     response: Any,
     *,
@@ -496,6 +559,7 @@ def _annotate_mcp_results_for_citations(
     server_name: str | None,
     refs_log_path: Path | None = None,
     reference_mapping: dict[str, Any] | None = None,
+    fallback_text: str | None = None,
 ) -> list[tuple[int, dict[str, Any]]]:
     """Assign per-turn ``[mcpsourceN]`` numbers to each retrieved item and append
     the refs manifest. Returns ``[(sourceNumber, item)]`` for the Sources block.
@@ -512,6 +576,7 @@ def _annotate_mcp_results_for_citations(
             tool_name=tool_name,
             server_name=server_name,
             reference_mapping=reference_mapping,
+            fallback_text=fallback_text,
         )
         with _locked_turn_refs_manifest(
             refs_log_path, lock_filename=_MCP_REFS_LOCK_FILENAME
@@ -542,6 +607,7 @@ def _annotate_mcp_results_for_citations(
                         "title": item.get("title"),
                         "snippet": item.get("snippet"),
                         "details": item.get("details"),
+                        "text": _ref_text(item),
                     }
                     try:
                         _append_turn_refs_manifest_entry(refs_log_path, manifest_entry)
@@ -563,13 +629,26 @@ def _annotate_mcp_results_for_citations(
                     if stored is not None and new_details and not stored.get("details"):
                         stored["details"] = new_details
                         needs_rewrite = True
+                    # ``text`` upgrades to the longer capture: the common turn
+                    # is a search (small per-record JSON) followed by a full
+                    # fetch of the same titled item — the later, richer text is
+                    # the better ground truth for the hallucination check.
+                    new_text = _ref_text(item)
+                    if stored is not None and new_text:
+                        stored_text = stored.get("text")
+                        stored_len = (
+                            len(stored_text) if isinstance(stored_text, str) else 0
+                        )
+                        if len(new_text) > stored_len:
+                            stored["text"] = new_text
+                            needs_rewrite = True
                 annotated.append((source_number, item))
             if needs_rewrite:
                 try:
                     _rewrite_turn_refs_manifest(refs_log_path, entries)
                 except (UnsafeRefsLogPathError, OSError) as exc:
                     _LOGGER.warning(
-                        "mcp: failed to backfill refs manifest details: %s", exc
+                        "mcp: failed to backfill refs manifest enrichment: %s", exc
                     )
     except (UnsafeRefsLogPathError, OSError) as exc:
         _LOGGER.warning("mcp: failed to append refs manifest: %s", exc)
@@ -656,7 +735,10 @@ def record_mcp_citations(
     - ``response`` is the raw ``unique_sdk.MCP`` result, used for citation
       extraction (titles from ``resource_link`` names / JSON bodies).
     - ``formatted_text`` is the source text the model actually saw for this
-      tool result, recorded as the hallucination groundedness context.
+      tool result, recorded as the hallucination groundedness context. It also
+      serves as the per-item ``text`` of the title-less fallback chip, so a
+      cited ``[mcpsourceN]`` without extractable records still grounds on the
+      whole output.
 
     Best-effort and never raises: the underlying manifest writers swallow their
     own errors, and ``_annotate_mcp_results_for_citations`` owns the per-turn
@@ -675,6 +757,7 @@ def record_mcp_citations(
         server_name=server_name,
         refs_log_path=unique_dir / _MCP_REFS_LOG_RELATIVE_PATH.name,
         reference_mapping=reference_mapping,
+        fallback_text=formatted_text,
     )
     return _citation_sources_block(annotated)
 

--- a/unique_sdk/unique_sdk/cli/commands/mcp.py
+++ b/unique_sdk/unique_sdk/cli/commands/mcp.py
@@ -361,14 +361,13 @@ def _first_text_title(response: Any, max_chars: int) -> str | None:
 def _all_text_blocks(response: Any) -> str | None:
     """Concatenation of every text block — the underlying text of a single-item
     result (e.g. a fetched document) recorded as that item's ground truth."""
-    texts = [
-        block.get("text")
-        for block in getattr(response, "content", None) or []
-        if isinstance(block, dict)
-        and block.get("type") == "text"
-        and isinstance(block.get("text"), str)
-        and block.get("text").strip()
-    ]
+    texts: list[str] = []
+    for block in getattr(response, "content", None) or []:
+        if not isinstance(block, dict) or block.get("type") != "text":
+            continue
+        text = block.get("text")
+        if isinstance(text, str) and text.strip():
+            texts.append(text)
     return "\n\n".join(texts) or None
 
 


### PR DESCRIPTION
## Summary

The SwappableIntelligence hallucination judge grounds MCP-cited answers only on the flat `.unique/mcp-output.jsonl` texts, which are head-truncated per source at eval time. A fact the agent cited from deep inside a large tool result never reaches the judge and gets flagged as a hallucination even though it was present in the retrieved ground truth.

This PR makes each `.unique/mcp-refs.jsonl` entry carry the cited item's underlying `text`, so the runner can ground every `[mcpsourceN]` citation on the full retrieved text (monorepo counterpart follows).

## Changes

- New `_MCP_REF_TEXT_CHAR_LIMIT = 100_000` writer-side cap (half the flat-output cap; the eval side adds a turn-wide budget).
- Per-extraction-mode text capture:
  - mapped list records / JSON-title heuristic: the serialized record (`json.dumps`), or the record itself when it is a plain string
  - `titleFromText` document fallback: all text blocks joined (new `_all_text_blocks` helper)
  - `resource_link`: the link description (links carry no body)
  - title-less fallback: the whole `formatted_text` the model saw (threaded via new `fallback_text` kwarg)
- Dedup across calls upgrades stored `text` to the longer capture (search → fetch of the same titled item), reusing the existing rewrite machinery; `details` keeps its fill-only-when-missing rule.
- Backward compatible: readers ignoring the new field see today's manifest shape.

## Testing

- `uv run pytest unique_sdk/tests/cli/test_mcp.py` — 45 passed (9 new cases covering all capture modes, the writer cap, and prefer-longer backfill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)