### PR TITLE
fix(unique_toolkit): add OVERLAPS/NOT_OVERLAPS UniqueQL operators (#2028)

### DIFF
--- a/unique_sdk/docs/uniqueql.md
+++ b/unique_sdk/docs/uniqueql.md
@@ -138,6 +138,26 @@ These operators work with both numbers and dates (ISO 8601 format).
     }
     ```
 
+??? example "OVERLAPS - Match if any value intersects a list-valued field"
+
+    ```python
+    {
+        "path": ["tags"],
+        "operator": UQLOperator.OVERLAPS,
+        "value": ["Engineering", "Sales"]
+    }
+    ```
+
+??? example "NOT_OVERLAPS - Exclude if any value intersects a list-valued field"
+
+    ```python
+    {
+        "path": ["tags"],
+        "operator": UQLOperator.NOT_OVERLAPS,
+        "value": ["internal", "draft"]
+    }
+    ```
+
 ### Null/Empty Operators
 
 ??? example "IS_NOT_NULL - Exclude null values"
@@ -484,6 +504,8 @@ Use `AND` and `OR` combinators to build complex queries:
 | `LESS_THAN_OR_EQUAL` | Less than or equal | Number, Date (ISO 8601) |
 | `IN` | Match any value in list | Array |
 | `NOT_IN` | Exclude values in list | Array |
+| `OVERLAPS` | Match if any value intersects a list-valued field | Array |
+| `NOT_OVERLAPS` | Exclude if any value intersects a list-valued field | Array |
 | `IS_NULL` | Value is null | None |
 | `IS_NOT_NULL` | Value is not null | None |
 | `IS_EMPTY` | Value is empty | None |

--- a/unique_sdk/tests/cli/test_metadata_filter.py
+++ b/unique_sdk/tests/cli/test_metadata_filter.py
@@ -60,6 +60,13 @@ class TestAllowsContent:
         assert not mf.allows_content("cont_x")
         assert mf.allows_content("cont_other")
 
+    def test_negated_overlaps_contentid_inverts(self) -> None:
+        mf, _ = _make_filter(
+            {"path": ["contentId"], "operator": "notOverlaps", "value": ["cont_x"]}
+        )
+        assert not mf.allows_content("cont_x")
+        assert mf.allows_content("cont_other")
+
     def test_folder_containment(self) -> None:
         mf, _ = _make_filter(
             {"path": ["folderIdPath"], "operator": "contains", "value": "scope_fund_a"},

--- a/unique_sdk/unique_sdk/_unique_ql.py
+++ b/unique_sdk/unique_sdk/_unique_ql.py
@@ -46,6 +46,8 @@ class UQLOperator:
     LESS_THAN_OR_EQUAL = "lessThanOrEqual"
     IN = "in"
     NOT_IN = "notIn"
+    OVERLAPS = "overlaps"
+    NOT_OVERLAPS = "notOverlaps"
     CONTAINS = "contains"
     NOT_CONTAINS = "notContains"
     IS_NULL = "isNull"

--- a/unique_sdk/unique_sdk/cli/metadata_filter.py
+++ b/unique_sdk/unique_sdk/cli/metadata_filter.py
@@ -32,7 +32,7 @@ _SCOPE_ID_RE = re.compile(r"scope_[a-z0-9_]+", re.IGNORECASE)
 # ``startswith("not")`` heuristic: that heuristic would also catch a future
 # ``notEmpty``-style operator and invert it wrongly. Mirrors the Operator enum
 # in unique_toolkit.content.smart_rules. See UN-21780.
-_NEGATED_OPERATORS = frozenset({"notequals", "notin", "notcontains"})
+_NEGATED_OPERATORS = frozenset({"notequals", "notin", "notcontains", "notoverlaps"})
 
 ScopePathResolver = Callable[[str], "str | None"]
 ContentOwnerPathResolver = Callable[[str], "str | None"]

--- a/unique_toolkit/tests/content/test_smart_rules.py
+++ b/unique_toolkit/tests/content/test_smart_rules.py
@@ -788,6 +788,53 @@ def test_to_dict__round_trips_model() -> None:
 
 
 @pytest.mark.ai
+def test_overlaps_operator_resolves_variables(user_metadata, tool_parameters) -> None:
+    """Purpose: Verify OVERLAPS substitutes variables in each array element like IN."""
+    query = Statement(
+        operator=Operator.OVERLAPS,
+        value=["<userMetadata.name>", "<toolParameters.category>", "fallback-tag"],
+        path=["tags"],
+    )
+    enriched = query.with_variables(user_metadata, tool_parameters)
+    assert isinstance(enriched, Statement)
+    assert enriched.value == ["John", "premium", "fallback-tag"]
+
+
+@pytest.mark.ai
+def test_not_overlaps_operator_resolves_variables(
+    user_metadata, tool_parameters
+) -> None:
+    """Purpose: Verify NOT_OVERLAPS substitutes variables in each array element like NOT_IN."""
+    query = Statement(
+        operator=Operator.NOT_OVERLAPS,
+        value=["<userMetadata.name>", "fallback-tag"],
+        path=["tags"],
+    )
+    enriched = query.with_variables(user_metadata, tool_parameters)
+    assert isinstance(enriched, Statement)
+    assert enriched.value == ["John", "fallback-tag"]
+
+
+@pytest.mark.ai
+def test_parse_uniqueql_overlaps_statement() -> None:
+    """Purpose: Verify OVERLAPS/NOT_OVERLAPS round-trip through parse_uniqueql."""
+    json_data = {
+        "or": [
+            {
+                "path": ["tags"],
+                "value": ["alpha", "beta"],
+                "operator": "overlaps",
+            }
+        ]
+    }
+    result = parse_uniqueql(json_data)
+    assert isinstance(result, OrStatement)
+    assert isinstance(result.or_list[0], Statement)
+    assert result.or_list[0].operator == Operator.OVERLAPS
+    assert result.or_list[0].value == ["alpha", "beta"]
+
+
+@pytest.mark.ai
 def test_uniqueql_to_dict__passes_through_wire_dict() -> None:
     """Purpose: Verify uniqueql_to_dict still normalizes plain dicts at API boundaries."""
     from unique_toolkit.content.smart_rules import uniqueql_to_dict

--- a/unique_toolkit/unique_toolkit/content/smart_rules.py
+++ b/unique_toolkit/unique_toolkit/content/smart_rules.py
@@ -19,6 +19,8 @@ class Operator(str, Enum):
     LESS_THAN_OR_EQUAL = "lessThanOrEqual"
     IN = "in"
     NOT_IN = "notIn"
+    OVERLAPS = "overlaps"
+    NOT_OVERLAPS = "notOverlaps"
     CONTAINS = "contains"
     NOT_CONTAINS = "notContains"
     IS_NULL = "isNull"
@@ -148,7 +150,12 @@ def eval_operator(
         return empty_operator(query.operator, user_metadata, tool_parameters)
     elif query.operator == Operator.NESTED:
         return eval_nested_operator(query.value, user_metadata, tool_parameters)
-    elif query.operator in [Operator.IN, Operator.NOT_IN]:
+    elif query.operator in [
+        Operator.IN,
+        Operator.NOT_IN,
+        Operator.OVERLAPS,
+        Operator.NOT_OVERLAPS,
+    ]:
         return array_operator(query.value, user_metadata, tool_parameters)
     else:
         raise ValueError(f"Operator {query.operator} not supported")


### PR DESCRIPTION
## Summary
Hotfix backport of #2028 to `release/2026.28`.

Fixes [UN-22761](https://unique-ch.atlassian.net/browse/UN-22761): assistants-core rejected `ChatEvent`s whose `rawScopeRules`/`metadataFilter` used the `overlaps`/`notOverlaps` UniqueQL operator with an HTTP 400, since `unique_toolkit`'s `Operator` enum didn't include them while Node.js already did.

## Backported commits
- bfc33dbdc8a1d913c1d23c5fe31f15f9fc3bbe29 — fix(unique_toolkit): add OVERLAPS/NOT_OVERLAPS UniqueQL operators (#2028)

## Test plan
- [x] Cherry-pick applied cleanly, no conflicts
- [ ] CI green on release branch (`check-release-lineage.sh` lineage check)

[UN-22761]: https://unique-ch.atlassian.net/browse/UN-22761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ