### PR TITLE
feat(unique_toolkit): expose per-invocation LLM usage with model identity [UN-20907] (1/3)

### DIFF
--- a/unique_sdk/tests/test_chat_in_space.py
+++ b/unique_sdk/tests/test_chat_in_space.py
@@ -62,6 +62,11 @@ class TestGetMessageUsage:
         message = {}
         assert get_message_usage(message) is None
 
+    @pytest.mark.ai
+    def test_get_message_usage__llm_invocations_not_a_dict__returns_none(self) -> None:
+        message = {"debugInfo": {"llm_invocations": "unexpected-string-payload"}}
+        assert get_message_usage(message) is None
+
 
 class TestGetMessageInvocations:
     @pytest.mark.ai
@@ -76,6 +81,13 @@ class TestGetMessageInvocations:
     @pytest.mark.ai
     def test_get_message_invocations__debug_info_missing__returns_empty(self) -> None:
         assert get_message_invocations({}) == []
+
+    @pytest.mark.ai
+    def test_get_message_invocations__llm_invocations_not_a_dict__returns_empty(
+        self,
+    ) -> None:
+        message = {"debugInfo": {"llm_invocations": ["unexpected", "list", "payload"]}}
+        assert get_message_invocations(message) == []
 
 
 @pytest.mark.asyncio

--- a/unique_sdk/tests/test_chat_in_space.py
+++ b/unique_sdk/tests/test_chat_in_space.py
@@ -2,7 +2,80 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from unique_sdk.utils.chat_in_space import send_message_and_wait_for_completion
+from unique_sdk.utils.chat_in_space import (
+    get_message_invocations,
+    get_message_usage,
+    send_message_and_wait_for_completion,
+)
+
+_REPORT_PAYLOAD = {
+    "invocations": [
+        {
+            "modelName": "AZURE_GPT_4o_2024_1120",
+            "tokenUsage": {
+                "completionTokens": 10,
+                "promptTokens": 30,
+                "totalTokens": 40,
+            },
+            "source": "main_loop",
+        },
+        {
+            "modelName": "litellm:anthropic-claude-sonnet-4-5",
+            "tokenUsage": {
+                "completionTokens": 2,
+                "promptTokens": 4,
+                "totalTokens": 6,
+            },
+            "source": "hallucination",
+        },
+    ],
+    "totalTokenUsage": {
+        "completionTokens": 12,
+        "promptTokens": 34,
+        "totalTokens": 46,
+    },
+}
+
+
+class TestGetMessageUsage:
+    @pytest.mark.ai
+    def test_get_message_usage__present__returns_totals(self) -> None:
+        message = {"debugInfo": {"llm_invocations": _REPORT_PAYLOAD}}
+        assert get_message_usage(message) == {
+            "completionTokens": 12,
+            "promptTokens": 34,
+            "totalTokens": 46,
+        }
+
+    @pytest.mark.ai
+    def test_get_message_usage__no_llm_invocations_key__returns_none(self) -> None:
+        message = {"debugInfo": {"execution_time": {"total_time": 1.0}}}
+        assert get_message_usage(message) is None
+
+    @pytest.mark.ai
+    def test_get_message_usage__debug_info_none__returns_none(self) -> None:
+        message = {"debugInfo": None}
+        assert get_message_usage(message) is None
+
+    @pytest.mark.ai
+    def test_get_message_usage__debug_info_missing__returns_none(self) -> None:
+        message = {}
+        assert get_message_usage(message) is None
+
+
+class TestGetMessageInvocations:
+    @pytest.mark.ai
+    def test_get_message_invocations__present__returns_entries(self) -> None:
+        message = {"debugInfo": {"llm_invocations": _REPORT_PAYLOAD}}
+        invocations = get_message_invocations(message)
+        assert len(invocations) == 2
+        assert invocations[0]["modelName"] == "AZURE_GPT_4o_2024_1120"
+        assert invocations[0]["source"] == "main_loop"
+        assert invocations[1]["tokenUsage"]["totalTokens"] == 6
+
+    @pytest.mark.ai
+    def test_get_message_invocations__debug_info_missing__returns_empty(self) -> None:
+        assert get_message_invocations({}) == []
 
 
 @pytest.mark.asyncio
@@ -55,7 +128,7 @@ async def test_send_message_and_wait_for_completion__calls_update_hook_for_chang
             "unique_sdk.utils.chat_in_space.Message.retrieve_async",
             new_callable=AsyncMock,
             return_value={"debugInfo": {"trace": "ok"}},
-        ),
+        ) as mock_message_retrieve,
         patch("unique_sdk.utils.chat_in_space.asyncio.sleep", new_callable=AsyncMock),
     ):
         response = await send_message_and_wait_for_completion(
@@ -74,6 +147,70 @@ async def test_send_message_and_wait_for_completion__calls_update_hook_for_chang
     assert on_message_update.await_count == 2
     assert on_message_update.await_args_list[0].args == (in_progress,)
     assert on_message_update.await_args_list[1].args == (completed,)
+    # debugInfo/llm_invocations is written to the USER message (message_id from
+    # create_message_async), not the assistant reply — the re-fetch must use
+    # that original id.
+    mock_message_retrieve.assert_awaited_once_with(
+        "user-1", "company-1", "user-msg", chatId="chat-1"
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_message_and_wait_for_completion__debug_info_from_user_not_assistant_message() -> (
+    None
+):
+    """debugInfo/llm_invocations is written via ChatService.update_debug_info_async(),
+    which always targets the USER message (assistant=False in
+    _construct_message_modify_params), not the assistant reply. Verify by
+    giving the user and assistant messages distinguishable debugInfo and
+    asserting the user's is the one that survives."""
+    completed = {
+        "id": "assistant-msg",
+        "chatId": "chat-1",
+        "role": "ASSISTANT",
+        "text": "done",
+        "originalText": "done",
+        "completedAt": "2026-01-01T00:00:00Z",
+        "stoppedStreamingAt": "2026-01-01T00:00:00Z",
+        "references": None,
+        "assessment": None,
+    }
+
+    async def fake_retrieve(user_id, company_id, message_id, chatId):
+        if message_id == "user-msg":
+            return {"debugInfo": {"llm_invocations": {"totalTokens": 46}}}
+        if message_id == "assistant-msg":
+            return {"debugInfo": None}
+        raise AssertionError(f"unexpected message_id: {message_id}")
+
+    with (
+        patch(
+            "unique_sdk.utils.chat_in_space.Space.create_message_async",
+            new_callable=AsyncMock,
+            return_value={"id": "user-msg", "chatId": "chat-1"},
+        ),
+        patch(
+            "unique_sdk.utils.chat_in_space.Space.get_latest_message_async",
+            new_callable=AsyncMock,
+            return_value=completed,
+        ),
+        patch(
+            "unique_sdk.utils.chat_in_space.Message.retrieve_async",
+            side_effect=fake_retrieve,
+        ),
+        patch("unique_sdk.utils.chat_in_space.asyncio.sleep", new_callable=AsyncMock),
+    ):
+        response = await send_message_and_wait_for_completion(
+            user_id="user-1",
+            company_id="company-1",
+            assistant_id="assistant-1",
+            text="hello",
+            poll_interval=0.01,
+            max_wait=1,
+            stop_condition="completedAt",
+        )
+
+    assert response["debugInfo"] == {"llm_invocations": {"totalTokens": 46}}
 
 
 @pytest.mark.asyncio

--- a/unique_sdk/tests/test_chat_in_space.py
+++ b/unique_sdk/tests/test_chat_in_space.py
@@ -4,74 +4,35 @@ import pytest
 
 from unique_sdk.utils.chat_in_space import (
     get_message_invocations,
-    get_message_usage,
     send_message_and_wait_for_completion,
 )
 
-_REPORT_PAYLOAD = {
-    "invocations": [
-        {
-            "modelName": "AZURE_GPT_4o_2024_1120",
-            "tokenUsage": {
-                "completionTokens": 10,
-                "promptTokens": 30,
-                "totalTokens": 40,
-            },
-            "source": "main_loop",
+_INVOCATIONS_PAYLOAD = [
+    {
+        "modelName": "AZURE_GPT_4o_2024_1120",
+        "tokenUsage": {
+            "completionTokens": 10,
+            "promptTokens": 30,
+            "totalTokens": 40,
         },
-        {
-            "modelName": "litellm:anthropic-claude-sonnet-4-5",
-            "tokenUsage": {
-                "completionTokens": 2,
-                "promptTokens": 4,
-                "totalTokens": 6,
-            },
-            "source": "hallucination",
-        },
-    ],
-    "totalTokenUsage": {
-        "completionTokens": 12,
-        "promptTokens": 34,
-        "totalTokens": 46,
+        "source": "main_loop",
     },
-}
-
-
-class TestGetMessageUsage:
-    @pytest.mark.ai
-    def test_get_message_usage__present__returns_totals(self) -> None:
-        message = {"debugInfo": {"llm_invocations": _REPORT_PAYLOAD}}
-        assert get_message_usage(message) == {
-            "completionTokens": 12,
-            "promptTokens": 34,
-            "totalTokens": 46,
-        }
-
-    @pytest.mark.ai
-    def test_get_message_usage__no_llm_invocations_key__returns_none(self) -> None:
-        message = {"debugInfo": {"execution_time": {"total_time": 1.0}}}
-        assert get_message_usage(message) is None
-
-    @pytest.mark.ai
-    def test_get_message_usage__debug_info_none__returns_none(self) -> None:
-        message = {"debugInfo": None}
-        assert get_message_usage(message) is None
-
-    @pytest.mark.ai
-    def test_get_message_usage__debug_info_missing__returns_none(self) -> None:
-        message = {}
-        assert get_message_usage(message) is None
-
-    @pytest.mark.ai
-    def test_get_message_usage__llm_invocations_not_a_dict__returns_none(self) -> None:
-        message = {"debugInfo": {"llm_invocations": "unexpected-string-payload"}}
-        assert get_message_usage(message) is None
+    {
+        "modelName": "litellm:anthropic-claude-sonnet-4-5",
+        "tokenUsage": {
+            "completionTokens": 2,
+            "promptTokens": 4,
+            "totalTokens": 6,
+        },
+        "source": "hallucination",
+    },
+]
 
 
 class TestGetMessageInvocations:
     @pytest.mark.ai
     def test_get_message_invocations__present__returns_entries(self) -> None:
-        message = {"debugInfo": {"llm_invocations": _REPORT_PAYLOAD}}
+        message = {"debugInfo": {"llm_invocations": _INVOCATIONS_PAYLOAD}}
         invocations = get_message_invocations(message)
         assert len(invocations) == 2
         assert invocations[0]["modelName"] == "AZURE_GPT_4o_2024_1120"
@@ -79,14 +40,35 @@ class TestGetMessageInvocations:
         assert invocations[1]["tokenUsage"]["totalTokens"] == 6
 
     @pytest.mark.ai
+    def test_get_message_invocations__empty_list__returns_empty(self) -> None:
+        """An empty list is the real "no usage reported" identity value --
+        still returned as-is, not treated as missing."""
+        message = {"debugInfo": {"llm_invocations": []}}
+        assert get_message_invocations(message) == []
+
+    @pytest.mark.ai
+    def test_get_message_invocations__no_llm_invocations_key__returns_empty(
+        self,
+    ) -> None:
+        message = {"debugInfo": {"execution_time": {"total_time": 1.0}}}
+        assert get_message_invocations(message) == []
+
+    @pytest.mark.ai
+    def test_get_message_invocations__debug_info_none__returns_empty(self) -> None:
+        message = {"debugInfo": None}
+        assert get_message_invocations(message) == []
+
+    @pytest.mark.ai
     def test_get_message_invocations__debug_info_missing__returns_empty(self) -> None:
         assert get_message_invocations({}) == []
 
     @pytest.mark.ai
-    def test_get_message_invocations__llm_invocations_not_a_dict__returns_empty(
+    def test_get_message_invocations__llm_invocations_not_a_list__returns_empty(
         self,
     ) -> None:
-        message = {"debugInfo": {"llm_invocations": ["unexpected", "list", "payload"]}}
+        """Guards against a stale/pre-migration debugInfo blob that still has
+        the old {"invocations": [...], "totalTokenUsage": {...}} shape."""
+        message = {"debugInfo": {"llm_invocations": _INVOCATIONS_PAYLOAD[0]}}
         assert get_message_invocations(message) == []
 
 

--- a/unique_sdk/unique_sdk/utils/chat_in_space.py
+++ b/unique_sdk/unique_sdk/utils/chat_in_space.py
@@ -22,7 +22,7 @@ def get_message_usage(message: Space.Message) -> Integrated.Usage | None:
     llm_invocations = debug_info.get("llm_invocations")
     if llm_invocations is None:
         return None
-    return llm_invocations["totalTokenUsage"]
+    return llm_invocations.get("totalTokenUsage")
 
 
 def get_message_invocations(message: Space.Message) -> list[dict[str, Any]]:
@@ -32,7 +32,7 @@ def get_message_invocations(message: Space.Message) -> list[dict[str, Any]]:
     """
     debug_info = message.get("debugInfo") or {}
     llm_invocations = debug_info.get("llm_invocations") or {}
-    return llm_invocations["invocations"] if llm_invocations else []
+    return llm_invocations.get("invocations") or []
 
 
 async def send_message_and_wait_for_completion(
@@ -66,6 +66,13 @@ async def send_message_and_wait_for_completion(
         poll_interval: Seconds between polls.
         max_wait: Maximum seconds to wait for completion.
         stop_condition: Defines when to expect a response back, when the assistant stop streaming or when it completes the message. (default: "stoppedStreamingAt")
+            Note: `debugInfo.llm_invocations` (see `get_message_usage`/`get_message_invocations`)
+            is written near the very end of the orchestrator's run -- after postprocessors and
+            evaluations, which happen after the visible text stream ends. With the default
+            `"stoppedStreamingAt"`, or even `"completedAt"` (set slightly before the debugInfo
+            write completes), the returned message's usage/invocations can still be incomplete
+            immediately after this function returns. Re-fetch the message after a short delay
+            if you need the full invocation list.
         correlation: Optional correlation data to link this message to a parent message in another chat.
             Should contain: parentMessageId, parentChatId, parentAssistantId.
         auto_approve_elicitation: When True, automatically approves elicitation requests during

--- a/unique_sdk/unique_sdk/utils/chat_in_space.py
+++ b/unique_sdk/unique_sdk/utils/chat_in_space.py
@@ -1,14 +1,38 @@
+from __future__ import annotations
+
 import asyncio
 import warnings
 from collections.abc import Awaitable, Callable, Sequence
 from typing import Any, Literal
 
+from unique_sdk.api_resources._integrated import Integrated
 from unique_sdk.api_resources._message import Message
 from unique_sdk.api_resources._space import Space
 from unique_sdk.utils.file_io import upload_file
 from unique_sdk.utils.file_io import (
     wait_for_ingestion_completion as _wait_for_ingestion_completion,
 )
+
+
+def get_message_usage(message: Space.Message) -> Integrated.Usage | None:
+    """Total token usage for a completed Space message, read from
+    `debugInfo.llm_invocations.totalTokenUsage`.
+    """
+    debug_info = message.get("debugInfo") or {}
+    llm_invocations = debug_info.get("llm_invocations")
+    if llm_invocations is None:
+        return None
+    return llm_invocations["totalTokenUsage"]
+
+
+def get_message_invocations(message: Space.Message) -> list[dict[str, Any]]:
+    """Per-LLM-invocation stats for a completed Space message.
+
+    Each entry has `modelName`, `tokenUsage`, and `source` keys.
+    """
+    debug_info = message.get("debugInfo") or {}
+    llm_invocations = debug_info.get("llm_invocations") or {}
+    return llm_invocations["invocations"] if llm_invocations else []
 
 
 async def send_message_and_wait_for_completion(
@@ -23,10 +47,10 @@ async def send_message_and_wait_for_completion(
     poll_interval: float = 1.0,
     max_wait: float = 60.0,
     stop_condition: Literal["stoppedStreamingAt", "completedAt"] = "stoppedStreamingAt",
-    correlation: "Space.Correlation | None" = None,
+    correlation: Space.Correlation | None = None,
     auto_approve_elicitation: bool | None = None,
-    on_message_update: Callable[["Space.Message"], Awaitable[None]] | None = None,
-) -> "Space.Message":
+    on_message_update: Callable[[Space.Message], Awaitable[None]] | None = None,
+) -> Space.Message:
     """
     Sends a prompt asynchronously and polls for completion. (until stoppedStreamingAt is not None)
 
@@ -91,6 +115,11 @@ async def send_message_and_wait_for_completion(
                 last_update_signature = update_signature
         if answer.get(stop_condition) is not None:
             try:
+                # debugInfo/llm_invocations is written via update_debug_info_async(),
+                # which always targets the original USER message, not the
+                # assistant reply (assistant=False in
+                # ChatService._construct_message_modify_params) — re-fetch by
+                # `message_id`, not the polled assistant message's own id.
                 user_message = await Message.retrieve_async(
                     user_id, company_id, message_id, chatId=chat_id
                 )
@@ -116,7 +145,7 @@ async def chat_against_file(
     poll_interval: float = 1.0,
     max_wait: float = 60.0,
     should_delete_chat: bool = True,
-) -> "Space.Message":
+) -> Space.Message:
     """
     Chat against a file by uploading it, sending a message and waiting for a reply.
     Args:

--- a/unique_sdk/unique_sdk/utils/chat_in_space.py
+++ b/unique_sdk/unique_sdk/utils/chat_in_space.py
@@ -20,7 +20,7 @@ def get_message_usage(message: Space.Message) -> Integrated.Usage | None:
     """
     debug_info = message.get("debugInfo") or {}
     llm_invocations = debug_info.get("llm_invocations")
-    if llm_invocations is None:
+    if not isinstance(llm_invocations, dict):
         return None
     return llm_invocations.get("totalTokenUsage")
 
@@ -31,7 +31,9 @@ def get_message_invocations(message: Space.Message) -> list[dict[str, Any]]:
     Each entry has `modelName`, `tokenUsage`, and `source` keys.
     """
     debug_info = message.get("debugInfo") or {}
-    llm_invocations = debug_info.get("llm_invocations") or {}
+    llm_invocations = debug_info.get("llm_invocations")
+    if not isinstance(llm_invocations, dict):
+        return []
     return llm_invocations.get("invocations") or []
 
 

--- a/unique_sdk/unique_sdk/utils/chat_in_space.py
+++ b/unique_sdk/unique_sdk/utils/chat_in_space.py
@@ -5,7 +5,6 @@ import warnings
 from collections.abc import Awaitable, Callable, Sequence
 from typing import Any, Literal
 
-from unique_sdk.api_resources._integrated import Integrated
 from unique_sdk.api_resources._message import Message
 from unique_sdk.api_resources._space import Space
 from unique_sdk.utils.file_io import upload_file
@@ -14,27 +13,15 @@ from unique_sdk.utils.file_io import (
 )
 
 
-def get_message_usage(message: Space.Message) -> Integrated.Usage | None:
-    """Total token usage for a completed Space message, read from
-    `debugInfo.llm_invocations.totalTokenUsage`.
-    """
-    debug_info = message.get("debugInfo") or {}
-    llm_invocations = debug_info.get("llm_invocations")
-    if not isinstance(llm_invocations, dict):
-        return None
-    return llm_invocations.get("totalTokenUsage")
-
-
 def get_message_invocations(message: Space.Message) -> list[dict[str, Any]]:
-    """Per-LLM-invocation stats for a completed Space message.
+    """Per-LLM-invocation stats for a completed Space message, read from
+    `debugInfo.llm_invocations` (a plain list, one entry per LLM call).
 
     Each entry has `modelName`, `tokenUsage`, and `source` keys.
     """
     debug_info = message.get("debugInfo") or {}
     llm_invocations = debug_info.get("llm_invocations")
-    if not isinstance(llm_invocations, dict):
-        return []
-    return llm_invocations.get("invocations") or []
+    return llm_invocations if isinstance(llm_invocations, list) else []
 
 
 async def send_message_and_wait_for_completion(
@@ -68,11 +55,11 @@ async def send_message_and_wait_for_completion(
         poll_interval: Seconds between polls.
         max_wait: Maximum seconds to wait for completion.
         stop_condition: Defines when to expect a response back, when the assistant stop streaming or when it completes the message. (default: "stoppedStreamingAt")
-            Note: `debugInfo.llm_invocations` (see `get_message_usage`/`get_message_invocations`)
-            is written near the very end of the orchestrator's run -- after postprocessors and
+            Note: `debugInfo.llm_invocations` (see `get_message_invocations`) is written
+            near the very end of the orchestrator's run -- after postprocessors and
             evaluations, which happen after the visible text stream ends. With the default
             `"stoppedStreamingAt"`, or even `"completedAt"` (set slightly before the debugInfo
-            write completes), the returned message's usage/invocations can still be incomplete
+            write completes), the returned message's invocations can still be incomplete
             immediately after this function returns. Re-fetch the message after a short delay
             if you need the full invocation list.
         correlation: Optional correlation data to link this message to a parent message in another chat.

--- a/unique_toolkit/tests/agentic/test_evaluation_manager_usage.py
+++ b/unique_toolkit/tests/agentic/test_evaluation_manager_usage.py
@@ -1,0 +1,209 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from unique_toolkit.agentic.evaluation.evaluation_manager import (
+    Evaluation,
+    EvaluationManager,
+)
+from unique_toolkit.agentic.evaluation.schemas import (
+    EvaluationMetricName,
+    EvaluationMetricResult,
+)
+from unique_toolkit.language_model.invocation_stats import (
+    LanguageModelInvocationStats,
+)
+from unique_toolkit.language_model.schemas import LanguageModelTokenUsage
+
+_MODEL_INFO = "gpt-4-test"
+
+
+class TestEvaluationManagerUsage:
+    """Test suite for EvaluationManager token-usage tracking.
+
+    Mirrors test_evaluation_manager_execution_times.py — evaluations like
+    HallucinationEvaluation make their own LLM call outside the main
+    answer-generating call, and that usage was previously silently dropped.
+    """
+
+    @pytest.fixture
+    def manager(self):
+        mock_logger = MagicMock()
+        mock_chat_service = MagicMock()
+        manager = EvaluationManager(logger=mock_logger, chat_service=mock_chat_service)
+        manager._chat_service.create_message_assessment_async = AsyncMock()
+        manager._chat_service.modify_message_assessment_async = AsyncMock()
+        return manager
+
+    def _make_evaluation(
+        self,
+        name: EvaluationMetricName,
+        invocation_stats: list[LanguageModelInvocationStats],
+    ) -> MagicMock:
+        eval_instance = MagicMock(spec=Evaluation)
+        eval_instance.get_name.return_value = name
+        eval_instance.name = name
+
+        async def fake_run(loop_response):
+            return EvaluationMetricResult(
+                name=name,
+                is_positive=True,
+                value="GREEN",
+                reason="ok",
+                invocation_stats=invocation_stats,
+            )
+
+        eval_instance.run = AsyncMock(side_effect=fake_run)
+        eval_instance.get_assessment_type.return_value = MagicMock()
+        return eval_instance
+
+    @pytest.mark.ai
+    def test_get_invocation_stats__no_evaluations_run__returns_empty_list(
+        self, manager
+    ) -> None:
+        assert manager.get_invocation_stats() == []
+
+    @pytest.mark.ai
+    @pytest.mark.asyncio
+    async def test_run_evaluations__single_evaluation__records_invocation_stats(
+        self, manager
+    ) -> None:
+        stats = LanguageModelInvocationStats.from_usage(
+            _MODEL_INFO,
+            LanguageModelTokenUsage(
+                completion_tokens=10, prompt_tokens=20, total_tokens=30
+            ),
+            source=str(EvaluationMetricName.HALLUCINATION),
+        )
+        evaluation = self._make_evaluation(EvaluationMetricName.HALLUCINATION, [stats])
+        manager.add_evaluation(evaluation)
+        mock_loop_response = MagicMock()
+
+        await manager.run_evaluations(
+            [EvaluationMetricName.HALLUCINATION], mock_loop_response, "msg_1"
+        )
+
+        assert manager.get_invocation_stats() == [
+            LanguageModelInvocationStats.from_usage(
+                _MODEL_INFO,
+                LanguageModelTokenUsage(
+                    completion_tokens=10, prompt_tokens=20, total_tokens=30
+                ),
+                source=str(EvaluationMetricName.HALLUCINATION),
+            )
+        ]
+
+    @pytest.mark.ai
+    @pytest.mark.asyncio
+    async def test_run_evaluations__multiple_evaluations__records_all_invocation_stats(
+        self, manager
+    ) -> None:
+        hallucination_stats = LanguageModelInvocationStats.from_usage(
+            _MODEL_INFO,
+            LanguageModelTokenUsage(
+                completion_tokens=10, prompt_tokens=20, total_tokens=30
+            ),
+            source=str(EvaluationMetricName.HALLUCINATION),
+        )
+        relevancy_stats = LanguageModelInvocationStats.from_usage(
+            _MODEL_INFO,
+            LanguageModelTokenUsage(
+                completion_tokens=1, prompt_tokens=2, total_tokens=3
+            ),
+            source=str(EvaluationMetricName.CONTEXT_RELEVANCY),
+        )
+        hallucination = self._make_evaluation(
+            EvaluationMetricName.HALLUCINATION, [hallucination_stats]
+        )
+        relevancy = self._make_evaluation(
+            EvaluationMetricName.CONTEXT_RELEVANCY, [relevancy_stats]
+        )
+        manager.add_evaluation(hallucination)
+        manager.add_evaluation(relevancy)
+        mock_loop_response = MagicMock()
+
+        await manager.run_evaluations(
+            [
+                EvaluationMetricName.HALLUCINATION,
+                EvaluationMetricName.CONTEXT_RELEVANCY,
+            ],
+            mock_loop_response,
+            "msg_1",
+        )
+
+        recorded = manager.get_invocation_stats()
+        assert len(recorded) == 2
+        assert recorded[0].source == str(EvaluationMetricName.HALLUCINATION)
+        assert recorded[0].token_usage == LanguageModelTokenUsage(
+            completion_tokens=10, prompt_tokens=20, total_tokens=30
+        )
+        assert recorded[1].source == str(EvaluationMetricName.CONTEXT_RELEVANCY)
+        assert recorded[1].token_usage == LanguageModelTokenUsage(
+            completion_tokens=1, prompt_tokens=2, total_tokens=3
+        )
+
+    @pytest.mark.ai
+    @pytest.mark.asyncio
+    async def test_run_evaluations__no_invocation_stats__not_recorded(
+        self, manager
+    ) -> None:
+        """An evaluation that made no LLM call (invocation_stats=[], e.g. a
+        deterministic/rule-based check) must not contribute any entries."""
+        evaluation = self._make_evaluation(EvaluationMetricName.HALLUCINATION, [])
+        manager.add_evaluation(evaluation)
+        mock_loop_response = MagicMock()
+
+        await manager.run_evaluations(
+            [EvaluationMetricName.HALLUCINATION], mock_loop_response, "msg_1"
+        )
+
+        assert manager.get_invocation_stats() == []
+
+    @pytest.mark.ai
+    @pytest.mark.asyncio
+    async def test_run_evaluations__resets_invocation_stats_between_runs(
+        self, manager
+    ) -> None:
+        stats = LanguageModelInvocationStats.from_usage(
+            _MODEL_INFO,
+            LanguageModelTokenUsage(
+                completion_tokens=10, prompt_tokens=20, total_tokens=30
+            ),
+            source=str(EvaluationMetricName.HALLUCINATION),
+        )
+        evaluation = self._make_evaluation(EvaluationMetricName.HALLUCINATION, [stats])
+        manager.add_evaluation(evaluation)
+        mock_loop_response = MagicMock()
+
+        await manager.run_evaluations(
+            [EvaluationMetricName.HALLUCINATION], mock_loop_response, "msg_1"
+        )
+        assert manager.get_invocation_stats() != []
+
+        await manager.run_evaluations([], mock_loop_response, "msg_1")
+        assert manager.get_invocation_stats() == []
+
+    @pytest.mark.ai
+    @pytest.mark.asyncio
+    async def test_run_evaluations__preserves_producer_source(self, manager) -> None:
+        """`source` is mandatory on LanguageModelInvocationStats -- the
+        manager just collects whatever each evaluation already set, it does
+        not stamp or override it."""
+        stats = LanguageModelInvocationStats.from_usage(
+            _MODEL_INFO,
+            LanguageModelTokenUsage(
+                completion_tokens=10, prompt_tokens=20, total_tokens=30
+            ),
+            source="custom_source",
+        )
+        evaluation = self._make_evaluation(EvaluationMetricName.HALLUCINATION, [stats])
+        manager.add_evaluation(evaluation)
+        mock_loop_response = MagicMock()
+
+        await manager.run_evaluations(
+            [EvaluationMetricName.HALLUCINATION], mock_loop_response, "msg_1"
+        )
+
+        recorded = manager.get_invocation_stats()
+        assert len(recorded) == 1
+        assert recorded[0].source == "custom_source"

--- a/unique_toolkit/tests/agentic/test_iteration_handler_utils.py
+++ b/unique_toolkit/tests/agentic/test_iteration_handler_utils.py
@@ -25,6 +25,7 @@ from unique_toolkit.language_model.schemas import (
     LanguageModelMessageRole,
     LanguageModelMessages,
     LanguageModelStreamResponse,
+    LanguageModelTokenUsage,
     LanguageModelUserMessage,
 )
 
@@ -34,6 +35,7 @@ def create_stream_response(
     text: str = "Response text",
     tool_calls: list[LanguageModelFunction] | None = None,
     references: list[ContentReference] | None = None,
+    usage: LanguageModelTokenUsage | None = None,
 ) -> LanguageModelStreamResponse:
     """Helper function to create LanguageModelStreamResponse instances for testing."""
     return LanguageModelStreamResponse(
@@ -47,6 +49,7 @@ def create_stream_response(
             references=references or [],
         ),
         tool_calls=tool_calls,
+        usage=usage,
     )
 
 
@@ -267,6 +270,82 @@ class TestRunForcedToolsIteration:
         assert len(result.tool_calls) == 2
         assert result.tool_calls[0].name == "Tool1"
         assert result.tool_calls[1].name == "Tool2"
+
+    @pytest.mark.ai
+    @patch(
+        "unique_toolkit.agentic.loop_runner._iteration_handler_utils.stream_response",
+        new_callable=AsyncMock,
+    )
+    async def test_run_forced_tools_iteration__sums_usage__from_multiple_responses(
+        self,
+        mock_stream: AsyncMock,
+        base_kwargs: _LoopIterationRunnerKwargs,
+    ) -> None:
+        """
+        Purpose: Verify token usage is summed, not just taken from the first
+        response, across all forced-tool-choice calls in one iteration.
+        Why this matters: each tool choice is a separate, real, billable LLM
+        call — dropping all but the first response's usage would silently
+        undercount actual token spend for any iteration with 2+ forced tools.
+        """
+        mock_stream.side_effect = [
+            create_stream_response(
+                usage=LanguageModelTokenUsage(
+                    completion_tokens=10, prompt_tokens=20, total_tokens=30
+                )
+            ),
+            create_stream_response(
+                usage=LanguageModelTokenUsage(
+                    completion_tokens=1, prompt_tokens=2, total_tokens=3
+                )
+            ),
+        ]
+
+        tool_choices: list[ChatCompletionNamedToolChoiceParam] = [
+            {"type": "function", "function": {"name": "Tool1"}},
+            {"type": "function", "function": {"name": "Tool2"}},
+        ]
+        base_kwargs["tool_choices"] = tool_choices
+        base_kwargs["tools"] = [create_mock_tool("Tool1"), create_mock_tool("Tool2")]
+
+        result = await run_forced_tools_iteration(loop_runner_kwargs=base_kwargs)
+
+        assert result.usage == LanguageModelTokenUsage(
+            completion_tokens=11,
+            prompt_tokens=22,
+            total_tokens=33,
+        )
+
+    @pytest.mark.ai
+    @patch(
+        "unique_toolkit.agentic.loop_runner._iteration_handler_utils.stream_response",
+        new_callable=AsyncMock,
+    )
+    async def test_run_forced_tools_iteration__usage_none_on_all_responses__returns_none(
+        self,
+        mock_stream: AsyncMock,
+        base_kwargs: _LoopIterationRunnerKwargs,
+    ) -> None:
+        """
+        Purpose: When no response carries usage (e.g. unsupported provider),
+        the merged result must be None, not a zeroed-out usage object that
+        would falsely imply zero tokens were spent.
+        """
+        mock_stream.side_effect = [
+            create_stream_response(),
+            create_stream_response(),
+        ]
+
+        tool_choices: list[ChatCompletionNamedToolChoiceParam] = [
+            {"type": "function", "function": {"name": "Tool1"}},
+            {"type": "function", "function": {"name": "Tool2"}},
+        ]
+        base_kwargs["tool_choices"] = tool_choices
+        base_kwargs["tools"] = [create_mock_tool("Tool1"), create_mock_tool("Tool2")]
+
+        result = await run_forced_tools_iteration(loop_runner_kwargs=base_kwargs)
+
+        assert result.usage is None
 
     @pytest.mark.ai
     @patch(

--- a/unique_toolkit/tests/agentic/test_planning_middleware.py
+++ b/unique_toolkit/tests/agentic/test_planning_middleware.py
@@ -1,0 +1,199 @@
+"""Tests for PlanningMiddleware (Chat Completions path)."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from unique_toolkit.agentic.loop_runner.middleware.planning.planning import (
+    PlanningConfig,
+    PlanningMiddleware,
+)
+from unique_toolkit.language_model.schemas import (
+    LanguageModelAssistantMessage,
+    LanguageModelMessages,
+    LanguageModelTokenUsage,
+    LanguageModelUserMessage,
+)
+
+
+def _make_middleware(
+    *,
+    loop_runner: AsyncMock | None = None,
+    history_manager: MagicMock | None = None,
+    config: PlanningConfig | None = None,
+) -> tuple[PlanningMiddleware, AsyncMock, AsyncMock]:
+    llm_service = AsyncMock()
+    runner = loop_runner or AsyncMock()
+    middleware = PlanningMiddleware(
+        loop_runner=runner,
+        config=config or PlanningConfig(),
+        llm_service=llm_service,
+        history_manager=history_manager,
+    )
+    return middleware, runner, llm_service
+
+
+def _make_model_mock(name: str = "gpt-4o") -> MagicMock:
+    model = MagicMock()
+    model.name = name
+    return model
+
+
+def _make_response(
+    parsed: dict | None = None,
+    *,
+    usage: LanguageModelTokenUsage | None = None,
+) -> MagicMock:
+    response = MagicMock()
+    response.choices = [MagicMock()]
+    response.choices[0].message.parsed = (
+        parsed if parsed is not None else {"plan": "do stuff"}
+    )
+    response.usage = usage
+    return response
+
+
+def _base_kwargs(**overrides):
+    defaults = dict(
+        iteration_index=0,
+        streaming_handler=MagicMock(),
+        messages=LanguageModelMessages([LanguageModelUserMessage(content="Hello")]),
+        model=_make_model_mock(),
+    )
+    defaults.update(overrides)
+    return defaults
+
+
+@pytest.mark.asyncio
+@pytest.mark.ai
+async def test_planning__calls_loop_runner_with_plan_appended() -> None:
+    middleware, runner, llm_service = _make_middleware()
+    llm_service.complete_async = AsyncMock(
+        return_value=_make_response({"plan": "search the docs"})
+    )
+
+    await middleware(**_base_kwargs())
+
+    runner.assert_awaited_once()
+    call_kwargs = runner.call_args[1]
+    last_msg = call_kwargs["messages"].root[-1]
+    assert isinstance(last_msg, LanguageModelAssistantMessage)
+
+
+@pytest.mark.asyncio
+@pytest.mark.ai
+async def test_planning__falls_back_when_plan_step_returns_none() -> None:
+    middleware, runner, _ = _make_middleware()
+    original_messages = LanguageModelMessages(
+        [LanguageModelUserMessage(content="Hello")]
+    )
+    kwargs = _base_kwargs(messages=original_messages)
+
+    with patch.object(
+        middleware, "_run_plan_step", new_callable=AsyncMock, return_value=None
+    ):
+        await middleware(**kwargs)
+
+    runner.assert_awaited_once()
+    assert runner.call_args[1]["messages"] is original_messages
+
+
+@pytest.mark.asyncio
+@pytest.mark.ai
+async def test_planning__adds_to_history_manager_when_present() -> None:
+    history_manager = MagicMock()
+    middleware, _, llm_service = _make_middleware(history_manager=history_manager)
+    llm_service.complete_async = AsyncMock(return_value=_make_response())
+
+    await middleware(**_base_kwargs())
+
+    history_manager.add_assistant_message.assert_called_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.ai
+async def test_planning__captures_invocation_stats_on_usage() -> None:
+    """The planning call is a real, separate LLM call the main loop never
+    sees — its usage must be captured under source="planning" so it isn't
+    silently dropped from the turn's total."""
+    middleware, _, llm_service = _make_middleware()
+    usage = LanguageModelTokenUsage(
+        completion_tokens=5, prompt_tokens=10, total_tokens=15
+    )
+    llm_service.complete_async = AsyncMock(return_value=_make_response(usage=usage))
+
+    model = _make_model_mock(name="gpt-4o-mini")
+    await middleware(**_base_kwargs(model=model))
+
+    stats = middleware.get_invocation_stats()
+    assert len(stats) == 1
+    assert stats[0].model_name == "gpt-4o-mini"
+    assert stats[0].source == "planning"
+    assert stats[0].token_usage == usage
+
+
+@pytest.mark.asyncio
+@pytest.mark.ai
+async def test_planning__no_usage_on_response__no_stats_captured() -> None:
+    middleware, _, llm_service = _make_middleware()
+    llm_service.complete_async = AsyncMock(return_value=_make_response(usage=None))
+
+    await middleware(**_base_kwargs())
+
+    assert middleware.get_invocation_stats() == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.ai
+async def test_planning__get_invocation_stats_drains_between_calls() -> None:
+    """get_invocation_stats() must return-and-clear so repeated iterations
+    (the middleware instance is reused across loop iterations) don't
+    double-count a prior iteration's planning call."""
+    middleware, _, llm_service = _make_middleware()
+    usage = LanguageModelTokenUsage(
+        completion_tokens=1, prompt_tokens=1, total_tokens=2
+    )
+    llm_service.complete_async = AsyncMock(return_value=_make_response(usage=usage))
+
+    await middleware(**_base_kwargs())
+    first_drain = middleware.get_invocation_stats()
+    second_drain = middleware.get_invocation_stats()
+
+    assert len(first_drain) == 1
+    assert second_drain == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.ai
+async def test_planning__plan_step_failure__no_stats_captured() -> None:
+    """When the plan step raises and is swallowed by @failsafe_async, no
+    usage was ever obtained, so nothing is captured."""
+    middleware, runner, llm_service = _make_middleware()
+    llm_service.complete_async = AsyncMock(side_effect=RuntimeError("boom"))
+
+    await middleware(**_base_kwargs())
+
+    runner.assert_awaited_once()
+    assert middleware.get_invocation_stats() == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.ai
+async def test_planning__parse_failure_after_usage__stats_still_captured() -> None:
+    """Tokens are spent even if the model's output fails to parse — the
+    usage must still be recorded even though the plan step itself falls
+    back to None."""
+    middleware, runner, llm_service = _make_middleware()
+    usage = LanguageModelTokenUsage(
+        completion_tokens=1, prompt_tokens=1, total_tokens=2
+    )
+    llm_service.complete_async = AsyncMock(
+        return_value=_make_response(parsed=None, usage=usage)
+    )
+
+    await middleware(**_base_kwargs())
+
+    runner.assert_awaited_once()
+    stats = middleware.get_invocation_stats()
+    assert len(stats) == 1
+    assert stats[0].token_usage == usage

--- a/unique_toolkit/tests/agentic/test_postprocessor_manager_usage.py
+++ b/unique_toolkit/tests/agentic/test_postprocessor_manager_usage.py
@@ -1,0 +1,211 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from unique_toolkit.agentic.postprocessor.postprocessor_manager import (
+    Postprocessor,
+    PostprocessorManager,
+)
+from unique_toolkit.language_model.invocation_stats import (
+    LanguageModelInvocationStats,
+)
+from unique_toolkit.language_model.schemas import LanguageModelTokenUsage
+
+_MODEL_INFO = "gpt-4-test"
+
+
+class TestPostprocessorManagerUsage:
+    """Test suite for PostprocessorManager token-usage tracking.
+
+    Mirrors test_postprocessor_manager_execution_times.py — usage is
+    collected the same way timing is, since a postprocessor's LLM call
+    (e.g. FollowUpPostprocessor) is otherwise silently dropped.
+    """
+
+    @pytest.fixture
+    def manager(self):
+        mock_logger = MagicMock()
+        mock_chat_service = MagicMock()
+        return PostprocessorManager(logger=mock_logger, chat_service=mock_chat_service)
+
+    def _make_postprocessor(
+        self, name: str, invocation_stats: list[LanguageModelInvocationStats]
+    ) -> MagicMock:
+        pp = MagicMock(spec=Postprocessor)
+        pp.name = name
+        pp.run = AsyncMock()
+        pp.invocation_stats = invocation_stats
+        return pp
+
+    @pytest.mark.ai
+    def test_default_invocation_stats__base_class__returns_empty_list(
+        self,
+    ) -> None:
+        """Postprocessor.invocation_stats defaults to [] so existing
+        postprocessors that don't make LLM calls are unaffected."""
+
+        class NoOpPostprocessor(Postprocessor):
+            async def run(self, loop_response) -> None:
+                return None
+
+        pp = NoOpPostprocessor(name="noop")
+        assert pp.invocation_stats == []
+
+    @pytest.mark.ai
+    def test_get_invocation_stats__no_postprocessors_run__returns_empty_list(
+        self, manager
+    ) -> None:
+        assert manager.get_invocation_stats() == []
+
+    @pytest.mark.ai
+    @pytest.mark.asyncio
+    async def test_execute_postprocessors__single_postprocessor__records_invocation_stats(
+        self, manager
+    ) -> None:
+        stats = LanguageModelInvocationStats.from_usage(
+            _MODEL_INFO,
+            LanguageModelTokenUsage(
+                completion_tokens=10, prompt_tokens=20, total_tokens=30
+            ),
+            source="follow_up",
+        )
+        pp = self._make_postprocessor("follow_up", [stats])
+        mock_loop_response = MagicMock()
+
+        await manager.execute_postprocessors(
+            loop_response=mock_loop_response,
+            postprocessor_instance=pp,
+        )
+
+        recorded = manager.get_invocation_stats()
+        assert len(recorded) == 1
+        assert recorded[0].source == "follow_up"
+        assert recorded[0].token_usage == LanguageModelTokenUsage(
+            completion_tokens=10, prompt_tokens=20, total_tokens=30
+        )
+
+    @pytest.mark.ai
+    @pytest.mark.asyncio
+    async def test_execute_postprocessors__multiple_postprocessors__records_all_invocation_stats(
+        self, manager
+    ) -> None:
+        stats1 = LanguageModelInvocationStats.from_usage(
+            _MODEL_INFO,
+            LanguageModelTokenUsage(
+                completion_tokens=10, prompt_tokens=20, total_tokens=30
+            ),
+            source="follow_up",
+        )
+        stats2 = LanguageModelInvocationStats.from_usage(
+            _MODEL_INFO,
+            LanguageModelTokenUsage(
+                completion_tokens=1, prompt_tokens=2, total_tokens=3
+            ),
+            source="user_memory",
+        )
+        pp1 = self._make_postprocessor("follow_up", [stats1])
+        pp2 = self._make_postprocessor("user_memory", [stats2])
+        mock_loop_response = MagicMock()
+
+        await manager.execute_postprocessors(
+            loop_response=mock_loop_response, postprocessor_instance=pp1
+        )
+        await manager.execute_postprocessors(
+            loop_response=mock_loop_response, postprocessor_instance=pp2
+        )
+
+        recorded = manager.get_invocation_stats()
+        assert len(recorded) == 2
+        assert recorded[0].source == "follow_up"
+        assert recorded[0].token_usage == LanguageModelTokenUsage(
+            completion_tokens=10, prompt_tokens=20, total_tokens=30
+        )
+        assert recorded[1].source == "user_memory"
+        assert recorded[1].token_usage == LanguageModelTokenUsage(
+            completion_tokens=1, prompt_tokens=2, total_tokens=3
+        )
+
+    @pytest.mark.ai
+    @pytest.mark.asyncio
+    async def test_execute_postprocessors__no_invocation_stats__not_recorded(
+        self, manager
+    ) -> None:
+        """A postprocessor that made no LLM call (invocation_stats -> [])
+        must not contribute any entries."""
+        stats = LanguageModelInvocationStats.from_usage(
+            _MODEL_INFO,
+            LanguageModelTokenUsage(
+                completion_tokens=10, prompt_tokens=20, total_tokens=30
+            ),
+            source="follow_up",
+        )
+        pp_with_stats = self._make_postprocessor("follow_up", [stats])
+        pp_without_stats = self._make_postprocessor("citation_fixer", [])
+        mock_loop_response = MagicMock()
+
+        await manager.execute_postprocessors(
+            loop_response=mock_loop_response, postprocessor_instance=pp_with_stats
+        )
+        await manager.execute_postprocessors(
+            loop_response=mock_loop_response, postprocessor_instance=pp_without_stats
+        )
+
+        recorded = manager.get_invocation_stats()
+        assert all(entry.source != "citation_fixer" for entry in recorded)
+        assert len(recorded) == 1
+        assert recorded[0].source == "follow_up"
+
+    @pytest.mark.ai
+    @pytest.mark.asyncio
+    async def test_run_postprocessors__resets_invocation_stats_between_runs(
+        self, manager
+    ) -> None:
+        """A prior run's invocation stats must not leak into a run with no
+        postprocessors registered — `run_postprocessors` clears
+        `_invocation_stats` up front."""
+        stats = LanguageModelInvocationStats.from_usage(
+            _MODEL_INFO,
+            LanguageModelTokenUsage(
+                completion_tokens=10, prompt_tokens=20, total_tokens=30
+            ),
+            source="follow_up",
+        )
+        pp = self._make_postprocessor("follow_up", [stats])
+        mock_loop_response = MagicMock()
+
+        # Seed state directly (bypassing routing) so a prior run's stats exist.
+        await manager.execute_postprocessors(
+            loop_response=mock_loop_response, postprocessor_instance=pp
+        )
+        assert manager.get_invocation_stats() != []
+
+        # No postprocessors registered on the manager itself -> nothing to
+        # re-populate stats with; reset must leave it empty, not stale.
+        await manager.run_postprocessors(mock_loop_response)
+        assert manager.get_invocation_stats() == []
+
+    @pytest.mark.ai
+    @pytest.mark.asyncio
+    async def test_execute_postprocessors__preserves_producer_source(
+        self, manager
+    ) -> None:
+        """`source` is mandatory on LanguageModelInvocationStats -- the
+        manager just collects whatever each postprocessor already set,
+        it does not stamp or override it."""
+        stats = LanguageModelInvocationStats.from_usage(
+            _MODEL_INFO,
+            LanguageModelTokenUsage(
+                completion_tokens=10, prompt_tokens=20, total_tokens=30
+            ),
+            source="custom_source",
+        )
+        pp = self._make_postprocessor("follow_up", [stats])
+        mock_loop_response = MagicMock()
+
+        await manager.execute_postprocessors(
+            loop_response=mock_loop_response, postprocessor_instance=pp
+        )
+
+        recorded = manager.get_invocation_stats()
+        assert len(recorded) == 1
+        assert recorded[0].source == "custom_source"

--- a/unique_toolkit/tests/agentic/test_responses_iteration_handler_utils.py
+++ b/unique_toolkit/tests/agentic/test_responses_iteration_handler_utils.py
@@ -1,0 +1,118 @@
+"""Tests for _responses_iteration_handler_utils module — specifically the
+usage-summing fix for handle_responses_forced_tools_iteration (mirrors the
+Chat Completions forced-tools usage merge in _iteration_handler_utils.py)."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from unique_toolkit.agentic.loop_runner._responses_iteration_handler_utils import (
+    handle_responses_forced_tools_iteration,
+)
+from unique_toolkit.agentic.loop_runner.base import (
+    _ResponsesLoopIterationRunnerKwargs,
+)
+from unique_toolkit.language_model.schemas import (
+    LanguageModelMessageRole,
+    LanguageModelStreamResponseMessage,
+    LanguageModelTokenUsage,
+    ResponsesLanguageModelStreamResponse,
+)
+
+
+def _make_message() -> LanguageModelStreamResponseMessage:
+    return LanguageModelStreamResponseMessage(
+        id="msg-1",
+        chat_id="chat-1",
+        previous_message_id=None,
+        role=LanguageModelMessageRole.ASSISTANT,
+        text="hello",
+    )
+
+
+def _make_response(
+    usage: LanguageModelTokenUsage | None = None,
+) -> ResponsesLanguageModelStreamResponse:
+    return ResponsesLanguageModelStreamResponse(
+        message=_make_message(),
+        output=[],
+        usage=usage,
+    )
+
+
+@pytest.fixture
+def base_kwargs() -> _ResponsesLoopIterationRunnerKwargs:
+    return {
+        "messages": None,  # type: ignore[typeddict-item]
+        "iteration_index": 0,
+        "streaming_handler": None,  # type: ignore[typeddict-item]
+        "model": None,  # type: ignore[typeddict-item]
+        "tools": [],
+        "content_chunks": [],
+        "start_text": None,
+        "debug_info": {},
+        "temperature": 0.0,
+        "tool_choices": [
+            {"type": "function", "function": {"name": "Tool1"}},
+            {"type": "function", "function": {"name": "Tool2"}},
+        ],
+        "other_options": None,
+    }
+
+
+@pytest.mark.ai
+@patch(
+    "unique_toolkit.agentic.loop_runner._responses_iteration_handler_utils.responses_stream_response",
+    new_callable=AsyncMock,
+)
+@pytest.mark.asyncio
+async def test_handle_responses_forced_tools_iteration__sums_usage__from_multiple_responses(
+    mock_stream: AsyncMock,
+    base_kwargs: _ResponsesLoopIterationRunnerKwargs,
+) -> None:
+    """
+    Purpose: Verify token usage is summed across all forced-tool-choice calls
+    in the Responses API path, matching the Chat Completions fix.
+    Why this matters: each tool choice is a separate, real, billable LLM call
+    — dropping all but the first response's usage would silently undercount
+    token spend for any iteration with 2+ forced tools.
+    """
+    mock_stream.side_effect = [
+        _make_response(
+            usage=LanguageModelTokenUsage(
+                completion_tokens=10, prompt_tokens=20, total_tokens=30
+            )
+        ),
+        _make_response(
+            usage=LanguageModelTokenUsage(
+                completion_tokens=1, prompt_tokens=2, total_tokens=3
+            )
+        ),
+    ]
+
+    result = await handle_responses_forced_tools_iteration(**base_kwargs)
+
+    assert result.usage == LanguageModelTokenUsage(
+        completion_tokens=11,
+        prompt_tokens=22,
+        total_tokens=33,
+    )
+
+
+@pytest.mark.ai
+@patch(
+    "unique_toolkit.agentic.loop_runner._responses_iteration_handler_utils.responses_stream_response",
+    new_callable=AsyncMock,
+)
+@pytest.mark.asyncio
+async def test_handle_responses_forced_tools_iteration__usage_none_on_all__returns_none(
+    mock_stream: AsyncMock,
+    base_kwargs: _ResponsesLoopIterationRunnerKwargs,
+) -> None:
+    """When no response carries usage, the merged result must be None, not a
+    zeroed-out usage object implying zero tokens were spent."""
+    mock_stream.side_effect = [_make_response(), _make_response()]
+
+    result = await handle_responses_forced_tools_iteration(**base_kwargs)
+
+    assert result.usage is None

--- a/unique_toolkit/tests/agentic/test_responses_planning_middleware.py
+++ b/unique_toolkit/tests/agentic/test_responses_planning_middleware.py
@@ -4,6 +4,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from openai.types.responses import Response, ResponseFunctionToolCall
+from openai.types.responses.response_usage import (
+    InputTokensDetails,
+    OutputTokensDetails,
+    ResponseUsage,
+)
 
 from unique_toolkit.agentic.loop_runner.middleware.planning.planning import (
     _PLAN_TOOL_NAME,
@@ -49,11 +54,30 @@ def _make_tool_call(arguments: str = '{"plan": "do stuff"}') -> MagicMock:
     return call
 
 
-def _make_response(arguments: str = '{"plan": "do stuff"}') -> MagicMock:
+def _make_response(
+    arguments: str = '{"plan": "do stuff"}', *, usage: MagicMock | None = None
+) -> MagicMock:
     """Create a mock Response whose output contains a single forced tool call."""
     response = MagicMock(spec=Response)
     response.output = [_make_tool_call(arguments)]
+    response.usage = usage
     return response
+
+
+def _make_usage(
+    input_tokens: int = 10,
+    output_tokens: int = 5,
+    total_tokens: int = 15,
+    reasoning_tokens: int = 0,
+    cached_tokens: int = 0,
+) -> ResponseUsage:
+    return ResponseUsage(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        total_tokens=total_tokens,
+        output_tokens_details=OutputTokensDetails(reasoning_tokens=reasoning_tokens),
+        input_tokens_details=InputTokensDetails(cached_tokens=cached_tokens),
+    )
 
 
 def _base_kwargs(**overrides):
@@ -335,6 +359,81 @@ async def test_responses_planning__converts_tool_description_objects() -> None:
     search_tool = call_kwargs["tools"][1]
     assert search_tool["type"] == "function"
     assert isinstance(search_tool["parameters"], dict)
+
+
+# ============================================================================
+# Tests for get_invocation_stats
+# ============================================================================
+
+
+@pytest.mark.asyncio
+@pytest.mark.ai
+async def test_responses_planning__captures_invocation_stats_on_usage() -> None:
+    """
+    Purpose: The planning call is a real, separate LLM call the main loop
+    never sees — its usage must be captured under source="planning" and
+    exposed via get_invocation_stats(), mapping OpenAI's ResponseUsage
+    (input_tokens/output_tokens/total_tokens) onto our LanguageModelTokenUsage.
+    """
+    middleware, _, openai_client = _make_middleware()
+    usage = _make_usage(input_tokens=10, output_tokens=5, total_tokens=15)
+    openai_client.responses.create = AsyncMock(return_value=_make_response(usage=usage))
+
+    model = _make_model_mock(name="o3-mini")
+    await middleware(**_base_kwargs(model=model))
+
+    stats = middleware.get_invocation_stats()
+    assert len(stats) == 1
+    assert stats[0].model_name == "o3-mini"
+    assert stats[0].source == "planning"
+    assert stats[0].token_usage.prompt_tokens == 10
+    assert stats[0].token_usage.completion_tokens == 5
+    assert stats[0].token_usage.total_tokens == 15
+
+
+@pytest.mark.asyncio
+@pytest.mark.ai
+async def test_responses_planning__no_usage_on_response__no_stats_captured() -> None:
+    """Provider responses without usage must not produce a stats entry."""
+    middleware, _, openai_client = _make_middleware()
+    openai_client.responses.create = AsyncMock(return_value=_make_response(usage=None))
+
+    await middleware(**_base_kwargs())
+
+    assert middleware.get_invocation_stats() == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.ai
+async def test_responses_planning__get_invocation_stats_drains_between_calls() -> None:
+    """get_invocation_stats() must return-and-clear so repeated iterations
+    (the middleware instance is reused across loop iterations) don't
+    double-count a prior iteration's planning call."""
+    middleware, _, openai_client = _make_middleware()
+    openai_client.responses.create = AsyncMock(
+        return_value=_make_response(usage=_make_usage())
+    )
+
+    await middleware(**_base_kwargs())
+    first_drain = middleware.get_invocation_stats()
+    second_drain = middleware.get_invocation_stats()
+
+    assert len(first_drain) == 1
+    assert second_drain == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.ai
+async def test_responses_planning__plan_step_failure__no_stats_captured() -> None:
+    """When the plan step raises (e.g. malformed response) and is swallowed
+    by @failsafe_async, no usage was ever obtained, so nothing is captured."""
+    middleware, runner, openai_client = _make_middleware()
+    openai_client.responses.create = AsyncMock(side_effect=RuntimeError("boom"))
+
+    await middleware(**_base_kwargs())
+
+    runner.assert_awaited_once()
+    assert middleware.get_invocation_stats() == []
 
 
 @pytest.mark.asyncio

--- a/unique_toolkit/tests/agentic/tools/a2a/test_sub_agent_evaluation_usage.py
+++ b/unique_toolkit/tests/agentic/tools/a2a/test_sub_agent_evaluation_usage.py
@@ -1,0 +1,158 @@
+import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from unique_toolkit.agentic.evaluation.schemas import EvaluationMetricName
+from unique_toolkit.agentic.tools.a2a.evaluation.config import (
+    SubAgentEvaluationConfig,
+    SubAgentEvaluationServiceConfig,
+)
+from unique_toolkit.agentic.tools.a2a.evaluation.evaluator import (
+    SubAgentEvaluationService,
+    SubAgentEvaluationSpec,
+)
+from unique_toolkit.agentic.tools.a2a.response_watcher import SubAgentResponseWatcher
+from unique_toolkit.chat.schemas import (
+    ChatMessageAssessmentLabel,
+    ChatMessageAssessmentStatus,
+)
+from unique_toolkit.language_model.invocation_stats import (
+    LanguageModelInvocationStats,
+)
+from unique_toolkit.language_model.schemas import (
+    LanguageModelCompletionChoice,
+    LanguageModelResponse,
+    LanguageModelTokenUsage,
+)
+
+
+def _make_message(label: str) -> dict:
+    return {
+        "id": "msg-1",
+        "chatId": "chat-1",
+        "role": "ASSISTANT",
+        "text": "some sub-agent answer",
+        "assessment": [
+            {
+                "label": label,
+                "status": ChatMessageAssessmentStatus.DONE,
+                "explanation": "looks fine",
+                "title": "Hallucination",
+                "type": "HALLUCINATION",
+            }
+        ],
+    }
+
+
+def _make_service(complete_async_mock: AsyncMock) -> SubAgentEvaluationService:
+    watcher = SubAgentResponseWatcher()
+    watcher.notify_response(
+        assistant_id="assistant-1",
+        name="Agent One",
+        sequence_number=1,
+        response=_make_message(ChatMessageAssessmentLabel.GREEN),
+        timestamp=datetime.datetime.now(datetime.UTC),
+    )
+    watcher.notify_response(
+        assistant_id="assistant-2",
+        name="Agent Two",
+        sequence_number=1,
+        response=_make_message(ChatMessageAssessmentLabel.GREEN),
+        timestamp=datetime.datetime.now(datetime.UTC),
+    )
+
+    language_model_service = MagicMock()
+    language_model_service.complete_async = complete_async_mock
+
+    return SubAgentEvaluationService(
+        config=SubAgentEvaluationServiceConfig(),
+        language_model_service=language_model_service,
+        response_watcher=watcher,
+        evaluation_specs=[
+            SubAgentEvaluationSpec(
+                display_name="Agent One",
+                assistant_id="assistant-1",
+                config=SubAgentEvaluationConfig(),
+            ),
+            SubAgentEvaluationSpec(
+                display_name="Agent Two",
+                assistant_id="assistant-2",
+                config=SubAgentEvaluationConfig(),
+            ),
+        ],
+    )
+
+
+@pytest.mark.ai
+@pytest.mark.asyncio
+async def test_sub_agent_evaluation__multiple_assessments__carries_invocation_stats() -> (
+    None
+):
+    """SubAgentEvaluationService.run(), in its multi-assessment branch, makes
+    its own LLM call to summarize the assessments (_get_reason) — that
+    response's usage was previously discarded (_get_reason returned only a
+    plain str). Verify it now survives onto the final EvaluationMetricResult
+    as an invocation_stats entry, tagged with the model used and the
+    evaluation's own name as source."""
+    complete_async_mock = AsyncMock(
+        return_value=LanguageModelResponse(
+            choices=[
+                LanguageModelCompletionChoice(
+                    index=0,
+                    message={"role": "assistant", "content": "summary text"},
+                    finish_reason="stop",
+                )
+            ],
+            usage=LanguageModelTokenUsage(
+                completion_tokens=12, prompt_tokens=34, total_tokens=46
+            ),
+        )
+    )
+    service = _make_service(complete_async_mock)
+
+    result = await service.run(loop_response=MagicMock())
+
+    complete_async_mock.assert_awaited_once()
+    assert result.reason == "summary text"
+    assert result.invocation_stats == [
+        LanguageModelInvocationStats.from_usage(
+            SubAgentEvaluationServiceConfig().summarization_model.name,
+            LanguageModelTokenUsage(
+                completion_tokens=12, prompt_tokens=34, total_tokens=46
+            ),
+            source=str(EvaluationMetricName.SUB_AGENT),
+        )
+    ]
+
+
+@pytest.mark.ai
+@pytest.mark.asyncio
+async def test_sub_agent_evaluation__no_responses__no_invocation_stats_no_llm_call() -> (
+    None
+):
+    """The no-responses early-return path makes no LLM call at all --
+    invocation_stats must stay empty, and complete_async must never be
+    called."""
+    complete_async_mock = AsyncMock()
+    watcher = SubAgentResponseWatcher()
+    language_model_service = MagicMock()
+    language_model_service.complete_async = complete_async_mock
+
+    service = SubAgentEvaluationService(
+        config=SubAgentEvaluationServiceConfig(),
+        language_model_service=language_model_service,
+        response_watcher=watcher,
+        evaluation_specs=[
+            SubAgentEvaluationSpec(
+                display_name="Agent One",
+                assistant_id="assistant-1",
+                config=SubAgentEvaluationConfig(),
+            )
+        ],
+    )
+
+    result = await service.run(loop_response=MagicMock())
+
+    complete_async_mock.assert_not_awaited()
+    assert result.invocation_stats == []

--- a/unique_toolkit/tests/agentic/tools/a2a/test_sub_agent_evaluation_usage.py
+++ b/unique_toolkit/tests/agentic/tools/a2a/test_sub_agent_evaluation_usage.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from unique_toolkit.agentic.evaluation.exception import EvaluatorException
 from unique_toolkit.agentic.evaluation.schemas import EvaluationMetricName
 from unique_toolkit.agentic.tools.a2a.evaluation.config import (
     SubAgentEvaluationConfig,
@@ -116,6 +117,38 @@ async def test_sub_agent_evaluation__multiple_assessments__carries_invocation_st
     complete_async_mock.assert_awaited_once()
     assert result.reason == "summary text"
     assert result.invocation_stats == [
+        LanguageModelInvocationStats.from_usage(
+            SubAgentEvaluationServiceConfig().summarization_model.name,
+            LanguageModelTokenUsage(
+                completion_tokens=12, prompt_tokens=34, total_tokens=46
+            ),
+            source=str(EvaluationMetricName.SUB_AGENT),
+        )
+    ]
+
+
+@pytest.mark.ai
+@pytest.mark.asyncio
+async def test_sub_agent_evaluation__preserves_invocation_stats__on_reason_read_error() -> (
+    None
+):
+    """A billed summarization call that returns no choices must still
+    surface its usage via EvaluatorException.invocation_stats, instead of
+    losing it when `response.choices[0]` raises."""
+    complete_async_mock = AsyncMock(
+        return_value=LanguageModelResponse(
+            choices=[],
+            usage=LanguageModelTokenUsage(
+                completion_tokens=12, prompt_tokens=34, total_tokens=46
+            ),
+        )
+    )
+    service = _make_service(complete_async_mock)
+
+    with pytest.raises(EvaluatorException) as exc_info:
+        await service.run(loop_response=MagicMock())
+
+    assert exc_info.value.invocation_stats == [
         LanguageModelInvocationStats.from_usage(
             SubAgentEvaluationServiceConfig().summarization_model.name,
             LanguageModelTokenUsage(

--- a/unique_toolkit/tests/experimental/integrations/openai/streaming/test_stream_event_routers.py
+++ b/unique_toolkit/tests/experimental/integrations/openai/streaming/test_stream_event_routers.py
@@ -16,11 +16,16 @@ from openai.types.responses import (
     ResponseFunctionCallArgumentsDoneEvent,
     ResponseOutputItemAddedEvent,
     ResponseTextDeltaEvent,
+    ResponseUsage,
 )
 from openai.types.responses.response_function_tool_call_item import (
     ResponseFunctionToolCallItem,
 )
 from openai.types.responses.response_text_delta_event import Logprob
+from openai.types.responses.response_usage import (
+    InputTokensDetails,
+    OutputTokensDetails,
+)
 
 from unique_toolkit._common.event_bus import TypedEventBus
 from unique_toolkit.experimental._internal.streaming import TextFlushed, TextState
@@ -473,7 +478,13 @@ async def test_AI_responses_completed_event_handler__on_completed__extracts_usag
     Setup summary: Build minimal event object; on_completed; assert usage and output list.
     """
     event_handler = ResponsesCompletedEventHandler()
-    usage_obj = SimpleNamespace(input_tokens=3, output_tokens=5, total_tokens=8)
+    usage_obj = ResponseUsage(
+        input_tokens=3,
+        output_tokens=5,
+        total_tokens=8,
+        input_tokens_details=InputTokensDetails(cached_tokens=0),
+        output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
+    )
     out_item = object()
     response = SimpleNamespace(usage=usage_obj, output=[out_item])
     event = SimpleNamespace(response=response)

--- a/unique_toolkit/tests/experimental/integrations/openai/streaming/test_text_event_handler.py
+++ b/unique_toolkit/tests/experimental/integrations/openai/streaming/test_text_event_handler.py
@@ -4,8 +4,6 @@ accumulation, flush throttling, and bus publishing semantics.
 
 from __future__ import annotations
 
-from types import SimpleNamespace
-
 import pytest
 from openai.types.chat.chat_completion_chunk import (
     ChatCompletionChunk,
@@ -14,6 +12,7 @@ from openai.types.chat.chat_completion_chunk import (
     ChoiceDeltaToolCall,
     ChoiceDeltaToolCallFunction,
 )
+from openai.types.completion_usage import CompletionUsage
 
 from unique_toolkit.experimental._internal.streaming import TextFlushed
 from unique_toolkit.experimental.integrations.openai.streaming.event_routing.chat_completions.text_event_handler import (
@@ -26,7 +25,7 @@ def _chunk(
     content: str | None = None,
     tool_calls: list[ChoiceDeltaToolCall] | None = None,
     no_choices: bool = False,
-    usage: SimpleNamespace | None = None,
+    usage: CompletionUsage | None = None,
 ) -> ChatCompletionChunk:
     choices = (
         []
@@ -138,7 +137,7 @@ async def test_AI_text_event_handler__on_chunk__captures_usage_from_terminal_chu
     await event_handler.on_chunk(
         _chunk(
             no_choices=True,
-            usage=SimpleNamespace(
+            usage=CompletionUsage(
                 completion_tokens=3,
                 prompt_tokens=5,
                 total_tokens=8,

--- a/unique_toolkit/tests/language_model/test_invocation_stats.py
+++ b/unique_toolkit/tests/language_model/test_invocation_stats.py
@@ -5,7 +5,6 @@ from pydantic import ValidationError
 
 from unique_toolkit.language_model.infos import LanguageModelName
 from unique_toolkit.language_model.invocation_stats import (
-    LanguageModelInvocationReport,
     LanguageModelInvocationStats,
 )
 from unique_toolkit.language_model.schemas import LanguageModelTokenUsage
@@ -38,73 +37,7 @@ class TestLanguageModelInvocationStatsFromUsage:
             LanguageModelInvocationStats.from_usage("gpt-4-test", usage)  # type: ignore[call-arg]
 
 
-class TestLanguageModelInvocationReportTotals:
-    @pytest.mark.ai
-    def test_empty_invocations__total_is_none(self) -> None:
-        report = LanguageModelInvocationReport()
-
-        assert report.invocations == []
-        assert report.total_token_usage is None
-
-    @pytest.mark.ai
-    def test_multiple_invocations__total_token_usage_sums_across_all(self) -> None:
-        stats_a = LanguageModelInvocationStats(
-            model_name="gpt-4-test",
-            token_usage=LanguageModelTokenUsage(
-                completion_tokens=10,
-                prompt_tokens=20,
-                total_tokens=30,
-                reasoning_tokens=5,
-                cached_tokens=8,
-            ),
-            source="main_loop",
-        )
-        stats_b = LanguageModelInvocationStats(
-            model_name="gpt-4-test",
-            token_usage=LanguageModelTokenUsage(
-                completion_tokens=1, prompt_tokens=2, total_tokens=3
-            ),
-            source="hallucination",
-        )
-        report = LanguageModelInvocationReport(invocations=[stats_a, stats_b])
-
-        assert report.total_token_usage == LanguageModelTokenUsage(
-            completion_tokens=11,
-            prompt_tokens=22,
-            total_tokens=33,
-            reasoning_tokens=5,
-            cached_tokens=8,
-            cache_write_tokens=None,
-        )
-
-    @pytest.mark.ai
-    def test_all_invocations_missing_a_field__total_stays_none_not_zero(self) -> None:
-        """If no invocation ever reported cache_write_tokens (the provider never
-        emits it), the total must stay `None` ("unknown"), not `0`
-        ("confirmed zero") -- summing must not invent data no entry has."""
-        stats_a = LanguageModelInvocationStats(
-            model_name="gpt-4-test",
-            token_usage=LanguageModelTokenUsage(
-                completion_tokens=10, prompt_tokens=20, total_tokens=30
-            ),
-            source="main_loop",
-        )
-        stats_b = LanguageModelInvocationStats(
-            model_name="gpt-4-test",
-            token_usage=LanguageModelTokenUsage(
-                completion_tokens=1, prompt_tokens=2, total_tokens=3
-            ),
-            source="hallucination",
-        )
-        report = LanguageModelInvocationReport(invocations=[stats_a, stats_b])
-
-        assert report.total_token_usage is not None
-        assert report.total_token_usage.reasoning_tokens is None
-        assert report.total_token_usage.cached_tokens is None
-        assert report.total_token_usage.cache_write_tokens is None
-
-
-class TestLanguageModelInvocationReportSerialization:
+class TestLanguageModelInvocationStatsSerialization:
     @pytest.mark.ai
     def test_model_dump_by_alias__camel_case_shape(self) -> None:
         stats = LanguageModelInvocationStats(
@@ -114,26 +47,12 @@ class TestLanguageModelInvocationReportSerialization:
             ),
             source="main_loop",
         )
-        report = LanguageModelInvocationReport(invocations=[stats])
 
-        dumped = report.model_dump(by_alias=True)
+        dumped = stats.model_dump(by_alias=True)
 
         assert dumped == {
-            "invocations": [
-                {
-                    "modelName": "gpt-4-test",
-                    "tokenUsage": {
-                        "completionTokens": 10,
-                        "promptTokens": 20,
-                        "totalTokens": 30,
-                        "reasoningTokens": None,
-                        "cachedTokens": None,
-                        "cacheWriteTokens": None,
-                    },
-                    "source": "main_loop",
-                }
-            ],
-            "totalTokenUsage": {
+            "modelName": "gpt-4-test",
+            "tokenUsage": {
                 "completionTokens": 10,
                 "promptTokens": 20,
                 "totalTokens": 30,
@@ -141,17 +60,7 @@ class TestLanguageModelInvocationReportSerialization:
                 "cachedTokens": None,
                 "cacheWriteTokens": None,
             },
-        }
-
-    @pytest.mark.ai
-    def test_model_dump_by_alias__empty_report(self) -> None:
-        report = LanguageModelInvocationReport()
-
-        dumped = report.model_dump(by_alias=True)
-
-        assert dumped == {
-            "invocations": [],
-            "totalTokenUsage": None,
+            "source": "main_loop",
         }
 
 
@@ -288,19 +197,6 @@ class TestLanguageModelInvocationStatsNoProtectedNamespaceWarning:
                 ),
                 source="main_loop",
             )
-
-        protected_namespace_warnings = [
-            warning
-            for warning in caught
-            if "protected namespace" in str(warning.message)
-        ]
-        assert protected_namespace_warnings == []
-
-    @pytest.mark.ai
-    def test_report_construction__emits_no_protected_namespace_warning(self) -> None:
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            LanguageModelInvocationReport()
 
         protected_namespace_warnings = [
             warning

--- a/unique_toolkit/tests/language_model/test_invocation_stats.py
+++ b/unique_toolkit/tests/language_model/test_invocation_stats.py
@@ -1,0 +1,310 @@
+import warnings
+
+import pytest
+from pydantic import ValidationError
+
+from unique_toolkit.language_model.infos import LanguageModelName
+from unique_toolkit.language_model.invocation_stats import (
+    LanguageModelInvocationReport,
+    LanguageModelInvocationStats,
+)
+from unique_toolkit.language_model.schemas import LanguageModelTokenUsage
+
+
+class TestLanguageModelInvocationStatsFromUsage:
+    """`from_usage` is the single constructor for per-invocation stats."""
+
+    @pytest.mark.ai
+    def test_from_usage__builds_stats(self) -> None:
+        usage = LanguageModelTokenUsage(
+            completion_tokens=10, prompt_tokens=20, total_tokens=30
+        )
+
+        stats = LanguageModelInvocationStats.from_usage(
+            "gpt-4-test", usage, source="main_loop"
+        )
+
+        assert stats.model_name == "gpt-4-test"
+        assert stats.token_usage == usage
+        assert stats.source == "main_loop"
+
+    @pytest.mark.ai
+    def test_from_usage__source_required(self) -> None:
+        usage = LanguageModelTokenUsage(
+            completion_tokens=1, prompt_tokens=2, total_tokens=3
+        )
+
+        with pytest.raises(TypeError):
+            LanguageModelInvocationStats.from_usage("gpt-4-test", usage)  # type: ignore[call-arg]
+
+
+class TestLanguageModelInvocationReportTotals:
+    @pytest.mark.ai
+    def test_empty_invocations__total_is_none(self) -> None:
+        report = LanguageModelInvocationReport()
+
+        assert report.invocations == []
+        assert report.total_token_usage is None
+
+    @pytest.mark.ai
+    def test_multiple_invocations__total_token_usage_sums_across_all(self) -> None:
+        stats_a = LanguageModelInvocationStats(
+            model_name="gpt-4-test",
+            token_usage=LanguageModelTokenUsage(
+                completion_tokens=10,
+                prompt_tokens=20,
+                total_tokens=30,
+                reasoning_tokens=5,
+                cached_tokens=8,
+            ),
+            source="main_loop",
+        )
+        stats_b = LanguageModelInvocationStats(
+            model_name="gpt-4-test",
+            token_usage=LanguageModelTokenUsage(
+                completion_tokens=1, prompt_tokens=2, total_tokens=3
+            ),
+            source="hallucination",
+        )
+        report = LanguageModelInvocationReport(invocations=[stats_a, stats_b])
+
+        assert report.total_token_usage == LanguageModelTokenUsage(
+            completion_tokens=11,
+            prompt_tokens=22,
+            total_tokens=33,
+            reasoning_tokens=5,
+            cached_tokens=8,
+            cache_write_tokens=None,
+        )
+
+    @pytest.mark.ai
+    def test_all_invocations_missing_a_field__total_stays_none_not_zero(self) -> None:
+        """If no invocation ever reported cache_write_tokens (the provider never
+        emits it), the total must stay `None` ("unknown"), not `0`
+        ("confirmed zero") -- summing must not invent data no entry has."""
+        stats_a = LanguageModelInvocationStats(
+            model_name="gpt-4-test",
+            token_usage=LanguageModelTokenUsage(
+                completion_tokens=10, prompt_tokens=20, total_tokens=30
+            ),
+            source="main_loop",
+        )
+        stats_b = LanguageModelInvocationStats(
+            model_name="gpt-4-test",
+            token_usage=LanguageModelTokenUsage(
+                completion_tokens=1, prompt_tokens=2, total_tokens=3
+            ),
+            source="hallucination",
+        )
+        report = LanguageModelInvocationReport(invocations=[stats_a, stats_b])
+
+        assert report.total_token_usage is not None
+        assert report.total_token_usage.reasoning_tokens is None
+        assert report.total_token_usage.cached_tokens is None
+        assert report.total_token_usage.cache_write_tokens is None
+
+
+class TestLanguageModelInvocationReportSerialization:
+    @pytest.mark.ai
+    def test_model_dump_by_alias__camel_case_shape(self) -> None:
+        stats = LanguageModelInvocationStats(
+            model_name="gpt-4-test",
+            token_usage=LanguageModelTokenUsage(
+                completion_tokens=10, prompt_tokens=20, total_tokens=30
+            ),
+            source="main_loop",
+        )
+        report = LanguageModelInvocationReport(invocations=[stats])
+
+        dumped = report.model_dump(by_alias=True)
+
+        assert dumped == {
+            "invocations": [
+                {
+                    "modelName": "gpt-4-test",
+                    "tokenUsage": {
+                        "completionTokens": 10,
+                        "promptTokens": 20,
+                        "totalTokens": 30,
+                        "reasoningTokens": None,
+                        "cachedTokens": None,
+                        "cacheWriteTokens": None,
+                    },
+                    "source": "main_loop",
+                }
+            ],
+            "totalTokenUsage": {
+                "completionTokens": 10,
+                "promptTokens": 20,
+                "totalTokens": 30,
+                "reasoningTokens": None,
+                "cachedTokens": None,
+                "cacheWriteTokens": None,
+            },
+        }
+
+    @pytest.mark.ai
+    def test_model_dump_by_alias__empty_report(self) -> None:
+        report = LanguageModelInvocationReport()
+
+        dumped = report.model_dump(by_alias=True)
+
+        assert dumped == {
+            "invocations": [],
+            "totalTokenUsage": None,
+        }
+
+
+class TestLanguageModelInvocationStatsModelName:
+    @pytest.mark.ai
+    def test_model_name__accepts_language_model_name_enum__dumps_as_plain_string(
+        self,
+    ) -> None:
+        stats = LanguageModelInvocationStats(
+            model_name=LanguageModelName.AZURE_GPT_4o_2024_1120,
+            token_usage=LanguageModelTokenUsage(
+                completion_tokens=1, prompt_tokens=1, total_tokens=2
+            ),
+            source="main_loop",
+        )
+
+        assert stats.model_name == LanguageModelName.AZURE_GPT_4o_2024_1120
+
+        dumped = stats.model_dump(by_alias=True)
+        assert dumped["modelName"] == LanguageModelName.AZURE_GPT_4o_2024_1120.value
+        assert isinstance(dumped["modelName"], str)
+
+    @pytest.mark.ai
+    def test_model_name__accepts_arbitrary_string(self) -> None:
+        stats = LanguageModelInvocationStats(
+            model_name="some-custom-model-id",
+            token_usage=LanguageModelTokenUsage(
+                completion_tokens=1, prompt_tokens=1, total_tokens=2
+            ),
+            source="main_loop",
+        )
+
+        assert stats.model_name == "some-custom-model-id"
+        assert stats.model_dump(by_alias=True)["modelName"] == "some-custom-model-id"
+
+    @pytest.mark.ai
+    def test_model_name__string_matching_known_name__normalized_to_enum(self) -> None:
+        """Capture sites pass `.name` strings; a string that matches a
+        `LanguageModelName` value must canonicalize to the enum so the same
+        model never appears as both enum and str across entries."""
+        stats = LanguageModelInvocationStats(
+            model_name=LanguageModelName.AZURE_GPT_4o_2024_1120.value,
+            token_usage=LanguageModelTokenUsage(
+                completion_tokens=1, prompt_tokens=1, total_tokens=2
+            ),
+            source="main_loop",
+        )
+
+        assert isinstance(stats.model_name, LanguageModelName)
+        assert stats.model_name is LanguageModelName.AZURE_GPT_4o_2024_1120
+
+    @pytest.mark.ai
+    def test_model_name__string_is_stripped(self) -> None:
+        stats = LanguageModelInvocationStats(
+            model_name="  some-custom-model-id  ",
+            token_usage=LanguageModelTokenUsage(
+                completion_tokens=1, prompt_tokens=1, total_tokens=2
+            ),
+            source="main_loop",
+        )
+
+        assert stats.model_name == "some-custom-model-id"
+
+    @pytest.mark.ai
+    def test_model_name__empty_string__raises(self) -> None:
+        with pytest.raises(ValidationError):
+            LanguageModelInvocationStats(
+                model_name="   ",
+                token_usage=LanguageModelTokenUsage(
+                    completion_tokens=1, prompt_tokens=1, total_tokens=2
+                ),
+                source="main_loop",
+            )
+
+
+class TestLanguageModelInvocationStatsSource:
+    @pytest.mark.ai
+    def test_source__missing__raises(self) -> None:
+        with pytest.raises(ValidationError):
+            LanguageModelInvocationStats(
+                model_name="gpt-4-test",
+                token_usage=LanguageModelTokenUsage(
+                    completion_tokens=1, prompt_tokens=1, total_tokens=2
+                ),
+            )  # type: ignore[call-arg]
+
+    @pytest.mark.ai
+    def test_source__empty_string__raises(self) -> None:
+        with pytest.raises(ValidationError):
+            LanguageModelInvocationStats(
+                model_name="gpt-4-test",
+                token_usage=LanguageModelTokenUsage(
+                    completion_tokens=1, prompt_tokens=1, total_tokens=2
+                ),
+                source="",
+            )
+
+    @pytest.mark.ai
+    def test_source__whitespace_only__raises(self) -> None:
+        with pytest.raises(ValidationError):
+            LanguageModelInvocationStats(
+                model_name="gpt-4-test",
+                token_usage=LanguageModelTokenUsage(
+                    completion_tokens=1, prompt_tokens=1, total_tokens=2
+                ),
+                source="   ",
+            )
+
+    @pytest.mark.ai
+    def test_source__is_stripped(self) -> None:
+        stats = LanguageModelInvocationStats(
+            model_name="gpt-4-test",
+            token_usage=LanguageModelTokenUsage(
+                completion_tokens=1, prompt_tokens=1, total_tokens=2
+            ),
+            source="  main_loop  ",
+        )
+
+        assert stats.source == "main_loop"
+
+
+class TestLanguageModelInvocationStatsNoProtectedNamespaceWarning:
+    @pytest.mark.ai
+    def test_construction__emits_no_protected_namespace_warning(self) -> None:
+        """`model_name` starts with `model_` which pydantic normally flags as
+        a protected-namespace clash; `protected_namespaces=()` on the shared
+        model_config must silence that warning."""
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            LanguageModelInvocationStats(
+                model_name="gpt-4-test",
+                token_usage=LanguageModelTokenUsage(
+                    completion_tokens=1, prompt_tokens=1, total_tokens=2
+                ),
+                source="main_loop",
+            )
+
+        protected_namespace_warnings = [
+            warning
+            for warning in caught
+            if "protected namespace" in str(warning.message)
+        ]
+        assert protected_namespace_warnings == []
+
+    @pytest.mark.ai
+    def test_report_construction__emits_no_protected_namespace_warning(self) -> None:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            LanguageModelInvocationReport()
+
+        protected_namespace_warnings = [
+            warning
+            for warning in caught
+            if "protected namespace" in str(warning.message)
+        ]
+        assert protected_namespace_warnings == []

--- a/unique_toolkit/tests/language_model/test_language_model_schemas.py
+++ b/unique_toolkit/tests/language_model/test_language_model_schemas.py
@@ -1,6 +1,7 @@
 import json
 
 import pytest
+from openai.types.completion_usage import CompletionTokensDetails, CompletionUsage
 from pydantic import BaseModel, Field, ValidationError
 
 from unique_toolkit.language_model.schemas import (
@@ -11,7 +12,10 @@ from unique_toolkit.language_model.schemas import (
     LanguageModelMessageRole,
     LanguageModelMessages,
     LanguageModelResponse,
+    LanguageModelStreamResponse,
+    LanguageModelStreamResponseMessage,
     LanguageModelSystemMessage,
+    LanguageModelTokenUsage,
     LanguageModelTool,
     LanguageModelToolDescription,
     LanguageModelToolMessage,
@@ -19,6 +23,282 @@ from unique_toolkit.language_model.schemas import (
     LanguageModelToolParameters,
     LanguageModelUserMessage,
 )
+
+
+def test_language_model_response_from_stream_response__carries_usage():
+    """LanguageModelResponse.from_stream_response() previously dropped
+    usage entirely, even though the source LanguageModelStreamResponse
+    already had it populated — e.g. ChatService.complete()/complete_async()
+    build a LanguageModelResponse this way, so any caller (DeepResearch's
+    self.chat_service.complete_async() among them) silently lost usage."""
+    stream_response = LanguageModelStreamResponse(
+        message=LanguageModelStreamResponseMessage(
+            id="msg-1",
+            chat_id="chat-1",
+            previous_message_id=None,
+            role=LanguageModelMessageRole.ASSISTANT,
+            text="hello",
+        ),
+        usage=LanguageModelTokenUsage(
+            completion_tokens=12, prompt_tokens=34, total_tokens=46
+        ),
+    )
+
+    response = LanguageModelResponse.from_stream_response(stream_response)
+
+    assert response.usage == LanguageModelTokenUsage(
+        completion_tokens=12, prompt_tokens=34, total_tokens=46
+    )
+
+
+def test_language_model_response_from_stream_response__usage_none__stays_none():
+    stream_response = LanguageModelStreamResponse(
+        message=LanguageModelStreamResponseMessage(
+            id="msg-1",
+            chat_id="chat-1",
+            previous_message_id=None,
+            role=LanguageModelMessageRole.ASSISTANT,
+            text="hello",
+        ),
+    )
+
+    response = LanguageModelResponse.from_stream_response(stream_response)
+
+    assert response.usage is None
+
+
+class TestLanguageModelTokenUsageProviderNormalization:
+    """Reasoning/cached/cache-write extraction across real provider usage shapes:
+    our own gateway, the Responses API, and litellm-proxied Anthropic/Gemini/GPT-5.6.
+    """
+
+    def test_unique_gateway_chat_shape__extracts_reasoning_and_cached(self):
+        """Path 1 (unique_sdk.ChatCompletion): camelCase totals, snake_case
+        nested details -- exact shape captured live against Azure GPT-5.1."""
+        usage = LanguageModelTokenUsage.model_validate(
+            {
+                "completionTokens": 826,
+                "promptTokens": 71,
+                "totalTokens": 897,
+                "completion_tokens_details": {
+                    "accepted_prediction_tokens": 0,
+                    "audio_tokens": 0,
+                    "reasoning_tokens": 108,
+                    "rejected_prediction_tokens": 0,
+                },
+                "prompt_tokens_details": {
+                    "audio_tokens": 0,
+                    "cached_tokens": 0,
+                },
+            }
+        )
+
+        assert usage.completion_tokens == 826
+        assert usage.prompt_tokens == 71
+        assert usage.total_tokens == 897
+        assert usage.reasoning_tokens == 108
+        assert usage.cached_tokens == 0
+        assert usage.cache_write_tokens is None
+
+    def test_unique_gateway_chat_shape__cache_hit(self):
+        """Same path, second call against a warm cache -- cached_tokens > 0."""
+        usage = LanguageModelTokenUsage.model_validate(
+            {
+                "completionTokens": 12,
+                "promptTokens": 5335,
+                "totalTokens": 5347,
+                "completion_tokens_details": {"reasoning_tokens": 0},
+                "prompt_tokens_details": {"cached_tokens": 5248},
+            }
+        )
+
+        assert usage.cached_tokens == 5248
+
+    def test_responses_api_shape__maps_input_output_vocabulary(self):
+        """Path 3 (Responses API): different vocabulary AND different nesting
+        names (output_tokens_details / input_tokens_details) than Chat
+        Completions -- must map onto the same fields without any call site
+        pre-flattening it first (defends the raw-dict gateway path, which may
+        route some models through Responses under the hood)."""
+        usage = LanguageModelTokenUsage.model_validate(
+            {
+                "input_tokens": 62,
+                "input_tokens_details": {"cached_tokens": 0},
+                "output_tokens": 1078,
+                "output_tokens_details": {"reasoning_tokens": 539},
+                "total_tokens": 1140,
+            }
+        )
+
+        assert usage.prompt_tokens == 62
+        assert usage.completion_tokens == 1078
+        assert usage.total_tokens == 1140
+        assert usage.reasoning_tokens == 539
+        assert usage.cached_tokens == 0
+
+    def test_responses_api_shape__missing_total__computed_from_parts(self):
+        usage = LanguageModelTokenUsage.model_validate(
+            {"input_tokens": 10, "output_tokens": 5}
+        )
+
+        assert usage.total_tokens == 15
+
+    def test_anthropic_shape__prefers_nested_over_top_level_alias(self):
+        """litellm's Anthropic mapping emits BOTH a nested
+        prompt_tokens_details.cached_tokens AND a top-level
+        cache_read_input_tokens for the same read count -- nested wins,
+        top-level is only a fallback."""
+        usage = LanguageModelTokenUsage.model_validate(
+            {
+                "completion_tokens": 5,
+                "prompt_tokens": 16,
+                "total_tokens": 21,
+                "prompt_tokens_details": {"cached_tokens": 6185},
+                "cache_read_input_tokens": 9999,  # must be ignored: nested wins
+            }
+        )
+
+        assert usage.cached_tokens == 6185
+
+    def test_anthropic_shape__top_level_alias_used_when_nested_absent(self):
+        usage = LanguageModelTokenUsage.model_validate(
+            {
+                "completion_tokens": 5,
+                "prompt_tokens": 16,
+                "total_tokens": 21,
+                "cache_read_input_tokens": 6185,
+                "cache_creation_input_tokens": 0,
+            }
+        )
+
+        assert usage.cached_tokens == 6185
+        assert usage.cache_write_tokens == 0
+
+    def test_anthropic_shape__cache_write_via_top_level_alias(self):
+        usage = LanguageModelTokenUsage.model_validate(
+            {
+                "completion_tokens": 5,
+                "prompt_tokens": 16,
+                "total_tokens": 21,
+                "cache_creation_input_tokens": 6185,
+            }
+        )
+
+        assert usage.cache_write_tokens == 6185
+
+    def test_gpt_56_shape__cache_write_nested_under_prompt_tokens_details(self):
+        """GPT-5.6 via litellm nests cache_write_tokens alongside cached_tokens,
+        not as a top-level Anthropic-style alias."""
+        usage = LanguageModelTokenUsage.model_validate(
+            {
+                "completion_tokens": 3,
+                "prompt_tokens": 5334,
+                "total_tokens": 5337,
+                "prompt_tokens_details": {
+                    "audio_tokens": 0,
+                    "cached_tokens": 0,
+                    "cache_write_tokens": 5313,
+                },
+            }
+        )
+
+        assert usage.cache_write_tokens == 5313
+        assert usage.cached_tokens == 0
+
+    def test_gemini_shape__ignores_unknown_detail_keys(self):
+        """Gemini's detail objects carry an extra `text_tokens` key we don't
+        model -- it must be ignored, not raise or leak through."""
+        usage = LanguageModelTokenUsage.model_validate(
+            {
+                "completion_tokens": 24,
+                "prompt_tokens": 10,
+                "total_tokens": 34,
+                "completion_tokens_details": {
+                    "reasoning_tokens": 22,
+                    "text_tokens": 2,
+                },
+                "prompt_tokens_details": {"text_tokens": 10},
+            }
+        )
+
+        assert usage.reasoning_tokens == 22
+        assert usage.cached_tokens is None
+
+    def test_mistral_shape__totals_only__optional_fields_stay_none_not_zero(self):
+        """No detail objects at all -- reasoning/cached/cache_write must be
+        `None` (unknown), never invented as `0`."""
+        usage = LanguageModelTokenUsage.model_validate(
+            {"completion_tokens": 3, "prompt_tokens": 14, "total_tokens": 17}
+        )
+
+        assert usage.reasoning_tokens is None
+        assert usage.cached_tokens is None
+        assert usage.cache_write_tokens is None
+
+    def test_explicit_kwargs_construction__unaffected_by_validator(self):
+        """Direct keyword construction (used by every call site that already
+        extracted values from an SDK object) must still work as a plain model
+        -- the validator only fills gaps in dict-shaped input, never fights
+        explicit values."""
+        usage = LanguageModelTokenUsage(
+            completion_tokens=10,
+            prompt_tokens=20,
+            total_tokens=30,
+            reasoning_tokens=5,
+            cached_tokens=8,
+            cache_write_tokens=2,
+        )
+
+        assert usage.reasoning_tokens == 5
+        assert usage.cached_tokens == 8
+        assert usage.cache_write_tokens == 2
+
+    def test_model_validate__accepts_raw_sdk_usage_object_directly(self):
+        """Callers pass the OpenAI SDK's own usage object straight to
+        model_validate() -- no manual `.model_dump()` at the call site; the
+        validator converts it internally."""
+        sdk_usage = CompletionUsage(
+            completion_tokens=670,
+            prompt_tokens=71,
+            total_tokens=741,
+            completion_tokens_details=CompletionTokensDetails(reasoning_tokens=277),
+        )
+
+        usage = LanguageModelTokenUsage.model_validate(sdk_usage)
+
+        assert usage.completion_tokens == 670
+        assert usage.prompt_tokens == 71
+        assert usage.reasoning_tokens == 277
+
+    def test_sum_usages__includes_cache_write_tokens(self):
+        total = LanguageModelTokenUsage.sum_usages(
+            [
+                LanguageModelTokenUsage(cache_write_tokens=5313),
+                LanguageModelTokenUsage(cache_write_tokens=100),
+            ]
+        )
+
+        assert total is not None
+        assert total.cache_write_tokens == 5413
+
+    def test_model_dump_by_alias__new_fields_camel_cased(self):
+        usage = LanguageModelTokenUsage(
+            completion_tokens=1,
+            prompt_tokens=2,
+            total_tokens=3,
+            reasoning_tokens=4,
+            cached_tokens=5,
+            cache_write_tokens=6,
+        )
+
+        assert usage.model_dump(by_alias=True) == {
+            "completionTokens": 1,
+            "promptTokens": 2,
+            "totalTokens": 3,
+            "reasoningTokens": 4,
+            "cachedTokens": 5,
+            "cacheWriteTokens": 6,
+        }
 
 
 class TestLanguageModelSchemas:

--- a/unique_toolkit/tests/language_model/test_language_model_schemas.py
+++ b/unique_toolkit/tests/language_model/test_language_model_schemas.py
@@ -281,6 +281,37 @@ class TestLanguageModelTokenUsageProviderNormalization:
         assert total is not None
         assert total.cache_write_tokens == 5413
 
+    def test_sum_usages__missing_total_on_one_entry__derives_from_completion_and_prompt(
+        self,
+    ):
+        """A manually-constructed or non-conforming usage entry can omit
+        `total_tokens` while still reporting completion/prompt tokens. Naively
+        summing `total_tokens` would then undercount relative to the summed
+        completion + prompt tokens for the same calls."""
+        total = LanguageModelTokenUsage.sum_usages(
+            [
+                LanguageModelTokenUsage(
+                    completion_tokens=10, prompt_tokens=20, total_tokens=30
+                ),
+                LanguageModelTokenUsage(completion_tokens=5, prompt_tokens=15),
+            ]
+        )
+
+        assert total is not None
+        assert total.completion_tokens == 15
+        assert total.prompt_tokens == 35
+        assert total.total_tokens == 50
+
+    def test_sum_usages__total_tokens_none_when_completion_or_prompt_unknown(self):
+        total = LanguageModelTokenUsage.sum_usages(
+            [LanguageModelTokenUsage(completion_tokens=10)]
+        )
+
+        assert total is not None
+        assert total.completion_tokens == 10
+        assert total.prompt_tokens is None
+        assert total.total_tokens is None
+
     def test_model_dump_by_alias__new_fields_camel_cased(self):
         usage = LanguageModelTokenUsage(
             completion_tokens=1,

--- a/unique_toolkit/tests/language_model/test_stream_transform.py
+++ b/unique_toolkit/tests/language_model/test_stream_transform.py
@@ -125,9 +125,17 @@ class FakeChoice:
         self.delta = delta
 
 
+class FakeUsage:
+    def __init__(self, completion_tokens=0, prompt_tokens=0, total_tokens=0):
+        self.completion_tokens = completion_tokens
+        self.prompt_tokens = prompt_tokens
+        self.total_tokens = total_tokens
+
+
 class FakeChunk:
-    def __init__(self, content=None, tool_calls=None):
+    def __init__(self, content=None, tool_calls=None, usage=None):
         self.choices = [FakeChoice(FakeDelta(content=content, tool_calls=tool_calls))]
+        self.usage = usage
 
 
 class FakeStream:
@@ -215,8 +223,9 @@ class FakeDeltaWithToolCalls:
 
 
 class FakeChunkWithToolCalls:
-    def __init__(self, tool_calls):
+    def __init__(self, tool_calls, usage=None):
         self.choices = [FakeChoice(FakeDeltaWithToolCalls(tool_calls=tool_calls))]
+        self.usage = usage
 
 
 @patch(

--- a/unique_toolkit/unique_toolkit/agentic/evaluation/context_relevancy/service.py
+++ b/unique_toolkit/unique_toolkit/agentic/evaluation/context_relevancy/service.py
@@ -32,6 +32,9 @@ from unique_toolkit.language_model.infos import (
     LanguageModelInfo,
     ModelCapabilities,
 )
+from unique_toolkit.language_model.invocation_stats import (
+    LanguageModelInvocationStats,
+)
 from unique_toolkit.language_model.schemas import (
     LanguageModelMessages,
     LanguageModelSystemMessage,
@@ -184,9 +187,18 @@ class ContextRelevancyEvaluator:
                 exception=e,
             )
 
-        return parse_eval_metric_result_structured_output(
+        evaluation_result = parse_eval_metric_result_structured_output(
             result_content, EvaluationMetricName.CONTEXT_RELEVANCY
         )
+        if result.usage is not None:
+            evaluation_result.invocation_stats = [
+                LanguageModelInvocationStats.from_usage(
+                    config.language_model.name,
+                    result.usage,
+                    source="context_relevancy",
+                )
+            ]
+        return evaluation_result
 
     async def _handle_regular_output(
         self,
@@ -209,9 +221,18 @@ class ContextRelevancyEvaluator:
                 user_message=error_message,
             )
 
-        return parse_eval_metric_result(
+        evaluation_result = parse_eval_metric_result(
             result_content, EvaluationMetricName.CONTEXT_RELEVANCY
         )
+        if result.usage is not None:
+            evaluation_result.invocation_stats = [
+                LanguageModelInvocationStats.from_usage(
+                    config.language_model.name,
+                    result.usage,
+                    source="context_relevancy",
+                )
+            ]
+        return evaluation_result
 
     def _compose_msgs(
         self,

--- a/unique_toolkit/unique_toolkit/agentic/evaluation/context_relevancy/service.py
+++ b/unique_toolkit/unique_toolkit/agentic/evaluation/context_relevancy/service.py
@@ -248,9 +248,18 @@ class ContextRelevancyEvaluator:
                 invocation_stats=invocation_stats,
             )
 
-        evaluation_result = parse_eval_metric_result(
-            result_content, EvaluationMetricName.CONTEXT_RELEVANCY
-        )
+        try:
+            evaluation_result = parse_eval_metric_result(
+                result_content, EvaluationMetricName.CONTEXT_RELEVANCY
+            )
+        except EvaluatorException as e:
+            # parse_eval_metric_result raises its own EvaluatorException (with
+            # no invocation_stats, since it has no usage context) -- attach
+            # ours if it didn't already carry stats, instead of letting it
+            # propagate stats-less.
+            if not e.invocation_stats:
+                e.invocation_stats = invocation_stats
+            raise
         evaluation_result.invocation_stats = invocation_stats
         return evaluation_result
 

--- a/unique_toolkit/unique_toolkit/agentic/evaluation/context_relevancy/service.py
+++ b/unique_toolkit/unique_toolkit/agentic/evaluation/context_relevancy/service.py
@@ -148,6 +148,10 @@ class ContextRelevancyEvaluator:
             # Handle regular output
             return await self._handle_regular_output(input, config)
 
+        except EvaluatorException:
+            # Already carries whatever invocation_stats were captured before
+            # the failure -- don't re-wrap it and lose them.
+            raise
         except Exception as e:
             error_message = (
                 "Unknown error occurred during context relevancy metric analysis"
@@ -175,6 +179,20 @@ class ContextRelevancyEvaluator:
             other_options=config.additional_llm_options,
         )
 
+        # Captured as soon as the (billable) LLM call returns, so a validation
+        # failure below can still report it instead of losing it.
+        invocation_stats = (
+            [
+                LanguageModelInvocationStats.from_usage(
+                    config.language_model.name,
+                    result.usage,
+                    source="context_relevancy",
+                )
+            ]
+            if result.usage is not None
+            else []
+        )
+
         try:
             result_content = EvaluationSchemaStructuredOutput.model_validate(
                 result.choices[0].message.parsed
@@ -185,19 +203,13 @@ class ContextRelevancyEvaluator:
                 error_message=error_message,
                 user_message=error_message,
                 exception=e,
+                invocation_stats=invocation_stats,
             )
 
         evaluation_result = parse_eval_metric_result_structured_output(
             result_content, EvaluationMetricName.CONTEXT_RELEVANCY
         )
-        if result.usage is not None:
-            evaluation_result.invocation_stats = [
-                LanguageModelInvocationStats.from_usage(
-                    config.language_model.name,
-                    result.usage,
-                    source="context_relevancy",
-                )
-            ]
+        evaluation_result.invocation_stats = invocation_stats
         return evaluation_result
 
     async def _handle_regular_output(
@@ -213,25 +225,33 @@ class ContextRelevancyEvaluator:
             other_options=config.additional_llm_options,
         )
 
-        result_content = result.choices[0].message.content
-        if not result_content or not isinstance(result_content, str):
-            error_message = "Context relevancy evaluation did not return a result."
-            raise EvaluatorException(
-                error_message=error_message,
-                user_message=error_message,
-            )
-
-        evaluation_result = parse_eval_metric_result(
-            result_content, EvaluationMetricName.CONTEXT_RELEVANCY
-        )
-        if result.usage is not None:
-            evaluation_result.invocation_stats = [
+        # Captured as soon as the (billable) LLM call returns, so a failure
+        # below can still report it instead of losing it.
+        invocation_stats = (
+            [
                 LanguageModelInvocationStats.from_usage(
                     config.language_model.name,
                     result.usage,
                     source="context_relevancy",
                 )
             ]
+            if result.usage is not None
+            else []
+        )
+
+        result_content = result.choices[0].message.content
+        if not result_content or not isinstance(result_content, str):
+            error_message = "Context relevancy evaluation did not return a result."
+            raise EvaluatorException(
+                error_message=error_message,
+                user_message=error_message,
+                invocation_stats=invocation_stats,
+            )
+
+        evaluation_result = parse_eval_metric_result(
+            result_content, EvaluationMetricName.CONTEXT_RELEVANCY
+        )
+        evaluation_result.invocation_stats = invocation_stats
         return evaluation_result
 
     def _compose_msgs(

--- a/unique_toolkit/unique_toolkit/agentic/evaluation/context_relevancy/service.py
+++ b/unique_toolkit/unique_toolkit/agentic/evaluation/context_relevancy/service.py
@@ -197,6 +197,9 @@ class ContextRelevancyEvaluator:
             result_content = EvaluationSchemaStructuredOutput.model_validate(
                 result.choices[0].message.parsed
             )
+            evaluation_result = parse_eval_metric_result_structured_output(
+                result_content, EvaluationMetricName.CONTEXT_RELEVANCY
+            )
         except ValidationError as e:
             error_message = "Error occurred during structured output validation of the context relevancy evaluation."
             raise EvaluatorException(
@@ -205,10 +208,18 @@ class ContextRelevancyEvaluator:
                 exception=e,
                 invocation_stats=invocation_stats,
             )
+        except Exception as e:
+            # Catches anything else reading the response (e.g. an empty
+            # `choices` list) -- must still carry invocation_stats, not just
+            # the validation-specific failure above.
+            error_message = "Error occurred while reading the structured output response for context relevancy evaluation."
+            raise EvaluatorException(
+                error_message=f"{error_message}: {e}",
+                user_message=error_message,
+                exception=e,
+                invocation_stats=invocation_stats,
+            )
 
-        evaluation_result = parse_eval_metric_result_structured_output(
-            result_content, EvaluationMetricName.CONTEXT_RELEVANCY
-        )
         evaluation_result.invocation_stats = invocation_stats
         return evaluation_result
 
@@ -239,27 +250,36 @@ class ContextRelevancyEvaluator:
             else []
         )
 
-        result_content = result.choices[0].message.content
-        if not result_content or not isinstance(result_content, str):
-            error_message = "Context relevancy evaluation did not return a result."
-            raise EvaluatorException(
-                error_message=error_message,
-                user_message=error_message,
-                invocation_stats=invocation_stats,
-            )
-
         try:
+            result_content = result.choices[0].message.content
+            if not result_content or not isinstance(result_content, str):
+                error_message = "Context relevancy evaluation did not return a result."
+                raise EvaluatorException(
+                    error_message=error_message,
+                    user_message=error_message,
+                    invocation_stats=invocation_stats,
+                )
             evaluation_result = parse_eval_metric_result(
                 result_content, EvaluationMetricName.CONTEXT_RELEVANCY
             )
         except EvaluatorException as e:
-            # parse_eval_metric_result raises its own EvaluatorException (with
-            # no invocation_stats, since it has no usage context) -- attach
-            # ours if it didn't already carry stats, instead of letting it
-            # propagate stats-less.
+            # Covers both the raise above and parse_eval_metric_result's own
+            # EvaluatorException (which has no invocation_stats, since it has
+            # no usage context) -- attach ours if it didn't already carry
+            # stats, instead of letting it propagate stats-less.
             if not e.invocation_stats:
                 e.invocation_stats = invocation_stats
             raise
+        except Exception as e:
+            # Catches anything else reading the response (e.g. an empty
+            # `choices` list).
+            error_message = "Error occurred while reading the context relevancy evaluation response."
+            raise EvaluatorException(
+                error_message=f"{error_message}: {e}",
+                user_message=error_message,
+                exception=e,
+                invocation_stats=invocation_stats,
+            )
         evaluation_result.invocation_stats = invocation_stats
         return evaluation_result
 

--- a/unique_toolkit/unique_toolkit/agentic/evaluation/evaluation_manager.py
+++ b/unique_toolkit/unique_toolkit/agentic/evaluation/evaluation_manager.py
@@ -17,6 +17,9 @@ from unique_toolkit.chat.schemas import (
     ChatMessageAssessmentType,
 )
 from unique_toolkit.chat.service import ChatService
+from unique_toolkit.language_model.invocation_stats import (
+    LanguageModelInvocationStats,
+)
 from unique_toolkit.language_model.schemas import (
     LanguageModelStreamResponse,
 )
@@ -88,6 +91,7 @@ class EvaluationManager:
         self._evaluations: dict[EvaluationMetricName, Evaluation] = {}
         self._evaluation_passed: bool = True
         self._execution_times: dict[str, float] = {}
+        self._invocation_stats: list[LanguageModelInvocationStats] = []
 
     def add_evaluation(self, evaluation: Evaluation):
         self._evaluations[evaluation.get_name()] = evaluation
@@ -102,6 +106,7 @@ class EvaluationManager:
         assistant_message_id: str,
     ) -> list[EvaluationMetricResult]:
         self._execution_times = {}
+        self._invocation_stats = []
 
         task_executor = SafeTaskExecutor(
             logger=self._logger,
@@ -125,6 +130,7 @@ class EvaluationManager:
             )
             if not unpacked_evaluation_result.is_positive:
                 self._evaluation_passed = False
+            self._invocation_stats.extend(unpacked_evaluation_result.invocation_stats)
             evaluation_results_unpacked.append(unpacked_evaluation_result)
 
         for evaluation_name, evaluation_result in zip(
@@ -140,6 +146,10 @@ class EvaluationManager:
 
     def get_execution_times(self) -> dict[str, float]:
         return self._execution_times.copy()
+
+    def get_invocation_stats(self) -> list[LanguageModelInvocationStats]:
+        """Per-LLM-call stats from every evaluation that made its own LLM call."""
+        return list(self._invocation_stats)
 
     async def execute_evaluation_call(
         self,

--- a/unique_toolkit/unique_toolkit/agentic/evaluation/evaluation_manager.py
+++ b/unique_toolkit/unique_toolkit/agentic/evaluation/evaluation_manager.py
@@ -7,6 +7,7 @@ from unique_toolkit._common.execution import (
     Result,
     SafeTaskExecutor,
 )
+from unique_toolkit.agentic.evaluation.exception import EvaluatorException
 from unique_toolkit.agentic.evaluation.schemas import (
     EvaluationAssessmentMessage,
     EvaluationMetricName,
@@ -188,12 +189,18 @@ class EvaluationManager:
         evaluation_name: EvaluationMetricName,
     ) -> EvaluationMetricResult:
         if not result.success:
+            invocation_stats = (
+                result.exception.invocation_stats
+                if isinstance(result.exception, EvaluatorException)
+                else []
+            )
             return EvaluationMetricResult(
                 name=evaluation_name,
                 is_positive=True,
                 value="RED",
                 reason=str(result.exception),
                 error=Exception("Evaluation result is not successful"),
+                invocation_stats=invocation_stats,
             )
         return result.unpack()
 

--- a/unique_toolkit/unique_toolkit/agentic/evaluation/exception.py
+++ b/unique_toolkit/unique_toolkit/agentic/evaluation/exception.py
@@ -1,5 +1,23 @@
 from unique_toolkit._common.exception import CommonException
+from unique_toolkit.language_model.invocation_stats import LanguageModelInvocationStats
 
 
 class EvaluatorException(CommonException):
-    pass
+    def __init__(
+        self,
+        user_message: str,
+        error_message: str,
+        exception: Exception | None = None,
+        invocation_stats: list[LanguageModelInvocationStats] | None = None,
+    ) -> None:
+        super().__init__(
+            user_message=user_message,
+            error_message=error_message,
+            exception=exception,
+        )
+        # Carries whatever usage was already captured before the failure, so a
+        # successful (billable) LLM call isn't silently dropped from the report
+        # just because something after it (parsing, validation) raised.
+        self.invocation_stats: list[LanguageModelInvocationStats] = (
+            invocation_stats or []
+        )

--- a/unique_toolkit/unique_toolkit/agentic/evaluation/hallucination/utils.py
+++ b/unique_toolkit/unique_toolkit/agentic/evaluation/hallucination/utils.py
@@ -114,7 +114,12 @@ async def check_hallucination(
         )
         eval_result.invocation_stats = invocation_stats
         return eval_result
-    except EvaluatorException:
+    except EvaluatorException as e:
+        # parse_eval_metric_result raises its own EvaluatorException (with no
+        # invocation_stats, since it has no usage context) -- attach ours if
+        # it didn't already carry stats, instead of re-raising it stats-less.
+        if not e.invocation_stats:
+            e.invocation_stats = invocation_stats
         raise
     except Exception as e:
         error_message = "Error occurred during hallucination metric analysis"

--- a/unique_toolkit/unique_toolkit/agentic/evaluation/hallucination/utils.py
+++ b/unique_toolkit/unique_toolkit/agentic/evaluation/hallucination/utils.py
@@ -76,36 +76,53 @@ async def check_hallucination(
 
     try:
         msgs = _get_msgs(input, config)
-
         result = await LanguageModelService.complete_async_util(
             company_id=company_id, user_id=user_id, messages=msgs, model_name=model_name
         )
-        usage = result.usage
-        result_content = result.choices[0].message.content
-        if not result_content or not isinstance(result_content, str):
-            error_message = "Hallucination evaluation did not return a text result."
-            raise EvaluatorException(
-                error_message=error_message,
-                user_message=error_message,
-            )
-        result = parse_eval_metric_result(
-            result_content,
-            EvaluationMetricName.HALLUCINATION,
-        )
-        if usage is not None:
-            result.invocation_stats = [
-                LanguageModelInvocationStats.from_usage(
-                    model_name, usage, source="hallucination"
-                )
-            ]
-
-        return result
     except Exception as e:
         error_message = "Error occurred during hallucination metric analysis"
         raise EvaluatorException(
             error_message=f"{error_message}: {e}",
             user_message=error_message,
             exception=e,
+        )
+
+    # Captured as soon as the (billable) LLM call returns, so a failure below
+    # (empty content, parsing) can still report it instead of losing it.
+    invocation_stats = (
+        [
+            LanguageModelInvocationStats.from_usage(
+                model_name, result.usage, source="hallucination"
+            )
+        ]
+        if result.usage is not None
+        else []
+    )
+
+    try:
+        result_content = result.choices[0].message.content
+        if not result_content or not isinstance(result_content, str):
+            error_message = "Hallucination evaluation did not return a text result."
+            raise EvaluatorException(
+                error_message=error_message,
+                user_message=error_message,
+                invocation_stats=invocation_stats,
+            )
+        eval_result = parse_eval_metric_result(
+            result_content,
+            EvaluationMetricName.HALLUCINATION,
+        )
+        eval_result.invocation_stats = invocation_stats
+        return eval_result
+    except EvaluatorException:
+        raise
+    except Exception as e:
+        error_message = "Error occurred during hallucination metric analysis"
+        raise EvaluatorException(
+            error_message=f"{error_message}: {e}",
+            user_message=error_message,
+            exception=e,
+            invocation_stats=invocation_stats,
         )
 
 

--- a/unique_toolkit/unique_toolkit/agentic/evaluation/hallucination/utils.py
+++ b/unique_toolkit/unique_toolkit/agentic/evaluation/hallucination/utils.py
@@ -18,6 +18,9 @@ from unique_toolkit.content import ContentReference
 from unique_toolkit.content.schemas import ContentChunk
 from unique_toolkit.language_model.builder import MessagesBuilder
 from unique_toolkit.language_model.infos import ModelCapabilities
+from unique_toolkit.language_model.invocation_stats import (
+    LanguageModelInvocationStats,
+)
 from unique_toolkit.language_model.schemas import (
     LanguageModelMessages,
     LanguageModelStreamResponse,
@@ -77,6 +80,7 @@ async def check_hallucination(
         result = await LanguageModelService.complete_async_util(
             company_id=company_id, user_id=user_id, messages=msgs, model_name=model_name
         )
+        usage = result.usage
         result_content = result.choices[0].message.content
         if not result_content or not isinstance(result_content, str):
             error_message = "Hallucination evaluation did not return a text result."
@@ -88,6 +92,12 @@ async def check_hallucination(
             result_content,
             EvaluationMetricName.HALLUCINATION,
         )
+        if usage is not None:
+            result.invocation_stats = [
+                LanguageModelInvocationStats.from_usage(
+                    model_name, usage, source="hallucination"
+                )
+            ]
 
         return result
     except Exception as e:

--- a/unique_toolkit/unique_toolkit/agentic/evaluation/schemas.py
+++ b/unique_toolkit/unique_toolkit/agentic/evaluation/schemas.py
@@ -10,6 +10,7 @@ from unique_toolkit.chat.schemas import (
     ChatMessageAssessmentStatus,
     ChatMessageAssessmentType,
 )
+from unique_toolkit.language_model.invocation_stats import LanguageModelInvocationStats
 
 
 class EvaluationMetricName(StrEnum):
@@ -102,6 +103,7 @@ class EvaluationMetricResult(BaseModel):
     user_info: Optional[str] = None
     error: Exception | None = None
     fact_list: list[str] = Field(default_factory=list[str])
+    invocation_stats: list[LanguageModelInvocationStats] = Field(default_factory=list)
 
 
 class EvaluationAssessmentMessage(BaseModel):

--- a/unique_toolkit/unique_toolkit/agentic/evaluation/tests/test_context_relevancy_service.py
+++ b/unique_toolkit/unique_toolkit/agentic/evaluation/tests/test_context_relevancy_service.py
@@ -16,6 +16,7 @@ from unique_toolkit.agentic.evaluation.schemas import (
 from unique_toolkit.language_model.schemas import (
     LanguageModelAssistantMessage,
     LanguageModelCompletionChoice,
+    LanguageModelTokenUsage,
 )
 from unique_toolkit.language_model.service import LanguageModelResponse
 
@@ -271,3 +272,73 @@ async def test_analyze__raises_evaluator_exception__with_unknown_error(
         assert "Unknown error occurred during context relevancy metric analysis" in str(
             exc_info.value
         )
+
+
+@pytest.mark.ai
+@pytest.mark.asyncio
+async def test_analyze__preserves_invocation_stats__on_regular_output_read_error(
+    context_relevancy_evaluator: MagicMock,
+    sample_evaluation_input: EvaluationMetricInput,
+    basic_evaluation_config: EvaluationMetricConfig,
+) -> None:
+    """
+    Purpose: A billed LLM call that returns no choices must still surface its
+    usage, instead of losing it to the generic error path.
+    Why this matters: `result.choices[0]` access is not otherwise guarded; an
+    empty `choices` list must not silently drop invocation_stats.
+    """
+    mock_result: LanguageModelResponse = LanguageModelResponse(
+        choices=[],
+        usage=LanguageModelTokenUsage(
+            completion_tokens=1, prompt_tokens=2, total_tokens=3
+        ),
+    )
+
+    with patch.object(
+        context_relevancy_evaluator.language_model_service,
+        "complete_async",
+        return_value=mock_result,
+    ):
+        with pytest.raises(EvaluatorException) as exc_info:
+            await context_relevancy_evaluator.analyze(
+                sample_evaluation_input, basic_evaluation_config
+            )
+
+    assert len(exc_info.value.invocation_stats) == 1
+    assert exc_info.value.invocation_stats[0].token_usage.total_tokens == 3
+
+
+@pytest.mark.ai
+@pytest.mark.asyncio
+async def test_analyze__preserves_invocation_stats__on_structured_output_read_error(
+    context_relevancy_evaluator: MagicMock,
+    sample_evaluation_input: EvaluationMetricInput,
+    structured_evaluation_config: EvaluationMetricConfig,
+) -> None:
+    """
+    Purpose: Same as the regular-output case, for the structured-output path.
+    """
+    mock_result: LanguageModelResponse = LanguageModelResponse(
+        choices=[],
+        usage=LanguageModelTokenUsage(
+            completion_tokens=1, prompt_tokens=2, total_tokens=3
+        ),
+    )
+    structured_output_schema: type[EvaluationSchemaStructuredOutput] = (
+        EvaluationSchemaStructuredOutput
+    )
+
+    with patch.object(
+        context_relevancy_evaluator.language_model_service,
+        "complete_async",
+        return_value=mock_result,
+    ):
+        with pytest.raises(EvaluatorException) as exc_info:
+            await context_relevancy_evaluator.analyze(
+                sample_evaluation_input,
+                structured_evaluation_config,
+                structured_output_schema,
+            )
+
+    assert len(exc_info.value.invocation_stats) == 1
+    assert exc_info.value.invocation_stats[0].token_usage.total_tokens == 3

--- a/unique_toolkit/unique_toolkit/agentic/loop_runner/__init__.py
+++ b/unique_toolkit/unique_toolkit/agentic/loop_runner/__init__.py
@@ -6,6 +6,7 @@ from unique_toolkit.agentic.loop_runner._iteration_handler_utils import (
 from unique_toolkit.agentic.loop_runner.base import (
     LoopIterationRunner,
     ResponsesLoopIterationRunner,
+    SupportsInvocationStats,
 )
 from unique_toolkit.agentic.loop_runner.middleware import (
     PlanningConfig,
@@ -42,4 +43,5 @@ __all__ = [
     "QWEN_MAX_LOOP_ITERATIONS",
     "ResponsesLoopIterationRunner",
     "ResponsesBasicLoopIterationRunner",
+    "SupportsInvocationStats",
 ]

--- a/unique_toolkit/unique_toolkit/agentic/loop_runner/_iteration_handler_utils.py
+++ b/unique_toolkit/unique_toolkit/agentic/loop_runner/_iteration_handler_utils.py
@@ -6,6 +6,7 @@ from unique_toolkit.agentic.loop_runner.base import (
     _LoopIterationRunnerKwargs,
 )
 from unique_toolkit.chat.functions import LanguageModelStreamResponse
+from unique_toolkit.language_model.schemas import LanguageModelTokenUsage
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -103,5 +104,6 @@ async def run_forced_tools_iteration(
     response = responses[0]
     response.tool_calls = tool_calls if len(tool_calls) > 0 else None
     response.message.references = references
+    response.usage = LanguageModelTokenUsage.sum_usages(r.usage for r in responses)
 
     return response

--- a/unique_toolkit/unique_toolkit/agentic/loop_runner/_responses_iteration_handler_utils.py
+++ b/unique_toolkit/unique_toolkit/agentic/loop_runner/_responses_iteration_handler_utils.py
@@ -7,7 +7,10 @@ from unique_toolkit.agentic.loop_runner._responses_stream_handler_utils import (
 from unique_toolkit.agentic.loop_runner.base import (
     _ResponsesLoopIterationRunnerKwargs,
 )
-from unique_toolkit.language_model.schemas import ResponsesLanguageModelStreamResponse
+from unique_toolkit.language_model.schemas import (
+    LanguageModelTokenUsage,
+    ResponsesLanguageModelStreamResponse,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -59,5 +62,6 @@ async def handle_responses_forced_tools_iteration(
     response = responses[0]
     response.tool_calls = tool_calls if len(tool_calls) > 0 else None
     response.message.references = references
+    response.usage = LanguageModelTokenUsage.sum_usages(r.usage for r in responses)
 
     return response

--- a/unique_toolkit/unique_toolkit/agentic/loop_runner/base.py
+++ b/unique_toolkit/unique_toolkit/agentic/loop_runner/base.py
@@ -1,4 +1,4 @@
-from typing import Any, Protocol, Required, Unpack
+from typing import Any, Protocol, Required, Unpack, runtime_checkable
 
 from openai.types.chat import ChatCompletionNamedToolChoiceParam
 from openai.types.responses import (
@@ -15,6 +15,9 @@ from unique_toolkit.chat.functions import LanguageModelStreamResponse
 from unique_toolkit.chat.service import LanguageModelMessages
 from unique_toolkit.content import ContentChunk
 from unique_toolkit.language_model.infos import LanguageModelInfo
+from unique_toolkit.language_model.invocation_stats import (
+    LanguageModelInvocationStats,
+)
 from unique_toolkit.language_model.schemas import (
     ResponsesLanguageModelStreamResponse,
     ResponsesMessageInput,
@@ -23,6 +26,17 @@ from unique_toolkit.protocols.support import (
     ResponsesSupportCompleteWithReferences,
     SupportCompleteWithReferences,
 )
+
+
+@runtime_checkable
+class SupportsInvocationStats(Protocol):
+    """Optional capability for a loop iteration runner (or middleware wrapping
+    one) that makes its own extra LLM call(s) beyond the main iteration
+    response — e.g. a planning step. `unique_ai.py` checks for this via
+    `isinstance` and, if present, folds the returned stats into the turn's
+    accumulator; runners that don't make extra calls need not implement it."""
+
+    def get_invocation_stats(self) -> list[LanguageModelInvocationStats]: ...
 
 
 class _LoopIterationRunnerKwargs(TypedDict, total=False):

--- a/unique_toolkit/unique_toolkit/agentic/loop_runner/middleware/planning/planning.py
+++ b/unique_toolkit/unique_toolkit/agentic/loop_runner/middleware/planning/planning.py
@@ -37,9 +37,13 @@ from unique_toolkit.language_model import (
     LanguageModelAssistantMessage,
     LanguageModelUserMessage,
 )
+from unique_toolkit.language_model.invocation_stats import (
+    LanguageModelInvocationStats,
+)
 from unique_toolkit.language_model.schemas import (
     LanguageModelMessageOptions,
     LanguageModelMessages,
+    LanguageModelTokenUsage,
     ResponsesLanguageModelStreamResponse,
 )
 
@@ -136,6 +140,12 @@ class PlanningMiddleware(LoopIterationRunner):
         self._loop_runner = loop_runner
         self._history_manager = history_manager
         self._llm_service = llm_service
+        self._invocation_stats: list[LanguageModelInvocationStats] = []
+
+    def get_invocation_stats(self) -> list[LanguageModelInvocationStats]:
+        """Return and clear the planning-step stats captured since the last call."""
+        stats, self._invocation_stats = self._invocation_stats, []
+        return stats
 
     @failsafe_async(failure_return_value=None, logger=_LOGGER)
     async def _run_plan_step(
@@ -154,6 +164,13 @@ class PlanningMiddleware(LoopIterationRunner):
             structured_output_model=planning_schema,
             other_options=other_options,
         )
+
+        if response.usage is not None:
+            self._invocation_stats.append(
+                LanguageModelInvocationStats.from_usage(
+                    kwargs["model"].name, response.usage, source="planning"
+                )
+            )
 
         if response.choices[0].message.parsed is None:
             _LOGGER.info("Error parsing planning response")
@@ -196,6 +213,12 @@ class ResponsesPlanningMiddleware(ResponsesLoopIterationRunner):
         self._loop_runner = loop_runner
         self._history_manager = history_manager
         self._openai_client = openai_client
+        self._invocation_stats: list[LanguageModelInvocationStats] = []
+
+    def get_invocation_stats(self) -> list[LanguageModelInvocationStats]:
+        """Return and clear the planning-step stats captured since the last call."""
+        stats, self._invocation_stats = self._invocation_stats, []
+        return stats
 
     def _build_forwarded_options(
         self, kwargs: _ResponsesLoopIterationRunnerKwargs
@@ -259,6 +282,15 @@ class ResponsesPlanningMiddleware(ResponsesLoopIterationRunner):
             parallel_tool_calls=False,
             **forwarded_options,
         )
+
+        if response.usage is not None:
+            self._invocation_stats.append(
+                LanguageModelInvocationStats.from_usage(
+                    model_name,
+                    LanguageModelTokenUsage.model_validate(response.usage),
+                    source="planning",
+                )
+            )
 
         output_text = _get_first_tool_call_arguments(response)
         if not output_text:

--- a/unique_toolkit/unique_toolkit/agentic/postprocessor/postprocessor_manager.py
+++ b/unique_toolkit/unique_toolkit/agentic/postprocessor/postprocessor_manager.py
@@ -5,6 +5,9 @@ from logging import Logger
 
 from unique_toolkit._common.execution import SafeTaskExecutor
 from unique_toolkit.chat.service import ChatService
+from unique_toolkit.language_model.invocation_stats import (
+    LanguageModelInvocationStats,
+)
 from unique_toolkit.language_model.schemas import (
     LanguageModelStreamResponse,
     ResponsesLanguageModelStreamResponse,
@@ -33,6 +36,11 @@ class Postprocessor(ABC):
             "Subclasses must implement this method to remove post-processing from the message."
         )
 
+    @property
+    def invocation_stats(self) -> list[LanguageModelInvocationStats]:
+        """Override in subclasses whose `run()` makes its own LLM call(s)."""
+        return []
+
 
 class ResponsesApiPostprocessor(ABC):
     def __init__(self, name: str):
@@ -57,6 +65,14 @@ class ResponsesApiPostprocessor(ABC):
         raise NotImplementedError(
             "Subclasses must implement this method to remove post-processing from the message."
         )
+
+    @property
+    def invocation_stats(self) -> list[LanguageModelInvocationStats]:
+        """Per-LLM-call stats from any call(s) this postprocessor made in its last `run()`.
+
+        Default empty — override in subclasses that make their own LLM calls.
+        """
+        return []
 
 
 class PostprocessorManager:
@@ -88,6 +104,7 @@ class PostprocessorManager:
         self._chat_service = chat_service
         self._postprocessors: list[Postprocessor | ResponsesApiPostprocessor] = []
         self._execution_times: dict[str, float] = {}
+        self._invocation_stats: list[LanguageModelInvocationStats] = []
 
         # Allow to add postprocessors that should be run before or after the others.
         self._first_postprocessor: Postprocessor | ResponsesApiPostprocessor | None = (
@@ -128,6 +145,7 @@ class PostprocessorManager:
         loop_response: LanguageModelStreamResponse,
     ) -> dict[str, object | None]:
         self._execution_times = {}
+        self._invocation_stats = []
 
         task_executor = SafeTaskExecutor(
             logger=self._logger,
@@ -174,6 +192,10 @@ class PostprocessorManager:
     def get_execution_times(self) -> dict[str, float]:
         return self._execution_times.copy()
 
+    def get_invocation_stats(self) -> list[LanguageModelInvocationStats]:
+        """Per-LLM-call stats from every postprocessor that made its own LLM call(s)."""
+        return list(self._invocation_stats)
+
     async def execute_postprocessors(
         self,
         loop_response: LanguageModelStreamResponse,
@@ -184,6 +206,7 @@ class PostprocessorManager:
         self._execution_times[postprocessor_instance.name] = round(
             time.perf_counter() - start, 3
         )
+        self._invocation_stats.extend(postprocessor_instance.invocation_stats)
         return result
 
     async def remove_from_text(

--- a/unique_toolkit/unique_toolkit/agentic/tools/a2a/evaluation/evaluator.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/a2a/evaluation/evaluator.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel
 
 from unique_toolkit._common.execution import failsafe
 from unique_toolkit.agentic.evaluation.evaluation_manager import Evaluation
+from unique_toolkit.agentic.evaluation.exception import EvaluatorException
 from unique_toolkit.agentic.evaluation.schemas import (
     EvaluationAssessmentMessage,
     EvaluationMetricName,
@@ -215,14 +216,11 @@ class SubAgentEvaluationService(Evaluation):
                 sub_agents_display_data.append(data)
 
         response = await self._get_reason(sub_agents_display_data)
-        reason = str(response.choices[0].message.content)
 
-        return EvaluationMetricResult(
-            name=self.get_name(),
-            value=value,
-            reason=reason,
-            is_positive=value == ChatMessageAssessmentLabel.GREEN,
-            invocation_stats=[
+        # Captured as soon as the (billable) LLM call returns, so a failure
+        # below can still report it instead of losing it.
+        invocation_stats = (
+            [
                 LanguageModelInvocationStats.from_usage(
                     self._config.summarization_model.name,
                     response.usage,
@@ -230,7 +228,28 @@ class SubAgentEvaluationService(Evaluation):
                 )
             ]
             if response.usage is not None
-            else [],
+            else []
+        )
+
+        try:
+            reason = str(response.choices[0].message.content)
+        except Exception as e:
+            error_message = (
+                "Error occurred while reading the sub-agent evaluation response."
+            )
+            raise EvaluatorException(
+                error_message=f"{error_message}: {e}",
+                user_message=error_message,
+                exception=e,
+                invocation_stats=invocation_stats,
+            )
+
+        return EvaluationMetricResult(
+            name=self.get_name(),
+            value=value,
+            reason=reason,
+            is_positive=value == ChatMessageAssessmentLabel.GREEN,
+            invocation_stats=invocation_stats,
         )
 
     @override

--- a/unique_toolkit/unique_toolkit/agentic/tools/a2a/evaluation/evaluator.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/a2a/evaluation/evaluator.py
@@ -31,7 +31,13 @@ from unique_toolkit.chat.schemas import (
     ChatMessageAssessmentType,
 )
 from unique_toolkit.language_model.builder import MessagesBuilder
-from unique_toolkit.language_model.schemas import LanguageModelStreamResponse
+from unique_toolkit.language_model.invocation_stats import (
+    LanguageModelInvocationStats,
+)
+from unique_toolkit.language_model.schemas import (
+    LanguageModelResponse,
+    LanguageModelStreamResponse,
+)
 from unique_toolkit.language_model.service import LanguageModelService
 
 logger = logging.getLogger(__name__)
@@ -208,13 +214,23 @@ class SubAgentEvaluationService(Evaluation):
 
                 sub_agents_display_data.append(data)
 
-        reason = await self._get_reason(sub_agents_display_data)
+        response = await self._get_reason(sub_agents_display_data)
+        reason = str(response.choices[0].message.content)
 
         return EvaluationMetricResult(
             name=self.get_name(),
             value=value,
             reason=reason,
             is_positive=value == ChatMessageAssessmentLabel.GREEN,
+            invocation_stats=[
+                LanguageModelInvocationStats.from_usage(
+                    self._config.summarization_model.name,
+                    response.usage,
+                    source=str(self.get_name()),
+                )
+            ]
+            if response.usage is not None
+            else [],
         )
 
     @override
@@ -250,7 +266,9 @@ class SubAgentEvaluationService(Evaluation):
             type=self.get_assessment_type(),
         )
 
-    async def _get_reason(self, sub_agents_display_data: list[dict[str, Any]]) -> str:
+    async def _get_reason(
+        self, sub_agents_display_data: list[dict[str, Any]]
+    ) -> LanguageModelResponse:
         messages = (
             MessagesBuilder()
             .system_message_append(self._config.summarization_system_message)
@@ -262,10 +280,8 @@ class SubAgentEvaluationService(Evaluation):
             .build()
         )
 
-        reason = await self._language_model_service.complete_async(
+        return await self._language_model_service.complete_async(
             messages=messages,
             model_name=self._config.summarization_model.name,
             temperature=0.0,
         )
-
-        return str(reason.choices[0].message.content)

--- a/unique_toolkit/unique_toolkit/agentic/tools/schemas.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/schemas.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_serializer, field_valid
 from unique_toolkit._common.pydantic_helpers import get_configuration_dict
 from unique_toolkit.agentic.tools.utils.source_handling.schema import SourceFormatConfig
 from unique_toolkit.content.schemas import ContentChunk
+from unique_toolkit.language_model.invocation_stats import LanguageModelInvocationStats
 
 
 # TODO: this needs to be more general as the tools can potentially return anything maybe make a base class and then derive per "type" of tool
@@ -19,6 +20,10 @@ class ToolCallResponse(BaseModel):
     content_chunks: Optional[list[ContentChunk]] = None  # TODO: Make the default []
     reasoning_result: Optional[dict[str, Any]] = None  # TODO: Make the default {}
     error_message: str = ""
+    invocation_stats: list[LanguageModelInvocationStats] = Field(
+        default_factory=list,
+        description="Per-LLM-call usage stats from any calls this tool made while producing this response.",
+    )
     image_data_urls: list[str] = Field(
         default_factory=list,
         description="Data URLs (e.g. data:image/png;base64,...) for images returned by this tool.",

--- a/unique_toolkit/unique_toolkit/experimental/integrations/openai/streaming/event_routing/chat_completions/complete_with_references.py
+++ b/unique_toolkit/unique_toolkit/experimental/integrations/openai/streaming/event_routing/chat_completions/complete_with_references.py
@@ -16,6 +16,9 @@ from typing import TYPE_CHECKING, Any, cast, overload
 
 import httpx
 from openai import AsyncOpenAI
+from openai.types.chat.chat_completion_stream_options_param import (
+    ChatCompletionStreamOptionsParam,
+)
 
 from unique_toolkit.chat.schemas import ChatMessage, ChatMessageRole
 from unique_toolkit.content.schemas import ContentReference
@@ -423,12 +426,24 @@ class ChatCompletionsCompleteWithReferences(SupportCompleteWithReferences):
                 )
             )
 
+            # Extract rather than pass both explicitly and via **optional_create_kwargs:
+            # a caller-supplied other_options["stream_options"] would otherwise raise
+            # "got multiple values for keyword argument" -- or, if merged the other way,
+            # could silently drop include_usage and break usage reporting.
+            caller_stream_options = optional_create_kwargs.pop("stream_options", {})
+            stream_options: ChatCompletionStreamOptionsParam = {
+                "include_usage": True,
+            }
+            if "include_obfuscation" in caller_stream_options:
+                stream_options["include_obfuscation"] = caller_stream_options[
+                    "include_obfuscation"
+                ]
             try:
                 stream = await self._client.chat.completions.create(
                     model=model,
                     messages=gpt_messages,
                     stream=True,
-                    stream_options={"include_usage": True},
+                    stream_options=stream_options,
                     temperature=temperature,
                     **optional_create_kwargs,
                 )

--- a/unique_toolkit/unique_toolkit/experimental/integrations/openai/streaming/event_routing/chat_completions/complete_with_references.py
+++ b/unique_toolkit/unique_toolkit/experimental/integrations/openai/streaming/event_routing/chat_completions/complete_with_references.py
@@ -428,6 +428,7 @@ class ChatCompletionsCompleteWithReferences(SupportCompleteWithReferences):
                     model=model,
                     messages=gpt_messages,
                     stream=True,
+                    stream_options={"include_usage": True},
                     temperature=temperature,
                     **optional_create_kwargs,
                 )

--- a/unique_toolkit/unique_toolkit/experimental/integrations/openai/streaming/event_routing/chat_completions/text_event_handler.py
+++ b/unique_toolkit/unique_toolkit/experimental/integrations/openai/streaming/event_routing/chat_completions/text_event_handler.py
@@ -64,11 +64,7 @@ class ChatCompletionTextEventHandler:
         bool-return semantics. All other chunks silently accumulate state.
         """
         if event.usage is not None:
-            self._usage = LanguageModelTokenUsage(
-                completion_tokens=event.usage.completion_tokens,
-                prompt_tokens=event.usage.prompt_tokens,
-                total_tokens=event.usage.total_tokens,
-            )
+            self._usage = LanguageModelTokenUsage.model_validate(event.usage)
 
         if len(event.choices) == 0:
             return

--- a/unique_toolkit/unique_toolkit/experimental/integrations/openai/streaming/event_routing/responses/completed_event_handler.py
+++ b/unique_toolkit/unique_toolkit/experimental/integrations/openai/streaming/event_routing/responses/completed_event_handler.py
@@ -42,8 +42,4 @@ def _extract_usage(event: ResponseCompletedEvent) -> LanguageModelTokenUsage | N
     usage = event.response.usage
     if usage is None:
         return None
-    return LanguageModelTokenUsage(
-        prompt_tokens=usage.input_tokens,
-        completion_tokens=usage.output_tokens,
-        total_tokens=usage.total_tokens,
-    )
+    return LanguageModelTokenUsage.model_validate(usage)

--- a/unique_toolkit/unique_toolkit/language_model/__init__.py
+++ b/unique_toolkit/unique_toolkit/language_model/__init__.py
@@ -7,7 +7,6 @@ from .functions import (
 )
 from .infos import LanguageModel, LanguageModelName, TypeDecoder, TypeEncoder
 from .invocation_stats import (
-    LanguageModelInvocationReport,
     LanguageModelInvocationStats,
 )
 from .prompt import (
@@ -66,7 +65,6 @@ __all__ = [
     "LanguageModelCompletionChoice",
     "LanguageModelFunction",
     "LanguageModelFunctionCall",
-    "LanguageModelInvocationReport",
     "LanguageModelInvocationStats",
     "LanguageModelMessage",
     "LanguageModelMessageRole",

--- a/unique_toolkit/unique_toolkit/language_model/__init__.py
+++ b/unique_toolkit/unique_toolkit/language_model/__init__.py
@@ -6,6 +6,10 @@ from .functions import (
     stream_complete_with_references_openai as stream_complete_with_references_openai,
 )
 from .infos import LanguageModel, LanguageModelName, TypeDecoder, TypeEncoder
+from .invocation_stats import (
+    LanguageModelInvocationReport,
+    LanguageModelInvocationStats,
+)
 from .prompt import (
     Prompt,
 )
@@ -62,6 +66,8 @@ __all__ = [
     "LanguageModelCompletionChoice",
     "LanguageModelFunction",
     "LanguageModelFunctionCall",
+    "LanguageModelInvocationReport",
+    "LanguageModelInvocationStats",
     "LanguageModelMessage",
     "LanguageModelMessageRole",
     "LanguageModelMessages",

--- a/unique_toolkit/unique_toolkit/language_model/functions.py
+++ b/unique_toolkit/unique_toolkit/language_model/functions.py
@@ -28,6 +28,7 @@ from unique_toolkit.language_model.schemas import (
     LanguageModelMessages,
     LanguageModelResponse,
     LanguageModelStreamResponse,
+    LanguageModelTokenUsage,
     LanguageModelTool,
     LanguageModelToolDescription,
 )
@@ -592,6 +593,7 @@ async def stream_complete_with_references_openai(
         "model": model_name_,
         "temperature": temperature,
         "stream": True,
+        "stream_options": {"include_usage": True},
     }
     if tool_choice is not None:
         stream_kwargs["tool_choice"] = tool_choice
@@ -600,10 +602,15 @@ async def stream_complete_with_references_openai(
 
     full_text: str = start_text or ""
     tool_calls_fragments: dict[int, dict[str, Any]] = {}
+    usage: LanguageModelTokenUsage | None = None
     try:
         stream = await client.chat.completions.create(**stream_kwargs)
         async with stream:
             async for chunk in stream:
+                # stream_options.include_usage sends one terminal chunk with the
+                # final cumulative totals, not a per-chunk delta -- overwrite, don't sum.
+                if chunk.usage is not None:
+                    usage = LanguageModelTokenUsage.model_validate(chunk.usage)
                 if not chunk.choices:
                     continue
                 choice_ = chunk.choices[0]
@@ -653,6 +660,7 @@ async def stream_complete_with_references_openai(
                 references=references_,
             ),
             tool_calls=tool_calls_list,
+            usage=usage,
         )
     except Exception as e:
         logger.error("Error streaming completion (model=%s): %s", model_name_, e)

--- a/unique_toolkit/unique_toolkit/language_model/invocation_stats.py
+++ b/unique_toolkit/unique_toolkit/language_model/invocation_stats.py
@@ -8,7 +8,7 @@ Lives in its own module (not ``schemas.py``) because it needs
 from typing import Annotated, Self
 
 from humps import camelize
-from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, computed_field
+from pydantic import BaseModel, BeforeValidator, ConfigDict
 
 from unique_toolkit.language_model.infos import LanguageModelName
 from unique_toolkit.language_model.schemas import LanguageModelTokenUsage
@@ -68,18 +68,3 @@ class LanguageModelInvocationStats(BaseModel):
         source: str,
     ) -> Self:
         return cls(model_name=model_name, token_usage=token_usage, source=source)
-
-
-class LanguageModelInvocationReport(BaseModel):
-    """All LLM invocations of one orchestration turn, with an aggregated total."""
-
-    model_config = model_config
-
-    invocations: list[LanguageModelInvocationStats] = Field(default_factory=list)
-
-    @computed_field
-    @property
-    def total_token_usage(self) -> LanguageModelTokenUsage | None:
-        return LanguageModelTokenUsage.sum_usages(
-            invocation.token_usage for invocation in self.invocations
-        )

--- a/unique_toolkit/unique_toolkit/language_model/invocation_stats.py
+++ b/unique_toolkit/unique_toolkit/language_model/invocation_stats.py
@@ -1,0 +1,85 @@
+"""Per-invocation LLM usage stats with model identity.
+
+Lives in its own module (not ``schemas.py``) because it needs
+``LanguageModelName`` from ``infos.py``, which itself imports from
+``schemas.py``.
+"""
+
+from typing import Annotated, Self
+
+from humps import camelize
+from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, computed_field
+
+from unique_toolkit.language_model.infos import LanguageModelName
+from unique_toolkit.language_model.schemas import LanguageModelTokenUsage
+
+# `protected_namespaces=()` allows the `model_name` field name.
+model_config = ConfigDict(
+    alias_generator=camelize,
+    populate_by_name=True,
+    protected_namespaces=(),
+)
+
+
+def _normalize_model_name(value: object) -> object:
+    """Canonicalize model_name: known names become the enum, customs stay str.
+
+    Pydantic's smart union keeps string inputs as `str` even when they match a
+    `LanguageModelName` value, so without this the same model could appear as
+    enum or str depending on the caller.
+    """
+    if isinstance(value, str) and not isinstance(value, LanguageModelName):
+        value = value.strip()
+        if not value:
+            raise ValueError("model_name must be a non-empty model name")
+        try:
+            return LanguageModelName(value)
+        except ValueError:
+            return value
+    return value
+
+
+def _validate_source(value: object) -> object:
+    if isinstance(value, str):
+        value = value.strip()
+        if not value:
+            raise ValueError("source must be a non-empty string")
+    return value
+
+
+ModelName = Annotated[LanguageModelName | str, BeforeValidator(_normalize_model_name)]
+Source = Annotated[str, BeforeValidator(_validate_source)]
+
+
+class LanguageModelInvocationStats(BaseModel):
+    """Usage of a single LLM invocation, tied to the model that served it."""
+
+    model_config = model_config
+
+    model_name: ModelName
+    token_usage: LanguageModelTokenUsage
+    source: Source  # e.g. "main_loop", tool/evaluation/postprocessor name
+
+    @classmethod
+    def from_usage(
+        cls,
+        model_name: LanguageModelName | str,
+        token_usage: LanguageModelTokenUsage,
+        source: str,
+    ) -> Self:
+        return cls(model_name=model_name, token_usage=token_usage, source=source)
+
+
+class LanguageModelInvocationReport(BaseModel):
+    """All LLM invocations of one orchestration turn, with an aggregated total."""
+
+    model_config = model_config
+
+    invocations: list[LanguageModelInvocationStats] = Field(default_factory=list)
+
+    @computed_field
+    @property
+    def total_token_usage(self) -> LanguageModelTokenUsage | None:
+        return LanguageModelTokenUsage.sum_usages(
+            invocation.token_usage for invocation in self.invocations
+        )

--- a/unique_toolkit/unique_toolkit/language_model/schemas.py
+++ b/unique_toolkit/unique_toolkit/language_model/schemas.py
@@ -294,7 +294,23 @@ class LanguageModelTokenUsage(BaseModel):
             "cached_tokens",
             "cache_write_tokens",
         )
-        return cls(**{field: sum_field(field) for field in fields})
+        summed = {field: sum_field(field) for field in fields}
+
+        # An invocation can omit `total_tokens` while still reporting
+        # completion/prompt tokens (e.g. a manually-constructed usage, or a
+        # provider quirk). Naively summing `total_tokens` across invocations then
+        # undercounts it relative to the summed completion/prompt tokens for the
+        # same set of calls. completion_tokens + prompt_tokens is always at least
+        # as accurate when both are known, so prefer it over the raw summed total.
+        if (
+            summed["completion_tokens"] is not None
+            and summed["prompt_tokens"] is not None
+        ):
+            derived_total = summed["completion_tokens"] + summed["prompt_tokens"]
+            if summed["total_tokens"] is None or derived_total > summed["total_tokens"]:
+                summed["total_tokens"] = derived_total
+
+        return cls(**summed)
 
 
 class LanguageModelStreamResponse(BaseModel):

--- a/unique_toolkit/unique_toolkit/language_model/schemas.py
+++ b/unique_toolkit/unique_toolkit/language_model/schemas.py
@@ -4,7 +4,7 @@ import json
 import math
 from collections.abc import Sequence
 from enum import StrEnum
-from typing import Any, Literal, Self, TypeAlias, TypeVar, cast, override
+from typing import Any, Iterable, Literal, Self, TypeAlias, TypeVar, cast, override
 from uuid import uuid4
 
 from humps import camelize
@@ -157,12 +157,144 @@ class LanguageModelFunction(BaseModel):
             )
 
 
+def _variants(*names: str) -> list[str]:
+    """Expand each snake_case candidate into its snake_case and camelCase spellings."""
+    expanded: list[str] = []
+    for name in names:
+        expanded.append(name)
+        camel = camelize(name)
+        if camel != name:
+            expanded.append(camel)
+    return expanded
+
+
+def _first_value(source: object, keys: Sequence[str]) -> object | None:
+    """First non-`None` value found under any of `keys`; `source` is a dict or SDK object."""
+    if source is None:
+        return None
+    for key in keys:
+        value = (
+            source.get(key) if isinstance(source, dict) else getattr(source, key, None)
+        )
+        if value is not None:
+            return value
+    return None
+
+
+def _first_int(source: object, keys: Sequence[str]) -> int | None:
+    value = _first_value(source, keys)
+    if not isinstance(value, (int, float, str)):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
 class LanguageModelTokenUsage(BaseModel):
     model_config = model_config
 
     completion_tokens: int | None = None
     prompt_tokens: int | None = None
     total_tokens: int | None = None
+    reasoning_tokens: int | None = None  # subset of completion_tokens
+    cached_tokens: int | None = None  # subset of prompt_tokens (cache read)
+    cache_write_tokens: int | None = None  # separate cost line, not cached_tokens
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_provider_usage(cls, data: Any) -> Any:
+        """Map Chat/Responses/Anthropic/litellm usage shapes onto this model's fields.
+
+        Only fills fields absent from the payload; never overwrites an explicit value
+        or invents 0 for a field the provider didn't report. Accepts a raw gateway
+        dict directly, or an SDK usage object (``CompletionUsage``/``ResponseUsage``)
+        via its own ``model_dump()`` -- callers never need to convert it themselves.
+        """
+        dump = getattr(data, "model_dump", None)
+        if dump is not None:
+            data = dump()
+        if not isinstance(data, dict):
+            return data
+        data = dict(data)
+
+        def present(field: str) -> bool:
+            return field in data or camelize(field) in data
+
+        def fill(field: str, *sources: tuple[object, Sequence[str]]) -> None:
+            if present(field):
+                return
+            for source, keys in sources:
+                value = _first_int(source, keys)
+                if value is not None:
+                    data[field] = value
+                    return
+
+        fill("prompt_tokens", (data, _variants("input_tokens")))
+        fill("completion_tokens", (data, _variants("output_tokens")))
+        if not present("total_tokens"):
+            prompt_tokens = _first_int(data, _variants("prompt_tokens", "input_tokens"))
+            completion_tokens = _first_int(
+                data, _variants("completion_tokens", "output_tokens")
+            )
+            if prompt_tokens is not None and completion_tokens is not None:
+                data["total_tokens"] = prompt_tokens + completion_tokens
+
+        prompt_details = _first_value(
+            data, _variants("prompt_tokens_details", "input_tokens_details")
+        )
+        completion_details = _first_value(
+            data, _variants("completion_tokens_details", "output_tokens_details")
+        )
+
+        fill("reasoning_tokens", (completion_details, _variants("reasoning_tokens")))
+        fill(
+            "cached_tokens",
+            (prompt_details, _variants("cached_tokens")),
+            # Anthropic (via litellm) also reports this top-level, unnested.
+            (data, _variants("cache_read_input_tokens")),
+        )
+        fill(
+            "cache_write_tokens",
+            (
+                prompt_details,
+                # cache_creation_tokens is Anthropic's name for the same concept.
+                _variants("cache_write_tokens", "cache_creation_tokens"),
+            ),
+            (data, _variants("cache_creation_input_tokens")),
+        )
+
+        return data
+
+    @classmethod
+    def sum_usages(
+        cls, usages: Iterable[LanguageModelTokenUsage | None]
+    ) -> LanguageModelTokenUsage | None:
+        """Sum usages, skipping `None` entries; returns `None` if none are present.
+
+        Per field: if no entry reported it, the sum stays `None` too -- otherwise a
+        field no provider ever reports (e.g. cache_write_tokens) would sum to a
+        misleading `0` ("confirmed zero") instead of "unknown".
+        """
+        present = [u for u in usages if u is not None]
+        if not present:
+            return None
+
+        def sum_field(attr: str) -> int | None:
+            values = [getattr(u, attr) for u in present]
+            if all(v is None for v in values):
+                return None
+            return sum(v or 0 for v in values)
+
+        fields = (
+            "completion_tokens",
+            "prompt_tokens",
+            "total_tokens",
+            "reasoning_tokens",
+            "cached_tokens",
+            "cache_write_tokens",
+        )
+        return cls(**{field: sum_field(field) for field in fields})
 
 
 class LanguageModelStreamResponse(BaseModel):
@@ -631,6 +763,7 @@ class LanguageModelResponse(BaseModel):
     model_config = model_config
 
     choices: list[LanguageModelCompletionChoice]
+    usage: LanguageModelTokenUsage | None = None
 
     @classmethod
     def from_stream_response(cls, response: LanguageModelStreamResponse):
@@ -640,7 +773,7 @@ class LanguageModelResponse(BaseModel):
             finish_reason="",
         )
 
-        return cls(choices=[choice])
+        return cls(choices=[choice], usage=response.usage)
 
 
 # The OpenAI SDK's ReasoningEffort type alias is generated from an older OpenAPI spec and is


### PR DESCRIPTION
## Summary

**Part 1/3 of a 3-PR split** — this PR is now scoped to `unique_toolkit` + `unique_sdk` only. Depended on by:
- part 2/3: #2077 (`unique_follow_up_questions`)
- part 3/3: #2078 (`unique_orchestrator`)

Each is a stacked PR (base = the previous one) — merge in order: this PR → #2077 → #2078.

- Tracks LLM token usage **per invocation**, not as one blended total: each LLM call (main loop, forced-tool-choice, postprocessors, evaluations, a planning step) is captured as a `LanguageModelInvocationStats` entry (`model_name`, `token_usage`, `source`), since a single Space turn routinely spans several different models and a flat total can't be attributed to any one of them.
- `LanguageModelTokenUsage` gains `reasoning_tokens`, `cached_tokens`, and `cache_write_tokens`, populated by a `model_validator` that normalizes Chat/Responses/Anthropic/litellm usage shapes (vocabulary, casing, nested vs top-level aliases) and accepts either a raw gateway dict or an SDK usage object directly via its own `model_dump()` — no manual extraction at call sites. `sum_usages()` keeps a field `None` when no invocation ever reported it, instead of summing to a misleading `0`.
- `source` is a mandatory field on every entry (e.g. `"main_loop"`, `"hallucination"`, `"context_relevancy"`, `"follow_up_questions"`, `"planning"`, or an evaluation/tool name) — always non-empty.
- Adds `LanguageModelInvocationStats.from_usage()` (the single constructor; every capture site uses it) and typed `get_message_usage()` / `get_message_invocations()` SDK accessors.
- Captures a previously-invisible planning step's usage (`PlanningMiddleware` / `ResponsesPlanningMiddleware`) — a real, separate LLM call that ran before the main iteration and was silently dropped before this PR.
- `Postprocessor`/`ResponsesApiPostprocessor`'s `invocation_stats` is now a property (was a method) per review feedback.
- Fixes `unique_sdk`'s `send_message_and_wait_for_completion`: it was re-fetching `debugInfo` using the wrong message id. `debugInfo` is always written to the **user** message (confirmed via `ChatService.update_debug_info_async` → `assistant=False`), not the assistant reply.

Naming convention: camelCase on the wire (`modelName`/`tokenUsage`/`totalTokenUsage`), matching the existing `Integrated.Usage` shape.

Driven by Jira UN-20907.

## Out of scope for this PR (by design)

- **Tool-internal LLM calls** (e.g. `unique_web_search`'s argument screening, content summarization, GDPR redaction) are **not** captured here. That implementation exists on `backup/UN-20907-with-web-search-2026-07-14` but is deliberately excluded pending a design discussion — this PR stays focused on the core loop/evaluation/postprocessor/planning paths.
- **Cost** (`calculated_cost`/`reported_cost`) is not part of this PR. An earlier iteration had cost fields; they were removed since the pricing source is undecided. `LanguageModelInvocationStats` carries only usage + model + source today.
- **Per-model aggregation of `total_token_usage`** — currently one blended total across all invocations regardless of model; open discussion with @klcd on whether to aggregate by model instead (see PR review thread).
- DeepResearch usage tracking — separate ticket.

## Live-test findings (reasoning/cached/cache-write tokens)

Live-tested across the three main-loop transport paths against a real gateway:
- `Integrated.chat_stream_completion_async` (default Chat-Completions loop): confirmed via raw payload dump that this specific node-chat backend endpoint does **not** forward `completion_tokens_details`/`prompt_tokens_details` — a backend limitation, not a client-side gap. Our parsing is correct; there's simply nothing to parse on this path today.
- `Integrated.responses_stream_async` and the experimental OpenAI-proxy Responses client: both confirmed working — `reasoningTokens`/`cachedTokens` populate correctly with real values.
- Every evaluation/postprocessor path (`ChatCompletion.create_async`): confirmed working.

## Test plan
- [x] Full `unique_toolkit` (3115), `unique_sdk` (1044, 39 skipped) suites pass.
- [x] New tests: `LanguageModelInvocationStats`/`LanguageModelInvocationReport` (construction, mandatory `source`, `model_name` normalization, serialization, provider-usage-shape normalization across Chat/Responses/Anthropic/litellm/Mistral/Gemini shapes), `PlanningMiddleware`/`ResponsesPlanningMiddleware` invocation-stats capture (including drain-between-iterations and failure paths), manager-level collection (`PostprocessorManager`/`EvaluationManager`), SDK accessors.
- [x] `basedpyright` clean on `unique_toolkit` and `unique_sdk` (no new errors).
- [x] Live-tested against a real gateway (see above).
