### PR TITLE
feat(web-search): plug exposable engine params into tool schemas [UN-21235]

### DIFF
--- a/tool_packages/unique_web_search/src/unique_web_search/service.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/service.py
@@ -5,6 +5,8 @@ from time import time
 
 from jinja2 import Template
 from typing_extensions import override
+from unique_search_proxy_core.param_policy.exposed_params import ExposedParams
+from unique_search_proxy_core.search_engines.base import BaseSearchEngineConfig
 from unique_toolkit._common.chunk_relevancy_sorter.service import ChunkRelevancySorter
 from unique_toolkit.agentic.evaluation.schemas import EvaluationMetricName
 from unique_toolkit.agentic.feature_flags.feature_flags import (
@@ -97,6 +99,7 @@ class WebSearchTool(Tool[WebSearchConfig]):
         )
         self.debug = self.config.debug
         self._display_name = kwargs.get("display_name", "Web Search")
+        self.exposed_params_cls = self._resolve_exposed_params_cls()
 
         def content_reducer(web_page_chunks: list[WebPageChunk]) -> list[WebPageChunk]:
 
@@ -111,6 +114,13 @@ class WebSearchTool(Tool[WebSearchConfig]):
 
         self.content_reducer = content_reducer
 
+    def _resolve_exposed_params_cls(self) -> type[ExposedParams] | None:
+        """Resolve the exposed-params model from the search-engine config, if any."""
+        cfg = self.config.search_engine_config
+        if isinstance(cfg, BaseSearchEngineConfig):
+            return cfg.exposed_params_model()
+        return None
+
     def _resolve_search_engine_mode(self) -> SearchEngineMode:
         """Derive the search-engine mode, respecting CustomAPI overrides."""
         cfg = self.search_engine_service.config
@@ -119,14 +129,16 @@ class WebSearchTool(Tool[WebSearchConfig]):
 
     @override
     def tool_description(self) -> LanguageModelToolDescription:
+        exposed = self.exposed_params_cls
         if self.config.web_search_mode_config.mode == WebSearchMode.V1:
-            self.tool_parameter_calls = WebSearchToolParameters.from_tool_parameter_query_description(
-                self.config.web_search_mode_config.tool_parameters_description.query_description,
-                self.config.web_search_mode_config.tool_parameters_description.date_restrict_description,
+            self.tool_parameter_calls = WebSearchToolParameters.with_exposed_params(
+                exposed
             )
         else:
             if self.config.web_search_mode_config.mode == WebSearchMode.V3:
-                self.tool_parameter_calls = WebSearchV3ToolParameters
+                self.tool_parameter_calls = (
+                    WebSearchV3ToolParameters.with_exposed_params(exposed)
+                )
             else:
                 engine_mode = self._resolve_search_engine_mode()
                 self.tool_parameter_calls = WebSearchPlan.with_search_engine_mode(
@@ -137,7 +149,7 @@ class WebSearchTool(Tool[WebSearchConfig]):
 
         if self.config.web_search_mode_config.mode == WebSearchMode.V3:
             tool_description = Template(tool_description).render(
-                tool_parameters_schema=WebSearchV3ToolParameters.schema_hint(),
+                tool_parameters_schema=WebSearchV3ToolParameters.schema_hint(exposed),
             )
 
         return LanguageModelToolDescription(
@@ -202,7 +214,7 @@ class WebSearchTool(Tool[WebSearchConfig]):
 
         screening_service = await self._get_argument_screening_service_if_ff_enabled()
 
-        parameters_dump = parameters.model_dump()
+        parameters_dump = parameters.model_dump(by_alias=True)
         debug_info = WebSearchDebugInfo(parameters=parameters_dump)
 
         web_search_message_logger = WebSearchMessageLogger(
@@ -333,6 +345,7 @@ class WebSearchTool(Tool[WebSearchConfig]):
                 callbacks=callbacks,
                 tool_call=tool_call,
                 tool_parameters=parameters,
+                exposed_params_cls=self.exposed_params_cls,
             )
         if isinstance(parameters, WebSearchPlan):
             assert search_config.mode == WebSearchMode.V2
@@ -343,6 +356,7 @@ class WebSearchTool(Tool[WebSearchConfig]):
                 tool_call=tool_call,
                 tool_parameters=parameters,
                 max_steps=search_config.max_steps,
+                exposed_params_cls=self.exposed_params_cls,
             )
         elif isinstance(parameters, WebSearchToolParameters):
             assert search_config.mode == WebSearchMode.V1
@@ -356,6 +370,7 @@ class WebSearchTool(Tool[WebSearchConfig]):
                 refine_query_language_model=search_config.refine_query_mode.language_model,
                 mode=search_config.refine_query_mode.mode,
                 max_queries=search_config.max_queries,
+                exposed_params_cls=self.exposed_params_cls,
             )
         else:
             raise ValueError(f"Invalid parameters: {parameters}")

--- a/tool_packages/unique_web_search/src/unique_web_search/services/executors/base_executor.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/executors/base_executor.py
@@ -4,6 +4,7 @@ from time import time
 from typing import Generic, TypeVar
 
 from pydantic import BaseModel
+from unique_search_proxy_core.param_policy.exposed_params import ExposedParams
 from unique_toolkit.agentic.tools.tool_progress_reporter import (
     ProgressState,
 )
@@ -39,6 +40,7 @@ class BaseWebSearchExecutor(ABC, Generic[T]):
         callbacks: ExecutorCallbacks,
         tool_call: LanguageModelFunction,
         tool_parameters: T,
+        exposed_params_cls: type[ExposedParams] | None = None,
     ):
         # Extract from service context
         self.search_service = services.search_engine_service
@@ -61,6 +63,7 @@ class BaseWebSearchExecutor(ABC, Generic[T]):
         # Store tool parameters
         self.tool_call = tool_call
         self.tool_parameters = tool_parameters
+        self.exposed_params_cls = exposed_params_cls
 
         # Initialize notification state
         self._notify_name = ""
@@ -77,6 +80,19 @@ class BaseWebSearchExecutor(ABC, Generic[T]):
                 )
 
         self.notify_callback = notify_callback
+
+    def _extract_search_params(self, source: BaseModel) -> ExposedParams | None:
+        """Validate ``source`` against the exposed-params class, dropping tool-only fields.
+
+        Returns ``None`` when no knobs are exposed for this deployment. Otherwise
+        re-validates the source dump through ``exposed_params_cls``
+        (``extra="ignore"``) so only admin-exposed engine knobs remain.
+        """
+        if self.exposed_params_cls is None:
+            return None
+        return self.exposed_params_cls.model_validate(
+            source.model_dump(by_alias=True)
+        )
 
     @property
     def notify_name(self):

--- a/tool_packages/unique_web_search/src/unique_web_search/services/executors/base_executor.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/executors/base_executor.py
@@ -90,9 +90,7 @@ class BaseWebSearchExecutor(ABC, Generic[T]):
         """
         if self.exposed_params_cls is None:
             return None
-        return self.exposed_params_cls.model_validate(
-            source.model_dump(by_alias=True)
-        )
+        return self.exposed_params_cls.model_validate(source.model_dump(by_alias=True))
 
     @property
     def notify_name(self):

--- a/tool_packages/unique_web_search/src/unique_web_search/services/executors/v1/__init__.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/executors/v1/__init__.py
@@ -1,17 +1,15 @@
 from unique_web_search.services.executors.v1.config import (
     QueryRefinementConfig,
     RefineQueryMode,
-    WebSearchToolParametersDescriptionConfig,
     WebSearchV1Config,
 )
-from unique_web_search.services.executors.v1.executor import (
-    WebSearchV1Executor,
-)
+from unique_web_search.services.executors.v1.executor import WebSearchV1Executor
+from unique_web_search.services.executors.v1.schema import WebSearchToolParameters
 
 __all__ = [
     "QueryRefinementConfig",
     "RefineQueryMode",
-    "WebSearchToolParametersDescriptionConfig",
     "WebSearchV1Config",
     "WebSearchV1Executor",
+    "WebSearchToolParameters",
 ]

--- a/tool_packages/unique_web_search/src/unique_web_search/services/executors/v1/config.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/executors/v1/config.py
@@ -15,7 +15,6 @@ from unique_web_search.services.executors.v1.prompts import (
     DEFAULT_TOOL_DESCRIPTION,
     DEFAULT_TOOL_DESCRIPTION_FOR_SYSTEM_PROMPT,
     REFINE_QUERY_SYSTEM_PROMPT,
-    RESTRICT_DATE_DESCRIPTION,
 )
 from unique_web_search.settings import env_settings
 
@@ -24,34 +23,6 @@ class RefineQueryMode(StrEnum):
     BASIC = "Basic"
     ADVANCED = "Advanced (Beta)"
     DEACTIVATED = "Deactivated"
-
-
-_DEFAULT_QUERY_DESCRIPTION = "The search query to issue to the web."
-
-
-class WebSearchToolParametersDescriptionConfig(BaseModel):
-    model_config = get_configuration_dict()
-
-    query_description: Annotated[
-        str,
-        RJSFMetaTag.StringWidget.textarea(
-            rows=len(_DEFAULT_QUERY_DESCRIPTION.split("\n"))
-        ),
-    ] = Field(
-        default=_DEFAULT_QUERY_DESCRIPTION,
-        title="Query Parameter Description",
-        description="Advanced: Description of the search query parameter shown to the AI model.",
-    )
-    date_restrict_description: Annotated[
-        str,
-        RJSFMetaTag.StringWidget.textarea(
-            rows=len(RESTRICT_DATE_DESCRIPTION.split("\n"))
-        ),
-    ] = Field(
-        default=RESTRICT_DATE_DESCRIPTION,
-        title="Date Filter Description",
-        description="Advanced: Description of the date restriction parameter shown to the AI model.",
-    )
 
 
 class QueryRefinementConfig(BaseModel):
@@ -99,12 +70,6 @@ class WebSearchV1Config(BaseWebSearchModeConfig[WebSearchMode.V1]):
         default=5,
         title="Maximum Search Queries",
         description="Maximum number of separate searches to run per user request. Only applies when Query Refinement is set to Advanced.",
-    )
-
-    tool_parameters_description: WebSearchToolParametersDescriptionConfig = Field(
-        default_factory=WebSearchToolParametersDescriptionConfig,
-        title="Search Parameter Descriptions",
-        description="Advanced: Descriptions of each search parameter, shown to the AI model.",
     )
 
     tool_description: Annotated[

--- a/tool_packages/unique_web_search/src/unique_web_search/services/executors/v1/executor.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/executors/v1/executor.py
@@ -3,6 +3,7 @@ from time import time
 from typing import Literal, overload, override
 
 from pydantic import Field
+from unique_search_proxy_core.param_policy.exposed_params import ExposedParams
 from unique_toolkit import LanguageModelService
 from unique_toolkit._common.utils.structured_output.schema import StructuredOutputModel
 from unique_toolkit._common.validators import LMI
@@ -33,9 +34,6 @@ from unique_web_search.services.executors.v1.config import RefineQueryMode
 from unique_web_search.services.executors.v1.schema import WebSearchToolParameters
 from unique_web_search.services.search_engine.schema import (
     WebSearchResult,
-)
-from unique_web_search.utils import (
-    query_params_to_human_string,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -149,6 +147,7 @@ class WebSearchV1Executor(BaseWebSearchExecutor[WebSearchToolParameters]):
         refine_query_language_model: LMI,
         mode: RefineQueryMode = RefineQueryMode.BASIC,
         max_queries: int = 10,
+        exposed_params_cls: type[ExposedParams] | None = None,
     ):
         super().__init__(
             services=services,
@@ -156,6 +155,7 @@ class WebSearchV1Executor(BaseWebSearchExecutor[WebSearchToolParameters]):
             callbacks=callbacks,
             tool_call=tool_call,
             tool_parameters=tool_parameters,
+            exposed_params_cls=exposed_params_cls,
         )
         self.mode = mode
         self.refine_query_system_prompt = refine_query_system_prompt
@@ -164,10 +164,10 @@ class WebSearchV1Executor(BaseWebSearchExecutor[WebSearchToolParameters]):
 
     async def run(self) -> list[ContentChunk]:
         query = self.tool_parameters.query
-        date_restrict = self.tool_parameters.date_restrict
+        search_params = self._extract_search_params(self.tool_parameters)
 
         self.notify_name = "**Refining Query**"
-        self.notify_message = query_params_to_human_string(query, date_restrict)
+        self.notify_message = query
         await self.notify_callback()
 
         await self._message_log_callback.log_progress(
@@ -179,11 +179,7 @@ class WebSearchV1Executor(BaseWebSearchExecutor[WebSearchToolParameters]):
 
         web_search_results = []
 
-        queries_wo_results = [
-            query_params_to_human_string(refined_query, date_restrict)
-            for refined_query in elicitated_queries
-        ]
-        await self._message_log_callback.log_queries(queries_wo_results)
+        await self._message_log_callback.log_queries(elicitated_queries)
 
         for index, query in enumerate(elicitated_queries):
             if len(elicitated_queries) > 1:
@@ -193,11 +189,11 @@ class WebSearchV1Executor(BaseWebSearchExecutor[WebSearchToolParameters]):
             else:
                 self.notify_name = "**Searching Web**"
 
-            self.notify_message = query_params_to_human_string(query, date_restrict)
+            self.notify_message = query
             await self.notify_callback()
             await self._message_log_callback.log_progress(self.notify_message)
 
-            search_results = await self._search(query, date_restrict=date_restrict)
+            search_results = await self._search(query, params=search_params)
 
             await self._message_log_callback.log_web_search_results(search_results)
 
@@ -270,16 +266,16 @@ class WebSearchV1Executor(BaseWebSearchExecutor[WebSearchToolParameters]):
         return queries, refined_query.objective
 
     async def _search(
-        self, query: str, date_restrict: str | None
+        self,
+        query: str,
+        params: ExposedParams | None,
     ) -> list[WebSearchResult]:
         engine = self.search_service.config.engine.value
         start_time = time()
         _LOGGER.info(f"Company {self.company_id} Searching with {engine}")
         with metric_scope(search_duration, search_errors, engine=engine):
             search_total.labels(engine=engine).inc()
-            search_results = await self.search_service.search(
-                query, date_restrict=date_restrict
-            )
+            search_results = await self.search_service.search(query, params=params)
         end_time = time()
         delta_time = end_time - start_time
         _LOGGER.info(f"Searched with {engine} completed in {delta_time} seconds")
@@ -290,7 +286,11 @@ class WebSearchV1Executor(BaseWebSearchExecutor[WebSearchToolParameters]):
                 config=self.search_service.config.engine.name,
                 extra={
                     "query": query,
-                    "date_restrict": date_restrict,
+                    "params": (
+                        params.model_dump(by_alias=True, exclude_none=True)
+                        if params
+                        else None
+                    ),
                     "number_of_results": len(search_results),
                     "urls": [result.url for result in search_results],
                 },

--- a/tool_packages/unique_web_search/src/unique_web_search/services/executors/v1/prompts/__init__.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/executors/v1/prompts/__init__.py
@@ -11,6 +11,3 @@ DEFAULT_TOOL_DESCRIPTION_FOR_SYSTEM_PROMPT: str = load_template(
 REFINE_QUERY_SYSTEM_PROMPT: str = load_template(
     _PROMPTS_DIR, "refine_query_system_prompt.j2"
 )
-RESTRICT_DATE_DESCRIPTION: str = load_template(
-    _PROMPTS_DIR, "restrict_date_description.j2"
-)

--- a/tool_packages/unique_web_search/src/unique_web_search/services/executors/v1/prompts/restrict_date_description.j2
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/executors/v1/prompts/restrict_date_description.j2
@@ -1,3 +1,0 @@
-Restricts results to a recent time window. Format: `[period][number]` — `d`=days, `w`=weeks, `m`=months, `y`=years.  
-Examples: `d1` (24h), `w1` (1 week), `m3` (3 months), `y1` (1 year).  
-Omit for no date filter. Avoid adding date terms in the main query.

--- a/tool_packages/unique_web_search/src/unique_web_search/services/executors/v1/schema.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/executors/v1/schema.py
@@ -1,26 +1,38 @@
 """V1 WebSearch tool parameters (single-query tool call)."""
 
-from pydantic import BaseModel, ConfigDict, Field, create_model
+from __future__ import annotations
+
+from pydantic import ConfigDict, Field, create_model
+from pydantic.alias_generators import to_camel
+from unique_search_proxy_core.param_policy.exposed_params import ExposedParams
+
+_DEFAULT_QUERY_DESCRIPTION = "The search query to issue to the web."
 
 
-class WebSearchToolParameters(BaseModel):
+class WebSearchToolParameters(ExposedParams):
     """Parameters for the Websearch tool."""
 
-    model_config = ConfigDict(extra="forbid")
-    query: str
-    date_restrict: str | None
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        populate_by_name=True,
+        extra="forbid",
+    )
+
+    query: str = Field(description=_DEFAULT_QUERY_DESCRIPTION)
 
     @classmethod
-    def from_tool_parameter_query_description(
-        cls, query_description: str, date_restrict_description: str | None
-    ) -> type["WebSearchToolParameters"]:
-        """Create a new model with the query field."""
+    def with_exposed_params(
+        cls,
+        exposed: type[ExposedParams] | None,
+    ) -> type[WebSearchToolParameters]:
+        """Graft admin-exposed engine knobs onto the V1 tool-parameter model.
+
+        Returns ``cls`` unchanged when nothing is exposed; otherwise builds a
+        dynamic subclass via ``create_model(__base__=(cls, exposed))``.
+        """
+        if exposed is None:
+            return cls
         return create_model(
             cls.__name__,
-            query=(str, Field(description=query_description)),
-            date_restrict=(
-                str | None,
-                Field(description=date_restrict_description),
-            ),
-            __base__=cls,
+            __base__=(cls, exposed),
         )

--- a/tool_packages/unique_web_search/src/unique_web_search/services/executors/v2/executor.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/executors/v2/executor.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 from time import time
 
+from unique_search_proxy_core.param_policy.exposed_params import ExposedParams
 from unique_toolkit.content import ContentChunk
 from unique_toolkit.language_model import LanguageModelFunction
 from unique_toolkit.monitoring import metric_scope
@@ -45,6 +46,7 @@ class WebSearchV2Executor(BaseWebSearchExecutor[WebSearchPlan]):
         tool_call: LanguageModelFunction,
         tool_parameters: WebSearchPlan,
         max_steps: int = 3,
+        exposed_params_cls: type[ExposedParams] | None = None,
     ):
         super().__init__(
             services=services,
@@ -52,6 +54,7 @@ class WebSearchV2Executor(BaseWebSearchExecutor[WebSearchPlan]):
             callbacks=callbacks,
             tool_call=tool_call,
             tool_parameters=tool_parameters,
+            exposed_params_cls=exposed_params_cls,
         )
 
         self.max_steps = max_steps

--- a/tool_packages/unique_web_search/src/unique_web_search/services/executors/v3/executor.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/executors/v3/executor.py
@@ -7,6 +7,7 @@ import logging
 from time import time
 
 from unidecode import unidecode
+from unique_search_proxy_core.param_policy.exposed_params import ExposedParams
 from unique_toolkit.content import ContentChunk
 from unique_toolkit.language_model import LanguageModelFunction
 from unique_toolkit.monitoring import metric_scope
@@ -45,6 +46,7 @@ class WebSearchV3Executor(BaseWebSearchExecutor[WebSearchV3ToolParameters]):
         callbacks: ExecutorCallbacks,
         tool_call: LanguageModelFunction,
         tool_parameters: WebSearchV3ToolParameters,
+        exposed_params_cls: type[ExposedParams] | None = None,
     ):
         super().__init__(
             services=services,
@@ -52,6 +54,7 @@ class WebSearchV3Executor(BaseWebSearchExecutor[WebSearchV3ToolParameters]):
             callbacks=callbacks,
             tool_call=tool_call,
             tool_parameters=tool_parameters,
+            exposed_params_cls=exposed_params_cls,
         )
 
     async def run(self) -> list[ContentChunk]:
@@ -59,7 +62,9 @@ class WebSearchV3Executor(BaseWebSearchExecutor[WebSearchV3ToolParameters]):
         if isinstance(p.payload, SearchPayload):
             await self._message_log_callback.log_progress("_Executing Search_")
             return await self._run_search(
-                query=p.payload.query, objective=p.relevance_focus()
+                query=p.payload.query,
+                objective=p.relevance_focus(),
+                params=self._extract_search_params(p.payload),
             )
         if isinstance(p.payload, FetchUrlsPayload):
             await self._message_log_callback.log_progress("_Reading Web Pages_")
@@ -76,6 +81,7 @@ class WebSearchV3Executor(BaseWebSearchExecutor[WebSearchV3ToolParameters]):
         *,
         query: str,
         objective: str,
+        params: ExposedParams | None,
     ) -> list[ContentChunk]:
         self.notify_name = "**Searching Web**"
         self.notify_message = objective
@@ -102,7 +108,7 @@ class WebSearchV3Executor(BaseWebSearchExecutor[WebSearchV3ToolParameters]):
         await self._message_log_callback.log_queries([query])
         with metric_scope(search_duration, search_errors, engine=engine):
             search_total.labels(engine=engine).inc()
-            results = await self.search_service.search(query)
+            results = await self.search_service.search(query, params=params)
         await self._message_log_callback.log_web_search_results(results)
 
         delta_time = time() - time_start
@@ -113,6 +119,11 @@ class WebSearchV3Executor(BaseWebSearchExecutor[WebSearchV3ToolParameters]):
                 config=engine,
                 extra={
                     "query": query,
+                    "params": (
+                        params.model_dump(by_alias=True, exclude_none=True)
+                        if params
+                        else None
+                    ),
                     "number_of_results": len(results),
                     "urls": [result.url for result in results],
                 },

--- a/tool_packages/unique_web_search/src/unique_web_search/services/executors/v3/schema.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/executors/v3/schema.py
@@ -1,9 +1,21 @@
 """V3 WebSearch tool parameters: a flat schema with exactly one of ``query`` or ``urls`` per call."""
 
+from __future__ import annotations
+
 import typing
 from enum import StrEnum
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, create_model
+from pydantic.alias_generators import to_camel
+from unique_search_proxy_core.param_policy.exposed_params import ExposedParams
+
+# Strict LLM-facing config: camelCase aliases + forbid extras, while still
+# inheriting ExposedParams.model_json_schema (strips title/default noise).
+_LLM_TOOL_MODEL_CONFIG = ConfigDict(
+    alias_generator=to_camel,
+    populate_by_name=True,
+    extra="forbid",
+)
 
 
 class Command(StrEnum):
@@ -19,7 +31,9 @@ class SearchPhase(StrEnum):
     REDIRECT = "redirect"
 
 
-class SearchPayload(BaseModel):
+class SearchPayload(ExposedParams):
+    model_config = _LLM_TOOL_MODEL_CONFIG
+
     gap: str = Field(
         description=(
             "One atomic facet this call addresses (e.g. '2023 revenue band for Company X in CH')—"
@@ -36,17 +50,32 @@ class SearchPayload(BaseModel):
         )
     )
 
+    @classmethod
+    def with_exposed_params(
+        cls,
+        exposed: type[ExposedParams] | None,
+    ) -> type[SearchPayload]:
+        """Graft admin-exposed engine knobs onto the search payload model."""
+        if exposed is None:
+            return cls
+        return create_model(
+            cls.__name__,
+            __base__=(cls, exposed),
+        )
+
 
 class FetchUrlsPayload(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     urls: list[str] = Field(
         description="HTTP(S) URLs to crawl for full-page text. Use only URLs returned by a prior search or pasted by the user."
     )
 
 
-class WebSearchV3ToolParameters(BaseModel):
+class WebSearchV3ToolParameters(ExposedParams):
     """Root JSON for the V3 WebSearch tool: set exactly one of ``query`` or ``urls``."""
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = _LLM_TOOL_MODEL_CONFIG
 
     command: Command = Field(
         description="The command to execute. Must be either 'search' or 'read_urls'."
@@ -67,6 +96,29 @@ class WebSearchV3ToolParameters(BaseModel):
         description="The payload of the command. Must be either a SearchPayload or a FetchUrlsPayload."
     )
 
+    @classmethod
+    def with_exposed_params(
+        cls,
+        exposed: type[ExposedParams] | None,
+    ) -> type[WebSearchV3ToolParameters]:
+        """Rebuild the payload union with an exposed ``SearchPayload`` subtype."""
+        search_payload = SearchPayload.with_exposed_params(exposed)
+        if search_payload is SearchPayload:
+            return cls
+        return create_model(
+            cls.__name__,
+            __base__=cls,
+            payload=(
+                search_payload | FetchUrlsPayload,
+                Field(
+                    description=(
+                        "The payload of the command. Must be either a SearchPayload "
+                        "or a FetchUrlsPayload."
+                    ),
+                ),
+            ),
+        )
+
     def relevance_focus(self) -> str:
         """Focus string for notify UI, snippet judging, and content processing."""
         phase_label = self.phase.value
@@ -78,23 +130,28 @@ class WebSearchV3ToolParameters(BaseModel):
         return f"[{phase_label}] {urls_preview}"
 
     @classmethod
-    def schema_hint(cls) -> str:
+    def schema_hint(
+        cls,
+        exposed: type[ExposedParams] | None = None,
+    ) -> str:
         """Return a markdown-bulleted hint mirroring the field descriptions of this model.
 
         Mirrors the legacy hand-written prompt block: one bullet per top-level
         field, with the ``payload`` bullet expanded into one inline JSON sketch
         per ``command`` value (since ``payload`` is a discriminated union).
         Field descriptions are inlined as ``<...>`` placeholders so the prompt
-        stays in sync with the Pydantic model.
+        stays in sync with the Pydantic model. Exposed knobs render under their
+        camelCase aliases.
         """
 
         def _inline_json(payload_model: type[BaseModel]) -> str:
             parts: list[str] = []
             for name, field in payload_model.model_fields.items():
-                placeholder = f"<{field.description or name}>"
+                key = field.alias or name
+                placeholder = f"<{field.description or key}>"
                 if typing.get_origin(field.annotation) is list:
                     placeholder = f"[{placeholder}]"
-                parts.append(f'"{name}": {placeholder}')
+                parts.append(f'"{key}": {placeholder}')
             return "{ " + ", ".join(parts) + " }"
 
         lines: list[str] = []
@@ -111,8 +168,9 @@ class WebSearchV3ToolParameters(BaseModel):
                 lines.append(f"- **`{name}`** — {field.description or name}")
 
         lines.append("- **`payload`** — Shape depends on `command`:")
+        search_payload = SearchPayload.with_exposed_params(exposed)
         for cmd, payload_model in (
-            (Command.SEARCH, SearchPayload),
+            (Command.SEARCH, search_payload),
             (Command.FETCH_URLS, FetchUrlsPayload),
         ):
             lines.append(f'  - For `"{cmd.value}"`: `{_inline_json(payload_model)}`.')

--- a/tool_packages/unique_web_search/src/unique_web_search/services/search_engine/base.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/search_engine/base.py
@@ -1,13 +1,35 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from enum import StrEnum
-from typing import ClassVar, Generic, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 from pydantic import BaseModel
+from unique_search_proxy_core.agent_engines.base import AgentEngineType
+from unique_search_proxy_core.agent_engines.config_types import ENGINE_NAME_TO_CONFIG
+from unique_search_proxy_core.param_policy.exposed_params import ExposedParams
+from unique_search_proxy_core.search_engines.base import (
+    BaseSearchEngineConfig,
+    SearchEngineType,
+)
 
-from unique_web_search.services.proxy.bridge import search_proxy_client_enabled
+from unique_web_search.services.proxy.bridge import (
+    open_search_proxy_client,
+    search_proxy_client_enabled,
+)
+from unique_web_search.services.proxy.mappers import (
+    agent_answer_text,
+    map_agent_answer,
+    map_search_response,
+)
 from unique_web_search.services.search_engine.schema import (
     WebSearchResult,
 )
+
+if TYPE_CHECKING:
+    from unique_web_search.services.search_engine.utils.grounding.response_parsing import (
+        ResponseParser,
+    )
 
 
 class SearchEngineMode(StrEnum):
@@ -19,6 +41,16 @@ class LocalSearchEngineType(StrEnum):
     CUSTOM_API = "custom_api"
 
 
+# Engine ids that the search proxy can serve. Every other engine
+# (e.g. ``LocalSearchEngineType``) is routed to the local legacy implementation.
+ProxyEngineType = SearchEngineType | AgentEngineType
+
+# Fields present on agent-engine configs that are not accepted as proxy call kwargs.
+_AGENT_PROXY_EXCLUDED_FIELDS = frozenset({"engine", "output_schema"})
+
+# Standard proxy client timeout (seconds); agent engines use ``config.timeout``.
+_STANDARD_PROXY_TIMEOUT = 30.0
+
 SearchEngineConfig = TypeVar(
     "SearchEngineConfig",
     bound=BaseModel,
@@ -26,18 +58,19 @@ SearchEngineConfig = TypeVar(
 
 
 class SearchEngine(ABC, Generic[SearchEngineConfig]):
-    """Base class for the search engine. It provides the common methods to search the web. This allows to use different search engines easily.
+    """Base class for the search engine.
 
-    Abstract Methods:
-        _legacy_search: Direct search implementation (no proxy).
-        requires_scraping: Whether the search engine requires scraping.
+    The search-proxy path (both standard engines like Google/Brave/Perplexity and
+    agent engines like Bing/VertexAI) is implemented entirely here. Subclasses only
+    provide the direct ``_legacy_search`` implementation.
 
-    Subclasses with proxy support set ``supports_proxy_search = True`` and
-    implement ``_proxy_search``.
-
+    ``search`` uses the proxy whenever it is enabled and the engine is supported by
+    it, otherwise it reroutes to the local legacy implementation. Engines that the
+    proxy cannot serve (e.g. custom APIs) always fall back to ``_legacy_search``.
     """
 
-    supports_proxy_search: ClassVar[bool] = False
+    # Set by agent engines (Bing/VertexAI) and consumed by the agent proxy path.
+    response_parsers: list[ResponseParser]
 
     def __init__(self, config: SearchEngineConfig):
         self.config = config
@@ -47,16 +80,115 @@ class SearchEngine(ABC, Generic[SearchEngineConfig]):
         """Whether the search engine requires scraping."""
         return False
 
-    async def search(self, query: str, **kwargs) -> list[WebSearchResult]:
+    @property
+    def _proxy_engine(self) -> ProxyEngineType | None:
+        """The proxy engine id for this config, or ``None`` if not proxy-supported."""
+        engine = getattr(self.config, "engine", None)
+        if isinstance(engine, (SearchEngineType, AgentEngineType)):
+            return engine
+        return None
+
+    async def search(
+        self,
+        query: str,
+        params: ExposedParams | None = None,
+    ) -> list[WebSearchResult]:
         """Search the web for the given query using the search engine."""
-        if search_proxy_client_enabled and self.supports_proxy_search:
-            return await self._proxy_search(query=query, **kwargs)
-        return await self._legacy_search(query=query, **kwargs)
+        proxy_engine = self._proxy_engine
+        if search_proxy_client_enabled and proxy_engine is not None:
+            return await self._proxy_search(query, params, proxy_engine)
+        return await self._legacy_search(query=query, params=params)
+
+    async def _proxy_search(
+        self,
+        query: str,
+        params: ExposedParams | None,
+        engine: ProxyEngineType,
+    ) -> list[WebSearchResult]:
+        """Dispatch to the appropriate proxy path for the given engine."""
+        if isinstance(engine, AgentEngineType):
+            return await self._agent_proxy_search(query, params, engine)
+        return await self._standard_proxy_search(query, params, engine)
+
+    async def _standard_proxy_search(
+        self,
+        query: str,
+        params: ExposedParams | None,
+        engine: SearchEngineType,
+    ) -> list[WebSearchResult]:
+        """Merge deployment config with per-call params and dispatch via the proxy SDK."""
+        if not isinstance(self.config, BaseSearchEngineConfig):
+            raise TypeError(
+                f"Standard proxy search requires BaseSearchEngineConfig, "
+                f"got {type(self.config).__name__}"
+            )
+        overrides = (
+            params.model_dump(by_alias=True, exclude_none=True) if params else {}
+        )
+        request = self.config.merge(overrides, query=query)
+        invocation = request.model_dump(by_alias=False, exclude_none=True)
+        invocation.pop("engine", None)
+        invocation.pop("query", None)
+        async with open_search_proxy_client(timeout=_STANDARD_PROXY_TIMEOUT) as client:
+            response = await client.search.search(
+                query=query,
+                engine=engine.value,
+                **invocation,
+            )
+        results = map_search_response(response)
+        return await self._postprocess_results(results)
+
+    async def _agent_proxy_search(
+        self,
+        query: str,
+        params: ExposedParams | None,
+        engine: AgentEngineType,
+    ) -> list[WebSearchResult]:
+        """Dispatch a grounded agent search via the proxy SDK and parse the answer."""
+        del params  # Agent engines do not expose LLM knobs today.
+        invocation = self._agent_proxy_invocation(engine)
+        async with open_search_proxy_client(
+            timeout=float(self.config.timeout)
+        ) as client:
+            response = await client.agent_search.search(
+                query=query,
+                engine=engine.value,
+                **invocation,
+            )
+        results = await map_agent_answer(
+            agent_answer_text(response),
+            self.response_parsers,
+        )
+        return await self._postprocess_results(results)
+
+    def _agent_proxy_invocation(self, engine: AgentEngineType) -> dict[str, Any]:
+        """Collect the config fields accepted by the agent proxy call for ``engine``."""
+        core_config_cls = ENGINE_NAME_TO_CONFIG[engine.value]
+        invocation: dict[str, Any] = {}
+        for field_name in core_config_cls.model_fields:
+            if field_name in _AGENT_PROXY_EXCLUDED_FIELDS:
+                continue
+            if not hasattr(self.config, field_name):
+                continue
+            value = getattr(self.config, field_name)
+            # Empty values fall through to the SDK/server defaults (e.g. an unset
+            # ``agent_id`` triggers server-side auto-provisioning).
+            if value == "":
+                continue
+            invocation[field_name] = value
+        return invocation
+
+    async def _postprocess_results(
+        self,
+        results: list[WebSearchResult],
+    ) -> list[WebSearchResult]:
+        """Hook for engine-specific result shaping shared by proxy and legacy paths."""
+        return results
 
     @abstractmethod
-    async def _proxy_search(self, query: str, **kwargs) -> list[WebSearchResult]:
-        """Search the web via the search proxy."""
-
-    @abstractmethod
-    async def _legacy_search(self, query: str, **kwargs) -> list[WebSearchResult]:
+    async def _legacy_search(
+        self,
+        query: str,
+        params: ExposedParams | None,
+    ) -> list[WebSearchResult]:
         """Search the web directly without the search proxy."""

--- a/tool_packages/unique_web_search/src/unique_web_search/services/search_engine/bing.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/search_engine/bing.py
@@ -4,17 +4,13 @@ from typing import override
 from pydantic import Field
 from unique_search_proxy_core.agent_engines.base import AgentEngineType
 from unique_search_proxy_core.agent_engines.bing.schema import BingAgentConfig
+from unique_search_proxy_core.param_policy.exposed_params import ExposedParams
 from unique_toolkit._common.default_language_model import DEFAULT_LANGUAGE_MODEL
 from unique_toolkit._common.validators import LMI, get_LMI_default_field
 from unique_toolkit.language_model import LanguageModelService
 
 from unique_web_search.services.proxy.bridge import (
-    open_search_proxy_client,
     search_proxy_client_enabled,
-)
-from unique_web_search.services.proxy.mappers import (
-    agent_answer_text,
-    map_agent_answer,
 )
 from unique_web_search.services.search_engine.base import SearchEngine, SearchEngineMode
 from unique_web_search.services.search_engine.registry import register_search_engine
@@ -62,8 +58,6 @@ class BingSearchConfig(BingAgentConfig):
     needs_language_model=True,
 )
 class BingSearch(SearchEngine[BingSearchConfig]):
-    supports_proxy_search = True
-
     def __init__(
         self,
         config: BingSearchConfig,
@@ -95,24 +89,12 @@ class BingSearch(SearchEngine[BingSearchConfig]):
         return self.config.requires_scraping
 
     @override
-    async def _proxy_search(self, query: str, **kwargs) -> list[WebSearchResult]:
-        async with open_search_proxy_client(
-            timeout=float(self.config.timeout)
-        ) as client:
-            response = await client.agent_search.bing(
-                query=query,
-                fetch_size=self.config.fetch_size,
-                agent_id=self.config.agent_id or None,
-                generation_instructions=self.config.generation_instructions,
-                timeout=self.config.timeout,
-            )
-            return await map_agent_answer(
-                agent_answer_text(response),
-                self.response_parsers,
-            )
-
-    @override
-    async def _legacy_search(self, query: str, **kwargs) -> list[WebSearchResult]:
+    async def _legacy_search(
+        self,
+        query: str,
+        params: ExposedParams | None,
+    ) -> list[WebSearchResult]:
+        del params
         agent_client = get_project_client(self.credentials, self.config.endpoint)
 
         search_results = await create_and_process_run(

--- a/tool_packages/unique_web_search/src/unique_web_search/services/search_engine/brave.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/search_engine/brave.py
@@ -1,14 +1,13 @@
 from typing import override
 
+from unique_search_proxy_core.param_policy.exposed_params import ExposedParams
 from unique_search_proxy_core.search_engines.base import SearchEngineType
 from unique_search_proxy_core.search_engines.brave.schema import BraveConfig
 
 from unique_web_search.client_settings import get_brave_search_settings
 from unique_web_search.services.proxy.bridge import (
-    open_search_proxy_client,
     search_proxy_client_enabled,
 )
-from unique_web_search.services.proxy.mappers import map_search_response
 from unique_web_search.services.search_engine.base import SearchEngine, SearchEngineMode
 from unique_web_search.services.search_engine.registry import register_search_engine
 from unique_web_search.services.search_engine.schema import (
@@ -24,8 +23,6 @@ from unique_web_search.services.search_engine.schema import (
     config_display_name="Brave Search",
 )
 class BraveSearch(SearchEngine[BraveConfig]):
-    supports_proxy_search = True
-
     def __init__(
         self,
         *args,
@@ -37,28 +34,9 @@ class BraveSearch(SearchEngine[BraveConfig]):
         )
 
     @override
-    async def _proxy_search(self, query: str, **kwargs) -> list[WebSearchResult]:
-        async with open_search_proxy_client(timeout=30.0) as client:
-            response = await client.search.brave(
-                query=query,
-                fetch_size=self.config.fetch_size,
-                extra_snippets=self.config.extra_snippets,
-                spellcheck=self.config.spellcheck,
-                text_decorations=self.config.text_decorations,
-                operators=self.config.operators,
-                ui_lang=self.config.ui_lang,
-                units=self.config.units,
-                summary=self.config.summary,
-                include_fetch_metadata=self.config.include_fetch_metadata,
-                goggles=self.config.goggles,
-                country=self.config.country.value,
-                freshness=self.config.freshness.value,
-                search_lang=self.config.search_lang.value,
-                safesearch=self.config.safesearch.value,
-                result_filter=self.config.result_filter.value,
-            )
-            return map_search_response(response)
-
-    @override
-    async def _legacy_search(self, query: str, **kwargs) -> list[WebSearchResult]:
+    async def _legacy_search(
+        self,
+        query: str,
+        params: ExposedParams | None,
+    ) -> list[WebSearchResult]:
         raise NotImplementedError("Brave search is not supported in the legacy mode")

--- a/tool_packages/unique_web_search/src/unique_web_search/services/search_engine/custom_api.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/search_engine/custom_api.py
@@ -4,6 +4,7 @@ from typing import Any, Literal, TypeVar, override
 from httpx import AsyncClient
 from pydantic import BaseModel, Field
 from pydantic.json_schema import SkipJsonSchema
+from unique_search_proxy_core.param_policy.exposed_params import ExposedParams
 from unique_toolkit.agentic.tools.config import get_configuration_dict
 
 from unique_web_search.services.search_engine.base import (
@@ -101,12 +102,13 @@ class CustomAPI(SearchEngine[CustomAPIConfig]):
         self.is_configured = True  # No possibility to check if the API is configured from our side. So we assume it is configured.
 
     @override
-    async def _proxy_search(self, query: str, **kwargs) -> list[WebSearchResult]:
-        return await self._legacy_search(query=query, **kwargs)
-
-    @override
-    async def _legacy_search(self, query: str, **kwargs) -> list[WebSearchResult]:
-        params, body = self._prepare_request_params_and_body(query)
+    async def _legacy_search(
+        self,
+        query: str,
+        params: ExposedParams | None,
+    ) -> list[WebSearchResult]:
+        del params
+        params_dict, body = self._prepare_request_params_and_body(query)
         async_client_params = self._client_config | {
             "timeout": self.config.timeout,
         }
@@ -115,7 +117,7 @@ class CustomAPI(SearchEngine[CustomAPIConfig]):
                 method=self._request_method,
                 headers=self._headers,
                 url=self.api_endpoint,
-                params=params,
+                params=params_dict,
                 json=body,
             )
 

--- a/tool_packages/unique_web_search/src/unique_web_search/services/search_engine/google.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/search_engine/google.py
@@ -1,62 +1,25 @@
 import logging
-from typing import Any, cast, override
+from typing import override
 from urllib.parse import urlparse
 
 from httpx import Response
-from unique_search_proxy_core.param_policy.exposable_param import ExposableParam
+from pydantic import BaseModel
+from unique_search_proxy_core.param_policy.exposed_params import ExposedParams
 from unique_search_proxy_core.search_engines.base import SearchEngineType
-from unique_search_proxy_core.search_engines.google.schema import (
-    GoogleConfig,
-    GoogleSiteSearchFilter,
-)
+from unique_search_proxy_core.search_engines.google.schema import GoogleConfig
 
 from unique_web_search.client_settings import get_google_search_settings
 from unique_web_search.services.client.proxy_config import async_client
-from unique_web_search.services.proxy.bridge import (
-    open_search_proxy_client,
-)
-from unique_web_search.services.proxy.mappers import map_search_response
 from unique_web_search.services.search_engine.base import SearchEngine, SearchEngineMode
 from unique_web_search.services.search_engine.registry import register_search_engine
 from unique_web_search.services.search_engine.schema import (
     WebSearchResult,
 )
-from unique_web_search.services.search_engine.utils.google.schema import (
-    GoogleSearchQueryParams,
-)
 
 _LOGGER = logging.getLogger(__name__)
 
-# Pagingation size fixed to 10 because of the Google Search API limit
+# Pagination size fixed to 10 because of the Google Search API limit
 PAGINATION_SIZE = 10
-
-_EXPOSABLE_LEGACY_API_KEYS: tuple[tuple[str, str], ...] = (
-    ("gl", "gl"),
-    ("hl", "hl"),
-    ("lr", "lr"),
-    ("date_restrict", "dateRestrict"),
-    ("exact_terms", "exactTerms"),
-    ("exclude_terms", "excludeTerms"),
-    ("file_type", "fileType"),
-    ("site_search", "siteSearch"),
-    ("site_search_filter", "siteSearchFilter"),
-    ("sort", "sort"),
-)
-
-
-def _exposable_value(param: ExposableParam[Any]) -> Any | None:
-    if param.is_active():
-        return param.value
-    return None
-
-
-def _google_legacy_query_params(config: GoogleConfig) -> dict[str, Any]:
-    params: dict[str, Any] = {"safe": config.safe}
-    for field_name, api_key in _EXPOSABLE_LEGACY_API_KEYS:
-        value = _exposable_value(getattr(config, field_name))
-        if value is not None:
-            params[api_key] = value
-    return params
 
 
 @register_search_engine(
@@ -67,44 +30,22 @@ def _google_legacy_query_params(config: GoogleConfig) -> dict[str, Any]:
     config_display_name="Google Search",
 )
 class GoogleSearch(SearchEngine[GoogleConfig]):
-    supports_proxy_search = True
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._additional_params = _google_legacy_query_params(self.config)
-
     @property
     def requires_scraping(self) -> bool:
         return True
 
     @override
-    async def _proxy_search(self, query: str, **kwargs) -> list[WebSearchResult]:
-        async with open_search_proxy_client(timeout=30.0) as client:
-            response = await client.search.google(
-                query=query,
-                fetch_size=self.config.fetch_size,
-                search_engine_id=self.config.search_engine_id,
-                gl=_exposable_value(self.config.gl),
-                hl=_exposable_value(self.config.hl),
-                lr=_exposable_value(self.config.lr),
-                date_restrict=_exposable_value(self.config.date_restrict),
-                exact_terms=_exposable_value(self.config.exact_terms),
-                exclude_terms=_exposable_value(self.config.exclude_terms),
-                file_type=_exposable_value(self.config.file_type),
-                site_search=_exposable_value(self.config.site_search),
-                site_search_filter=cast(
-                    GoogleSiteSearchFilter | None,
-                    _exposable_value(self.config.site_search_filter),
-                ),
-                sort=_exposable_value(self.config.sort),
-            )
-            return map_search_response(response)
-
-    @override
-    async def _legacy_search(self, query: str, **kwargs) -> list[WebSearchResult]:
+    async def _legacy_search(
+        self,
+        query: str,
+        params: ExposedParams | None,
+    ) -> list[WebSearchResult]:
         """Search the web for the given query."""
         try:
-            search_results = await self._paginated_url_extraction(query=query, **kwargs)
+            search_results = await self._paginated_url_extraction(
+                query=query,
+                params=params,
+            )
             _LOGGER.info(f"Found {len(search_results)} URLs")
 
         except Exception as e:
@@ -113,18 +54,21 @@ class GoogleSearch(SearchEngine[GoogleConfig]):
 
         return search_results
 
-    async def _perform_web_search_request(self, query: str, **kwargs) -> Response:
-        """Send a request to the search engine.
-
-        Args:
-            query: The query.
-            start_index: The start index.
-
-        Returns:
-            list[dict]: The search results.
-
-        """
-        request_params = self._get_request_params(query=query, **kwargs)
+    async def _perform_web_search_request(
+        self,
+        query: str,
+        params: ExposedParams | None,
+        *,
+        start_index: int,
+        num_fetch: int,
+    ) -> Response:
+        """Send a request to the search engine."""
+        request_params = self._get_request_params(
+            query=query,
+            params=params,
+            start_index=start_index,
+            num_fetch=num_fetch,
+        )
         async with async_client() as client:
             response = await client.get(**request_params)
         return response
@@ -139,41 +83,40 @@ class GoogleSearch(SearchEngine[GoogleConfig]):
             ],
         )
 
-    def _update_pagination_params(self, start_index: int, num_fetch: int):
-        self._additional_params = self._additional_params | {
-            "start": start_index,
-            "num": num_fetch,
-        }
+    def _merged_request(self, query: str, params: ExposedParams | None) -> BaseModel:
+        """Deployment defaults + call-time overrides -> validated Google request."""
+        overrides = (
+            params.model_dump(by_alias=True, exclude_none=True) if params else {}
+        )
+        return self.config.merge(overrides, query=query)
 
-    def _update_date_restrict_params(self, date_restrict: str | None):
-        if date_restrict:
-            self._additional_params = self._additional_params | {
-                "dateRestrict": date_restrict,
-            }
-
-    def _get_request_params(self, query, **kwargs) -> dict:
+    def _get_request_params(
+        self,
+        query: str,
+        params: ExposedParams | None,
+        *,
+        start_index: int,
+        num_fetch: int,
+    ) -> dict:
         """Get the request parameters."""
-        # Ensure required settings are available
         google_search_settings = get_google_search_settings()
         assert google_search_settings.is_configured
         assert google_search_settings.search_engine_id is not None
         assert google_search_settings.api_key is not None
+        assert google_search_settings.api_endpoint is not None
 
-        # Create query parameters using the Pydantic model
-        query_params = GoogleSearchQueryParams(
-            q=query,
-            cx=google_search_settings.search_engine_id,
-            key=google_search_settings.api_key,
-        ).model_dump(exclude_none=True)
-
-        self._update_date_restrict_params(kwargs.get("date_restrict", None))
-
-        params = {
+        request = self._merged_request(query, params)
+        return {
             "url": google_search_settings.api_endpoint,
-            "params": query_params | self._additional_params,
+            "params": {
+                "q": query,
+                "cx": google_search_settings.search_engine_id,
+                "key": google_search_settings.api_key,
+                "start": start_index,
+                "num": num_fetch,
+                **GoogleConfig.provider_query_params(request),
+            },
         }
-
-        return params
 
     def _extract_urls(self, response: Response) -> list[WebSearchResult]:
         """Clean the response from the search engine."""
@@ -188,11 +131,14 @@ class GoogleSearch(SearchEngine[GoogleConfig]):
         ]
         return links
 
-    async def _paginated_url_extraction(self, query: str, **kwargs):
+    async def _paginated_url_extraction(
+        self,
+        query: str,
+        params: ExposedParams | None,
+    ):
         """Extract the URLs from the search results."""
 
         search_results = []
-        start_index = 1
         fetch_size = self.config.fetch_size
 
         for start_index in range(1, fetch_size + 1, PAGINATION_SIZE):
@@ -200,10 +146,12 @@ class GoogleSearch(SearchEngine[GoogleConfig]):
             _LOGGER.info(
                 f"Fetching {effective_num_fetch} URLs from {start_index} to {start_index + effective_num_fetch - 1}"
             )
-            self._update_pagination_params(
-                start_index=start_index, num_fetch=effective_num_fetch
+            response = await self._perform_web_search_request(
+                query=query,
+                params=params,
+                start_index=start_index,
+                num_fetch=effective_num_fetch,
             )
-            response = await self._perform_web_search_request(query=query, **kwargs)
             search_results.extend(self._extract_urls(response=response))
 
         return search_results

--- a/tool_packages/unique_web_search/src/unique_web_search/services/search_engine/perplexity.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/search_engine/perplexity.py
@@ -1,5 +1,6 @@
 from typing import override
 
+from unique_search_proxy_core.param_policy.exposed_params import ExposedParams
 from unique_search_proxy_core.search_engines.base import SearchEngineType
 from unique_search_proxy_core.search_engines.perplexity.schema import (
     PerplexityConfig,
@@ -7,10 +8,8 @@ from unique_search_proxy_core.search_engines.perplexity.schema import (
 
 from unique_web_search.client_settings import get_perplexity_search_settings
 from unique_web_search.services.proxy.bridge import (
-    open_search_proxy_client,
     search_proxy_client_enabled,
 )
-from unique_web_search.services.proxy.mappers import map_search_response
 from unique_web_search.services.search_engine.base import SearchEngine, SearchEngineMode
 from unique_web_search.services.search_engine.registry import register_search_engine
 from unique_web_search.services.search_engine.schema import (
@@ -26,8 +25,6 @@ from unique_web_search.services.search_engine.schema import (
     config_display_name="Perplexity Search",
 )
 class PerplexitySearch(SearchEngine[PerplexityConfig]):
-    supports_proxy_search = True
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.is_configured = (
@@ -36,27 +33,11 @@ class PerplexitySearch(SearchEngine[PerplexityConfig]):
         )
 
     @override
-    async def _proxy_search(self, query: str, **kwargs) -> list[WebSearchResult]:
-        async with open_search_proxy_client(timeout=30.0) as client:
-            response = await client.search.perplexity(
-                query=query,
-                fetch_size=self.config.fetch_size,
-                max_tokens=self.config.max_tokens,
-                max_tokens_per_page=self.config.max_tokens_per_page,
-                country=self.config.country.value,
-                search_context_size=self.config.search_context_size.value,
-                search_language_filter=self.config.search_language_filter.value,
-                search_domain_filter=self.config.search_domain_filter.value,
-                search_recency_filter=self.config.search_recency_filter.value,
-                last_updated_after_filter=self.config.last_updated_after_filter.value,
-                last_updated_before_filter=self.config.last_updated_before_filter.value,
-                search_after_date_filter=self.config.search_after_date_filter.value,
-                search_before_date_filter=self.config.search_before_date_filter.value,
-            )
-            return map_search_response(response)
-
-    @override
-    async def _legacy_search(self, query: str, **kwargs) -> list[WebSearchResult]:
+    async def _legacy_search(
+        self,
+        query: str,
+        params: ExposedParams | None,
+    ) -> list[WebSearchResult]:
         raise NotImplementedError(
             "Perplexity search is not supported in the legacy mode"
         )

--- a/tool_packages/unique_web_search/src/unique_web_search/services/search_engine/vertexai.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/search_engine/vertexai.py
@@ -7,17 +7,13 @@ from httpx import HTTPError
 from pydantic import Field
 from unique_search_proxy_core.agent_engines.base import AgentEngineType
 from unique_search_proxy_core.agent_engines.vertexai.schema import VertexAIAgentConfig
+from unique_search_proxy_core.param_policy.exposed_params import ExposedParams
 from unique_toolkit._common.default_language_model import DEFAULT_LANGUAGE_MODEL
 from unique_toolkit._common.validators import LMI, get_LMI_default_field
 from unique_toolkit.language_model import LanguageModelService
 
 from unique_web_search.services.proxy.bridge import (
-    open_search_proxy_client,
     search_proxy_client_enabled,
-)
-from unique_web_search.services.proxy.mappers import (
-    agent_answer_text,
-    map_agent_answer,
 )
 from unique_web_search.services.search_engine.base import SearchEngine, SearchEngineMode
 from unique_web_search.services.search_engine.registry import register_search_engine
@@ -66,8 +62,6 @@ class VertexAIConfig(VertexAIAgentConfig):
     needs_language_model=True,
 )
 class VertexAI(SearchEngine[VertexAIConfig]):
-    supports_proxy_search = True
-
     def __init__(
         self,
         config: VertexAIConfig,
@@ -90,28 +84,22 @@ class VertexAI(SearchEngine[VertexAIConfig]):
         return self.config.requires_scraping
 
     @override
-    async def _proxy_search(self, query: str, **kwargs) -> list[WebSearchResult]:
-        async with open_search_proxy_client(
-            timeout=float(self.config.timeout)
-        ) as client:
-            response = await client.agent_search.vertexai(
-                query=query,
-                vertexai_model_name=self.config.vertexai_model_name,
-                generation_instructions=self.config.generation_instructions,
-                enable_enterprise_search=self.config.enable_enterprise_search,
-                timeout=self.config.timeout,
-            )
-            results = await map_agent_answer(
-                agent_answer_text(response),
-                self.response_parsers,
-            )
-            if self.config.enable_redirect_resolution:
-                resolved = await resolve_all(WebSearchResults(results=results))
-                return resolved.results
-            return results
+    async def _postprocess_results(
+        self,
+        results: list[WebSearchResult],
+    ) -> list[WebSearchResult]:
+        if self.config.enable_redirect_resolution:
+            resolved = await resolve_all(WebSearchResults(results=results))
+            return resolved.results
+        return results
 
     @override
-    async def _legacy_search(self, query: str, **kwargs) -> list[WebSearchResult]:
+    async def _legacy_search(
+        self,
+        query: str,
+        params: ExposedParams | None,
+    ) -> list[WebSearchResult]:
+        del params
         assert self._client is not None, "VertexAI client is not configured"
 
         response = await generate_vertexai_response(
@@ -130,11 +118,7 @@ class VertexAI(SearchEngine[VertexAIConfig]):
             answer_with_citations, self.response_parsers
         )
 
-        if self.config.enable_redirect_resolution:
-            resolved = await resolve_all(WebSearchResults(results=results))
-            results = resolved.results
-
-        return results
+        return await self._postprocess_results(results)
 
 
 async def resolve_url(client: HttpxAsyncClient, web_search_result: WebSearchResult):

--- a/tool_packages/unique_web_search/src/unique_web_search/utils.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/utils.py
@@ -9,37 +9,6 @@ from unique_web_search.schema import WebPageChunk
 _LOGGER = getLogger(__name__)
 
 
-def query_params_to_human_string(query: str, date_restrict: str | None) -> str:
-    """
-    Converts the WebSearchToolParameters and optional date_restrict to a human-understandable string.
-    Maps date_restrict codes to human-readable periods.
-    """
-    query_str = f"{query}"
-    if date_restrict:
-        # Map date_restrict codes to human-readable strings
-        mapping = {
-            "d": "day",
-            "w": "week",
-            "m": "month",
-            "y": "year",
-        }
-        import re
-
-        match = re.fullmatch(r"([dwmy])(\d+)", date_restrict)
-        if match:
-            period, number = match.groups()
-            period_str = mapping.get(period, period)
-            # Pluralize if number > 1
-            if number == "1":
-                date_str = f"1 {period_str}"
-            else:
-                date_str = f"{number} {period_str}s"
-        else:
-            date_str = date_restrict
-        query_str += f" (For the last {date_str})"
-    return query_str
-
-
 def _get_max_tokens(
     language_model_max_input_tokens: int | None,
     percentage_of_input_tokens_for_sources: float,

--- a/tool_packages/unique_web_search/tests/conftest.py
+++ b/tool_packages/unique_web_search/tests/conftest.py
@@ -46,9 +46,7 @@ def event_loop():
 @pytest.fixture
 def sample_web_search_tool_parameters():
     """Sample WebSearchToolParameters for testing."""
-    return WebSearchToolParameters(
-        query="Python web scraping best practices", date_restrict="m1"
-    )
+    return WebSearchToolParameters(query="Python web scraping best practices")
 
 
 @pytest.fixture
@@ -144,10 +142,6 @@ def mock_web_search_config_v1():
     config.web_search_mode_config.tool_description_for_system_prompt = (
         "V1 system prompt"
     )
-    config.web_search_mode_config.tool_parameters_description.query_description = (
-        "Query description"
-    )
-    config.web_search_mode_config.tool_parameters_description.date_restrict_description = "Date restrict description"
     config.web_search_mode_config.refine_query_mode.mode = Mock()
     config.web_search_mode_config.refine_query_mode.language_model = Mock()
     config.web_search_mode_config.max_queries = 5

--- a/tool_packages/unique_web_search/tests/test_basic_functionality.py
+++ b/tool_packages/unique_web_search/tests/test_basic_functionality.py
@@ -1,7 +1,10 @@
 import pytest
 from unique_search_proxy_core.agent_engines import AgentEngineType
 from unique_search_proxy_core.search_engines import SearchEngineType
-from unique_search_proxy_core.search_engines.google.schema import GoogleConfig
+from unique_search_proxy_core.search_engines.google.schema import (
+    ExposableStrOrNone,
+    GoogleConfig,
+)
 
 from unique_web_search.services.crawlers.base import CrawlerType
 from unique_web_search.services.crawlers.basic import BasicCrawlerConfig
@@ -10,7 +13,6 @@ from unique_web_search.services.executors.v2.schema import Step, StepType, WebSe
 from unique_web_search.services.search_engine.base import (
     LocalSearchEngineType,
 )
-from unique_web_search.utils import query_params_to_human_string
 
 
 class TestWebSearchSchema:
@@ -18,13 +20,18 @@ class TestWebSearchSchema:
 
     def test_web_search_tool_parameters_basic(self):
         """Test basic WebSearchToolParameters creation."""
-        params = WebSearchToolParameters(query="Python programming", date_restrict=None)
+        params = WebSearchToolParameters(query="Python programming")
         assert params.query == "Python programming"
-        assert params.date_restrict is None
 
-    def test_web_search_tool_parameters_with_date(self):
-        """Test WebSearchToolParameters with date restriction."""
-        params = WebSearchToolParameters(query="Recent AI news", date_restrict="w1")
+    def test_web_search_tool_parameters_with_exposed_date(self):
+        """Test WebSearchToolParameters with exposed date restriction."""
+        config = GoogleConfig(
+            date_restrict=ExposableStrOrNone(expose=True, value=None)
+        )
+        Params = WebSearchToolParameters.with_exposed_params(
+            config.exposed_params_model()
+        )
+        params = Params(query="Recent AI news", dateRestrict="w1")
         assert params.query == "Recent AI news"
         assert params.date_restrict == "w1"
 
@@ -70,40 +77,6 @@ class TestWebSearchSchema:
         """Test StepType enum values."""
         assert StepType.SEARCH == "search"
         assert StepType.READ_URL == "read_url"
-
-
-class TestUtilityFunctions:
-    """Test utility functions."""
-
-    def test_query_params_to_human_string_no_date(self):
-        """Test query conversion without date restriction."""
-        result = query_params_to_human_string("Python tutorials", None)
-        assert result == "Python tutorials"
-
-    def test_query_params_to_human_string_with_date(self):
-        """Test query conversion with date restriction."""
-        result = query_params_to_human_string("Recent news", "d7")
-        assert result == "Recent news (For the last 7 days)"
-
-    def test_query_params_to_human_string_single_day(self):
-        """Test query conversion with single day."""
-        result = query_params_to_human_string("Today's news", "d1")
-        assert result == "Today's news (For the last 1 day)"
-
-    def test_query_params_to_human_string_weeks(self):
-        """Test query conversion with weeks."""
-        result = query_params_to_human_string("Weekly report", "w2")
-        assert result == "Weekly report (For the last 2 weeks)"
-
-    def test_query_params_to_human_string_months(self):
-        """Test query conversion with months."""
-        result = query_params_to_human_string("Monthly data", "m3")
-        assert result == "Monthly data (For the last 3 months)"
-
-    def test_query_params_to_human_string_years(self):
-        """Test query conversion with years."""
-        result = query_params_to_human_string("Historical data", "y1")
-        assert result == "Historical data (For the last 1 year)"
 
 
 class TestConfigurationBasics:

--- a/tool_packages/unique_web_search/tests/test_basic_functionality.py
+++ b/tool_packages/unique_web_search/tests/test_basic_functionality.py
@@ -25,9 +25,7 @@ class TestWebSearchSchema:
 
     def test_web_search_tool_parameters_with_exposed_date(self):
         """Test WebSearchToolParameters with exposed date restriction."""
-        config = GoogleConfig(
-            date_restrict=ExposableStrOrNone(expose=True, value=None)
-        )
+        config = GoogleConfig(date_restrict=ExposableStrOrNone(expose=True, value=None))
         Params = WebSearchToolParameters.with_exposed_params(
             config.exposed_params_model()
         )

--- a/tool_packages/unique_web_search/tests/test_brave.py
+++ b/tool_packages/unique_web_search/tests/test_brave.py
@@ -27,13 +27,12 @@ class TestBraveSearchConfig:
 
     def test_default_safesearch_value(self):
         config = BraveConfig()
-        assert config.safesearch.value == "moderate"
-        assert config.safesearch.expose is False
+        assert config.safesearch == "moderate"
 
-    def test_default_country_is_inactive(self):
+    def test_default_country_is_inactive_expose(self):
         config = BraveConfig()
-        assert config.country.value is None
         assert config.country.expose is False
+        assert config.country.value == "US"
 
 
 @pytest.fixture
@@ -69,7 +68,7 @@ class TestBraveSearch:
             NotImplementedError,
             match="Brave search is not supported in the legacy mode",
         ):
-            await search._legacy_search("query")
+            await search._legacy_search("query", params=None)
 
     @pytest.mark.asyncio
     async def test_proxy_search_passes_config_to_client(self, _mock_brave_settings):
@@ -85,7 +84,7 @@ class TestBraveSearch:
                 content="",
             )
         ]
-        mock_brave = AsyncMock(return_value=mock_response)
+        mock_search = AsyncMock(return_value=mock_response)
 
         with (
             patch(
@@ -93,33 +92,24 @@ class TestBraveSearch:
                 True,
             ),
             patch(
-                "unique_web_search.services.search_engine.brave.open_search_proxy_client"
+                "unique_web_search.services.search_engine.base.open_search_proxy_client"
             ) as mock_open_client,
         ):
             mock_client = AsyncMock()
-            mock_client.search.brave = mock_brave
+            mock_client.search.search = mock_search
             mock_open_client.return_value.__aenter__.return_value = mock_client
 
             results = await search.search("test query")
 
-        mock_brave.assert_awaited_once_with(
-            query="test query",
-            fetch_size=3,
-            extra_snippets=True,
-            spellcheck=False,
-            text_decorations=True,
-            operators=True,
-            ui_lang="en-US",
-            units=None,
-            summary=True,
-            include_fetch_metadata=False,
-            goggles=None,
-            country=None,
-            freshness=None,
-            search_lang=None,
-            safesearch="moderate",
-            result_filter=None,
-        )
+        mock_search.assert_awaited_once()
+        call_kwargs = mock_search.await_args.kwargs
+        assert call_kwargs["query"] == "test query"
+        assert call_kwargs["engine"] == "brave"
+        assert call_kwargs["fetch_size"] == 3
+        assert call_kwargs["extra_snippets"] is True
+        assert call_kwargs["safesearch"] == "moderate"
+        assert call_kwargs["country"] == "US"
+        assert call_kwargs["search_lang"] == "en"
         assert results == [
             WebSearchResult(
                 url="https://example.com/page",

--- a/tool_packages/unique_web_search/tests/test_config.py
+++ b/tool_packages/unique_web_search/tests/test_config.py
@@ -27,7 +27,6 @@ from unique_web_search.services.executors.base_config import WebSearchMode
 from unique_web_search.services.executors.v1.config import (
     QueryRefinementConfig,
     RefineQueryMode,
-    WebSearchToolParametersDescriptionConfig,
     WebSearchV1Config,
 )
 from unique_web_search.services.executors.v2.config import WebSearchV2Config
@@ -267,27 +266,6 @@ class TestQueryRefinementConfig:
         config = QueryRefinementConfig(mode=RefineQueryMode.ADVANCED)
 
         assert config.mode == RefineQueryMode.ADVANCED
-
-
-class TestWebSearchToolParametersDescriptionConfig:
-    """Test cases for WebSearchToolParametersDescriptionConfig."""
-
-    def test_tool_parameters_description_config_defaults(self):
-        """Test WebSearchToolParametersDescriptionConfig with default values."""
-        config = WebSearchToolParametersDescriptionConfig()
-
-        assert "search query" in config.query_description.lower()
-        assert len(config.date_restrict_description) > 0
-
-    def test_tool_parameters_description_config_custom(self):
-        """Test WebSearchToolParametersDescriptionConfig with custom values."""
-        config = WebSearchToolParametersDescriptionConfig(
-            query_description="Custom query description",
-            date_restrict_description="Custom date restriction description",
-        )
-
-        assert config.query_description == "Custom query description"
-        assert config.date_restrict_description == "Custom date restriction description"
 
 
 class TestWebSearchConfig:
@@ -604,10 +582,6 @@ class TestWebSearchConfig:
                 system_prompt="Custom refinement prompt",
             ),
             max_queries=7,
-            tool_parameters_description=WebSearchToolParametersDescriptionConfig(
-                query_description="Custom query description",
-                date_restrict_description="Custom date description",
-            ),
         )
 
         config = WebSearchConfig(
@@ -640,10 +614,6 @@ class TestWebSearchConfig:
             == RefineQueryMode.ADVANCED
         )
         assert config.web_search_mode_config.max_queries == 7
-        assert (
-            config.web_search_mode_config.tool_parameters_description.query_description
-            == "Custom query description"
-        )
         assert config.debug is True
 
     def test_web_search_config_with_all_features_v2(self, mock_language_model_info):

--- a/tool_packages/unique_web_search/tests/test_executors.py
+++ b/tool_packages/unique_web_search/tests/test_executors.py
@@ -181,7 +181,7 @@ class TestWebSearchV1ExecutorInit:
         Why this matters: Ensures proper initialization of the executor.
         Setup summary: Provide all required dependencies.
         """
-        tool_parameters = WebSearchToolParameters(query="test", date_restrict=None)
+        tool_parameters = WebSearchToolParameters(query="test")
 
         executor = WebSearchV1Executor(
             services=executor_context_objects["services"],
@@ -216,9 +216,7 @@ class TestWebSearchV1ExecutorRun:
         Why this matters: Ensures the main execution flow works correctly.
         Setup summary: Mock all services to return successful results.
         """
-        tool_parameters = WebSearchToolParameters(
-            query="test query", date_restrict=None
-        )
+        tool_parameters = WebSearchToolParameters(query="test query")
 
         mock_executor_dependencies["search_service"].search = AsyncMock(
             return_value=sample_web_search_results
@@ -257,9 +255,7 @@ class TestWebSearchV1ExecutorRun:
         Why this matters: Some search engines don't return content, requiring crawling.
         Setup summary: Set requires_scraping=True on search service.
         """
-        tool_parameters = WebSearchToolParameters(
-            query="test query", date_restrict=None
-        )
+        tool_parameters = WebSearchToolParameters(query="test query")
 
         mock_executor_dependencies["search_service"].search = AsyncMock(
             return_value=sample_web_search_results
@@ -299,9 +295,7 @@ class TestWebSearchV1ExecutorRun:
         Why this matters: Search-driven crawl flows must not bypass the shared SSRF guard.
         Setup summary: Return a localhost URL from the search service with scraping enabled and assert CrawlTargetValidationError is raised.
         """
-        tool_parameters = WebSearchToolParameters(
-            query="test query", date_restrict=None
-        )
+        tool_parameters = WebSearchToolParameters(query="test query")
 
         mock_executor_dependencies["search_service"].search = AsyncMock(
             return_value=[
@@ -348,7 +342,7 @@ class TestWebSearchV1ExecutorRefineQuery:
         Why this matters: BASIC mode should return one refined query.
         Setup summary: Mock LLM to return a RefinedQuery.
         """
-        tool_parameters = WebSearchToolParameters(query="test", date_restrict=None)
+        tool_parameters = WebSearchToolParameters(query="test")
 
         mock_response = Mock()
         mock_response.choices = [Mock()]
@@ -389,7 +383,7 @@ class TestWebSearchV1ExecutorRefineQuery:
         Why this matters: ADVANCED mode should return multiple refined queries.
         Setup summary: Mock LLM to return RefinedQueries.
         """
-        tool_parameters = WebSearchToolParameters(query="test", date_restrict=None)
+        tool_parameters = WebSearchToolParameters(query="test")
 
         mock_response = Mock()
         mock_response.choices = [Mock()]
@@ -437,7 +431,7 @@ class TestWebSearchV1ExecutorEnforceMaxQueries:
         Why this matters: Queries under the limit should not be truncated.
         Setup summary: Provide queries list smaller than max_queries.
         """
-        tool_parameters = WebSearchToolParameters(query="test", date_restrict=None)
+        tool_parameters = WebSearchToolParameters(query="test")
 
         executor = WebSearchV1Executor(
             services=executor_context_objects["services"],
@@ -467,7 +461,7 @@ class TestWebSearchV1ExecutorEnforceMaxQueries:
         Why this matters: Prevents excessive queries that could slow down execution.
         Setup summary: Provide queries list larger than max_queries.
         """
-        tool_parameters = WebSearchToolParameters(query="test", date_restrict=None)
+        tool_parameters = WebSearchToolParameters(query="test")
 
         executor = WebSearchV1Executor(
             services=executor_context_objects["services"],

--- a/tool_packages/unique_web_search/tests/test_exposed_params.py
+++ b/tool_packages/unique_web_search/tests/test_exposed_params.py
@@ -1,0 +1,179 @@
+"""Tests for flat engine-exposed parameter injection (V1 and V3)."""
+
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+from unique_search_proxy_core.param_policy.exposed_params import ExposedParams
+from unique_search_proxy_core.search_engines.google.schema import (
+    ExposableStrOrNone,
+    GoogleConfig,
+)
+from unique_toolkit.content import ContentChunk
+from unique_toolkit.language_model import LanguageModelFunction
+
+from unique_web_search.services.executors.base_executor import BaseWebSearchExecutor
+from unique_web_search.services.executors.context import (
+    ExecutorCallbacks,
+    ExecutorConfiguration,
+    ExecutorServiceContext,
+)
+from unique_web_search.services.executors.v1.schema import WebSearchToolParameters
+from unique_web_search.services.executors.v3.schema import (
+    SearchPayload,
+    WebSearchV3ToolParameters,
+)
+
+
+class _StubExecutor(BaseWebSearchExecutor[Any]):
+    """Concrete executor for unit-testing ``_extract_search_params``."""
+
+    async def run(self) -> list[ContentChunk]:
+        return []
+
+
+def _make_stub_executor(
+    exposed_params_cls: type[ExposedParams] | None,
+) -> _StubExecutor:
+    return _StubExecutor(
+        services=ExecutorServiceContext(
+            search_engine_service=None,  # type: ignore[arg-type]
+            crawler_service=None,  # type: ignore[arg-type]
+            content_processor=None,  # type: ignore[arg-type]
+            language_model_service=None,  # type: ignore[arg-type]
+            chunk_relevancy_sorter=None,
+        ),
+        config=ExecutorConfiguration(
+            chunk_relevancy_sort_config=None,  # type: ignore[arg-type]
+            company_id="test",
+            debug_info=None,  # type: ignore[arg-type]
+        ),
+        callbacks=ExecutorCallbacks(
+            message_log_callback=None,  # type: ignore[arg-type]
+            content_reducer=lambda x: x,
+            query_elicitation=None,  # type: ignore[arg-type]
+            tool_progress_reporter=None,
+        ),
+        tool_call=LanguageModelFunction(id="1", name="WebSearch", arguments={}),
+        tool_parameters=WebSearchToolParameters(query="q"),
+        exposed_params_cls=exposed_params_cls,
+    )
+
+
+class TestV1FlatExposedParams:
+    @pytest.mark.ai
+    def test_v1_tool_schema_includes_flat_exposed_fields(self) -> None:
+        config = GoogleConfig(
+            gl=ExposableStrOrNone(expose=True, value="us"),
+        )
+        exposed = config.exposed_params_model()
+        tool_model = WebSearchToolParameters.with_exposed_params(exposed)
+        assert "gl" in tool_model.model_fields
+        assert "parameters" not in tool_model.model_fields
+
+    @pytest.mark.ai
+    def test_v1_tool_schema_has_no_legacy_date_restrict_without_exposure(self) -> None:
+        config = GoogleConfig()
+        exposed = config.exposed_params_model()
+        tool_model = WebSearchToolParameters.with_exposed_params(exposed)
+        assert "date_restrict" not in tool_model.model_fields
+
+    @pytest.mark.ai
+    def test_v1_json_schema_uses_camel_case_aliases(self) -> None:
+        config = GoogleConfig(
+            date_restrict=ExposableStrOrNone(expose=True, value="d7"),
+        )
+        exposed = config.exposed_params_model()
+        tool_model = WebSearchToolParameters.with_exposed_params(exposed)
+        props = tool_model.model_json_schema()["properties"]
+        assert "dateRestrict" in props
+        assert "date_restrict" not in props
+        assert "title" not in props["dateRestrict"]
+        assert "default" not in props["dateRestrict"]
+
+    @pytest.mark.ai
+    def test_v1_rejects_misspelled_param(self) -> None:
+        config = GoogleConfig(
+            date_restrict=ExposableStrOrNone(expose=True, value=None),
+        )
+        exposed = config.exposed_params_model()
+        tool_model = WebSearchToolParameters.with_exposed_params(exposed)
+        with pytest.raises(ValidationError):
+            tool_model.model_validate(
+                {"query": "q", "search_domainfilter": "example.com"}
+            )
+
+
+class TestV3FlatExposedParams:
+    @pytest.mark.ai
+    def test_search_payload_includes_flat_exposed_fields(self) -> None:
+        config = GoogleConfig(
+            gl=ExposableStrOrNone(expose=True, value="us"),
+        )
+        exposed = config.exposed_params_model()
+        payload_model = SearchPayload.with_exposed_params(exposed)
+        assert "gl" in payload_model.model_fields
+        assert "parameters" not in payload_model.model_fields
+
+    @pytest.mark.ai
+    def test_search_payload_unchanged_when_nothing_exposed(self) -> None:
+        config = GoogleConfig()
+        exposed = config.exposed_params_model()
+        assert exposed is None
+        assert SearchPayload.with_exposed_params(exposed) is SearchPayload
+
+    @pytest.mark.ai
+    def test_v3_tool_schema_has_no_parameters_key(self) -> None:
+        config = GoogleConfig(
+            gl=ExposableStrOrNone(expose=True, value="us"),
+            date_restrict=ExposableStrOrNone(expose=True, value="d7"),
+        )
+        exposed = config.exposed_params_model()
+        tool_model = WebSearchV3ToolParameters.with_exposed_params(exposed)
+        schema = tool_model.model_json_schema()
+        payload_props = schema["$defs"]["SearchPayload"]["properties"]
+        assert "parameters" not in payload_props
+        assert "gl" in payload_props
+        # Exposed to the LLM under the camelCase alias, not the snake_case name.
+        assert "dateRestrict" in payload_props
+        assert "date_restrict" not in payload_props
+        assert "title" not in payload_props["gl"]
+        assert "default" not in payload_props["gl"]
+
+    @pytest.mark.ai
+    def test_schema_hint_renders_camel_case_aliases(self) -> None:
+        config = GoogleConfig(
+            date_restrict=ExposableStrOrNone(expose=True, value=None),
+        )
+        exposed = config.exposed_params_model()
+        hint = WebSearchV3ToolParameters.schema_hint(exposed)
+        assert "dateRestrict" in hint
+        assert "date_restrict" not in hint
+
+
+class TestExtractSearchParams:
+    @pytest.mark.ai
+    def test_extract_omits_none_and_tool_only_fields(self) -> None:
+        config = GoogleConfig(
+            gl=ExposableStrOrNone(expose=True, value="us"),
+            date_restrict=ExposableStrOrNone(expose=True, value="d7"),
+        )
+        exposed = config.exposed_params_model()
+        assert exposed is not None
+        PayloadModel = SearchPayload.with_exposed_params(exposed)
+        payload = PayloadModel(gap="facet", query="q", gl="ch")
+
+        executor = _make_stub_executor(exposed)
+        params = executor._extract_search_params(payload)
+
+        assert params is not None
+        assert params.model_dump(by_alias=True, exclude_none=True) == {"gl": "ch"}
+        dumped = params.model_dump(exclude_none=True)
+        assert "gap" not in dumped
+        assert "query" not in dumped
+
+    @pytest.mark.ai
+    def test_extract_returns_none_when_no_class(self) -> None:
+        executor = _make_stub_executor(None)
+        params = executor._extract_search_params(WebSearchToolParameters(query="q"))
+        assert params is None

--- a/tool_packages/unique_web_search/tests/test_google.py
+++ b/tool_packages/unique_web_search/tests/test_google.py
@@ -2,7 +2,10 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from unique_search_proxy_core.param_policy.exposable_param import ExposableParam
-from unique_search_proxy_core.search_engines.google.schema import GoogleConfig
+from unique_search_proxy_core.search_engines.google.schema import (
+    ExposableStrOrNone,
+    GoogleConfig,
+)
 
 from unique_web_search.services.search_engine.google import GoogleSearch
 from unique_web_search.services.search_engine.schema import WebSearchResult
@@ -10,7 +13,7 @@ from unique_web_search.services.search_engine.schema import WebSearchResult
 
 class TestGoogleSearch:
     @pytest.mark.asyncio
-    async def test_proxy_search_passes_flat_config_to_client(self):
+    async def test_proxy_search_passes_merged_config_to_client(self):
         config = GoogleConfig(
             fetch_size=3,
             search_engine_id="cx-123",
@@ -28,7 +31,7 @@ class TestGoogleSearch:
                 content="",
             )
         ]
-        mock_google = AsyncMock(return_value=mock_response)
+        mock_search = AsyncMock(return_value=mock_response)
 
         with (
             patch(
@@ -36,30 +39,24 @@ class TestGoogleSearch:
                 True,
             ),
             patch(
-                "unique_web_search.services.search_engine.google.open_search_proxy_client"
+                "unique_web_search.services.search_engine.base.open_search_proxy_client"
             ) as mock_open_client,
         ):
             mock_client = AsyncMock()
-            mock_client.search.google = mock_google
+            mock_client.search.search = mock_search
             mock_open_client.return_value.__aenter__.return_value = mock_client
 
             results = await search.search("test query")
 
-        mock_google.assert_awaited_once_with(
-            query="test query",
-            fetch_size=3,
-            search_engine_id="cx-123",
-            gl="us",
-            hl=None,
-            lr=None,
-            date_restrict=None,
-            exact_terms=None,
-            exclude_terms=None,
-            file_type=None,
-            site_search="example.com",
-            site_search_filter=None,
-            sort=None,
-        )
+        mock_search.assert_awaited_once()
+        call_kwargs = mock_search.await_args.kwargs
+        assert call_kwargs["query"] == "test query"
+        assert call_kwargs["engine"] == "google"
+        assert call_kwargs["fetch_size"] == 3
+        assert call_kwargs["search_engine_id"] == "cx-123"
+        assert call_kwargs["gl"] == "us"
+        assert call_kwargs["site_search"] == "example.com"
+        assert "date_restrict" not in call_kwargs
         assert results == [
             WebSearchResult(
                 url="https://example.com/page",
@@ -68,7 +65,47 @@ class TestGoogleSearch:
             )
         ]
 
-    def test_legacy_additional_params_built_from_flat_fields(self):
+    def test_legacy_request_params_merge_config_and_call_overrides(self):
+        config = GoogleConfig(
+            safe="off",
+            gl=ExposableParam(expose=False, value="de"),
+            date_restrict=ExposableStrOrNone(expose=True, value="m1"),
+        )
+        search = GoogleSearch(config)
+        Exposed = config.exposed_params_model()
+        assert Exposed is not None
+        call_params = Exposed(dateRestrict="d7")
+
+        mock_settings = Mock(
+            is_configured=True,
+            search_engine_id="cx-legacy",
+            api_key="key-legacy",
+            api_endpoint="https://example.test/customsearch",
+        )
+        with patch(
+            "unique_web_search.services.search_engine.google.get_google_search_settings",
+            return_value=mock_settings,
+        ):
+            request = search._get_request_params(
+                query="ai news",
+                params=call_params,
+                start_index=1,
+                num_fetch=5,
+            )
+
+        assert request["url"] == "https://example.test/customsearch"
+        assert request["params"] == {
+            "q": "ai news",
+            "cx": "cx-legacy",
+            "key": "key-legacy",
+            "start": 1,
+            "num": 5,
+            "safe": "off",
+            "gl": "de",
+            "dateRestrict": "d7",
+        }
+
+    def test_legacy_request_params_use_config_defaults_without_call_params(self):
         config = GoogleConfig(
             safe="off",
             gl=ExposableParam(expose=False, value="de"),
@@ -76,7 +113,29 @@ class TestGoogleSearch:
         )
         search = GoogleSearch(config)
 
-        assert search._additional_params == {
+        mock_settings = Mock(
+            is_configured=True,
+            search_engine_id="cx-legacy",
+            api_key="key-legacy",
+            api_endpoint="https://example.test/customsearch",
+        )
+        with patch(
+            "unique_web_search.services.search_engine.google.get_google_search_settings",
+            return_value=mock_settings,
+        ):
+            request = search._get_request_params(
+                query="ai news",
+                params=None,
+                start_index=11,
+                num_fetch=10,
+            )
+
+        assert request["params"] == {
+            "q": "ai news",
+            "cx": "cx-legacy",
+            "key": "key-legacy",
+            "start": 11,
+            "num": 10,
             "safe": "off",
             "gl": "de",
             "dateRestrict": "m1",

--- a/tool_packages/unique_web_search/tests/test_perplexity.py
+++ b/tool_packages/unique_web_search/tests/test_perplexity.py
@@ -62,7 +62,7 @@ class TestPerplexitySearch:
             NotImplementedError,
             match="Perplexity search is not supported in the legacy mode",
         ):
-            await search._legacy_search("query")
+            await search._legacy_search("query", params=None)
 
     @pytest.mark.asyncio
     async def test_proxy_search_passes_config_to_client(
@@ -70,7 +70,7 @@ class TestPerplexitySearch:
     ):
         config = PerplexityConfig(
             fetch_size=3,
-            country="US",
+            country=ExposableStrOrNone(expose=False, value="US"),
             max_tokens=1024,
             max_tokens_per_page=512,
             search_recency_filter=ExposableRecencyFilter(expose=False, value="week"),
@@ -93,7 +93,7 @@ class TestPerplexitySearch:
                 content="",
             )
         ]
-        mock_perplexity = AsyncMock(return_value=mock_response)
+        mock_search = AsyncMock(return_value=mock_response)
 
         with (
             patch(
@@ -101,30 +101,30 @@ class TestPerplexitySearch:
                 True,
             ),
             patch(
-                "unique_web_search.services.search_engine.perplexity.open_search_proxy_client"
+                "unique_web_search.services.search_engine.base.open_search_proxy_client"
             ) as mock_open_client,
         ):
             mock_client = AsyncMock()
-            mock_client.search.perplexity = mock_perplexity
+            mock_client.search.search = mock_search
             mock_open_client.return_value.__aenter__.return_value = mock_client
 
             results = await search.search("test query")
 
-        mock_perplexity.assert_awaited_once_with(
-            query="test query",
-            fetch_size=3,
-            max_tokens=1024,
-            max_tokens_per_page=512,
-            country="US",
-            search_context_size=None,
-            search_language_filter=["en"],
-            search_domain_filter=["example.com"],
-            search_recency_filter="week",
-            last_updated_after_filter=None,
-            last_updated_before_filter=None,
-            search_after_date_filter="01/01/2024",
-            search_before_date_filter=None,
-        )
+        mock_search.assert_awaited_once()
+        call_kwargs = mock_search.await_args.kwargs
+        assert call_kwargs["query"] == "test query"
+        assert call_kwargs["engine"] == "perplexity"
+        assert call_kwargs["fetch_size"] == 3
+        assert call_kwargs["max_tokens"] == 1024
+        assert call_kwargs["max_tokens_per_page"] == 512
+        assert call_kwargs["country"] == "US"
+        assert call_kwargs["search_language_filter"] == ["en"]
+        assert call_kwargs["search_domain_filter"] == ["example.com"]
+        assert call_kwargs["search_recency_filter"] == "week"
+        assert call_kwargs["search_after_date_filter"] == "01/01/2024"
+        # search_context_size is dropped by Perplexity provider rules when token
+        # limits are set — merge still includes the config default; the SDK/server
+        # apply the omit rule. Here we only assert the merged kwargs from config.
         assert results == [
             WebSearchResult(
                 url="https://example.com/page",

--- a/tool_packages/unique_web_search/tests/test_schema.py
+++ b/tool_packages/unique_web_search/tests/test_schema.py
@@ -59,49 +59,38 @@ class TestWebSearchToolParameters:
 
     def test_valid_parameters(self):
         """Test creating valid WebSearchToolParameters."""
-        params = WebSearchToolParameters(
-            query="Python web scraping tutorial", date_restrict="m1"
-        )
+        params = WebSearchToolParameters(query="Python web scraping tutorial")
 
         assert params.query == "Python web scraping tutorial"
-        assert params.date_restrict == "m1"
-
-    def test_parameters_without_date_restrict(self):
-        """Test creating parameters without date restriction."""
-        params = WebSearchToolParameters(query="Python tutorial", date_restrict=None)
-
-        assert params.query == "Python tutorial"
-        assert params.date_restrict is None
 
     def test_empty_query_validation(self):
         """Test that query validation works as expected."""
-        params = WebSearchToolParameters(query="", date_restrict=None)
+        params = WebSearchToolParameters(query="")
         assert params.query == ""
 
-    def test_from_tool_parameter_query_description(self):
-        """Test creating model with custom query description."""
-        CustomParams = WebSearchToolParameters.from_tool_parameter_query_description(
-            query_description="Custom query description",
-            date_restrict_description="Custom date restrict description",
+    def test_with_exposed_params_from_google_config(self):
+        """Test grafting exposed Google knobs onto the V1 tool model."""
+        from unique_search_proxy_core.search_engines.google.schema import (
+            ExposableStrOrNone,
+            GoogleConfig,
         )
 
-        # Test that we can create an instance
-        params = CustomParams(query="test query", date_restrict="d1")
+        config = GoogleConfig(
+            date_restrict=ExposableStrOrNone(expose=True, value=None),
+        )
+        CustomParams = WebSearchToolParameters.with_exposed_params(
+            config.exposed_params_model()
+        )
+
+        params = CustomParams(query="test query", dateRestrict="d1")
 
         assert params.query == "test query"
         assert params.date_restrict == "d1"
         assert CustomParams.__name__ == "WebSearchToolParameters"
 
-    def test_from_tool_parameter_query_description_none_date_restrict(self):
-        """Test creating model with None date restrict description."""
-        CustomParams = WebSearchToolParameters.from_tool_parameter_query_description(
-            query_description="Custom query description", date_restrict_description=None
-        )
-
-        params = CustomParams(query="test query", date_restrict=None)
-
-        assert params.query == "test query"
-        assert params.date_restrict is None
+    def test_with_exposed_params_none_returns_base(self):
+        """Test that with_exposed_params(None) returns the base class."""
+        assert WebSearchToolParameters.with_exposed_params(None) is WebSearchToolParameters
 
 
 class TestStepType:

--- a/tool_packages/unique_web_search/tests/test_schema.py
+++ b/tool_packages/unique_web_search/tests/test_schema.py
@@ -90,7 +90,9 @@ class TestWebSearchToolParameters:
 
     def test_with_exposed_params_none_returns_base(self):
         """Test that with_exposed_params(None) returns the base class."""
-        assert WebSearchToolParameters.with_exposed_params(None) is WebSearchToolParameters
+        assert (
+            WebSearchToolParameters.with_exposed_params(None) is WebSearchToolParameters
+        )
 
 
 class TestStepType:

--- a/tool_packages/unique_web_search/tests/test_service.py
+++ b/tool_packages/unique_web_search/tests/test_service.py
@@ -33,6 +33,7 @@ class TestWebSearchToolDescription:
 
         tool = WebSearchTool.__new__(WebSearchTool)
         tool.config = mock_web_search_config_v1
+        tool.exposed_params_cls = None
         tool.tool_parameter_calls = None  # type: ignore
 
         result = tool.tool_description()
@@ -66,6 +67,7 @@ class TestWebSearchToolDescription:
 
         tool = WebSearchTool.__new__(WebSearchTool)
         tool.config = mock_web_search_config_v2
+        tool.exposed_params_cls = None
         tool.tool_parameter_calls = None  # type: ignore
         mock_engine = Mock()
         mock_engine.config.engine = SearchEngineType.GOOGLE
@@ -104,6 +106,7 @@ class TestWebSearchToolDescriptionForSystemPrompt:
 
         tool = WebSearchTool.__new__(WebSearchTool)
         tool.config = mock_web_search_config_v1
+        tool.exposed_params_cls = None
 
         result: str = tool.tool_description_for_system_prompt()
 
@@ -133,6 +136,7 @@ class TestWebSearchToolDescriptionForSystemPrompt:
 
         tool = WebSearchTool.__new__(WebSearchTool)
         tool.config = mock_web_search_config_v2
+        tool.exposed_params_cls = None
         mock_engine = Mock()
         mock_engine.config.engine = SearchEngineType.GOOGLE
         tool.search_engine_service = mock_engine
@@ -170,6 +174,7 @@ class TestWebSearchToolDescriptionForSystemPrompt:
 
         tool = WebSearchTool.__new__(WebSearchTool)
         tool.config = mock_web_search_config_v2
+        tool.exposed_params_cls = None
         mock_engine = Mock()
         mock_engine.config.engine = SearchEngineType.GOOGLE
         tool.search_engine_service = mock_engine
@@ -203,6 +208,7 @@ class TestWebSearchToolDescriptionForSystemPrompt:
 
         tool = WebSearchTool.__new__(WebSearchTool)
         tool.config = mock_web_search_config_v3
+        tool.exposed_params_cls = None
         mock_engine = Mock()
         mock_engine.config.engine = SearchEngineType.GOOGLE
         tool.search_engine_service = mock_engine
@@ -238,6 +244,7 @@ class TestWebSearchToolFormatInformation:
 
         tool = WebSearchTool.__new__(WebSearchTool)
         tool.config = mock_web_search_config_v1
+        tool.exposed_params_cls = None
 
         result: str = tool.tool_format_information_for_system_prompt()
 
@@ -264,6 +271,7 @@ class TestWebSearchToolFormatInformation:
 
         tool = WebSearchTool.__new__(WebSearchTool)
         tool.config = mock_web_search_config_v3
+        tool.exposed_params_cls = None
 
         result: str = tool.tool_format_information_for_system_prompt()
 
@@ -297,6 +305,7 @@ class TestWebSearchToolEvaluationCheckList:
 
         tool = WebSearchTool.__new__(WebSearchTool)
         tool.config = mock_web_search_config_v1
+        tool.exposed_params_cls = None
 
         result: list = tool.evaluation_check_list()
 
@@ -340,6 +349,7 @@ class TestWebSearchToolGetExecutor:
 
         tool = WebSearchTool.__new__(WebSearchTool)
         tool.config = mock_web_search_config_v2
+        tool.exposed_params_cls = None
         tool.search_engine_service = Mock()
         tool._language_model_service = Mock()
         tool.crawler_service = Mock()
@@ -399,6 +409,7 @@ class TestWebSearchToolGetExecutor:
 
         tool = WebSearchTool.__new__(WebSearchTool)
         tool.config = mock_web_search_config_v1
+        tool.exposed_params_cls = None
         tool.search_engine_service = Mock()
         tool._language_model_service = Mock()
         tool.crawler_service = Mock()
@@ -414,7 +425,7 @@ class TestWebSearchToolGetExecutor:
         tool._chat_service = Mock()
 
         tool_call = Mock()
-        parameters = WebSearchToolParameters(query="test", date_restrict=None)
+        parameters = WebSearchToolParameters(query="test")
         debug_info = Mock()
         web_search_message_logger = Mock()
 
@@ -453,6 +464,7 @@ class TestWebSearchToolGetExecutor:
 
         tool = WebSearchTool.__new__(WebSearchTool)
         tool.config = mock_web_search_config_v1
+        tool.exposed_params_cls = None
         tool._chat_service = Mock()
         tool._display_name = "Web Search"
         tool.settings = Mock()
@@ -527,6 +539,7 @@ class TestWebSearchToolGetEvaluationChecksBasedOnToolResponse:
 
         tool = WebSearchTool.__new__(WebSearchTool)
         tool.config = mock_web_search_config_v1
+        tool.exposed_params_cls = None
 
         tool_response = Mock()
         tool_response.content_chunks = []
@@ -558,6 +571,7 @@ class TestWebSearchToolGetEvaluationChecksBasedOnToolResponse:
 
         tool = WebSearchTool.__new__(WebSearchTool)
         tool.config = mock_web_search_config_v1
+        tool.exposed_params_cls = None
 
         tool_response = Mock()
         tool_response.content_chunks = sample_content_chunks
@@ -622,6 +636,7 @@ class TestWebSearchToolRun:
 
         tool = WebSearchTool.__new__(WebSearchTool)
         tool.config = mock_web_search_config_v1
+        tool.exposed_params_cls = None
         tool.tool_parameter_calls = WebSearchToolParameters
         tool.logger = Mock()
         tool._message_step_logger = Mock()
@@ -638,7 +653,7 @@ class TestWebSearchToolRun:
 
         tool_call = Mock()
         tool_call.id = "test-id"
-        tool_call.arguments = {"query": "test", "date_restrict": None}
+        tool_call.arguments = {"query": "test"}
 
         result = await tool.run(tool_call)
 
@@ -716,6 +731,7 @@ class TestWebSearchToolRun:
 
         tool = WebSearchTool.__new__(WebSearchTool)
         tool.config = mock_web_search_config_v1
+        tool.exposed_params_cls = None
         tool.tool_parameter_calls = WebSearchToolParameters
         tool.logger = Mock()
         tool._message_step_logger = Mock()
@@ -732,7 +748,7 @@ class TestWebSearchToolRun:
 
         tool_call = Mock()
         tool_call.id = "test-id"
-        tool_call.arguments = {"query": "test", "date_restrict": None}
+        tool_call.arguments = {"query": "test"}
 
         result = await tool.run(tool_call)
 
@@ -792,6 +808,7 @@ class TestWebSearchToolRun:
 
         tool = WebSearchTool.__new__(WebSearchTool)
         tool.config = mock_web_search_config_v3
+        tool.exposed_params_cls = None
         tool.tool_parameter_calls = WebSearchV3ToolParameters
         tool.logger = Mock()
         tool._message_step_logger = Mock()
@@ -867,6 +884,7 @@ class TestWebSearchToolRun:
 
         tool = WebSearchTool.__new__(WebSearchTool)
         tool.config = mock_web_search_config_v1
+        tool.exposed_params_cls = None
         tool.tool_parameter_calls = WebSearchToolParameters
         tool.logger = Mock()
         tool._message_step_logger = Mock()
@@ -883,7 +901,7 @@ class TestWebSearchToolRun:
 
         tool_call = Mock()
         tool_call.id = "test-id"
-        tool_call.arguments = {"query": "test", "date_restrict": None}
+        tool_call.arguments = {"query": "test"}
 
         result = await tool.run(tool_call)
 
@@ -951,6 +969,7 @@ class TestWebSearchToolRun:
 
         tool = WebSearchTool.__new__(WebSearchTool)
         tool.config = mock_web_search_config_v1
+        tool.exposed_params_cls = None
         tool.tool_parameter_calls = WebSearchToolParameters
         tool.logger = Mock()
         tool._message_step_logger = Mock()
@@ -973,7 +992,7 @@ class TestWebSearchToolRun:
 
         tool_call = Mock()
         tool_call.id = "test-id"
-        tool_call.arguments = {"query": "test", "date_restrict": None}
+        tool_call.arguments = {"query": "test"}
 
         await tool.run(tool_call)
 

--- a/tool_packages/unique_web_search/tests/test_utils.py
+++ b/tool_packages/unique_web_search/tests/test_utils.py
@@ -1,61 +1,6 @@
 import pytest
 
 from unique_web_search.schema import WebPageChunk
-from unique_web_search.utils import query_params_to_human_string
-
-
-class TestQueryParamsToHumanString:
-    """Test cases for query_params_to_human_string function."""
-
-    def test_query_without_date_restrict(self):
-        """Test query conversion without date restriction."""
-        result = query_params_to_human_string("Python tutorials", None)
-        assert result == "Python tutorials"
-
-    def test_query_with_single_day(self):
-        """Test query conversion with single day restriction."""
-        result = query_params_to_human_string("Python tutorials", "d1")
-        assert result == "Python tutorials (For the last 1 day)"
-
-    def test_query_with_multiple_days(self):
-        """Test query conversion with multiple days restriction."""
-        result = query_params_to_human_string("Python tutorials", "d7")
-        assert result == "Python tutorials (For the last 7 days)"
-
-    def test_query_with_single_week(self):
-        """Test query conversion with single week restriction."""
-        result = query_params_to_human_string("Python tutorials", "w1")
-        assert result == "Python tutorials (For the last 1 week)"
-
-    def test_query_with_multiple_weeks(self):
-        """Test query conversion with multiple weeks restriction."""
-        result = query_params_to_human_string("Python tutorials", "w2")
-        assert result == "Python tutorials (For the last 2 weeks)"
-
-    def test_query_with_single_month(self):
-        """Test query conversion with single month restriction."""
-        result = query_params_to_human_string("Python tutorials", "m1")
-        assert result == "Python tutorials (For the last 1 month)"
-
-    def test_query_with_multiple_months(self):
-        """Test query conversion with multiple months restriction."""
-        result = query_params_to_human_string("Python tutorials", "m6")
-        assert result == "Python tutorials (For the last 6 months)"
-
-    def test_query_with_single_year(self):
-        """Test query conversion with single year restriction."""
-        result = query_params_to_human_string("Python tutorials", "y1")
-        assert result == "Python tutorials (For the last 1 year)"
-
-    def test_query_with_multiple_years(self):
-        """Test query conversion with multiple years restriction."""
-        result = query_params_to_human_string("Python tutorials", "y2")
-        assert result == "Python tutorials (For the last 2 years)"
-
-    def test_query_with_invalid_date_restrict(self):
-        """Test query conversion with invalid date restriction format."""
-        result = query_params_to_human_string("Python tutorials", "invalid")
-        assert result == "Python tutorials (For the last invalid)"
 
 
 class TestWebPageChunk:


### PR DESCRIPTION
## Summary
- Wire `config.exposed_params_model()` into V1/V3 web-search tool schemas so admin-exposed engine knobs reach the LLM under camelCase aliases with `extra="forbid"`.
- Thread validated call-time params through executors into `SearchEngine.search`, then `config.merge` for proxy dispatch (centralized in `search_engine/base.py`).
- Align Google legacy requests with `provider_query_params`; drop V1 date-restrict description config and human-string notify formatting.

## Changes
- **Schemas / service:** V1 `with_exposed_params`, remove `WebSearchToolParametersDescriptionConfig`; V3 payload grafting + schema hints; resolve exposed model once at tool init.
- **Executors:** pass `exposed_params_cls`, extract via `model_validate`; V1 notifications use raw query strings.
- **Search engines:** shared proxy merge path; Google legacy uses `merge` + `provider_query_params` (no dateRestrict special-case).
- **Tests:** add `test_exposed_params.py`; update Google/service/schema coverage; remove obsolete util tests.

## Test plan
- [x] `pytest tool_packages/unique_web_search/tests/test_google.py`
- [x] `pytest tool_packages/unique_web_search/tests/test_service.py`
- [x] `pytest tool_packages/unique_web_search/tests/test_exposed_params.py`
- [x] Full `unique_web_search` suite in CI

## Risk / rollout
- V1 no longer ships configurable query/dateRestrict tool descriptions; exposed knobs come only from engine config.
- Tool schemas become stricter (`extra="forbid"`) for grafted params — malformed knob names fail validation instead of being dropped.

Refs: UN-21235


Made with [Cursor](https://cursor.com)