### PR TITLE
docs(sdk): use elicit create + wait polling in agent harness [UN-23003]

### DIFF
--- a/unique_sdk/unique_sdk/cli/skills/unique-cli-elicitation/SKILL.md
+++ b/unique_sdk/unique_sdk/cli/skills/unique-cli-elicitation/SKILL.md
@@ -5,8 +5,9 @@ description: >-
   question in free-form chat -- for clarifications, confirmations
   (especially destructive actions), missing parameters, multiple-choice
   decisions, or structured form input. Elicitations are routed through
-  the Unique AI Platform UI via `unique-cli elicit ask` so the user gets
-  a proper structured prompt and you get a structured answer back.
+  the Unique AI Platform UI via `unique-cli elicit create` + `elicit wait`
+  (or `elicit ask` outside an agent harness) so the user gets a proper
+  structured prompt and you get a structured answer back.
   Do NOT ask the user in plain chat when you can use this skill instead.
 ---
 
@@ -14,21 +15,79 @@ description: >-
 
 Use this skill **whenever you need input from the user** -- a clarifying question, a confirmation before a destructive action, a choice between options, or a structured form. Elicitations create a first-class UI prompt on the Unique AI Platform and return the answer as structured JSON.
 
-> **Rule of thumb:** if you catch yourself about to write "Could you clarify…?" or "Do you want me to…?" or "Which one should I pick?" in chat, stop and call `unique-cli elicit ask` instead.
+> **Rule of thumb:** if you catch yourself about to write "Could you clarify…?" or "Do you want me to…?" or "Which one should I pick?" in chat, stop and use `unique-cli elicit create` + `elicit wait` instead (see "The pattern" below).
 
 !!! danger "`--visible` is currently MANDATORY"
-    You **must always run `elicit ask` with visibility on** (it is on by default — just don't pass `--no-visible`). Until the UN-19815 UI fix ships in your environment, an elicitation created without the visibility workaround is stored by the backend but **never rendered in the chat UI** — the user simply never sees the question and you will wait forever. There is no situation in which you should disable it today.
+    You **must always create elicitations with visibility on** (it is on by default for both `elicit create` and `elicit ask` — just don't pass `--no-visible`). Until the UN-19815 UI fix ships in your environment, an elicitation created without the visibility workaround is stored by the backend but **never rendered in the chat UI** — the user simply never sees the question and you will wait forever. There is no situation in which you should disable it today.
 
-## The only command you need: `elicit ask`
+## The pattern: `elicit create` + short polling loop with `elicit wait`
 
-`elicit ask` is a **single call that creates the elicitation, shows it to the user, and blocks until the user answers** (or declines / cancels / expires). This is the command you reach for every time. You do not need to learn `elicit create`, `elicit wait`, `elicit pending`, `elicit get`, or `elicit respond` — they exist for scripting and tests, not for agent workflows.
+Do **not** call `elicit ask` from inside an agent harness (Claude Code, Codex,
+or any environment where your Bash/shell tool has its own foreground-wait
+timeout — commonly ~2 minutes). `elicit ask` blocks synchronously for up to
+`--timeout` seconds (default 2 hours) waiting for the human to answer, but a
+human reading and answering a prompt routinely takes longer than a typical
+Bash tool timeout. If that timeout fires first, your harness will silently
+detach the process to the background and hand you a "running in background"
+stub instead of the real answer — you will not see the user's response, and
+the chat may appear stuck to the user.
+
+Instead, use `elicit create` (returns immediately) followed by a short
+polling loop with `elicit wait`, where **every individual command finishes
+comfortably under your harness's Bash foreground timeout** (90s is a safe
+default — comfortably under Claude Code's ~120s):
+
+1. **Create** the elicitation:
+
+   ```bash
+   create_output=$(unique-cli elicit create "<question>" \
+     --mode FORM \
+     --tool-name "<tool_name>" \
+     --chat-id "$UNIQUE_CHAT_ID" \
+     --message-id "$UNIQUE_MESSAGE_ID" \
+     --expires-in 7200 \
+     --schema '<json schema>')
+   elicitation_id=$(echo "$create_output" | awk '/^Created elicitation/{print $3}')
+   ```
+
+2. **Poll in short bursts**, each well under your harness's Bash foreground
+   timeout:
+
+   ```bash
+   status="PENDING"
+   elapsed=0
+   total_timeout=7200   # match --expires-in above
+   chunk=90
+   while [ "$elapsed" -lt "$total_timeout" ]; do
+     result=$(unique-cli elicit wait "$elicitation_id" --timeout "$chunk" --poll-interval 3)
+     status=$(echo "$result" | awk -F': *' '/^Status:/{print $2}')
+     case "$status" in
+       RESPONDED|ACCEPTED|DECLINED|CANCELLED|REJECTED|EXPIRED|COMPLETED) break ;;
+     esac
+     elapsed=$((elapsed + chunk))
+   done
+   ```
+
+   Each `elicit wait ... --timeout 90` call is a normal, short-lived Bash
+   invocation that always returns within ~90 seconds — either with a
+   terminal status (done) or the current non-terminal status (loop again).
+   Your harness never sees a single call run long enough to background it.
+
+3. Parse `Response:` from the final `$result` exactly as you would with
+   `elicit ask`'s output — the format is identical (see "Reading the
+   response" below).
+
+`elicit ask` remains the right choice for **non-agent, scripted, or
+human-operated CLI usage** where a single blocking call is expected and
+there is no surrounding tool-timeout concern (tests, ops scripts, manual CLI
+use). Do not reach for it from inside an agent turn.
 
 ```bash
 unique-cli elicit ask "<question>" [options]
 ```
 
 !!! danger "`--chat-id` and `--message-id` are MANDATORY"
-    You **must always pass both** `--chat-id "$UNIQUE_CHAT_ID"` **and** `--message-id "$UNIQUE_MESSAGE_ID"` on every `elicit ask` call. These environment variables are always available in the agent environment. Without both flags the elicitation is not correctly anchored to the current conversation and the user will not see it.
+    You **must always pass both** `--chat-id "$UNIQUE_CHAT_ID"` **and** `--message-id "$UNIQUE_MESSAGE_ID"` on every `elicit create`/`elicit ask` call. These environment variables are always available in the agent environment. Without both flags the elicitation is not correctly anchored to the current conversation and the user will not see it.
 
 ## When to use
 
@@ -42,6 +101,11 @@ unique-cli elicit ask "<question>" [options]
 | Purely informational output (results, summaries) | No |
 
 ## Examples
+
+> The examples below use `elicit ask` for brevity to show the schema shapes.
+> From an agent harness, use the same `--schema`/`--message`/`--tool-name`
+> arguments with `elicit create` instead, then poll with `elicit wait` as
+> shown in "The pattern" above.
 
 ### Minimal — free-text answer
 
@@ -127,6 +191,12 @@ unique-cli elicit ask "Please provide report settings" \
 
 ## Options
 
+The table below documents `elicit ask`'s flags. `elicit create` takes the
+same `--chat-id`, `--message-id`, `--tool-name`, `--schema`, `--metadata`,
+and `--assistant-id` flags, but uses `--expires-in <seconds>` instead of
+`--timeout`/`--poll-interval` (those two apply only to `elicit wait`, which
+you call separately in the polling pattern).
+
 | Option | Short | Default | Description |
 |--------|-------|---------|-------------|
 | `--chat-id` | `-c` | none | **MANDATORY.** Chat to show the question in. Always pass `"$UNIQUE_CHAT_ID"`. Without it the visibility workaround cannot run and the user will not see the elicitation. |
@@ -187,7 +257,14 @@ If the exact structured response is useful for auditing or debugging, put it beh
 
 Do not expose raw JSON by default when a natural-language confirmation would be clearer.
 
-## Scripting pattern
+## Scripting pattern (non-agent-harness only)
+
+This one-shot pattern is for **scripts, tests, or manual CLI use outside an
+agent harness** — i.e. contexts with no Bash-tool foreground timeout to worry
+about. From inside an agent harness, use the `elicit create` + `elicit wait`
+polling pattern from "The pattern" section above instead; the output parsing
+below (pulling `Response:` out of the text) is identical either way, only the
+command(s) producing that output differ.
 
 In a shell script or agent tool wrapper, capture the output and pull out the `Response:` line:
 
@@ -220,7 +297,7 @@ esac
 
 ## Agent workflow rules
 
-1. **Default to `elicit ask`.** If you need an answer from the user, use this command, not a chat message. Do not use any of the other `elicit *` subcommands from an agent.
+1. **Default to `elicit create` + `elicit wait` polling.** If you need an answer from the user, use this pattern, not a chat message and not a single blocking `elicit ask` call. See "The pattern" above.
 2. **Always pass `--chat-id "$UNIQUE_CHAT_ID"`.** Without it the elicitation is not attached to a chat and the user will not see it.
 3. **Always pass `--message-id "$UNIQUE_MESSAGE_ID"`.** This anchors the elicitation to the current message in the conversation. Both `$UNIQUE_CHAT_ID` and `$UNIQUE_MESSAGE_ID` are always available as environment variables — never omit either.
 4. **Never pass `--no-visible`.** See the warning above. The visibility workaround is mandatory today.
@@ -231,7 +308,7 @@ esac
 9. **Handle non-`RESPONDED` outcomes explicitly.** If the status is `DECLINED` / `CANCELLED` / `EXPIRED`, tell the user you stopped and ask what they want to do next instead of silently proceeding.
 10. **Don't spam elicitations.** One well-designed form with a few related fields is better than five sequential yes/no questions.
 11. **Cap each elicitation at 5 questions.** If you need more than 5 answers, split them into multiple focused elicitations so the user can respond confidently.
-12. **Respect timeouts.** The default `--timeout` is 2 hours -- override it only when the task needs a shorter or longer wait.
+12. **Never make a single blocking call longer than your harness's Bash foreground timeout.** Use `--expires-in` on `elicit create` to set the real, human-scale deadline (e.g. 7200s / 2 hours), but keep each individual `elicit wait --timeout N` call short (≈90s) and loop until a terminal status or the overall deadline is reached. Never call `elicit ask` with a multi-minute `--timeout` from an agent harness.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary
- Fix the [UN-23003](https://unique-ch.atlassian.net/browse/UN-23003) failure mode where agent harnesses (Claude Code Bash ~2 min foreground timeout) silently background long `unique-cli elicit ask` calls, so the agent acts on a stub instead of the real user answer.
- Update the `unique-cli-elicitation` skill to recommend `elicit create` + short `elicit wait` polling (≤90s per call) for agent-harness use.
- Leave `elicit ask` unchanged (CLI contract/defaults) and still documented for non-harness / scripted use.

## Changes
- `unique_sdk/unique_sdk/cli/skills/unique-cli-elicitation/SKILL.md`
  - Replace "only command you need: elicit ask" with create + short polling pattern
  - Update agent workflow rules 1 and 12
  - Scope examples / scripting pattern as non-harness convenience

## Test plan
- [x] `uv run pytest tests/cli/test_skills.py tests/cli/test_elicitation.py` — 100 passed
- [x] Full `unique_sdk` suite — 1026 passed, 39 skipped
- [x] Sanity-checked new bash `awk` parsing against real CLI output shapes (`Created elicitation …`, `Status:`, `Response:`)
- [ ] Monorepo follow-up: update `edit-skill` / `create-skill` hardcoded `elicit ask` calls; E2E UI confirm with >2 min human delay (out of scope for this PR)

## Risk / rollout
- Docs-only; no CLI behavior change. Risk is low.
- Full fix for UN-23003 also needs monorepo callers to adopt the new pattern; this PR unblocks that.

Refs: [UN-23003](https://unique-ch.atlassian.net/browse/UN-23003)

Made with [Cursor](https://cursor.com)

[UN-23003]: https://unique-ch.atlassian.net/browse/UN-23003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[UN-23003]: https://unique-ch.atlassian.net/browse/UN-23003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ