### PR TITLE
fix(unique_toolkit): allow setting stoppedStreamingAt before post-processing

### DIFF
--- a/unique_toolkit/tests/chat/test_chat_functions_unit.py
+++ b/unique_toolkit/tests/chat/test_chat_functions_unit.py
@@ -253,6 +253,52 @@ def test_modify_message_with_segment_kind(mock_sdk, sample_message_data):
     assert call_kwargs["segmentKind"] == "PREFACE"
 
 
+def test_modify_message_with_set_stopped_streaming_at(mock_sdk, sample_message_data):
+    # Setup
+    mock_sdk.Message.modify.return_value = sample_message_data
+
+    # Execute
+    modify_message(
+        user_id="user123",
+        company_id="company123",
+        assistant_message_id="asst123",
+        chat_id="chat123",
+        user_message_id="user123",
+        user_message_text="Hello",
+        assistant=True,
+        content="Modified content",
+        set_stopped_streaming_at=True,
+    )
+
+    # Assert
+    call_kwargs = mock_sdk.Message.modify.call_args[1]
+    assert call_kwargs["stoppedStreamingAt"] is not None
+    assert call_kwargs["completedAt"] is None
+
+
+def test_modify_message_without_set_stopped_streaming_at_defaults_to_none(
+    mock_sdk, sample_message_data
+):
+    # Setup
+    mock_sdk.Message.modify.return_value = sample_message_data
+
+    # Execute
+    modify_message(
+        user_id="user123",
+        company_id="company123",
+        assistant_message_id="asst123",
+        chat_id="chat123",
+        user_message_id="user123",
+        user_message_text="Hello",
+        assistant=True,
+        content="Modified content",
+    )
+
+    # Assert
+    call_kwargs = mock_sdk.Message.modify.call_args[1]
+    assert call_kwargs["stoppedStreamingAt"] is None
+
+
 def test_modify_message_without_segment_kind_omits_key(mock_sdk, sample_message_data):
     # Setup
     mock_sdk.Message.modify.return_value = sample_message_data

--- a/unique_toolkit/tests/chat/test_chat_service_unit.py
+++ b/unique_toolkit/tests/chat/test_chat_service_unit.py
@@ -168,6 +168,7 @@ class TestChatServiceUnit:
                 ],
                 debugInfo={},
                 completedAt=mocked_datetime,
+                stoppedStreamingAt=None,
             )
         ]
         mock_modify.assert_has_calls(expected_calls)
@@ -212,6 +213,7 @@ class TestChatServiceUnit:
                 ],
                 debugInfo={},
                 completedAt=None,
+                stoppedStreamingAt=None,
             )
         ]
         mock_modify.assert_has_calls(expected_calls)
@@ -244,6 +246,7 @@ class TestChatServiceUnit:
                 references=[],
                 debugInfo=None,
                 completedAt=None,
+                stoppedStreamingAt=None,
                 segmentKind="PREFACE",
             )
         ]
@@ -494,6 +497,7 @@ class TestChatServiceUnit:
                 ],
                 debugInfo={},
                 completedAt=mocked_datetime,
+                stoppedStreamingAt=None,
             )
         ]
         mock_modify.assert_has_calls(expected_calls)
@@ -538,6 +542,7 @@ class TestChatServiceUnit:
                 ],
                 debugInfo={},
                 completedAt=None,
+                stoppedStreamingAt=None,
             )
         ]
         mock_modify.assert_has_calls(expected_calls)

--- a/unique_toolkit/tests/chat/test_chat_service_unit.py
+++ b/unique_toolkit/tests/chat/test_chat_service_unit.py
@@ -252,6 +252,66 @@ class TestChatServiceUnit:
         ]
         mock_modify.assert_has_calls(expected_calls)
 
+    @patch.object(unique_sdk.Message, "modify", autospec=True)
+    def test_modify_assistant_message_with_set_stopped_streaming_at(self, mock_modify):
+        mock_modify.return_value = {
+            "id": "test_message",
+            "chatId": "chatId123",
+            "content": "Modified message",
+            "role": "assistant",
+        }
+
+        result = self.service.modify_assistant_message(
+            content="Modified message",
+            message_id="test_assistant_message",
+            set_stopped_streaming_at=True,
+        )
+
+        assert isinstance(result, ChatMessage)
+
+        expected_calls = [
+            mock.call(
+                user_id="test_user",
+                company_id="test_company",
+                id="test_assistant_message",
+                chatId="test_chat",
+                text="Modified message",
+                originalText=None,
+                references=[],
+                debugInfo=None,
+                completedAt=None,
+                stoppedStreamingAt=mocked_datetime,
+            )
+        ]
+        mock_modify.assert_has_calls(expected_calls)
+
+    @patch.object(unique_sdk.Message, "modify", autospec=True)
+    def test_signal_streaming_stopped(self, mock_modify):
+        mock_modify.return_value = {
+            "id": "test_message",
+            "chatId": "chatId123",
+            "content": "",
+            "role": "assistant",
+        }
+
+        self.service.signal_streaming_stopped()
+
+        expected_calls = [
+            mock.call(
+                user_id="test_user",
+                company_id="test_company",
+                id="assistant_message_id",
+                chatId="test_chat",
+                text=None,
+                originalText=None,
+                references=[],
+                debugInfo=None,
+                completedAt=None,
+                stoppedStreamingAt=mocked_datetime,
+            )
+        ]
+        mock_modify.assert_has_calls(expected_calls)
+
     @patch.object(unique_sdk.Message, "list", autospec=True)
     def test_get_history(self, mock_list):
         mock_list.return_value = {

--- a/unique_toolkit/unique_toolkit/chat/functions.py
+++ b/unique_toolkit/unique_toolkit/chat/functions.py
@@ -66,6 +66,7 @@ def modify_message(
     debug_info: dict[str, Any] | None = None,
     message_id: str | None = None,
     set_completed_at: bool = False,
+    set_stopped_streaming_at: bool = False,
     segment_kind: str | None = None,
 ) -> ChatMessage:
     """Modifies a chat message synchronously.
@@ -84,6 +85,7 @@ def modify_message(
         references (list[ContentReference]): list of ContentReference objects. Defaults to None.
         debug_info (dict[str, Any]], optional): Debug information. Defaults to None.
         set_completed_at (bool, optional): Whether to set the completedAt field with the current date time. Defaults to False.
+        set_stopped_streaming_at (bool, optional): Whether to set the stoppedStreamingAt field with the current date time. Use this to signal that model streaming has finished while post-processing (e.g. evaluations) is still running, so clients can unblock user input before completedAt is set. Defaults to False.
         segment_kind (str, optional): The segment kind (e.g. "PROCESS", "PREFACE", "ELICITATION", "ANSWER") to relabel the segment to in place. Defaults to None (kind unchanged).
 
     Returns:
@@ -108,6 +110,7 @@ def modify_message(
             debug_info=debug_info,
             message_id=message_id,
             set_completed_at=set_completed_at,
+            set_stopped_streaming_at=set_stopped_streaming_at,
             segment_kind=segment_kind,
         )
         message = unique_sdk.Message.modify(**params)
@@ -131,6 +134,7 @@ async def modify_message_async(
     debug_info: dict[str, Any] | None = None,
     message_id: str | None = None,
     set_completed_at: bool = False,
+    set_stopped_streaming_at: bool = False,
     segment_kind: str | None = None,
 ) -> ChatMessage:
     """Modifies a chat message asynchronously.
@@ -149,6 +153,7 @@ async def modify_message_async(
         references (list[ContentReference]): list of ContentReference objects. Defaults to None.
         debug_info (dict[str, Any]], optional): Debug information. Defaults to None.
         set_completed_at (bool, optional): Whether to set the completedAt field with the current date time. Defaults to False.
+        set_stopped_streaming_at (bool, optional): Whether to set the stoppedStreamingAt field with the current date time. Use this to signal that model streaming has finished while post-processing (e.g. evaluations) is still running, so clients can unblock user input before completedAt is set. Defaults to False.
         segment_kind (str, optional): The segment kind (e.g. "PROCESS", "PREFACE", "ELICITATION", "ANSWER") to relabel the segment to in place. Defaults to None (kind unchanged).
 
     Returns:
@@ -173,6 +178,7 @@ async def modify_message_async(
             debug_info=debug_info,
             message_id=message_id,
             set_completed_at=set_completed_at,
+            set_stopped_streaming_at=set_stopped_streaming_at,
             segment_kind=segment_kind,
         )
         message = await unique_sdk.Message.modify_async(**params)
@@ -231,9 +237,11 @@ def _construct_message_modify_params(
     debug_info: dict[str, Any] | None = None,
     message_id: str | None = None,
     set_completed_at: bool = False,
+    set_stopped_streaming_at: bool = False,
     segment_kind: str | None = None,
 ) -> dict[str, Any]:
     completed_at_datetime = None
+    stopped_streaming_at_datetime = None
 
     if message_id:
         # Message ID specified. No need to guess
@@ -249,6 +257,9 @@ def _construct_message_modify_params(
     if set_completed_at:
         completed_at_datetime = _time_utils.get_datetime_now()
 
+    if set_stopped_streaming_at:
+        stopped_streaming_at_datetime = _time_utils.get_datetime_now()
+
     params: dict[str, Any] = {
         "user_id": user_id,
         "company_id": company_id,
@@ -259,6 +270,7 @@ def _construct_message_modify_params(
         "references": map_references(references) if references else [],
         "debugInfo": debug_info,
         "completedAt": completed_at_datetime,
+        "stoppedStreamingAt": stopped_streaming_at_datetime,
     }
     if segment_kind is not None:
         params["segmentKind"] = segment_kind

--- a/unique_toolkit/unique_toolkit/services/chat_service.py
+++ b/unique_toolkit/unique_toolkit/services/chat_service.py
@@ -392,6 +392,7 @@ class ChatService(ChatServiceDeprecated):
         debug_info: dict[str, Any] | None = None,
         message_id: str | None = None,
         set_completed_at: bool | None = None,
+        set_stopped_streaming_at: bool | None = None,
         segment_kind: str | None = None,
     ) -> ChatMessage:
         """Modifies a message in the chat session synchronously if parameter is not specified the corresponding field will remain as is.
@@ -403,6 +404,7 @@ class ChatService(ChatServiceDeprecated):
             debug_info (dict[str, Any]]]): Debug information. Defaults to {}.
             message_id (Optional[str]): The message ID. Defaults to None.
             set_completed_at (Optional[bool]): Whether to set the completedAt field with the current date time. Defaults to False.
+            set_stopped_streaming_at (Optional[bool]): Whether to set the stoppedStreamingAt field with the current date time. Use this to unblock user input as soon as model streaming ends, ahead of slower post-processing (e.g. evaluations) that still needs to run before completedAt is set. Defaults to False.
             segment_kind (str, optional): The segment kind (e.g. "PROCESS", "PREFACE", "ELICITATION", "ANSWER") to relabel the segment to in place, e.g. relabeling M0 from PROCESS to PREFACE once content is set. Defaults to None (kind unchanged).
 
         Returns:
@@ -427,6 +429,7 @@ class ChatService(ChatServiceDeprecated):
             debug_info=debug_info,
             message_id=message_id,
             set_completed_at=set_completed_at or False,
+            set_stopped_streaming_at=set_stopped_streaming_at or False,
             segment_kind=segment_kind,
         )
 
@@ -438,6 +441,7 @@ class ChatService(ChatServiceDeprecated):
         debug_info: dict[str, Any] | None = None,
         message_id: str | None = None,
         set_completed_at: bool | None = False,
+        set_stopped_streaming_at: bool | None = False,
         segment_kind: str | None = None,
     ) -> ChatMessage:
         """Modifies a message in the chat session asynchronously.
@@ -449,6 +453,7 @@ class ChatService(ChatServiceDeprecated):
             references (list[ContentReference]): list of ContentReference objects. Defaults to None.
             debug_info (dict[str, Any]], optional): Debug information. Defaults to None.
             set_completed_at (bool, optional): Whether to set the completedAt field with the current date time. Defaults to False.
+            set_stopped_streaming_at (bool, optional): Whether to set the stoppedStreamingAt field with the current date time. Use this to unblock user input as soon as model streaming ends, ahead of slower post-processing (e.g. evaluations) that still needs to run before completedAt is set. Defaults to False.
             segment_kind (str, optional): The segment kind (e.g. "PROCESS", "PREFACE", "ELICITATION", "ANSWER") to relabel the segment to in place, e.g. relabeling M0 from PROCESS to PREFACE once content is set. Defaults to None (kind unchanged).
 
         Returns:
@@ -472,6 +477,7 @@ class ChatService(ChatServiceDeprecated):
             debug_info=debug_info,
             message_id=message_id,
             set_completed_at=set_completed_at or False,
+            set_stopped_streaming_at=set_stopped_streaming_at or False,
             segment_kind=segment_kind,
         )
 
@@ -654,6 +660,17 @@ class ChatService(ChatServiceDeprecated):
     def free_user_input(self) -> None:
         """Unblocks the next user input"""
         self.modify_assistant_message(set_completed_at=True)
+
+    def signal_streaming_stopped(self) -> None:
+        """Marks model streaming as finished without marking the message fully completed.
+
+        Call this as soon as the model stops emitting tokens, before running any
+        slower post-processing (e.g. evaluations, hallucination checks). Clients
+        that unblock user input on ``stoppedStreamingAt`` (in addition to
+        ``completedAt``) will re-enable input immediately instead of waiting for
+        post-processing to finish.
+        """
+        self.modify_assistant_message(set_stopped_streaming_at=True)
 
     # History Methods
     ############################################################################


### PR DESCRIPTION
## Summary

[UN-22887](https://unique-ch.atlassian.net/browse/UN-22887): conduct has a ~20s delay after streaming finishes before links become clickable / a new message can be sent, specifically on turns after the first (i.e. once chat history exists).

Proposal from Joao Mazarelo (with input from Aurel Gruber) in Slack: `stoppedStreamingAt` is never set on conduct, and `completedAt` is only set after post-processing finishes — which is what's blocking the client. Since a post-process can't really be "stopped" anyway, it makes more sense to set `stoppedStreamingAt` before post-processing starts, rather than waiting for `completedAt` at the very end.

This PR is the `unique_toolkit` side of that proposal: it's currently impossible for a caller to set `stoppedStreamingAt` at all — `ModifyParams` already supports it at the `unique_sdk` wire level, but `unique_toolkit` never threaded it through.

## Changes

- `chat/functions.py`: `modify_message` / `modify_message_async` / `_construct_message_modify_params` gain a `set_stopped_streaming_at` param (mirrors the existing `set_completed_at` pattern), mapping to `stoppedStreamingAt` on the SDK call.
- `services/chat_service.py`: `modify_assistant_message` / `modify_assistant_message_async` accept the same param, plus a new `signal_streaming_stopped()` convenience method (mirrors `free_user_input()`) for callers to mark streaming done ahead of post-processing.
- Purely additive — all new params default to `False`/`None`, no existing behavior changes.

This is not yet a fix for UN-22887 by itself — it just makes the capability available. See "Next steps" below for what's needed to actually close the ticket.

## Next steps to make this work in conduct

1. **Release this `unique_toolkit` change** and bump the version conduct's backend depends on.
2. **Find and update conduct's turn-completion code** (lives outside this repo — not found in `ai` or the `monorepo` checkout searched so far). Call `chat_service.signal_streaming_stopped()` right when the model stops emitting tokens, *before* kicking off post-processing (evaluations, hallucination checks, reference resolution, etc.), instead of only calling `free_user_input()` at the very end.
3. **Target the right segment on multi-segment/tool-use turns.** Only call it on the final answer segment of a turn — firing it on an intermediate `PROCESS`/tool-call segment would re-enable user input while the agent is still working on the same turn.
4. **Verify the conduct frontend actually unblocks on `stoppedStreamingAt` alone.** The WS handler in `next/apps/chat` (`ChatMessages/index.tsx:308-334`, `useSubmitMessage/index.ts:52-64`) appears to watch both `completedAt`/`stoppedStreamingAt`, but this needs confirming — if it currently requires `completedAt` too, that's a small frontend fix to land alongside step 2.
5. **Test on QA**: start a chat, send a 2nd message, confirm links/input unblock immediately after streaming ends instead of ~20s later, and confirm nothing regresses for tool-using/multi-segment turns.
6. **Coordinate with Joao/Aurel and whoever owns the conduct backend** call site for review, since it's outside `unique_toolkit`.

## Open questions / risks

- The actual conduct backend call site isn't in this repo — step 2 above needs a follow-up PR there.
- Frontend behavior on `stoppedStreamingAt` alone is assumed, not confirmed (step 4).
- Multi-segment turns need care to avoid unblocking input mid-turn (step 3).

## Test plan

- [x] `uv run pytest tests/chat/test_chat_functions_unit.py tests/chat/test_chat_service_unit.py -q` — 79 passed
- [x] `uv run ruff check` on touched files
- [ ] Verify with conduct backend owner where to call `signal_streaming_stopped()`
- [ ] End-to-end QA verification per "Next steps" above


[UN-22887]: https://unique-ch.atlassian.net/browse/UN-22887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ