### PR TITLE
feat(unique-orchestrator): adding analytics parameters to debug info

### DIFF
--- a/unique_orchestrator/unique_orchestrator/tests/test_unique_ai_execution_timing.py
+++ b/unique_orchestrator/unique_orchestrator/tests/test_unique_ai_execution_timing.py
@@ -1,4 +1,5 @@
 import time
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -737,6 +738,27 @@ class TestRunExecutionTimingIntegration:
 
     @pytest.mark.ai
     @pytest.mark.asyncio
+    async def test_run__analytics__includes_total_time_to_answer_ms(
+        self, monkeypatch
+    ) -> None:
+        """
+        Purpose: Verify analytics measures from user creation through completion.
+        Why this matters: Internal loop timing excludes queueing and completion latency.
+        Setup summary: Return a known completion timestamp and assert the full delta.
+        """
+        ua = self._build_run_ua(monkeypatch)
+        ua._event.payload.user_message.created_at = "2026-07-13T20:00:00Z"
+        ua._chat_service.modify_assistant_message_async.return_value = MagicMock(
+            completed_at=datetime(2026, 7, 13, 20, 0, 2, 345000, tzinfo=timezone.utc)
+        )
+
+        await ua.run()
+
+        analytics_call = ua._debug_info_manager.add_analytics.call_args
+        assert analytics_call.kwargs["total_time_to_answer_ms"] == 2345
+
+    @pytest.mark.ai
+    @pytest.mark.asyncio
     async def test_run__execution_times__contains_one_entry_after_single_iteration(
         self, monkeypatch
     ) -> None:
@@ -836,10 +858,10 @@ class TestRunExecutionTimingIntegration:
     ) -> None:
         """
         Purpose: Verify that a failure in update_debug_info_async propagates to the caller.
-        Why this matters: After refactoring, debug info failures are no longer silently
-        swallowed; callers must handle them.
+        Why this matters: Debug failures remain visible without preventing answer
+        completion.
         Setup summary: Make update_debug_info_async raise; run; assert RuntimeError
-        propagates and modify_assistant_message_async is never reached.
+        propagates after modify_assistant_message_async completes the answer.
         """
         ua = self._build_run_ua(monkeypatch)
         ua._chat_service.update_debug_info_async.side_effect = RuntimeError("boom")
@@ -847,7 +869,9 @@ class TestRunExecutionTimingIntegration:
         with pytest.raises(RuntimeError, match="boom"):
             await ua.run()
 
-        ua._chat_service.modify_assistant_message_async.assert_not_called()
+        ua._chat_service.modify_assistant_message_async.assert_awaited_once_with(
+            set_completed_at=True
+        )
 
     @pytest.mark.ai
     @pytest.mark.asyncio

--- a/unique_orchestrator/unique_orchestrator/tests/test_unique_ai_loop_debug_params.py
+++ b/unique_orchestrator/unique_orchestrator/tests/test_unique_ai_loop_debug_params.py
@@ -76,6 +76,7 @@ def _make_loop_response() -> MagicMock:
     response.message = MagicMock()
     response.message.references = []
     response.message.text = "response text"
+    response.message.original_text = "original response text"
     response.is_empty.return_value = False
     return response
 
@@ -279,6 +280,9 @@ class TestRunLoopDebugParams:
         mock_config = MagicMock()
         mock_config.effective_max_loop_iterations = 1
         mock_config.agent.prompt_config.user_metadata = []
+        mock_config.space.language_model.name = "AZURE_GPT_5_2025_0807"
+        mock_config.space.language_model.family = "openai"
+        mock_config.space.language_model.provider = "AZURE"
 
         mock_history_manager = MagicMock()
         mock_history_manager.get_history_for_model_call = AsyncMock(
@@ -345,6 +349,10 @@ class TestRunLoopDebugParams:
         as the first argument.
         """
         ua = self._build_run_ua(monkeypatch)
+        tool = MagicMock()
+        tool.name = "InternalSearch"
+        tool.display_name.return_value = "Knowledge Base Search"
+        ua._tool_manager.available_tools = [tool]
 
         await ua.run()
 
@@ -359,7 +367,54 @@ class TestRunLoopDebugParams:
             if c.args[0] == "skills"
         )
         ua._debug_info_manager.add_analytics.assert_called_once_with(
-            skills_call.args[1]
+            skills_call.args[1],
+            language_model={
+                "name": "AZURE_GPT_5_2025_0807",
+                "family": "openai",
+                "provider": "AZURE",
+            },
+            tool_display_names={"InternalSearch": "Knowledge Base Search"},
+            references=0,
+            user_prompt_length=5,
+            answer_length=22,
+            loop_iteration_count=1,
+        )
+
+    @pytest.mark.ai
+    @pytest.mark.asyncio
+    async def test_run__analytics__counts_unique_reference_sources(
+        self, monkeypatch
+    ) -> None:
+        ua = self._build_run_ua(monkeypatch)
+        references = [
+            MagicMock(url="source_1"),
+            MagicMock(url="source_1"),
+            MagicMock(url="source_2"),
+            MagicMock(url="source_3"),
+            MagicMock(url="source_3"),
+        ]
+        ua._loop_iteration_runner.return_value.message.references = references
+        ua._reference_manager.get_latest_references.return_value = references
+
+        await ua.run()
+
+        skills_call = next(
+            call
+            for call in ua._debug_info_manager.add.call_args_list
+            if call.args[0] == "skills"
+        )
+        ua._debug_info_manager.add_analytics.assert_called_once_with(
+            skills_call.args[1],
+            language_model={
+                "name": "AZURE_GPT_5_2025_0807",
+                "family": "openai",
+                "provider": "AZURE",
+            },
+            tool_display_names={},
+            references=3,
+            user_prompt_length=5,
+            answer_length=22,
+            loop_iteration_count=1,
         )
 
     @pytest.mark.ai

--- a/unique_orchestrator/unique_orchestrator/tests/test_unique_ai_loop_debug_params.py
+++ b/unique_orchestrator/unique_orchestrator/tests/test_unique_ai_loop_debug_params.py
@@ -257,6 +257,9 @@ class TestRunLoopDebugParams:
         mock_chat_service.cancellation = mock_cancellation
         mock_chat_service.get_debug_info_async = AsyncMock(return_value={})
         mock_chat_service.update_debug_info_async = AsyncMock(return_value=None)
+        # Returns None by default → no completed_at, so total_time_to_answer_ms
+        # resolves to None. Tests that exercise timing override this return value
+        # with a MagicMock(completed_at=...).
         mock_chat_service.modify_assistant_message_async = AsyncMock(return_value=None)
         mock_chat_service.create_assistant_message_async = AsyncMock(
             return_value=MagicMock(id="assist_new")
@@ -361,25 +364,21 @@ class TestRunLoopDebugParams:
         ]
         assert "loop_params" in keys_written
         assert "skills" in keys_written
+        # This test owns one contract: run() forwards the same skills value it
+        # wrote under "skills" as the first positional arg to add_analytics.
+        # Per-field kwargs (references / timing / lengths) are covered by the
+        # focused sibling tests below, so we don't re-pin the whole call here.
         skills_call = next(
             c
             for c in ua._debug_info_manager.add.call_args_list
             if c.args[0] == "skills"
         )
-        ua._debug_info_manager.add_analytics.assert_called_once_with(
-            skills_call.args[1],
-            language_model={
-                "name": "AZURE_GPT_5_2025_0807",
-                "family": "openai",
-                "provider": "AZURE",
-            },
-            tool_display_names={"InternalSearch": "Knowledge Base Search"},
-            references=0,
-            user_prompt_length=5,
-            answer_length=22,
-            loop_iteration_count=1,
-            total_time_to_answer_ms=None,
-        )
+        ua._debug_info_manager.add_analytics.assert_called_once()
+        analytics_call = ua._debug_info_manager.add_analytics.call_args
+        assert analytics_call.args[0] == skills_call.args[1]
+        assert analytics_call.kwargs["tool_display_names"] == {
+            "InternalSearch": "Knowledge Base Search"
+        }
 
     @pytest.mark.ai
     @pytest.mark.asyncio
@@ -399,25 +398,8 @@ class TestRunLoopDebugParams:
 
         await ua.run()
 
-        skills_call = next(
-            call
-            for call in ua._debug_info_manager.add.call_args_list
-            if call.args[0] == "skills"
-        )
-        ua._debug_info_manager.add_analytics.assert_called_once_with(
-            skills_call.args[1],
-            language_model={
-                "name": "AZURE_GPT_5_2025_0807",
-                "family": "openai",
-                "provider": "AZURE",
-            },
-            tool_display_names={},
-            references=3,
-            user_prompt_length=5,
-            answer_length=22,
-            loop_iteration_count=1,
-            total_time_to_answer_ms=None,
-        )
+        analytics_call = ua._debug_info_manager.add_analytics.call_args
+        assert analytics_call.kwargs["references"] == 3
 
     @pytest.mark.ai
     @pytest.mark.asyncio
@@ -473,6 +455,28 @@ class TestRunLoopDebugParams:
 
         analytics_call = ua._debug_info_manager.add_analytics.call_args
         assert analytics_call.kwargs["references"] == 2
+
+    @pytest.mark.ai
+    @pytest.mark.asyncio
+    async def test_run__analytics__total_time_to_answer_ms_none_without_completed_at(
+        self, monkeypatch
+    ) -> None:
+        """
+        Purpose: Verify total_time_to_answer_ms is None when the completed message
+        carries no completed_at.
+        Why this matters: Makes the None case deliberate — run() must degrade to
+        None (not crash) when completion time is unavailable, e.g. a tool took
+        control. Pairs with test_run__analytics__includes_total_time_to_answer_ms
+        (execution-timing suite) which covers the populated case.
+        Setup summary: modify_assistant_message_async returns None (fixture default);
+        assert the kwarg is present and None.
+        """
+        ua = self._build_run_ua(monkeypatch)
+
+        await ua.run()
+
+        analytics_call = ua._debug_info_manager.add_analytics.call_args
+        assert analytics_call.kwargs["total_time_to_answer_ms"] is None
 
     @pytest.mark.ai
     @pytest.mark.asyncio

--- a/unique_orchestrator/unique_orchestrator/tests/test_unique_ai_loop_debug_params.py
+++ b/unique_orchestrator/unique_orchestrator/tests/test_unique_ai_loop_debug_params.py
@@ -378,6 +378,7 @@ class TestRunLoopDebugParams:
             user_prompt_length=5,
             answer_length=22,
             loop_iteration_count=1,
+            total_time_to_answer_ms=None,
         )
 
     @pytest.mark.ai
@@ -415,6 +416,7 @@ class TestRunLoopDebugParams:
             user_prompt_length=5,
             answer_length=22,
             loop_iteration_count=1,
+            total_time_to_answer_ms=None,
         )
 
     @pytest.mark.ai

--- a/unique_orchestrator/unique_orchestrator/tests/test_unique_ai_loop_debug_params.py
+++ b/unique_orchestrator/unique_orchestrator/tests/test_unique_ai_loop_debug_params.py
@@ -419,6 +419,30 @@ class TestRunLoopDebugParams:
 
     @pytest.mark.ai
     @pytest.mark.asyncio
+    async def test_run__analytics__counts_distinct_references_without_urls(
+        self, monkeypatch
+    ) -> None:
+        """
+        Purpose: Verify URL-less references are identified by source and source ID.
+        Why this matters: MCP citations can omit URLs and must not collapse into one
+        analytics source.
+        Setup summary: Run with two distinct URL-less references and assert both count.
+        """
+        ua = self._build_run_ua(monkeypatch)
+        references = [
+            MagicMock(url=None, source="mcp", source_id="resource_1"),
+            MagicMock(url=None, source="mcp", source_id="resource_2"),
+        ]
+        ua._loop_iteration_runner.return_value.message.references = references
+        ua._reference_manager.get_latest_references.return_value = references
+
+        await ua.run()
+
+        analytics_call = ua._debug_info_manager.add_analytics.call_args
+        assert analytics_call.kwargs["references"] == 2
+
+    @pytest.mark.ai
+    @pytest.mark.asyncio
     async def test_run__loop_params__contains_one_entry_per_iteration(
         self, monkeypatch
     ) -> None:

--- a/unique_orchestrator/unique_orchestrator/tests/test_unique_ai_loop_debug_params.py
+++ b/unique_orchestrator/unique_orchestrator/tests/test_unique_ai_loop_debug_params.py
@@ -395,7 +395,7 @@ class TestRunLoopDebugParams:
             MagicMock(url="source_3"),
         ]
         ua._loop_iteration_runner.return_value.message.references = references
-        ua._reference_manager.get_latest_references.return_value = references
+        ua._reference_manager.get_references.return_value = [references]
 
         await ua.run()
 
@@ -421,6 +421,37 @@ class TestRunLoopDebugParams:
 
     @pytest.mark.ai
     @pytest.mark.asyncio
+    async def test_run__analytics__counts_references_across_iterations(
+        self, monkeypatch
+    ) -> None:
+        """
+        Purpose: Verify analytics includes reference sources from every loop iteration.
+        Why this matters: Earlier citations belong to the same run and must not be
+        omitted when a later iteration appends another reference batch.
+        Setup summary: Return two stored batches with one duplicate source and assert
+        that all three distinct sources are counted.
+        """
+        ua = self._build_run_ua(monkeypatch)
+        first_iteration_references = [
+            MagicMock(url="source_1"),
+            MagicMock(url="source_2"),
+        ]
+        latest_iteration_references = [
+            MagicMock(url="source_2"),
+            MagicMock(url="source_3"),
+        ]
+        ua._reference_manager.get_references.return_value = [
+            first_iteration_references,
+            latest_iteration_references,
+        ]
+
+        await ua.run()
+
+        analytics_call = ua._debug_info_manager.add_analytics.call_args
+        assert analytics_call.kwargs["references"] == 3
+
+    @pytest.mark.ai
+    @pytest.mark.asyncio
     async def test_run__analytics__counts_distinct_references_without_urls(
         self, monkeypatch
     ) -> None:
@@ -436,7 +467,7 @@ class TestRunLoopDebugParams:
             MagicMock(url=None, source="mcp", source_id="resource_2"),
         ]
         ua._loop_iteration_runner.return_value.message.references = references
-        ua._reference_manager.get_latest_references.return_value = references
+        ua._reference_manager.get_references.return_value = [references]
 
         await ua.run()
 

--- a/unique_orchestrator/unique_orchestrator/unique_ai.py
+++ b/unique_orchestrator/unique_orchestrator/unique_ai.py
@@ -8,6 +8,7 @@ import jinja2
 from typing_extensions import deprecated
 from unique_skill_tool.service import SkillTool
 from unique_toolkit.agentic.debug_info_manager.debug_info_manager import (
+    AnalyticsLanguageModel,
     DebugInfoManager,
 )
 from unique_toolkit.agentic.evaluation.evaluation_manager import EvaluationManager
@@ -261,9 +262,8 @@ class UniqueAI:
                     self._finalize_loop_timing(loop_start)
                     break
 
-                self._reference_manager.add_references(
-                    loop_response.message.references or []
-                )
+                references = loop_response.message.references or []
+                self._reference_manager.add_references(references)
                 self._last_assistant_text = (
                     loop_response.message.original_text or loop_response.message.text
                 )
@@ -318,7 +318,28 @@ class UniqueAI:
             self._debug_info_manager.add("loop_params", self._loop_debug_params)
             skills_debug_info = self._get_activated_skills_debug_info()
             self._debug_info_manager.add("skills", skills_debug_info)
-            self._debug_info_manager.add_analytics(skills_debug_info)
+            reference_sources = {
+                reference.url
+                for reference in self._reference_manager.get_latest_references()
+            }
+            language_model = self._config.space.language_model
+            tool_display_names = {
+                str(tool.name): tool.display_name() or str(tool.name)
+                for tool in self._tool_manager.available_tools
+            }
+            self._debug_info_manager.add_analytics(
+                skills_debug_info,
+                language_model=AnalyticsLanguageModel(
+                    name=str(language_model.name),
+                    family=str(language_model.family),
+                    provider=str(language_model.provider),
+                ),
+                tool_display_names=tool_display_names,
+                references=len(reference_sources),
+                user_prompt_length=len(self._event.payload.user_message.text),
+                answer_length=len(self._last_assistant_text or ""),
+                loop_iteration_count=len(self._execution_times),
+            )
 
             tool_names = [
                 tool["name"] for tool in self._debug_info_manager.get()["tools"]

--- a/unique_orchestrator/unique_orchestrator/unique_ai.py
+++ b/unique_orchestrator/unique_orchestrator/unique_ai.py
@@ -322,7 +322,8 @@ class UniqueAI:
                 ("url", reference.url)
                 if reference.url is not None
                 else ("source", reference.source, reference.source_id)
-                for reference in self._reference_manager.get_latest_references()
+                for references in self._reference_manager.get_references()
+                for reference in references
             }
             language_model = self._config.space.language_model
             tool_display_names = {

--- a/unique_orchestrator/unique_orchestrator/unique_ai.py
+++ b/unique_orchestrator/unique_orchestrator/unique_ai.py
@@ -1,6 +1,6 @@
 import asyncio
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from logging import Logger
 from typing import Any, cast, overload
 
@@ -329,6 +329,26 @@ class UniqueAI:
                 str(tool.name): tool.display_name() or str(tool.name)
                 for tool in self._tool_manager.available_tools
             }
+            tool_names = [
+                tool["name"] for tool in self._debug_info_manager.get()["tools"]
+            ]
+
+            total_time_to_answer_ms: int | None = None
+            if not self._chat_service.cancellation.is_cancelled:
+                if self._config.agent.input_token_distribution.enable_tool_call_persistence:
+                    await self._persist_tool_calls()
+                completed_message = (
+                    await self._chat_service.modify_assistant_message_async(
+                        set_completed_at=not self._tool_took_control,
+                    )
+                )
+                total_time_to_answer_ms = self._calculate_total_time_to_answer_ms(
+                    user_message_created_at=self._event.payload.user_message.created_at,
+                    assistant_completed_at=getattr(
+                        completed_message, "completed_at", None
+                    ),
+                )
+
             self._debug_info_manager.add_analytics(
                 skills_debug_info,
                 language_model=AnalyticsLanguageModel(
@@ -341,11 +361,8 @@ class UniqueAI:
                 user_prompt_length=len(self._event.payload.user_message.text),
                 answer_length=len(self._last_assistant_text or ""),
                 loop_iteration_count=len(self._execution_times),
+                total_time_to_answer_ms=total_time_to_answer_ms,
             )
-
-            tool_names = [
-                tool["name"] for tool in self._debug_info_manager.get()["tools"]
-            ]
 
             # Get current debug info from chat service and add debug info from run. Do not update if DeepResearch is in the tool names.
             if "DeepResearch" not in tool_names:
@@ -354,15 +371,28 @@ class UniqueAI:
                     **self._debug_info_manager.get(),
                 }
                 await self._chat_service.update_debug_info_async(debug_info=debug_info)
-
-            if not self._chat_service.cancellation.is_cancelled:
-                if self._config.agent.input_token_distribution.enable_tool_call_persistence:
-                    await self._persist_tool_calls()
-                await self._chat_service.modify_assistant_message_async(
-                    set_completed_at=not self._tool_took_control,
-                )
         finally:
             sub.cancel()
+
+    @staticmethod
+    def _calculate_total_time_to_answer_ms(
+        user_message_created_at: str,
+        assistant_completed_at: datetime | None,
+    ) -> int | None:
+        if assistant_completed_at is None:
+            return None
+
+        try:
+            user_created_at = datetime.fromisoformat(user_message_created_at)
+        except ValueError:
+            return None
+
+        if user_created_at.tzinfo is None:
+            user_created_at = user_created_at.replace(tzinfo=timezone.utc)
+        if assistant_completed_at.tzinfo is None:
+            assistant_completed_at = assistant_completed_at.replace(tzinfo=timezone.utc)
+
+        return round((assistant_completed_at - user_created_at).total_seconds() * 1000)
 
     def _record_loop_debug_params(self, other_options: dict) -> None:
         reasoning = other_options.get("reasoning")

--- a/unique_orchestrator/unique_orchestrator/unique_ai.py
+++ b/unique_orchestrator/unique_orchestrator/unique_ai.py
@@ -385,7 +385,8 @@ class UniqueAI:
 
         try:
             user_created_at = datetime.fromisoformat(user_message_created_at)
-        except ValueError:
+        except (ValueError, TypeError):
+            # ValueError: malformed timestamp; TypeError: created_at not a str.
             return None
 
         if user_created_at.tzinfo is None:

--- a/unique_orchestrator/unique_orchestrator/unique_ai.py
+++ b/unique_orchestrator/unique_orchestrator/unique_ai.py
@@ -319,7 +319,9 @@ class UniqueAI:
             skills_debug_info = self._get_activated_skills_debug_info()
             self._debug_info_manager.add("skills", skills_debug_info)
             reference_sources = {
-                reference.url
+                ("url", reference.url)
+                if reference.url is not None
+                else ("source", reference.source, reference.source_id)
                 for reference in self._reference_manager.get_latest_references()
             }
             language_model = self._config.space.language_model

--- a/unique_toolkit/tests/agentic/test_debug_info_manager.py
+++ b/unique_toolkit/tests/agentic/test_debug_info_manager.py
@@ -7,6 +7,7 @@ import pytest
 from openai.types.responses import ResponseCodeInterpreterToolCall
 
 from unique_toolkit.agentic.debug_info_manager.debug_info_manager import (
+    AnalyticsLanguageModel,
     DebugInfoManager,
     _extract_tool_calls_from_stream_response,
 )
@@ -457,6 +458,16 @@ def test_extract_tool_calls_from_stream_response__is_forced_true__when_in_tool_c
 
 
 class TestAddAnalytics:
+    language_model = AnalyticsLanguageModel(
+        name="AZURE_GPT_5_2025_0807",
+        family="openai",
+        provider="AZURE",
+    )
+    tool_display_names = {
+        "InternalSearch": "Knowledge Base Search",
+        "WebSearch": "Web Search",
+    }
+
     @pytest.mark.ai
     def test_add_analytics__copies_tools_and_skills__into_new_key(
         self, debug_info_manager: DebugInfoManager
@@ -470,11 +481,33 @@ class TestAddAnalytics:
         debug_info_manager.debug_info["tools"] = [{"name": "WebSearch", "info": {}}]
         skills = [{"name": "plot-skill", "content_id": "c1", "is_forced": True}]
 
-        debug_info_manager.add_analytics(skills)
+        debug_info_manager.add_analytics(
+            skills,
+            language_model=self.language_model,
+            tool_display_names=self.tool_display_names,
+            references=2,
+            user_prompt_length=17,
+            answer_length=42,
+            loop_iteration_count=3,
+        )
 
         analytics = debug_info_manager.get()["analytics"]
-        assert analytics["tools"] == [{"name": "WebSearch"}]
-        assert analytics["skills"] == skills
+        assert analytics["tools_used"] == [
+            {"name": "WebSearch", "display_name": "Web Search"}
+        ]
+        assert analytics["tool_call_count"] == 1
+        assert analytics["skills_used"] == skills
+        assert analytics["references_count"] == 2
+        assert analytics["user_prompt_length"] == 17
+        assert analytics["answer_length"] == 42
+        assert analytics["loop_iteration_count"] == 3
+        assert analytics["subagent_names_used"] == []
+        assert analytics["mcp_tool_names_used"] == []
+        assert analytics["language_model"] == {
+            "name": "AZURE_GPT_5_2025_0807",
+            "family": "openai",
+            "provider": "AZURE",
+        }
 
     @pytest.mark.ai
     def test_add_analytics__does_not_remove_top_level_tools_or_skills_keys(
@@ -490,7 +523,11 @@ class TestAddAnalytics:
         tools = [{"name": "InternalSearch", "info": {}}]
         debug_info_manager.debug_info["tools"] = tools
 
-        debug_info_manager.add_analytics([])
+        debug_info_manager.add_analytics(
+            [],
+            language_model=self.language_model,
+            tool_display_names=self.tool_display_names,
+        )
 
         assert debug_info_manager.get()["tools"] == tools
 
@@ -499,8 +536,8 @@ class TestAddAnalytics:
         self, debug_info_manager: DebugInfoManager
     ) -> None:
         """
-        Purpose: Verify every analytics tool entry keeps only name plus
-        is_forced / is_exclusive / loop_iteration.
+        Purpose: Verify every analytics tool entry keeps only attribution fields,
+        including whether it is a sub-agent or MCP tool.
         Why this matters: Query/filter/timing payloads must not enter the
         ROI/usage analytics envelope for any tool.
         Setup summary: Seed InternalSearch and WebSearch with full debug info;
@@ -515,6 +552,7 @@ class TestAddAnalytics:
                     "is_forced": True,
                     "contentIds": None,
                     "is_exclusive": False,
+                    "is_sub_agent": True,
                     "searchStrings": ["meaning of the character o umlaut"],
                     "loop_iteration": 0,
                     "metadataFilter": {"and": []},
@@ -534,21 +572,35 @@ class TestAddAnalytics:
             },
         ]
 
-        debug_info_manager.add_analytics([])
+        debug_info_manager.add_analytics(
+            [],
+            language_model=self.language_model,
+            tool_display_names=self.tool_display_names,
+        )
 
-        assert debug_info_manager.get()["analytics"]["tools"] == [
+        assert debug_info_manager.get()["analytics"]["tools_used"] == [
             {
                 "name": "InternalSearch",
+                "display_name": "Knowledge Base Search",
                 "is_forced": True,
                 "is_exclusive": False,
+                "is_sub_agent": True,
                 "loop_iteration": 0,
             },
             {
                 "name": "WebSearch",
+                "display_name": "Web Search",
                 "is_forced": False,
                 "is_exclusive": True,
+                "is_mcp": True,
                 "loop_iteration": 1,
             },
+        ]
+        assert debug_info_manager.get()["analytics"]["subagent_names_used"] == [
+            "Knowledge Base Search"
+        ]
+        assert debug_info_manager.get()["analytics"]["mcp_tool_names_used"] == [
+            "Web Search"
         ]
 
     @pytest.mark.ai
@@ -575,7 +627,11 @@ class TestAddAnalytics:
         ]
         debug_info_manager.debug_info["tools"] = tools
 
-        debug_info_manager.add_analytics([])
+        debug_info_manager.add_analytics(
+            [],
+            language_model=self.language_model,
+            tool_display_names=self.tool_display_names,
+        )
 
         assert debug_info_manager.get()["tools"] is tools
         assert debug_info_manager.get()["tools"][0]["info"]["searchStrings"] == [

--- a/unique_toolkit/tests/agentic/test_debug_info_manager.py
+++ b/unique_toolkit/tests/agentic/test_debug_info_manager.py
@@ -489,6 +489,7 @@ class TestAddAnalytics:
             user_prompt_length=17,
             answer_length=42,
             loop_iteration_count=3,
+            total_time_to_answer_ms=1234,
         )
 
         analytics = debug_info_manager.get()["analytics"]
@@ -501,6 +502,7 @@ class TestAddAnalytics:
         assert analytics["user_prompt_length"] == 17
         assert analytics["answer_length"] == 42
         assert analytics["loop_iteration_count"] == 3
+        assert analytics["total_time_to_answer_ms"] == 1234
         assert analytics["subagent_names_used"] == []
         assert analytics["mcp_tool_names_used"] == []
         assert analytics["language_model"] == {

--- a/unique_toolkit/tests/agentic/test_debug_info_manager.py
+++ b/unique_toolkit/tests/agentic/test_debug_info_manager.py
@@ -510,6 +510,31 @@ class TestAddAnalytics:
             "family": "openai",
             "provider": "AZURE",
         }
+        # Reserved placeholders — always present, populated in a later step.
+        assert analytics["artifacts_created_count"] is None
+        assert analytics["artifacts_created_filetype"] is None
+
+    @pytest.mark.ai
+    def test_add_analytics__total_time_to_answer_ms__always_present_as_null(
+        self, debug_info_manager: DebugInfoManager
+    ) -> None:
+        """
+        Purpose: Verify total_time_to_answer_ms is always emitted, as null when
+        unknown, rather than being omitted from the analytics envelope.
+        Why this matters: A stable schema lets consumers rely on the key existing
+        (read None) instead of handling a sometimes-missing key.
+        Setup summary: Call add_analytics without a timing value; assert the key is
+        present and None.
+        """
+        debug_info_manager.add_analytics(
+            [],
+            language_model=self.language_model,
+            tool_display_names=self.tool_display_names,
+        )
+
+        analytics = debug_info_manager.get()["analytics"]
+        assert "total_time_to_answer_ms" in analytics
+        assert analytics["total_time_to_answer_ms"] is None
 
     @pytest.mark.ai
     def test_add_analytics__does_not_remove_top_level_tools_or_skills_keys(
@@ -599,10 +624,10 @@ class TestAddAnalytics:
             },
         ]
         assert debug_info_manager.get()["analytics"]["subagent_names_used"] == [
-            "Knowledge Base Search"
+            {"name": "InternalSearch", "display_name": "Knowledge Base Search"}
         ]
         assert debug_info_manager.get()["analytics"]["mcp_tool_names_used"] == [
-            "Web Search"
+            {"name": "WebSearch", "display_name": "Web Search"}
         ]
 
     @pytest.mark.ai

--- a/unique_toolkit/unique_toolkit/agentic/debug_info_manager/debug_info_manager.py
+++ b/unique_toolkit/unique_toolkit/agentic/debug_info_manager/debug_info_manager.py
@@ -1,4 +1,4 @@
-from typing import Any, Required, TypedDict
+from typing import Any, NotRequired, Required, TypedDict
 
 from unique_toolkit.agentic.tools.openai_builtin import OpenAICodeInterpreterTool
 from unique_toolkit.agentic.tools.openai_builtin.base import OpenAIBuiltInToolName
@@ -42,6 +42,7 @@ class Analytics(TypedDict):
     subagent_names_used: list[str]
     tool_call_count: int
     tools_used: list[AnalyticsTool]
+    total_time_to_answer_ms: NotRequired[int]
     user_prompt_length: int
 
 
@@ -97,6 +98,7 @@ class DebugInfoManager:
         user_prompt_length: int = 0,
         answer_length: int = 0,
         loop_iteration_count: int = 0,
+        total_time_to_answer_ms: int | None = None,
     ) -> None:
         """Add a stable 'analytics' snapshot for downstream ROI/usage reporting.
 
@@ -112,40 +114,40 @@ class DebugInfoManager:
             _to_analytics_tool_entry(tool, tool_display_names)
             for tool in self.debug_info.get("tools", [])
         ]
-        self.add(
-            "analytics",
-            Analytics(
-                tools_used=analytics_tools,
-                tool_call_count=len(analytics_tools),
-                skills_used=[
-                    AnalyticsSkill(
-                        name=skill["name"],
-                        content_id=skill["content_id"],
-                        is_forced=skill["is_forced"],
-                    )
-                    for skill in skills
-                ],
-                references_count=references,
-                user_prompt_length=user_prompt_length,
-                answer_length=answer_length,
-                language_model=language_model.copy(),
-                loop_iteration_count=loop_iteration_count,
-                subagent_names_used=list(
-                    dict.fromkeys(
-                        tool["display_name"]
-                        for tool in analytics_tools
-                        if tool.get("is_sub_agent")
-                    )
-                ),
-                mcp_tool_names_used=list(
-                    dict.fromkeys(
-                        tool["display_name"]
-                        for tool in analytics_tools
-                        if tool.get("is_mcp")
-                    )
-                ),
+        analytics = Analytics(
+            tools_used=analytics_tools,
+            tool_call_count=len(analytics_tools),
+            skills_used=[
+                AnalyticsSkill(
+                    name=skill["name"],
+                    content_id=skill["content_id"],
+                    is_forced=skill["is_forced"],
+                )
+                for skill in skills
+            ],
+            references_count=references,
+            user_prompt_length=user_prompt_length,
+            answer_length=answer_length,
+            language_model=language_model.copy(),
+            loop_iteration_count=loop_iteration_count,
+            subagent_names_used=list(
+                dict.fromkeys(
+                    tool["display_name"]
+                    for tool in analytics_tools
+                    if tool.get("is_sub_agent")
+                )
+            ),
+            mcp_tool_names_used=list(
+                dict.fromkeys(
+                    tool["display_name"]
+                    for tool in analytics_tools
+                    if tool.get("is_mcp")
+                )
             ),
         )
+        if total_time_to_answer_ms is not None:
+            analytics["total_time_to_answer_ms"] = total_time_to_answer_ms
+        self.add("analytics", analytics)
 
 
 def _to_analytics_tool_entry(

--- a/unique_toolkit/unique_toolkit/agentic/debug_info_manager/debug_info_manager.py
+++ b/unique_toolkit/unique_toolkit/agentic/debug_info_manager/debug_info_manager.py
@@ -12,8 +12,11 @@ from unique_toolkit.language_model.schemas import (
 
 class AnalyticsTool(TypedDict, total=False):
     name: Required[str]
+    display_name: Required[str]
     is_forced: bool
     is_exclusive: bool
+    is_sub_agent: bool
+    is_mcp: bool
     loop_iteration: int
 
 
@@ -23,9 +26,23 @@ class AnalyticsSkill(TypedDict):
     is_forced: bool
 
 
+class AnalyticsLanguageModel(TypedDict):
+    name: str
+    family: str
+    provider: str
+
+
 class Analytics(TypedDict):
-    tools: list[AnalyticsTool]
-    skills: list[AnalyticsSkill]
+    answer_length: int
+    language_model: AnalyticsLanguageModel
+    loop_iteration_count: int
+    mcp_tool_names_used: list[str]
+    references_count: int
+    skills_used: list[AnalyticsSkill]
+    subagent_names_used: list[str]
+    tool_call_count: int
+    tools_used: list[AnalyticsTool]
+    user_prompt_length: int
 
 
 class DebugInfoManager:
@@ -71,24 +88,36 @@ class DebugInfoManager:
     def get(self) -> dict[str, Any]:
         return self.debug_info
 
-    def add_analytics(self, skills: list[dict[str, Any]]) -> None:
+    def add_analytics(
+        self,
+        skills: list[dict[str, Any]],
+        language_model: AnalyticsLanguageModel,
+        tool_display_names: dict[str, str],
+        references: int = 0,
+        user_prompt_length: int = 0,
+        answer_length: int = 0,
+        loop_iteration_count: int = 0,
+    ) -> None:
         """Add a stable 'analytics' snapshot for downstream ROI/usage reporting.
 
         Copies the current `tools` list (with each tool's info reduced to
-        attribution fields only) plus the given `skills` list into a new
-        `analytics` key, so later appends to `debug_info["tools"]` (e.g. from
+        attribution fields only), the given `skills` list, usage counts, prompt
+        and answer lengths, and language-model attribution into a new
+        `analytics` key. Later appends to `debug_info["tools"]` (e.g. from
         extract_tool_debug_info) can't leak into the frozen snapshot. Existing
         top-level keys (`tools`, `skills`, ...) are left untouched, so this is
-        additive for any consumer already reading the old shape.
+        additive for consumers reading the old shape.
         """
+        analytics_tools = [
+            _to_analytics_tool_entry(tool, tool_display_names)
+            for tool in self.debug_info.get("tools", [])
+        ]
         self.add(
             "analytics",
             Analytics(
-                tools=[
-                    _to_analytics_tool_entry(tool)
-                    for tool in self.debug_info.get("tools", [])
-                ],
-                skills=[
+                tools_used=analytics_tools,
+                tool_call_count=len(analytics_tools),
+                skills_used=[
                     AnalyticsSkill(
                         name=skill["name"],
                         content_id=skill["content_id"],
@@ -96,21 +125,50 @@ class DebugInfoManager:
                     )
                     for skill in skills
                 ],
+                references_count=references,
+                user_prompt_length=user_prompt_length,
+                answer_length=answer_length,
+                language_model=language_model.copy(),
+                loop_iteration_count=loop_iteration_count,
+                subagent_names_used=list(
+                    dict.fromkeys(
+                        tool["display_name"]
+                        for tool in analytics_tools
+                        if tool.get("is_sub_agent")
+                    )
+                ),
+                mcp_tool_names_used=list(
+                    dict.fromkeys(
+                        tool["display_name"]
+                        for tool in analytics_tools
+                        if tool.get("is_mcp")
+                    )
+                ),
             ),
         )
 
 
-def _to_analytics_tool_entry(tool: dict[str, Any]) -> AnalyticsTool:
+def _to_analytics_tool_entry(
+    tool: dict[str, Any], tool_display_names: dict[str, str]
+) -> AnalyticsTool:
     """Return an analytics-safe copy of a tool debug-info entry.
 
-    Keeps only name plus is_forced / is_exclusive / loop_iteration.
+    Keeps only tool attribution fields.
     """
     info = tool.get("info") or {}
-    analytics_tool = AnalyticsTool(name=tool["name"])
+    name = tool["name"]
+    analytics_tool = AnalyticsTool(
+        name=name,
+        display_name=tool_display_names.get(name) or name,
+    )
     if "is_forced" in info:
         analytics_tool["is_forced"] = info["is_forced"]
     if "is_exclusive" in info:
         analytics_tool["is_exclusive"] = info["is_exclusive"]
+    if info.get("is_sub_agent"):
+        analytics_tool["is_sub_agent"] = True
+    if info.get("is_mcp") or tool.get("mcp_server"):
+        analytics_tool["is_mcp"] = True
     if "loop_iteration" in info:
         analytics_tool["loop_iteration"] = info["loop_iteration"]
     return analytics_tool

--- a/unique_toolkit/unique_toolkit/agentic/debug_info_manager/debug_info_manager.py
+++ b/unique_toolkit/unique_toolkit/agentic/debug_info_manager/debug_info_manager.py
@@ -1,4 +1,4 @@
-from typing import Any, NotRequired, Required, TypedDict
+from typing import Any, Required, TypedDict
 
 from unique_toolkit.agentic.tools.openai_builtin import OpenAICodeInterpreterTool
 from unique_toolkit.agentic.tools.openai_builtin.base import OpenAIBuiltInToolName
@@ -32,17 +32,24 @@ class AnalyticsLanguageModel(TypedDict):
     provider: str
 
 
+class AnalyticsToolName(TypedDict):
+    name: str
+    display_name: str
+
+
 class Analytics(TypedDict):
     answer_length: int
+    artifacts_created_count: int | None
+    artifacts_created_filetype: list[str] | None
     language_model: AnalyticsLanguageModel
     loop_iteration_count: int
-    mcp_tool_names_used: list[str]
+    mcp_tool_names_used: list[AnalyticsToolName]
     references_count: int
     skills_used: list[AnalyticsSkill]
-    subagent_names_used: list[str]
+    subagent_names_used: list[AnalyticsToolName]
     tool_call_count: int
     tools_used: list[AnalyticsTool]
-    total_time_to_answer_ms: NotRequired[int]
+    total_time_to_answer_ms: int | None
     user_prompt_length: int
 
 
@@ -130,24 +137,33 @@ class DebugInfoManager:
             answer_length=answer_length,
             language_model=language_model.copy(),
             loop_iteration_count=loop_iteration_count,
-            subagent_names_used=list(
-                dict.fromkeys(
-                    tool["display_name"]
-                    for tool in analytics_tools
-                    if tool.get("is_sub_agent")
-                )
-            ),
-            mcp_tool_names_used=list(
-                dict.fromkeys(
-                    tool["display_name"]
-                    for tool in analytics_tools
-                    if tool.get("is_mcp")
-                )
-            ),
+            subagent_names_used=_unique_tool_names(analytics_tools, "is_sub_agent"),
+            mcp_tool_names_used=_unique_tool_names(analytics_tools, "is_mcp"),
+            total_time_to_answer_ms=total_time_to_answer_ms,
+            # Reserved placeholders — schema present so consumers can rely on the
+            # keys, populated in a follow-up step (artifacts instrumentation).
+            artifacts_created_count=None,
+            artifacts_created_filetype=None,
         )
-        if total_time_to_answer_ms is not None:
-            analytics["total_time_to_answer_ms"] = total_time_to_answer_ms
         self.add("analytics", analytics)
+
+
+def _unique_tool_names(
+    analytics_tools: list[AnalyticsTool], flag: str
+) -> list[AnalyticsToolName]:
+    """Dedupe the tools carrying `flag` into `{name, display_name}` entries.
+
+    Keyed on the stable `name` so downstream reporting can join on a stable
+    identifier while still carrying the user-facing `display_name` for labels.
+    """
+    unique: dict[str, AnalyticsToolName] = {}
+    for tool in analytics_tools:
+        if tool.get(flag) and tool["name"] not in unique:
+            unique[tool["name"]] = AnalyticsToolName(
+                name=tool["name"],
+                display_name=tool["display_name"],
+            )
+    return list(unique.values())
 
 
 def _to_analytics_tool_entry(

--- a/unique_toolkit/unique_toolkit/agentic/tools/tool_manager.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/tool_manager.py
@@ -525,6 +525,10 @@ class _ToolManager(Generic[_ApiMode]):
             unpacked_tool_call_result.debug_info["is_forced"] = (
                 tool_calls[i].name in self.get_tool_choices()
             )
+            if any(tool.name == tool_calls[i].name for tool in self._sub_agents):
+                unpacked_tool_call_result.debug_info["is_sub_agent"] = True
+            if any(tool.name == tool_calls[i].name for tool in self._mcp_tools):
+                unpacked_tool_call_result.debug_info["is_mcp"] = True
             tool_call_results_unpacked.append(unpacked_tool_call_result)
 
         return tool_call_results_unpacked


### PR DESCRIPTION
Refs: https://unique-ch.atlassian.net/browse/UN-22110

Covered:
    "tools_used"
    "skills_used"
    "answer_length"
    "language_model"
    "tool_call_count"
    "references_count"
    "user_prompt_length"
    "mcp_tool_names_used"
    "subagent_names_used"
    "loop_iteration_count"
    "total_time_to_answer_ms"
  

Not Covered
- Artifacts created count
- Filetypes of artifacts created 
- Output size
- Cost (cost per message based on configured cost management dashboard) 
- Token usage

