### PR TITLE
feat(unique_toolkit): Reenable file content serialization

### DIFF
--- a/unique_orchestrator/tests/test_unique_ai_builder_selected_uploaded_files.py
+++ b/unique_orchestrator/tests/test_unique_ai_builder_selected_uploaded_files.py
@@ -43,8 +43,6 @@ def _patch_constructors(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(f"{MODULE}.ToolProgressReporter", lambda **kw: MagicMock())
     monkeypatch.setattr(f"{MODULE}.ThinkingManager", lambda **kw: MagicMock())
     monkeypatch.setattr(f"{MODULE}.ReferenceManager", MagicMock)
-    monkeypatch.setattr(f"{MODULE}.HistoryManager", lambda *a, **kw: MagicMock())
-    monkeypatch.setattr(f"{MODULE}.HistoryManagerConfig", lambda **kw: MagicMock())
     monkeypatch.setattr(f"{MODULE}.EvaluationManager", lambda **kw: MagicMock())
     monkeypatch.setattr(f"{MODULE}.MCPManager", lambda **kw: MagicMock())
     monkeypatch.setattr(f"{MODULE}.A2AManager", lambda **kw: MagicMock())

--- a/unique_orchestrator/tests/test_unique_ai_builder_uploaded_search.py
+++ b/unique_orchestrator/tests/test_unique_ai_builder_uploaded_search.py
@@ -2,9 +2,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from unique_internal_search.uploaded_search.service import UploadedSearchTool
-from unique_toolkit.agentic.tools.experimental.open_file_tool.config import (
-    OpenFileToolConfig,
-)
+from unique_toolkit.agentic.tools.experimental.open_file_tool import OpenFileTool
 from unique_toolkit.agentic.tools.openai_builtin.base import OpenAIBuiltInToolName
 from unique_toolkit.agentic.tools.openai_builtin.code_interpreter.config import (
     CodeInterpreterExtendedConfig,
@@ -14,6 +12,10 @@ from unique_toolkit.agentic.tools.tool_manager import ToolManagerConfig
 from unique_toolkit.content.schemas import Content
 from unique_user_memory.user_memory import UserMemoryState
 
+from unique_orchestrator._builders.history_manager import (
+    build_history_manager,
+    serialize_uploaded_file_for_history,
+)
 from unique_orchestrator._builders.open_file_setup import configure_file_payload
 from unique_orchestrator.config import UniqueAIConfig, UploadedSearchToolConfig
 from unique_orchestrator.unique_ai_builder import (
@@ -34,7 +36,6 @@ def _make_common_components(uploaded_documents):
         uploaded_images=[],
         thinking_manager=MagicMock(),
         reference_manager=MagicMock(),
-        history_manager=MagicMock(),
         evaluation_manager=MagicMock(),
         postprocessor_manager=MagicMock(),
         message_step_logger=MagicMock(),
@@ -90,10 +91,6 @@ def _patch_build_common_user_memory(
     )
     monkeypatch.setattr(
         "unique_orchestrator.unique_ai_builder.ThinkingManager",
-        MagicMock(return_value=MagicMock()),
-    )
-    monkeypatch.setattr(
-        "unique_orchestrator.unique_ai_builder.HistoryManager",
         MagicMock(return_value=MagicMock()),
     )
     monkeypatch.setattr(
@@ -154,7 +151,6 @@ async def test_build_common_registers_user_memory_when_space_allow_user_memory(
     event, load_user_memory = _patch_build_common_user_memory(monkeypatch)
 
     config = UniqueAIConfig(space={"allowUserMemory": True})
-
     common_components = await _build_common(
         event=event,
         logger=MagicMock(),
@@ -172,6 +168,59 @@ async def test_build_common_registers_user_memory_when_space_allow_user_memory(
     assert "UserMemoryPostprocessor" in postprocessor_names
 
 
+class TestSerializeUploadedFileForHistory:
+    def test_describes_all_available_file_operations(self) -> None:
+        content = Content(id="cont_1", key="report.pdf")
+
+        result = serialize_uploaded_file_for_history(
+            content,
+            uploaded_search_available=True,
+            code_interpreter_available=True,
+        )
+
+        assert result == (
+            "User uploaded file: report.pdf (cont_1)\n"
+            "- Searchable using UploadedSearchTool\n"
+            "- Available for processing in the code execution container"
+        )
+
+    def test_omits_search_for_non_ingested_file(self) -> None:
+        content = Content(
+            id="cont_1",
+            key="report.pdf",
+            applied_ingestion_config={"uniqueIngestionMode": "SKIP_INGESTION"},
+        )
+
+        result = serialize_uploaded_file_for_history(
+            content,
+            uploaded_search_available=True,
+            code_interpreter_available=False,
+        )
+
+        assert result == "User uploaded file: report.pdf (cont_1)"
+
+    def test_excludes_code_interpreter_generated_file(self) -> None:
+        content = Content(
+            id="cont_1",
+            key="generated.csv",
+            metadata={
+                "codeExecutionArtifactMetadata": {
+                    "container_id": "container_1",
+                    "file_id": "file_1",
+                    "filepath": "/mnt/data/generated.csv",
+                }
+            },
+        )
+
+        result = serialize_uploaded_file_for_history(
+            content,
+            uploaded_search_available=True,
+            code_interpreter_available=True,
+        )
+
+        assert result is None
+
+
 class _FakeResponsesApiToolManager:
     instances = []
 
@@ -186,6 +235,29 @@ class _FakeResponsesApiToolManager:
 
     def add_tool(self, tool: object) -> None:
         return None
+
+    def get_tool_by_name(self, tool_name: str):
+        return next(
+            (
+                tool
+                for tool in self.kwargs["config"].tools
+                if tool.is_enabled and tool.name == tool_name
+            ),
+            None,
+        )
+
+
+def test_configure_file_payload_registers_open_file_tool() -> None:
+    config = UniqueAIConfig()
+    config.agent.experimental.open_file_tool_config.send_files_in_payload = True
+    event = _make_event(tool_choices=[])
+    tool_manager = MagicMock()
+
+    registry = configure_file_payload(config, event, tool_manager)
+
+    registered_tool = tool_manager.add_tool.call_args.args[0]
+    assert isinstance(registered_tool, OpenFileTool)
+    assert registry == []
 
 
 @pytest.mark.asyncio
@@ -357,27 +429,18 @@ async def test_build_responses_keeps_uploaded_search_when_code_interpreter_is_au
     ]
 
 
-def test_configure_file_payload_preserves_tool_call_persistence_and_language_model(
+def test_build_history_manager_uses_final_tool_availability(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     event = _make_event(tool_choices=[])
-    history_manager = MagicMock()
     reference_manager = MagicMock()
     logger = MagicMock()
     tool_manager = MagicMock()
-    config = UniqueAIConfig(
-        agent={
-            "input_token_distribution": {
-                "enable_tool_call_persistence": True,
-            },
-            "experimental": {
-                "responses_api_config": {"use_responses_api": True},
-                "open_file_tool_config": OpenFileToolConfig(
-                    enabled=True,
-                    send_uploaded_files_in_payload=True,
-                ),
-            },
-        }
+    tool_manager.get_tool_by_name.return_value = object()
+    config = UniqueAIConfig()
+    config.agent.input_token_distribution.enable_tool_call_persistence = True
+    config.agent.input_token_distribution.serialize_uploaded_files_in_user_message = (
+        True
     )
     language_model = config.space.language_model
 
@@ -391,36 +454,43 @@ def test_configure_file_payload_preserves_tool_call_persistence_and_language_mod
             config_arg,
             language_model_arg,
             reference_manager_arg,
+            *,
+            file_content_serializer,
         ):
             captured["logger"] = logger_arg
             captured["event"] = event_arg
             captured["config"] = config_arg
             captured["language_model"] = language_model_arg
             captured["reference_manager"] = reference_manager_arg
+            captured["file_content_serializer"] = file_content_serializer
 
     monkeypatch.setattr(
-        "unique_orchestrator._builders.open_file_setup.HistoryManager",
+        "unique_orchestrator._builders.history_manager.HistoryManager",
         _FakeHistoryManager,
     )
 
-    updated_history_manager, agent_file_registry = configure_file_payload(
-        config=config,
+    history_manager = build_history_manager(
         event=event,
         logger=logger,
-        history_manager=history_manager,
+        config=config,
         reference_manager=reference_manager,
-        language_model=language_model,
         tool_manager=tool_manager,
     )
 
-    assert updated_history_manager is not history_manager
-    assert agent_file_registry == []
+    assert isinstance(history_manager, _FakeHistoryManager)
     assert captured["logger"] is logger
     assert captured["event"] is event
     assert captured["language_model"] is language_model
     assert captured["reference_manager"] is reference_manager
     assert captured["config"].language_model is language_model
     assert captured["config"].enable_tool_call_persistence is True
+    file_content_serializer = captured["file_content_serializer"]
+    assert callable(file_content_serializer)
+    assert file_content_serializer(Content(id="cont_1", key="report.pdf")) == (
+        "User uploaded file: report.pdf (cont_1)\n"
+        "- Searchable using UploadedSearchTool\n"
+        "- Available for processing in the code execution container"
+    )
 
 
 class TestConfigureUploadedSearchToolIngestionFilter:

--- a/unique_orchestrator/unique_orchestrator/_builders/history_manager.py
+++ b/unique_orchestrator/unique_orchestrator/_builders/history_manager.py
@@ -1,0 +1,97 @@
+from functools import partial
+from logging import Logger
+
+from unique_internal_search.uploaded_search.service import UploadedSearchTool
+from unique_toolkit.agentic.history_manager import (
+    history_manager as history_manager_module,
+)
+from unique_toolkit.agentic.history_manager.history_construction_with_contents import (
+    FileContentSerializer,
+)
+from unique_toolkit.agentic.history_manager.history_manager import (
+    HistoryManager,
+    HistoryManagerConfig,
+)
+from unique_toolkit.agentic.reference_manager.reference_manager import ReferenceManager
+from unique_toolkit.agentic.tools.openai_builtin.base import OpenAIBuiltInToolName
+from unique_toolkit.agentic.tools.openai_builtin.code_interpreter.postprocessors.artifacts import (
+    load_code_execution_metadata,
+)
+from unique_toolkit.agentic.tools.tool_manager import (
+    ResponsesApiToolManager,
+    ToolManager,
+)
+from unique_toolkit.app.schemas import ChatEvent
+from unique_toolkit.content import Content
+
+from unique_orchestrator.config import UniqueAIConfig
+
+
+def serialize_uploaded_file_for_history(
+    content: Content,
+    *,
+    uploaded_search_available: bool,
+    code_interpreter_available: bool,
+) -> str | None:
+    """Serialize user-uploaded file metadata for model history."""
+    if load_code_execution_metadata(content) is not None:
+        return None
+
+    lines = [f"User uploaded file: {content.key} ({content.id})"]
+    if (
+        uploaded_search_available
+        and content.is_ingested(default_if_unknown=True)
+        and not content.is_expired()
+    ):
+        lines.append("- Searchable using UploadedSearchTool")
+    if code_interpreter_available:
+        lines.append("- Available for processing in the code execution container")
+    return "\n".join(lines)
+
+
+def _get_file_content_serializer(
+    config: UniqueAIConfig,
+    tool_manager: ToolManager | ResponsesApiToolManager,
+) -> FileContentSerializer | None:
+    if not config.agent.input_token_distribution.serialize_uploaded_files_in_user_message:
+        return None
+
+    return partial(
+        serialize_uploaded_file_for_history,
+        uploaded_search_available=(
+            tool_manager.get_tool_by_name(UploadedSearchTool.name) is not None
+        ),
+        code_interpreter_available=(
+            tool_manager.get_tool_by_name(OpenAIBuiltInToolName.CODE_INTERPRETER)
+            is not None
+        ),
+    )
+
+
+def build_history_manager(
+    *,
+    event: ChatEvent,
+    logger: Logger,
+    config: UniqueAIConfig,
+    reference_manager: ReferenceManager,
+    tool_manager: ToolManager | ResponsesApiToolManager,
+) -> HistoryManager:
+    """Build a history manager after the active tools are known."""
+    history_manager_config = HistoryManagerConfig(
+        experimental_features=history_manager_module.ExperimentalFeatures(),
+        percent_of_max_tokens_for_history=config.agent.input_token_distribution.percent_for_history,
+        language_model=config.space.language_model,
+        uploaded_content_config=config.agent.services.uploaded_content_config,
+        enable_tool_call_persistence=config.agent.input_token_distribution.enable_tool_call_persistence,
+    )
+    return HistoryManager(
+        logger,
+        event,
+        history_manager_config,
+        config.space.language_model,
+        reference_manager,
+        file_content_serializer=_get_file_content_serializer(
+            config=config,
+            tool_manager=tool_manager,
+        ),
+    )

--- a/unique_orchestrator/unique_orchestrator/_builders/open_file_setup.py
+++ b/unique_orchestrator/unique_orchestrator/_builders/open_file_setup.py
@@ -8,29 +8,15 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from logging import Logger
-from typing import TYPE_CHECKING
 
-from unique_toolkit.agentic.history_manager import (
-    history_manager as history_manager_module,
-)
-from unique_toolkit.agentic.history_manager.history_manager import (
-    HistoryManager,
-    HistoryManagerConfig,
-)
 from unique_toolkit.agentic.tools.experimental.open_file_tool import OpenFileTool
 from unique_toolkit.agentic.tools.tool_manager import (
     ResponsesApiToolManager,
 )
 from unique_toolkit.app.schemas import ChatEvent
 from unique_toolkit.content import Content
-from unique_toolkit.language_model.infos import LanguageModelInfo
 
 from unique_orchestrator.config import UniqueAIConfig
-
-if TYPE_CHECKING:
-    from unique_toolkit.agentic.reference_manager.reference_manager import (
-        ReferenceManager,
-    )
 
 
 def handle_uploaded_file_tool_choices(
@@ -76,39 +62,15 @@ def handle_uploaded_file_tool_choices(
 def configure_file_payload(
     config: UniqueAIConfig,
     event: ChatEvent,
-    logger: Logger,
-    history_manager: HistoryManager,
-    reference_manager: ReferenceManager,
-    language_model: LanguageModelInfo,
     tool_manager: ResponsesApiToolManager,
-) -> tuple[HistoryManager, list[str]]:
+) -> list[str]:
     """Configure file-in-payload handling for the Responses API.
 
-    When sending uploaded files as file parts, disables the UploadedContentConfig
-    mechanism so the HistoryManager doesn't also inject uploaded content as text
-    (which would duplicate what the input_file parts already provide).
+    Registers the OpenFileTool when send_files_in_payload is enabled, backed by
+    a shared registry for agent-requested KB file IDs.
 
-    Also registers the OpenFileTool when send_files_in_payload is enabled,
-    backed by a shared registry for agent-requested KB file IDs.
-
-    Returns the (possibly updated) history_manager and the agent file registry.
+    Returns the registry shared with the OpenFileTool.
     """
-    if config.agent.experimental.open_file_tool_config.send_uploaded_files_in_payload:
-        upload_free_config = HistoryManagerConfig(
-            experimental_features=history_manager_module.ExperimentalFeatures(),
-            percent_of_max_tokens_for_history=config.agent.input_token_distribution.percent_for_history,
-            language_model=language_model,
-            uploaded_content_config=None,
-            enable_tool_call_persistence=config.agent.input_token_distribution.enable_tool_call_persistence,
-        )
-        history_manager = HistoryManager(
-            logger,
-            event,
-            upload_free_config,
-            language_model,
-            reference_manager,
-        )
-
     agent_file_registry: list[str] = []
 
     if config.agent.experimental.open_file_tool_config.send_files_in_payload:
@@ -120,4 +82,4 @@ def configure_file_payload(
             )
         )
 
-    return history_manager, agent_file_registry
+    return agent_file_registry

--- a/unique_orchestrator/unique_orchestrator/config.py
+++ b/unique_orchestrator/unique_orchestrator/config.py
@@ -348,6 +348,11 @@ class HistoryConfig(BaseToolConfig):
         description="Persist tool calls and reconstruct tool call history across turns.",
     )
 
+    serialize_uploaded_files_in_user_message: bool = Field(
+        default=False,
+        description="Include an indication of each uploaded file in the user message.",
+    )
+
     def max_history_tokens(self, max_input_token: int) -> int:
         return int(self.percent_for_history * max_input_token)
 

--- a/unique_orchestrator/unique_orchestrator/unique_ai_builder.py
+++ b/unique_orchestrator/unique_orchestrator/unique_ai_builder.py
@@ -20,13 +20,7 @@ from unique_toolkit.agentic.evaluation.evaluation_manager import EvaluationManag
 from unique_toolkit.agentic.evaluation.hallucination.hallucination_evaluation import (
     HallucinationEvaluation,
 )
-from unique_toolkit.agentic.history_manager import (
-    history_manager as history_manager_module,
-)
-from unique_toolkit.agentic.history_manager.history_manager import (
-    HistoryManager,
-    HistoryManagerConfig,
-)
+from unique_toolkit.agentic.history_manager.history_manager import HistoryManager
 from unique_toolkit.agentic.message_log_manager.service import MessageStepLogger
 from unique_toolkit.agentic.postprocessor.postprocessor_manager import (
     PostprocessorManager,
@@ -81,6 +75,7 @@ from unique_orchestrator._builders import (
     build_loop_iteration_runner,
     build_responses_loop_iteration_runner,
 )
+from unique_orchestrator._builders.history_manager import build_history_manager
 from unique_orchestrator._builders.open_file_setup import (
     configure_file_payload,
     handle_uploaded_file_tool_choices,
@@ -96,6 +91,27 @@ from unique_orchestrator.config import (
 )
 from unique_orchestrator.unique_ai import UniqueAI
 from unique_orchestrator.utils import filter_uploaded_documents_by_selection
+
+
+def _configure_follow_up_questions(
+    *,
+    config: UniqueAIConfig,
+    event: ChatEvent,
+    logger: Logger,
+    history_manager: HistoryManager,
+    postprocessor_manager: PostprocessorManager,
+) -> None:
+    follow_up_config = config.agent.services.follow_up_questions_config
+    if follow_up_config and follow_up_config.number_of_questions > 0:
+        postprocessor_manager.set_last_postprocessor(
+            FollowUpPostprocessor(
+                logger=logger,
+                config=follow_up_config,
+                event=event,
+                historyManager=history_manager,
+                llm_service=LanguageModelService.from_event(event),
+            )
+        )
 
 
 class ResponsesStreamingHandler(ResponsesSupportCompleteWithReferences):
@@ -190,7 +206,6 @@ class _CommonComponents(NamedTuple):
     uploaded_images: list[Content]
     thinking_manager: ThinkingManager
     reference_manager: ReferenceManager
-    history_manager: HistoryManager
     evaluation_manager: EvaluationManager
     postprocessor_manager: PostprocessorManager
     message_step_logger: MessageStepLogger
@@ -312,21 +327,6 @@ async def _build_common(
 
     reference_manager = ReferenceManager()
 
-    history_manager_config = HistoryManagerConfig(
-        experimental_features=history_manager_module.ExperimentalFeatures(),
-        percent_of_max_tokens_for_history=config.agent.input_token_distribution.percent_for_history,
-        language_model=config.space.language_model,
-        uploaded_content_config=config.agent.services.uploaded_content_config,
-        enable_tool_call_persistence=config.agent.input_token_distribution.enable_tool_call_persistence,
-    )
-    history_manager = HistoryManager(
-        logger,
-        event,
-        history_manager_config,
-        config.space.language_model,
-        reference_manager,
-    )
-
     evaluation_manager = EvaluationManager(logger=logger, chat_service=chat_service)
     if config.agent.services.evaluation_config:
         evaluation_manager.add_evaluation(
@@ -370,21 +370,6 @@ async def _build_common(
             )
         )
 
-    if (
-        config.agent.services.follow_up_questions_config
-        and config.agent.services.follow_up_questions_config.number_of_questions > 0
-    ):
-        # Should run last to make sure the follow up questions are displayed last.
-        postprocessor_manager.set_last_postprocessor(
-            FollowUpPostprocessor(
-                logger=logger,
-                config=config.agent.services.follow_up_questions_config,
-                event=event,
-                historyManager=history_manager,
-                llm_service=LanguageModelService.from_event(event),
-            )
-        )
-
     user_memory_text = ""
     if config.space.allow_user_memory:
         user_memory_config = config.agent.services.user_memory_config
@@ -423,7 +408,6 @@ async def _build_common(
         uploaded_images=uploaded_images,
         thinking_manager=thinking_manager,
         reference_manager=reference_manager,
-        history_manager=history_manager,
         evaluation_manager=evaluation_manager,
         tool_progress_reporter=tool_progress_reporter,
         mcp_manager=mcp_manager,
@@ -565,18 +549,26 @@ async def _build_responses(
 
     agent_file_registry: list[str] = []
     if config.agent.experimental.open_file_tool_config.enabled:
-        history_manager, agent_file_registry = configure_file_payload(
+        agent_file_registry = configure_file_payload(
             config,
             event,
-            logger,
-            common_components.history_manager,
-            common_components.reference_manager,
-            config.space.language_model,
             tool_manager,
         )
-        common_components = common_components._replace(
-            history_manager=history_manager,
-        )
+
+    history_manager = build_history_manager(
+        event=event,
+        logger=logger,
+        config=config,
+        reference_manager=common_components.reference_manager,
+        tool_manager=tool_manager,
+    )
+    _configure_follow_up_questions(
+        config=config,
+        event=event,
+        logger=logger,
+        history_manager=history_manager,
+        postprocessor_manager=postprocessor_manager,
+    )
 
     await configure_skill_tool(
         config=config,
@@ -590,7 +582,7 @@ async def _build_responses(
 
     loop_iteration_runner = build_responses_loop_iteration_runner(
         config=config,
-        history_manager=common_components.history_manager,
+        history_manager=history_manager,
         openai_client=client,
     )
 
@@ -637,7 +629,7 @@ async def _build_responses(
         tool_manager=tool_manager,
         thinking_manager=common_components.thinking_manager,
         streaming_handler=streaming_handler,
-        history_manager=common_components.history_manager,
+        history_manager=history_manager,
         reference_manager=common_components.reference_manager,
         evaluation_manager=common_components.evaluation_manager,
         postprocessor_manager=postprocessor_manager,
@@ -677,6 +669,21 @@ async def _build_completions(
     if force_uploaded_search:
         tool_manager.add_forced_tool(UploadedSearchTool.name)
 
+    history_manager = build_history_manager(
+        event=event,
+        logger=logger,
+        config=config,
+        reference_manager=common_components.reference_manager,
+        tool_manager=tool_manager,
+    )
+    _configure_follow_up_questions(
+        config=config,
+        event=event,
+        logger=logger,
+        history_manager=history_manager,
+        postprocessor_manager=common_components.postprocessor_manager,
+    )
+
     await configure_skill_tool(
         config=config,
         logger=logger,
@@ -705,7 +712,7 @@ async def _build_completions(
 
     loop_iteration_runner = build_loop_iteration_runner(
         config=config,
-        history_manager=common_components.history_manager,
+        history_manager=history_manager,
         llm_service=common_components.llm_service,
         chat_service=common_components.chat_service,
     )
@@ -719,7 +726,7 @@ async def _build_completions(
         uploaded_documents=common_components.uploaded_documents,
         tool_manager=tool_manager,
         thinking_manager=common_components.thinking_manager,
-        history_manager=common_components.history_manager,
+        history_manager=history_manager,
         reference_manager=common_components.reference_manager,
         streaming_handler=common_components.chat_service,
         evaluation_manager=common_components.evaluation_manager,

--- a/unique_toolkit/tests/agentic/test_history_construction_async.py
+++ b/unique_toolkit/tests/agentic/test_history_construction_async.py
@@ -206,7 +206,6 @@ async def test_append_element_to_builder_async_no_contents():
     """Messages without contents take the simple message_append path."""
     from unique_toolkit.agentic.history_manager.history_construction_with_contents import (
         ChatMessageWithContents,
-        FileContentSerialization,
     )
 
     builder = MagicMock()
@@ -225,7 +224,6 @@ async def test_append_element_to_builder_async_no_contents():
         c=msg,
         text="hello",
         include_images=ImageContentInclusion.ALL,
-        file_content_serialization_type=FileContentSerialization.NONE,
         content_service=MagicMock(),
         chat_id="c1",
     )
@@ -236,13 +234,18 @@ async def test_append_element_to_builder_async_no_contents():
 @pytest.mark.ai
 @pytest.mark.asyncio
 async def test_append_element_to_builder_async_with_file_contents():
-    """Messages with file (non-image) contents use message_append with file info."""
+    """Verify each uploaded file becomes a separately serialized user text part.
+
+    Purpose: Check multipart construction and custom per-file serialization.
+    Why this matters: File metadata must remain distinct from the user prompt.
+    Setup summary: Append two files and assert serializer order and exact parts.
+    """
     from unique_toolkit.agentic.history_manager.history_construction_with_contents import (
         ChatMessageWithContents,
-        FileContentSerialization,
     )
 
-    file_content = _make_file_content()
+    first_file = _make_file_content()
+    second_file = _make_file_content("appendix.docx", "cont_file2")
     builder = MagicMock()
     msg = ChatMessageWithContents(
         id="m1",
@@ -251,7 +254,64 @@ async def test_append_element_to_builder_async_with_file_contents():
         role=ChatRole.USER,
         gpt_request=None,
         created_at=datetime(2026, 1, 1, 12, 0),
-        contents=[file_content],
+        contents=[first_file, second_file],
+    )
+    serialized_ids: list[str] = []
+
+    def serialize_file(content: Content) -> str:
+        serialized_ids.append(content.id)
+        return f"File: {content.key} ({content.id})"
+
+    with (
+        patch(
+            "unique_toolkit.agentic.history_manager.history_construction_with_contents.FileUtils.is_file_content",
+            return_value=True,
+        ),
+        patch(
+            "unique_toolkit.agentic.history_manager.history_construction_with_contents.FileUtils.is_image_content",
+            return_value=False,
+        ),
+    ):
+        await _append_element_to_builder_async(
+            builder=builder,
+            c=msg,
+            text="see attached",
+            include_images=ImageContentInclusion.ALL,
+            content_service=MagicMock(),
+            chat_id="c1",
+            file_content_serializer=serialize_file,
+        )
+
+    assert serialized_ids == ["cont_file1", "cont_file2"]
+    assert (
+        builder.message_append.call_args.kwargs["content"]
+        == "see attached\n\nFile: report.pdf (cont_file1)\n"
+        "File: appendix.docx (cont_file2)"
+    )
+
+
+@pytest.mark.ai
+@pytest.mark.asyncio
+async def test_append_element_to_builder_async_without_file_serializer():
+    """Verify uploaded files are omitted when no serializer is configured.
+
+    Purpose: Cover the default-off uploaded-file serialization behavior.
+    Why this matters: File metadata must only enter model context when explicitly enabled.
+    Setup summary: Append one file without a serializer and assert plain user text.
+    """
+    from unique_toolkit.agentic.history_manager.history_construction_with_contents import (
+        ChatMessageWithContents,
+    )
+
+    builder = MagicMock()
+    msg = ChatMessageWithContents(
+        id="m1",
+        chat_id="c1",
+        text="see attached",
+        role=ChatRole.USER,
+        gpt_request=None,
+        created_at=datetime(2026, 1, 1, 12, 0),
+        contents=[_make_file_content()],
     )
 
     with (
@@ -269,24 +329,28 @@ async def test_append_element_to_builder_async_with_file_contents():
             c=msg,
             text="see attached",
             include_images=ImageContentInclusion.ALL,
-            file_content_serialization_type=FileContentSerialization.FILE_NAME,
             content_service=MagicMock(),
             chat_id="c1",
         )
 
-    builder.message_append.assert_called_once()
+    assert builder.message_append.call_args.kwargs["content"] == "see attached"
 
 
 @pytest.mark.ai
 @pytest.mark.asyncio
-async def test_append_element_to_builder_async_with_image_contents():
-    """Messages with image contents use image_message_append."""
+async def test_append_element_to_builder_async_with_file_and_image_contents():
+    """Verify serialized file text is included before attached images.
+
+    Purpose: Check that uploaded files and images coexist in one user message.
+    Why this matters: Mixed uploads must retain deterministic model-input ordering.
+    Setup summary: Append one file and one image and assert the image-builder input.
+    """
     from unique_toolkit.agentic.history_manager.history_construction_with_contents import (
         ChatMessageWithContents,
-        FileContentSerialization,
     )
 
     img_content = _make_image_content()
+    file_content = _make_file_content()
     content_service = MagicMock()
     content_service.download_content_to_bytes_async = AsyncMock(return_value=b"\x89PNG")
     builder = MagicMock()
@@ -298,17 +362,17 @@ async def test_append_element_to_builder_async_with_image_contents():
         role=ChatRole.USER,
         gpt_request=None,
         created_at=datetime(2026, 1, 1, 12, 0),
-        contents=[img_content],
+        contents=[file_content, img_content],
     )
 
     with (
         patch(
             "unique_toolkit.agentic.history_manager.history_construction_with_contents.FileUtils.is_file_content",
-            return_value=False,
+            side_effect=lambda key: key.endswith(".pdf"),
         ),
         patch(
             "unique_toolkit.agentic.history_manager.history_construction_with_contents.FileUtils.is_image_content",
-            return_value=True,
+            side_effect=lambda key: key.endswith(".png"),
         ),
     ):
         await _append_element_to_builder_async(
@@ -316,12 +380,18 @@ async def test_append_element_to_builder_async_with_image_contents():
             c=msg,
             text="see this image",
             include_images=ImageContentInclusion.ALL,
-            file_content_serialization_type=FileContentSerialization.NONE,
             content_service=content_service,
             chat_id="c1",
+            file_content_serializer=lambda content: f"File: {content.key}",
         )
 
-    builder.image_message_append.assert_called_once()
+    assert (
+        builder.image_message_append.call_args.kwargs["content"]
+        == "see this image\n\nFile: report.pdf"
+    )
+    assert builder.image_message_append.call_args.kwargs["images"] == [
+        "data:image/png;base64,iVBORw=="
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -677,7 +747,6 @@ async def test_append_element_to_builder_async_selected_content_ids_filters_imag
     """When selected_content_ids is set, only matching images should be attached."""
     from unique_toolkit.agentic.history_manager.history_construction_with_contents import (
         ChatMessageWithContents,
-        FileContentSerialization,
     )
 
     img_selected = _make_image_content(key="selected.png", content_id="img_sel")
@@ -711,7 +780,6 @@ async def test_append_element_to_builder_async_selected_content_ids_filters_imag
             c=msg,
             text="two images",
             include_images=ImageContentInclusion.ALL,
-            file_content_serialization_type=FileContentSerialization.NONE,
             content_service=content_service,
             chat_id="c1",
             selected_content_ids={"img_sel"},
@@ -730,7 +798,6 @@ async def test_append_element_to_builder_async_selected_content_ids_empty_exclud
     """When selected_content_ids is an empty set, no images should be attached."""
     from unique_toolkit.agentic.history_manager.history_construction_with_contents import (
         ChatMessageWithContents,
-        FileContentSerialization,
     )
 
     img = _make_image_content(key="photo.png", content_id="img_1")
@@ -761,7 +828,6 @@ async def test_append_element_to_builder_async_selected_content_ids_empty_exclud
             c=msg,
             text="one image",
             include_images=ImageContentInclusion.ALL,
-            file_content_serialization_type=FileContentSerialization.NONE,
             content_service=MagicMock(),
             chat_id="c1",
             selected_content_ids=set(),
@@ -777,7 +843,6 @@ async def test_append_element_to_builder_async_selected_content_ids_none_include
     """When selected_content_ids is None (FF disabled), all images are included."""
     from unique_toolkit.agentic.history_manager.history_construction_with_contents import (
         ChatMessageWithContents,
-        FileContentSerialization,
     )
 
     img = _make_image_content(key="photo.png", content_id="img_1")
@@ -810,7 +875,6 @@ async def test_append_element_to_builder_async_selected_content_ids_none_include
             c=msg,
             text="one image",
             include_images=ImageContentInclusion.ALL,
-            file_content_serialization_type=FileContentSerialization.NONE,
             content_service=content_service,
             chat_id="c1",
             selected_content_ids=None,

--- a/unique_toolkit/tests/agentic/test_loop_token_reducer.py
+++ b/unique_toolkit/tests/agentic/test_loop_token_reducer.py
@@ -122,7 +122,6 @@ def loop_token_reducer(
         logger=mock_logger,
         event=test_event,
         max_history_tokens=4000,
-        has_uploaded_content_config=False,
         reference_manager=mock_reference_manager,
         language_model=language_model_info,
     )
@@ -204,14 +203,13 @@ def test_loop_token_reducer__initializes__with_valid_parameters_AI(
         logger=mock_logger,
         event=test_event,
         max_history_tokens=4000,
-        has_uploaded_content_config=False,
         reference_manager=mock_reference_manager,
         language_model=language_model_info,
     )
 
     # Assert
     assert reducer._max_history_tokens == 4000
-    assert reducer._has_uploaded_content_config is False
+    assert reducer._file_content_serializer is None
     assert reducer._logger == mock_logger
     assert reducer._reference_manager == mock_reference_manager
     assert reducer._language_model == language_model_info
@@ -1272,7 +1270,6 @@ async def test_get_history_from_db__calls_without_tool_calls__when_persistence_d
         logger=mock_logger,
         event=test_event,
         max_history_tokens=4000,
-        has_uploaded_content_config=False,
         reference_manager=mock_reference_manager,
         language_model=language_model_info,
         enable_tool_call_persistence=False,
@@ -1294,6 +1291,10 @@ async def test_get_history_from_db__calls_without_tool_calls__when_persistence_d
     )
 
     mock_get_history.assert_called_once()
+    assert (
+        mock_get_history.call_args.kwargs["file_content_serializer"]
+        is reducer._file_content_serializer
+    )
 
 
 @pytest.mark.ai
@@ -1322,7 +1323,6 @@ async def test_get_history_from_db__calls_with_tool_calls__when_persistence_enab
         logger=mock_logger,
         event=test_event,
         max_history_tokens=4000,
-        has_uploaded_content_config=False,
         reference_manager=mock_reference_manager,
         language_model=language_model_info,
         enable_tool_call_persistence=True,

--- a/unique_toolkit/tests/agentic/test_loop_token_reducer_encoder.py
+++ b/unique_toolkit/tests/agentic/test_loop_token_reducer_encoder.py
@@ -52,7 +52,6 @@ def test_loop_token_reducer_get_encoder_with_gpt():
     reducer = LoopTokenReducer(
         event=event,
         max_history_tokens=1000,
-        has_uploaded_content_config=False,
         logger=None,
         reference_manager=reference_manager,
         language_model=language_model,
@@ -98,7 +97,6 @@ def test_loop_token_reducer_get_encoder_with_qwen():
     reducer = LoopTokenReducer(
         event=event,
         max_history_tokens=1000,
-        has_uploaded_content_config=False,
         logger=None,
         reference_manager=reference_manager,
         language_model=language_model,
@@ -144,7 +142,6 @@ def test_loop_token_reducer_count_message_tokens():
     reducer = LoopTokenReducer(
         event=event,
         max_history_tokens=1000,
-        has_uploaded_content_config=False,
         logger=None,
         reference_manager=reference_manager,
         language_model=language_model,

--- a/unique_toolkit/unique_toolkit/agentic/history_manager/history_construction_with_contents.py
+++ b/unique_toolkit/unique_toolkit/agentic/history_manager/history_construction_with_contents.py
@@ -6,7 +6,7 @@ import mimetypes
 from datetime import datetime
 from enum import StrEnum
 from itertools import groupby
-from typing import TYPE_CHECKING, Iterator
+from typing import TYPE_CHECKING, Callable, Iterator
 
 if TYPE_CHECKING:
     from unique_toolkit.content.schemas import ContentChunk
@@ -200,9 +200,7 @@ async def download_encoded_images_async(
     return base64_encoded_images
 
 
-class FileContentSerialization(StrEnum):
-    NONE = "none"
-    FILE_NAME = "file_name"
+FileContentSerializer = Callable[[Content], str | None]
 
 
 class ImageContentInclusion(StrEnum):
@@ -210,23 +208,17 @@ class ImageContentInclusion(StrEnum):
     ALL = "all"
 
 
-def file_content_serialization(
+def _serialize_file_contents(
+    text: str,
     file_contents: list[Content],
-    file_content_serialization: FileContentSerialization,
+    file_content_serializer: FileContentSerializer | None,
 ) -> str:
-    match file_content_serialization:
-        case FileContentSerialization.NONE:
-            return ""
-        case FileContentSerialization.FILE_NAME:
-            file_names = [
-                f"- Uploaded file: {f.key} at {f.created_at}" for f in file_contents
-            ]
-            return "\n".join(
-                [
-                    "Files Uploaded to Chat can be accessed by internal search tool if available:\n",
-                ]
-                + file_names,
-            )
+    serialized_files: list[str] = []
+    if file_content_serializer is not None:
+        for file_content in file_contents:
+            if serialized_file := file_content_serializer(file_content):
+                serialized_files.append(serialized_file)
+    return (text + "\n\n" + "\n".join(serialized_files)).strip()
 
 
 def _append_element_to_builder(
@@ -234,9 +226,9 @@ def _append_element_to_builder(
     c: ChatMessageWithContents,
     text: str,
     include_images: ImageContentInclusion,
-    file_content_serialization_type: FileContentSerialization,
     content_service: ContentService,
     chat_id: str,
+    file_content_serializer: FileContentSerializer | None = None,
     selected_content_ids: set[str] | None = None,
 ) -> None:
     if len(c.contents) > 0:
@@ -249,15 +241,12 @@ def _append_element_to_builder(
             image_contents = [
                 co for co in image_contents if co.id in selected_content_ids
             ]
-        content = (
-            text
-            + "\n\n"
-            + file_content_serialization(
-                file_contents,
-                file_content_serialization_type,
-            )
-        ).strip()
-        if include_images and len(image_contents) > 0:
+        content = _serialize_file_contents(
+            text,
+            file_contents,
+            file_content_serializer,
+        )
+        if include_images and image_contents:
             builder.image_message_append(
                 content=content,
                 images=download_encoded_images(
@@ -285,9 +274,9 @@ async def _append_element_to_builder_async(
     c: ChatMessageWithContents,
     text: str,
     include_images: ImageContentInclusion,
-    file_content_serialization_type: FileContentSerialization,
     content_service: ContentService,
     chat_id: str,
+    file_content_serializer: FileContentSerializer | None = None,
     selected_content_ids: set[str] | None = None,
 ) -> None:
     if len(c.contents) > 0:
@@ -300,15 +289,12 @@ async def _append_element_to_builder_async(
             image_contents = [
                 co for co in image_contents if co.id in selected_content_ids
             ]
-        content = (
-            text
-            + "\n\n"
-            + file_content_serialization(
-                file_contents,
-                file_content_serialization_type,
-            )
-        ).strip()
-        if include_images and len(image_contents) > 0:
+        content = _serialize_file_contents(
+            text,
+            file_contents,
+            file_content_serializer,
+        )
+        if include_images and image_contents:
             builder.image_message_append(
                 content=content,
                 images=await download_encoded_images_async(
@@ -336,7 +322,7 @@ def get_full_history_with_contents(
     chat_service: ChatService,
     content_service: ContentService,
     include_images: ImageContentInclusion = ImageContentInclusion.ALL,
-    file_content_serialization_type: FileContentSerialization = FileContentSerialization.FILE_NAME,
+    file_content_serializer: FileContentSerializer | None = None,
     selected_content_ids: set[str] | None = None,
 ) -> LanguageModelMessages:
     grouped_elements = get_chat_history_with_contents(
@@ -361,7 +347,7 @@ def get_full_history_with_contents(
             c=c,
             text=text,
             include_images=include_images,
-            file_content_serialization_type=file_content_serialization_type,
+            file_content_serializer=file_content_serializer,
             content_service=content_service,
             chat_id=chat_id,
             selected_content_ids=selected_content_ids,
@@ -376,7 +362,7 @@ async def get_full_history_with_contents_async(
     chat_service: ChatService,
     content_service: ContentService,
     include_images: ImageContentInclusion = ImageContentInclusion.ALL,
-    file_content_serialization_type: FileContentSerialization = FileContentSerialization.FILE_NAME,
+    file_content_serializer: FileContentSerializer | None = None,
     selected_content_ids: set[str] | None = None,
 ) -> LanguageModelMessages:
     grouped_elements = await get_chat_history_with_contents_async(
@@ -400,7 +386,7 @@ async def get_full_history_with_contents_async(
             c=c,
             text=text,
             include_images=include_images,
-            file_content_serialization_type=file_content_serialization_type,
+            file_content_serializer=file_content_serializer,
             content_service=content_service,
             chat_id=chat_id,
             selected_content_ids=selected_content_ids,
@@ -415,7 +401,7 @@ def get_full_history_with_contents_and_tool_calls(
     chat_service: ChatService,
     content_service: ContentService,
     include_images: ImageContentInclusion = ImageContentInclusion.ALL,
-    file_content_serialization_type: FileContentSerialization = FileContentSerialization.FILE_NAME,
+    file_content_serializer: FileContentSerializer | None = None,
     selected_content_ids: set[str] | None = None,
 ) -> tuple[LanguageModelMessages, int, dict[int, "ContentChunk"]]:
     """Build the full LLM message history, including persisted tool call rounds.
@@ -544,7 +530,7 @@ def get_full_history_with_contents_and_tool_calls(
             c=c,
             text=text,
             include_images=include_images,
-            file_content_serialization_type=file_content_serialization_type,
+            file_content_serializer=file_content_serializer,
             content_service=content_service,
             chat_id=chat_id,
             selected_content_ids=selected_content_ids,
@@ -559,7 +545,7 @@ async def get_full_history_with_contents_and_tool_calls_async(
     chat_service: ChatService,
     content_service: ContentService,
     include_images: ImageContentInclusion = ImageContentInclusion.ALL,
-    file_content_serialization_type: FileContentSerialization = FileContentSerialization.FILE_NAME,
+    file_content_serializer: FileContentSerializer | None = None,
     selected_content_ids: set[str] | None = None,
 ) -> tuple[LanguageModelMessages, int, dict[int, "ContentChunk"]]:
     """Async version of get_full_history_with_contents_and_tool_calls."""
@@ -662,7 +648,7 @@ async def get_full_history_with_contents_and_tool_calls_async(
             c=c,
             text=text,
             include_images=include_images,
-            file_content_serialization_type=file_content_serialization_type,
+            file_content_serializer=file_content_serializer,
             content_service=content_service,
             chat_id=chat_id,
             selected_content_ids=selected_content_ids,

--- a/unique_toolkit/unique_toolkit/agentic/history_manager/history_manager.py
+++ b/unique_toolkit/unique_toolkit/agentic/history_manager/history_manager.py
@@ -10,6 +10,9 @@ from unique_toolkit._common.feature_flags.schema import (
 )
 from unique_toolkit._common.pydantic_helpers import DeactivatedNone
 from unique_toolkit._common.validators import LMI
+from unique_toolkit.agentic.history_manager.history_construction_with_contents import (
+    FileContentSerializer,
+)
 from unique_toolkit.agentic.history_manager.loop_token_reducer import LoopTokenReducer
 from unique_toolkit.agentic.history_manager.utils import (
     serialize_tool_content_json,
@@ -115,6 +118,7 @@ class HistoryManager:
         config: HistoryManagerConfig,
         language_model: LMI,
         reference_manager: ReferenceManager,
+        file_content_serializer: FileContentSerializer | None = None,
     ):
         self._config = config
         self._logger = logger
@@ -123,10 +127,10 @@ class HistoryManager:
             logger=self._logger,
             event=event,
             max_history_tokens=self._config.max_history_tokens,
-            has_uploaded_content_config=bool(self._config.uploaded_content_config),
             language_model=self._language_model,
             reference_manager=reference_manager,
             enable_tool_call_persistence=self._config.enable_tool_call_persistence,
+            file_content_serializer=file_content_serializer,
         )
         self._reference_manager = reference_manager
         self._tool_call_result_history: list[ToolCallResponse] = []

--- a/unique_toolkit/unique_toolkit/agentic/history_manager/loop_token_reducer.py
+++ b/unique_toolkit/unique_toolkit/agentic/history_manager/loop_token_reducer.py
@@ -9,7 +9,7 @@ from unique_toolkit._common.token.token_counting import (
 )
 from unique_toolkit._common.validators import LMI
 from unique_toolkit.agentic.history_manager.history_construction_with_contents import (
-    FileContentSerialization,
+    FileContentSerializer,
     get_full_history_with_contents_and_tool_calls_async,
     get_full_history_with_contents_async,
 )
@@ -54,13 +54,13 @@ class LoopTokenReducer:
         logger: Logger,
         event: ChatEvent,
         max_history_tokens: int,
-        has_uploaded_content_config: bool,
         reference_manager: ReferenceManager,
         language_model: LMI,
         enable_tool_call_persistence: bool = False,
+        file_content_serializer: FileContentSerializer | None = None,
     ):
         self._max_history_tokens = max_history_tokens
-        self._has_uploaded_content_config = has_uploaded_content_config
+        self._file_content_serializer = file_content_serializer
         self._logger = logger
         self._reference_manager = reference_manager
         self._language_model = language_model
@@ -309,11 +309,6 @@ class LoopTokenReducer:
         Returns:
             list[LanguageModelMessage]: The history
         """
-        file_content_serialization_type = (
-            FileContentSerialization.NONE
-            if self._has_uploaded_content_config
-            else FileContentSerialization.FILE_NAME
-        )
         if self._enable_tool_call_persistence:
             (
                 full_history,
@@ -324,7 +319,7 @@ class LoopTokenReducer:
                 chat_id=self._chat_id,
                 chat_service=self._chat_service,
                 content_service=self._content_service,
-                file_content_serialization_type=file_content_serialization_type,
+                file_content_serializer=self._file_content_serializer,
                 selected_content_ids=self._selected_content_ids,
             )
             self._max_db_source_number = max_src
@@ -335,7 +330,7 @@ class LoopTokenReducer:
                 chat_id=self._chat_id,
                 chat_service=self._chat_service,
                 content_service=self._content_service,
-                file_content_serialization_type=file_content_serialization_type,
+                file_content_serializer=self._file_content_serializer,
                 selected_content_ids=self._selected_content_ids,
             )
 


### PR DESCRIPTION
Optionally enable file serialization in history.

Reason: Agent is confused when uploaded files are done in multiple different turns