### PR TITLE
fix(cli): resolve message ID from per-turn identity file [UN-22947]

### DIFF
--- a/unique_sdk/tests/cli/test_identity.py
+++ b/unique_sdk/tests/cli/test_identity.py
@@ -1,0 +1,127 @@
+"""Tests for unique_sdk.cli.identity turn-identity resolution (UN-22947)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from unique_sdk.cli.cli import main
+from unique_sdk.cli.identity import (
+    TURN_IDENTITY_ENV_VAR,
+    TurnIdentityError,
+    resolve_message_id,
+)
+
+
+def _write_identity(path: Path, *, message_id: str = "msg-live") -> Path:
+    path.write_text(
+        json.dumps(
+            {
+                "message_id": message_id,
+                "chat_id": "chat-1",
+                "user_id": "u1",
+                "company_id": "c1",
+                "assistant_id": "a1",
+                "turn": 2,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+class TestResolveMessageId:
+    def test_explicit_wins_over_file_and_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        identity = _write_identity(tmp_path / "turn-identity.json")
+        monkeypatch.setenv(TURN_IDENTITY_ENV_VAR, str(identity))
+        monkeypatch.setenv("UNIQUE_MESSAGE_ID", "msg-env")
+        assert resolve_message_id("msg-explicit") == "msg-explicit"
+
+    def test_file_wins_over_stale_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        identity = _write_identity(
+            tmp_path / "turn-identity.json", message_id="msg-file"
+        )
+        monkeypatch.setenv(TURN_IDENTITY_ENV_VAR, str(identity))
+        monkeypatch.setenv("UNIQUE_MESSAGE_ID", "msg-stale")
+        assert resolve_message_id(None) == "msg-file"
+
+    def test_env_fallback_when_no_file(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv(TURN_IDENTITY_ENV_VAR, raising=False)
+        monkeypatch.setenv("UNIQUE_MESSAGE_ID", "msg-env")
+        assert resolve_message_id(None) == "msg-env"
+
+    def test_missing_file_fails_loud(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        missing = tmp_path / "missing.json"
+        monkeypatch.setenv(TURN_IDENTITY_ENV_VAR, str(missing))
+        monkeypatch.setenv("UNIQUE_MESSAGE_ID", "msg-stale")
+        with pytest.raises(TurnIdentityError, match="missing"):
+            resolve_message_id(None)
+
+    def test_malformed_file_fails_loud(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        bad = tmp_path / "turn-identity.json"
+        bad.write_text("{not-json", encoding="utf-8")
+        monkeypatch.setenv(TURN_IDENTITY_ENV_VAR, str(bad))
+        with pytest.raises(TurnIdentityError, match="failed to read"):
+            resolve_message_id(None)
+
+    def test_missing_message_id_field_fails_loud(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        bad = tmp_path / "turn-identity.json"
+        bad.write_text(json.dumps({"chat_id": "c1"}), encoding="utf-8")
+        monkeypatch.setenv(TURN_IDENTITY_ENV_VAR, str(bad))
+        with pytest.raises(TurnIdentityError, match="message_id"):
+            resolve_message_id(None)
+
+
+@patch("unique_sdk.cli.cli.cmd_mcp")
+def test_mcp_cli_passes_resolved_message_id(
+    mock_cmd_mcp: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    mock_cmd_mcp.return_value = "ok"
+    identity = _write_identity(
+        tmp_path / "turn-identity.json", message_id="msg-from-file"
+    )
+    monkeypatch.setenv(TURN_IDENTITY_ENV_VAR, str(identity))
+    monkeypatch.setenv("UNIQUE_MESSAGE_ID", "msg-stale")
+    monkeypatch.setenv("UNIQUE_USER_ID", "u1")
+    monkeypatch.setenv("UNIQUE_COMPANY_ID", "c1")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["mcp", "-c", "chat_1", '{"name": "tool", "arguments": {}}'],
+    )
+    assert result.exit_code == 0
+    assert mock_cmd_mcp.call_args.kwargs["message_id"] == "msg-from-file"
+
+
+@patch("unique_sdk.cli.cli.cmd_mcp")
+def test_mcp_cli_fails_when_turn_identity_file_missing(
+    mock_cmd_mcp: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(TURN_IDENTITY_ENV_VAR, str(tmp_path / "gone.json"))
+    monkeypatch.setenv("UNIQUE_MESSAGE_ID", "msg-stale")
+    monkeypatch.setenv("UNIQUE_USER_ID", "u1")
+    monkeypatch.setenv("UNIQUE_COMPANY_ID", "c1")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["mcp", "-c", "chat_1", '{"name": "tool", "arguments": {}}'],
+    )
+    assert result.exit_code == 2
+    assert "Error" in result.output
+    mock_cmd_mcp.assert_not_called()

--- a/unique_sdk/tests/cli/test_identity.py
+++ b/unique_sdk/tests/cli/test_identity.py
@@ -12,7 +12,9 @@ from click.testing import CliRunner
 from unique_sdk.cli.cli import main
 from unique_sdk.cli.identity import (
     TURN_IDENTITY_ENV_VAR,
+    TurnIdentity,
     TurnIdentityError,
+    read_turn_identity,
     resolve_message_id,
 )
 
@@ -32,6 +34,32 @@ def _write_identity(path: Path, *, message_id: str = "msg-live") -> Path:
         encoding="utf-8",
     )
     return path
+
+
+class TestReadTurnIdentity:
+    def test_returns_typed_identity(self, tmp_path: Path) -> None:
+        path = _write_identity(tmp_path / "turn-identity.json")
+        identity = read_turn_identity(path)
+        assert identity == TurnIdentity(
+            message_id="msg-live",
+            chat_id="chat-1",
+            user_id="u1",
+            company_id="c1",
+            assistant_id="a1",
+            turn=2,
+        )
+
+    def test_returns_none_when_unconfigured(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv(TURN_IDENTITY_ENV_VAR, raising=False)
+        assert read_turn_identity() is None
+
+    def test_optional_fields_default_to_none(self, tmp_path: Path) -> None:
+        path = tmp_path / "turn-identity.json"
+        path.write_text(json.dumps({"message_id": "msg-1"}), encoding="utf-8")
+        identity = read_turn_identity(path)
+        assert identity == TurnIdentity(message_id="msg-1")
 
 
 class TestResolveMessageId:

--- a/unique_sdk/unique_sdk/cli/cli.py
+++ b/unique_sdk/unique_sdk/cli/cli.py
@@ -84,10 +84,37 @@ from unique_sdk.cli.commands.web_search import (
 )
 from unique_sdk.cli.commands.web_search_config import ENV_CONFIG_PATH
 from unique_sdk.cli.config import load_config
+from unique_sdk.cli.identity import TurnIdentityError, resolve_message_id
 from unique_sdk.cli.shell import UniqueShell
 from unique_sdk.cli.state import ShellState
 
 _DYNAMIC_FRONTEND_ERROR_PREFIX = "dynamic-frontend "
+
+
+def _resolve_cli_message_id(
+    ctx: click.Context,
+    explicit: str | None,
+    *,
+    required: bool = False,
+) -> str | None:
+    """Resolve message id for Click commands; exit on turn-identity errors.
+
+    When *required* is True and no source yields a value, exits with code 2.
+    """
+    try:
+        resolved = resolve_message_id(explicit)
+    except TurnIdentityError as exc:
+        click.echo(f"Error: {exc}", err=True)
+        ctx.exit(2)
+    if required and not resolved:
+        click.echo(
+            "Error: message id is required. Pass --message-id, or set "
+            "UNIQUE_TURN_IDENTITY_FILE / UNIQUE_MESSAGE_ID.",
+            err=True,
+        )
+        ctx.exit(2)
+    return resolved
+
 
 MAIN_HELP = """\
 Unique CLI -- Linux-like file explorer for the Unique AI Platform.
@@ -802,8 +829,12 @@ def uploaded_search(
 @click.option(
     "--message-id",
     "-m",
-    required=True,
-    help="Message ID for the MCP tool call context.",
+    default=None,
+    help=(
+        "Message ID for the MCP tool call context. Defaults to the "
+        "current turn identity file ($UNIQUE_TURN_IDENTITY_FILE), then "
+        "$UNIQUE_MESSAGE_ID."
+    ),
 )
 @click.option(
     "--file",
@@ -824,7 +855,7 @@ def mcp(
     ctx: click.Context,
     payload: str | None,
     chat_id: str,
-    message_id: str,
+    message_id: str | None,
     file_path: str | None,
     use_stdin: bool,
 ) -> None:
@@ -837,7 +868,8 @@ def mcp(
     \b
     The JSON is forwarded 1:1 to the MCP call-tool API. Chat ID and
     message ID are provided as separate flags to identify the
-    conversation context.
+    conversation context. When --message-id is omitted, the CLI resolves
+    it from $UNIQUE_TURN_IDENTITY_FILE (preferred) or $UNIQUE_MESSAGE_ID.
 
     \b
     Input sources (exactly one required):
@@ -854,11 +886,12 @@ def mcp(
 
       cat payload.json | unique-cli mcp -c chat_123 -m msg_456 --stdin
     """
+    resolved_message_id = _resolve_cli_message_id(ctx, message_id, required=True)
     click.echo(
         cmd_mcp(
             LazyState.get(ctx),
             chat_id=chat_id,
-            message_id=message_id,
+            message_id=resolved_message_id or "",
             payload=payload,
             file=file_path,
             stdin=use_stdin,
@@ -887,8 +920,11 @@ def mcp(
     "--message-id",
     "parent_message_id",
     default=None,
-    envvar="UNIQUE_MESSAGE_ID",
-    help="Parent message ID for message correlation.",
+    help=(
+        "Parent message ID for message correlation. Defaults to the "
+        "current turn identity file ($UNIQUE_TURN_IDENTITY_FILE), then "
+        "$UNIQUE_MESSAGE_ID."
+    ),
 )
 @click.option(
     "--assistant-id",
@@ -931,13 +967,14 @@ def subagent(
       unique-cli subagent LegalReview "Review this contract clause"
       unique-cli subagent Finance "Summarize Q4 revenue" --reset-chat
     """
+    resolved_message_id = _resolve_cli_message_id(ctx, parent_message_id)
     output = cmd_subagent(
         LazyState.get(ctx),
         tool_name=tool_name,
         message=message,
         config_path=config_path,
         parent_chat_id=parent_chat_id,
-        parent_message_id=parent_message_id,
+        parent_message_id=resolved_message_id,
         parent_assistant_id=parent_assistant_id,
         reset_chat=reset_chat,
         output_json=output_json,
@@ -1195,7 +1232,15 @@ def elicit() -> None:
     ),
 )
 @click.option("--chat-id", "-c", default=None, help="Associated chat ID.")
-@click.option("--message-id", "-m", default=None, help="Associated message ID.")
+@click.option(
+    "--message-id",
+    "-m",
+    default=None,
+    help=(
+        "Associated message ID. Defaults to the current turn identity "
+        "file ($UNIQUE_TURN_IDENTITY_FILE), then $UNIQUE_MESSAGE_ID."
+    ),
+)
 @click.option(
     "--timeout",
     type=int,
@@ -1299,7 +1344,7 @@ def elicit_ask(
         "tool_name": tool_name,
         "schema": schema,
         "chat_id": chat_id,
-        "message_id": message_id,
+        "message_id": _resolve_cli_message_id(ctx, message_id),
         "timeout": timeout,
         "poll_interval": poll_interval,
         "metadata": parsed_metadata or None,
@@ -1334,7 +1379,15 @@ def elicit_ask(
 )
 @click.option("--url", default=None, help="External URL (required for --mode URL).")
 @click.option("--chat-id", "-c", default=None, help="Associated chat ID.")
-@click.option("--message-id", "-m", default=None, help="Associated message ID.")
+@click.option(
+    "--message-id",
+    "-m",
+    default=None,
+    help=(
+        "Associated message ID. Defaults to the current turn identity "
+        "file ($UNIQUE_TURN_IDENTITY_FILE), then $UNIQUE_MESSAGE_ID."
+    ),
+)
 @click.option(
     "--expires-in",
     "expires_in_seconds",
@@ -1439,7 +1492,7 @@ def elicit_create(
         "schema": schema,
         "url": url,
         "chat_id": chat_id,
-        "message_id": message_id,
+        "message_id": _resolve_cli_message_id(ctx, message_id),
         "expires_in_seconds": expires_in_seconds,
         "external_elicitation_id": external_elicitation_id,
         "metadata": parsed_metadata or None,

--- a/unique_sdk/unique_sdk/cli/identity.py
+++ b/unique_sdk/unique_sdk/cli/identity.py
@@ -1,0 +1,121 @@
+"""Resolve the current turn's assistant message identity.
+
+Persistent agent subprocesses freeze their OS environment at spawn time, so
+``UNIQUE_MESSAGE_ID`` can be stale on later turns. The parent runner writes a
+per-turn identity file and exposes its path via ``UNIQUE_TURN_IDENTITY_FILE``
+(stable across turns). Fresh ``unique-cli`` invocations then read the current
+message ID from that file.
+
+Resolution precedence for message IDs:
+
+1. Explicit ``--message-id`` / ``-m`` flag value
+2. Turn-identity file pointed to by ``$UNIQUE_TURN_IDENTITY_FILE``
+3. ``$UNIQUE_MESSAGE_ID`` environment variable (one-shot / external callers)
+
+When ``UNIQUE_TURN_IDENTITY_FILE`` is set but the file is missing or malformed,
+resolution fails loudly — silent fallback to a stale env value is forbidden.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+TURN_IDENTITY_ENV_VAR = "UNIQUE_TURN_IDENTITY_FILE"
+MESSAGE_ID_ENV_VAR = "UNIQUE_MESSAGE_ID"
+CHAT_ID_ENV_VAR = "UNIQUE_CHAT_ID"
+
+
+class TurnIdentityError(ValueError):
+    """Raised when the turn-identity file is configured but unusable."""
+
+
+def read_turn_identity(
+    path: str | Path | None = None,
+) -> dict[str, Any]:
+    """Load and validate the turn-identity JSON file.
+
+    When *path* is ``None``, reads ``$UNIQUE_TURN_IDENTITY_FILE``. Raises
+    ``TurnIdentityError`` if the env var / path is set but the file cannot be
+    read or does not contain a non-empty ``message_id`` string.
+    """
+    raw_path = str(path) if path is not None else os.environ.get(TURN_IDENTITY_ENV_VAR)
+    if not raw_path:
+        return {}
+
+    identity_path = Path(raw_path)
+    if not identity_path.is_file():
+        raise TurnIdentityError(
+            f"{TURN_IDENTITY_ENV_VAR} is set to {raw_path!r} but the file "
+            "is missing; refusing to fall back to a stale message id"
+        )
+    if identity_path.is_symlink():
+        raise TurnIdentityError(
+            f"refusing to read turn-identity file {raw_path!r}: path is a symlink"
+        )
+
+    try:
+        payload = json.loads(identity_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise TurnIdentityError(
+            f"failed to read turn-identity file {raw_path!r}: {exc}"
+        ) from exc
+
+    if not isinstance(payload, dict):
+        raise TurnIdentityError(
+            f"turn-identity file {raw_path!r} must contain a JSON object"
+        )
+
+    message_id = payload.get("message_id")
+    if not isinstance(message_id, str) or not message_id.strip():
+        raise TurnIdentityError(
+            f"turn-identity file {raw_path!r} is missing a non-empty "
+            "'message_id' string"
+        )
+    return payload
+
+
+def resolve_message_id(explicit: str | None = None) -> str | None:
+    """Resolve the assistant message ID for a message-bound CLI operation.
+
+    Returns ``None`` when no source yields a value (callers may then mint a
+    placeholder message, as elicit does for visible prompts without a chat
+    context). Raises ``TurnIdentityError`` when the turn-identity file is
+    configured but unusable.
+    """
+    if explicit is not None and str(explicit).strip():
+        return str(explicit).strip()
+
+    identity = read_turn_identity()
+    if identity:
+        message_id = identity.get("message_id")
+        if isinstance(message_id, str) and message_id.strip():
+            return message_id.strip()
+
+    env_id = os.environ.get(MESSAGE_ID_ENV_VAR)
+    if env_id is not None and env_id.strip():
+        return env_id.strip()
+    return None
+
+
+def resolve_chat_id(explicit: str | None = None) -> str | None:
+    """Resolve chat ID with the same file-then-env precedence as message ID.
+
+    Explicit flag wins. The turn-identity file is consulted next (and fails
+    loudly when configured but unusable). Falls back to ``$UNIQUE_CHAT_ID``.
+    """
+    if explicit is not None and str(explicit).strip():
+        return str(explicit).strip()
+
+    identity = read_turn_identity()
+    if identity:
+        chat_id = identity.get("chat_id")
+        if isinstance(chat_id, str) and chat_id.strip():
+            return chat_id.strip()
+
+    env_id = os.environ.get(CHAT_ID_ENV_VAR)
+    if env_id is not None and env_id.strip():
+        return env_id.strip()
+    return None

--- a/unique_sdk/unique_sdk/cli/identity.py
+++ b/unique_sdk/unique_sdk/cli/identity.py
@@ -20,8 +20,8 @@ from __future__ import annotations
 
 import json
 import os
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
 
 TURN_IDENTITY_ENV_VAR = "UNIQUE_TURN_IDENTITY_FILE"
 MESSAGE_ID_ENV_VAR = "UNIQUE_MESSAGE_ID"
@@ -32,18 +32,42 @@ class TurnIdentityError(ValueError):
     """Raised when the turn-identity file is configured but unusable."""
 
 
+@dataclass(frozen=True)
+class TurnIdentity:
+    """Parsed contents of the per-turn identity file.
+
+    Mirrors the JSON contract written by the platform runner. Only
+    ``message_id`` is mandatory; the remaining fields are informational.
+    """
+
+    message_id: str
+    chat_id: str | None = None
+    user_id: str | None = None
+    company_id: str | None = None
+    assistant_id: str | None = None
+    turn: int | None = None
+
+
+def _optional_str(payload: dict[str, object], key: str) -> str | None:
+    value = payload.get(key)
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
 def read_turn_identity(
     path: str | Path | None = None,
-) -> dict[str, Any]:
+) -> TurnIdentity | None:
     """Load and validate the turn-identity JSON file.
 
-    When *path* is ``None``, reads ``$UNIQUE_TURN_IDENTITY_FILE``. Raises
-    ``TurnIdentityError`` if the env var / path is set but the file cannot be
-    read or does not contain a non-empty ``message_id`` string.
+    When *path* is ``None``, reads ``$UNIQUE_TURN_IDENTITY_FILE``. Returns
+    ``None`` when neither is set. Raises ``TurnIdentityError`` if the env
+    var / path is set but the file cannot be read or does not contain a
+    non-empty ``message_id`` string.
     """
     raw_path = str(path) if path is not None else os.environ.get(TURN_IDENTITY_ENV_VAR)
     if not raw_path:
-        return {}
+        return None
 
     identity_path = Path(raw_path)
     if not identity_path.is_file():
@@ -74,7 +98,16 @@ def read_turn_identity(
             f"turn-identity file {raw_path!r} is missing a non-empty "
             "'message_id' string"
         )
-    return payload
+
+    raw_turn = payload.get("turn")
+    return TurnIdentity(
+        message_id=message_id.strip(),
+        chat_id=_optional_str(payload, "chat_id"),
+        user_id=_optional_str(payload, "user_id"),
+        company_id=_optional_str(payload, "company_id"),
+        assistant_id=_optional_str(payload, "assistant_id"),
+        turn=raw_turn if isinstance(raw_turn, int) else None,
+    )
 
 
 def resolve_message_id(explicit: str | None = None) -> str | None:
@@ -89,10 +122,8 @@ def resolve_message_id(explicit: str | None = None) -> str | None:
         return str(explicit).strip()
 
     identity = read_turn_identity()
-    if identity:
-        message_id = identity.get("message_id")
-        if isinstance(message_id, str) and message_id.strip():
-            return message_id.strip()
+    if identity is not None:
+        return identity.message_id
 
     env_id = os.environ.get(MESSAGE_ID_ENV_VAR)
     if env_id is not None and env_id.strip():
@@ -110,10 +141,8 @@ def resolve_chat_id(explicit: str | None = None) -> str | None:
         return str(explicit).strip()
 
     identity = read_turn_identity()
-    if identity:
-        chat_id = identity.get("chat_id")
-        if isinstance(chat_id, str) and chat_id.strip():
-            return chat_id.strip()
+    if identity is not None and identity.chat_id is not None:
+        return identity.chat_id
 
     env_id = os.environ.get(CHAT_ID_ENV_VAR)
     if env_id is not None and env_id.strip():

--- a/unique_sdk/unique_sdk/cli/skills/unique-cli-elicitation/SKILL.md
+++ b/unique_sdk/unique_sdk/cli/skills/unique-cli-elicitation/SKILL.md
@@ -44,7 +44,6 @@ default — comfortably under Claude Code's ~120s):
      --mode FORM \
      --tool-name "<tool_name>" \
      --chat-id "$UNIQUE_CHAT_ID" \
-     --message-id "$UNIQUE_MESSAGE_ID" \
      --expires-in 7200 \
      --schema '<json schema>')
    elicitation_id=$(echo "$create_output" | awk '/^Created elicitation/{print $3}')
@@ -86,8 +85,12 @@ use). Do not reach for it from inside an agent turn.
 unique-cli elicit ask "<question>" [options]
 ```
 
-!!! danger "`--chat-id` and `--message-id` are MANDATORY"
-    You **must always pass both** `--chat-id "$UNIQUE_CHAT_ID"` **and** `--message-id "$UNIQUE_MESSAGE_ID"` on every `elicit create`/`elicit ask` call. These environment variables are always available in the agent environment. Without both flags the elicitation is not correctly anchored to the current conversation and the user will not see it.
+!!! danger "`--chat-id` is MANDATORY"
+    You **must always pass** `--chat-id "$UNIQUE_CHAT_ID"` on every
+    `elicit create`/`elicit ask` call. Omit `--message-id`: the CLI resolves
+    the current turn's assistant message ID from `$UNIQUE_TURN_IDENTITY_FILE`
+    (preferred) or `$UNIQUE_MESSAGE_ID`. Do **not** pass a stale
+    `$UNIQUE_MESSAGE_ID` from a persistent process environment.
 
 ## When to use
 
@@ -111,8 +114,7 @@ unique-cli elicit ask "<question>" [options]
 
 ```bash
 unique-cli elicit ask "Which quarter should I report on?" \
-  --chat-id "$UNIQUE_CHAT_ID" \
-  --message-id "$UNIQUE_MESSAGE_ID"
+  --chat-id "$UNIQUE_CHAT_ID"
 ```
 
 Under the hood this creates a form with a single required string field `answer`. The reply you receive will look like:
@@ -135,7 +137,6 @@ Provide an explicit JSON schema so the user sees proper UI controls instead of a
 ```bash
 unique-cli elicit ask "Which report format do you want?" \
   --chat-id "$UNIQUE_CHAT_ID" \
-  --message-id "$UNIQUE_MESSAGE_ID" \
   --schema '{
     "type": "object",
     "properties": {
@@ -156,7 +157,6 @@ Always use this before `rm`, `rmdir -r`, mass uploads, or anything irreversible.
 ```bash
 unique-cli elicit ask "Confirm deleting /Archive/2024 and everything inside it" \
   --chat-id "$UNIQUE_CHAT_ID" \
-  --message-id "$UNIQUE_MESSAGE_ID" \
   --schema '{
     "type": "object",
     "properties": {
@@ -176,7 +176,6 @@ Proceed **only** if the response contains `"confirm": true`. Treat `DECLINED`, `
 ```bash
 unique-cli elicit ask "Please provide report settings" \
   --chat-id "$UNIQUE_CHAT_ID" \
-  --message-id "$UNIQUE_MESSAGE_ID" \
   --schema '{
     "type": "object",
     "properties": {
@@ -200,7 +199,7 @@ you call separately in the polling pattern).
 | Option | Short | Default | Description |
 |--------|-------|---------|-------------|
 | `--chat-id` | `-c` | none | **MANDATORY.** Chat to show the question in. Always pass `"$UNIQUE_CHAT_ID"`. Without it the visibility workaround cannot run and the user will not see the elicitation. |
-| `--message-id` | `-m` | none | **MANDATORY.** The current assistant message ID. Always pass `"$UNIQUE_MESSAGE_ID"`. Anchors the elicitation to the correct message in the conversation thread. |
+| `--message-id` | `-m` | auto | Optional. Prefer omitting this flag — the CLI resolves the current turn's message ID from `$UNIQUE_TURN_IDENTITY_FILE` (preferred) or `$UNIQUE_MESSAGE_ID`. Do not pass a stale env value from a persistent process. |
 | `--tool-name` | `-t` | `agent_question` | Short snake_case label shown to the user (e.g. `clarify`, `confirm_delete`, `choose_report`). |
 | `--schema` | | single `answer` string | JSON Schema for the form body. |
 | `--timeout` | | `7200` | Max seconds to block locally before giving up. This is the single knob for `ask`: it also sets when the request expires on the platform, so the prompt expires exactly when you stop waiting and the chat UI can offer the user a way to continue. |
@@ -271,7 +270,6 @@ In a shell script or agent tool wrapper, capture the output and pull out the `Re
 ```bash
 result=$(unique-cli elicit ask "Which region?" \
   --chat-id "$UNIQUE_CHAT_ID" \
-  --message-id "$UNIQUE_MESSAGE_ID" \
   --schema '{
     "type":"object",
     "properties":{"region":{"type":"string","enum":["EU","US","APAC"]}},
@@ -299,7 +297,7 @@ esac
 
 1. **Default to `elicit create` + `elicit wait` polling.** If you need an answer from the user, use this pattern, not a chat message and not a single blocking `elicit ask` call. See "The pattern" above.
 2. **Always pass `--chat-id "$UNIQUE_CHAT_ID"`.** Without it the elicitation is not attached to a chat and the user will not see it.
-3. **Always pass `--message-id "$UNIQUE_MESSAGE_ID"`.** This anchors the elicitation to the current message in the conversation. Both `$UNIQUE_CHAT_ID` and `$UNIQUE_MESSAGE_ID` are always available as environment variables — never omit either.
+3. **Omit `--message-id`.** The CLI resolves the current turn's assistant message ID from `$UNIQUE_TURN_IDENTITY_FILE` (preferred) or `$UNIQUE_MESSAGE_ID`. Do not pass a stale `$UNIQUE_MESSAGE_ID` from a persistent process environment.
 4. **Never pass `--no-visible`.** See the warning above. The visibility workaround is mandatory today.
 5. **Never run destructive CLI commands without a confirmation elicitation.** This includes `rm`, `rmdir -r`, bulk renames, large uploads, schedule deletion, etc.
 6. **Pick a meaningful `--tool-name`.** `confirm_delete`, `choose_region`, `pick_report` -- short snake_case describing the intent.
@@ -320,7 +318,8 @@ UNIQUE_COMPANY_ID # Company ID (required)
 UNIQUE_API_KEY    # API key -- optional on localhost / secured cluster
 UNIQUE_APP_ID     # App ID -- optional on localhost / secured cluster
 UNIQUE_CHAT_ID    # Current chat ID -- always pass as --chat-id (required)
-UNIQUE_MESSAGE_ID # Current message ID -- always pass as --message-id (required)
+UNIQUE_TURN_IDENTITY_FILE # Per-turn identity JSON — CLI resolves message ID from here
+UNIQUE_MESSAGE_ID # Fallback message ID when no turn-identity file is present
 ```
 
 Install: `pip install unique-sdk`

--- a/unique_sdk/unique_sdk/cli/skills/unique-cli-mcp/SKILL.md
+++ b/unique_sdk/unique_sdk/cli/skills/unique-cli-mcp/SKILL.md
@@ -77,7 +77,7 @@ unique-cli mcp [--chat-id <id>] [--message-id <id>] [PAYLOAD | --file <path> | -
 | Option | Short | Required | Description |
 |--------|-------|----------|-------------|
 | `--chat-id` | `-c` | Yes | Chat ID for the conversation context |
-| `--message-id` | `-m` | Yes | Message ID for the conversation context |
+| `--message-id` | `-m` | No | Message ID for the conversation context. Optional — resolved from `$UNIQUE_TURN_IDENTITY_FILE` (preferred) or `$UNIQUE_MESSAGE_ID` when omitted. |
 | `PAYLOAD` | | One of three | Inline JSON string |
 | `--file` | `-f` | One of three | Path to a JSON file |
 | `--stdin` | | One of three | Read JSON from stdin |

--- a/unique_sdk/unique_sdk/cli/skills/unique-cli-subagent/SKILL.md
+++ b/unique_sdk/unique_sdk/cli/skills/unique-cli-subagent/SKILL.md
@@ -17,9 +17,11 @@ the tool name shown in the generated connected-space skill.
 ```bash
 unique-cli subagent "<tool_name>" "<message>" \
   --chat-id "$UNIQUE_CHAT_ID" \
-  --message-id "$UNIQUE_MESSAGE_ID" \
   --assistant-id "$UNIQUE_ASSISTANT_ID"
 ```
+
+Omit `--message-id`: the CLI resolves the current turn's assistant message ID
+from `$UNIQUE_TURN_IDENTITY_FILE` automatically.
 
 ## Rules
 
@@ -49,7 +51,7 @@ The platform sets these environment variables automatically:
 UNIQUE_USER_ID
 UNIQUE_COMPANY_ID
 UNIQUE_CHAT_ID
-UNIQUE_MESSAGE_ID
+UNIQUE_TURN_IDENTITY_FILE
 UNIQUE_ASSISTANT_ID
 UNIQUE_API_KEY
 UNIQUE_APP_ID


### PR DESCRIPTION
## Summary
- Add `unique-cli` message-ID resolution from `$UNIQUE_TURN_IDENTITY_FILE` (preferred) with fail-loud semantics when the file is configured but missing/malformed
- Make `--message-id` optional for `mcp`, `elicit ask`/`create`, and `subagent` so persistent agent subprocesses no longer rely on a frozen `$UNIQUE_MESSAGE_ID`
- Update CLI skills to omit stale `--message-id "$UNIQUE_MESSAGE_ID"`

Refs: UN-22947

## Test plan
- [x] `uv run pytest tests/cli/test_identity.py`
- [x] Related CLI regression: `tests/cli/test_cli.py::TestClickCLI::test_mcp_missing_message_id`, `tests/cli/test_subagent.py`
- [ ] Pair with monorepo PR that writes `.unique/turn-identity.json` and sets `UNIQUE_TURN_IDENTITY_FILE`

## Notes for reviewers
- Backward compatible: without the turn-identity file/env, behavior matches today (`$UNIQUE_MESSAGE_ID` / explicit flag)
- Ship this SDK change before (or with) the monorepo skill edits that drop `--message-id`


Made with [Cursor](https://cursor.com)