### PR TITLE
refactor(sdk): trim TurnIdentity to the single consumed field

### DIFF
--- a/unique_sdk/tests/cli/test_identity.py
+++ b/unique_sdk/tests/cli/test_identity.py
@@ -37,17 +37,10 @@ def _write_identity(path: Path, *, message_id: str = "msg-live") -> Path:
 
 
 class TestReadTurnIdentity:
-    def test_returns_typed_identity(self, tmp_path: Path) -> None:
+    def test_returns_typed_identity_ignoring_extra_keys(self, tmp_path: Path) -> None:
         path = _write_identity(tmp_path / "turn-identity.json")
         identity = read_turn_identity(path)
-        assert identity == TurnIdentity(
-            message_id="msg-live",
-            chat_id="chat-1",
-            user_id="u1",
-            company_id="c1",
-            assistant_id="a1",
-            turn=2,
-        )
+        assert identity == TurnIdentity(message_id="msg-live")
 
     def test_returns_none_when_unconfigured(
         self, monkeypatch: pytest.MonkeyPatch
@@ -55,7 +48,7 @@ class TestReadTurnIdentity:
         monkeypatch.delenv(TURN_IDENTITY_ENV_VAR, raising=False)
         assert read_turn_identity() is None
 
-    def test_optional_fields_default_to_none(self, tmp_path: Path) -> None:
+    def test_minimal_file_with_only_message_id(self, tmp_path: Path) -> None:
         path = tmp_path / "turn-identity.json"
         path.write_text(json.dumps({"message_id": "msg-1"}), encoding="utf-8")
         identity = read_turn_identity(path)

--- a/unique_sdk/unique_sdk/cli/identity.py
+++ b/unique_sdk/unique_sdk/cli/identity.py
@@ -25,7 +25,6 @@ from pathlib import Path
 
 TURN_IDENTITY_ENV_VAR = "UNIQUE_TURN_IDENTITY_FILE"
 MESSAGE_ID_ENV_VAR = "UNIQUE_MESSAGE_ID"
-CHAT_ID_ENV_VAR = "UNIQUE_CHAT_ID"
 
 
 class TurnIdentityError(ValueError):
@@ -36,23 +35,13 @@ class TurnIdentityError(ValueError):
 class TurnIdentity:
     """Parsed contents of the per-turn identity file.
 
-    Mirrors the JSON contract written by the platform runner. Only
-    ``message_id`` is mandatory; the remaining fields are informational.
+    The runner writes a richer JSON object (chat/user/company/assistant IDs,
+    turn counter), but the CLI only consumes ``message_id`` — the one value
+    that goes stale in a persistent process environment. Extra keys are
+    ignored; parse a field here only once the CLI actually relies on it.
     """
 
     message_id: str
-    chat_id: str | None = None
-    user_id: str | None = None
-    company_id: str | None = None
-    assistant_id: str | None = None
-    turn: int | None = None
-
-
-def _optional_str(payload: dict[str, object], key: str) -> str | None:
-    value = payload.get(key)
-    if isinstance(value, str) and value.strip():
-        return value.strip()
-    return None
 
 
 def read_turn_identity(
@@ -99,15 +88,7 @@ def read_turn_identity(
             "'message_id' string"
         )
 
-    raw_turn = payload.get("turn")
-    return TurnIdentity(
-        message_id=message_id.strip(),
-        chat_id=_optional_str(payload, "chat_id"),
-        user_id=_optional_str(payload, "user_id"),
-        company_id=_optional_str(payload, "company_id"),
-        assistant_id=_optional_str(payload, "assistant_id"),
-        turn=raw_turn if isinstance(raw_turn, int) else None,
-    )
+    return TurnIdentity(message_id=message_id.strip())
 
 
 def resolve_message_id(explicit: str | None = None) -> str | None:
@@ -126,25 +107,6 @@ def resolve_message_id(explicit: str | None = None) -> str | None:
         return identity.message_id
 
     env_id = os.environ.get(MESSAGE_ID_ENV_VAR)
-    if env_id is not None and env_id.strip():
-        return env_id.strip()
-    return None
-
-
-def resolve_chat_id(explicit: str | None = None) -> str | None:
-    """Resolve chat ID with the same file-then-env precedence as message ID.
-
-    Explicit flag wins. The turn-identity file is consulted next (and fails
-    loudly when configured but unusable). Falls back to ``$UNIQUE_CHAT_ID``.
-    """
-    if explicit is not None and str(explicit).strip():
-        return str(explicit).strip()
-
-    identity = read_turn_identity()
-    if identity is not None and identity.chat_id is not None:
-        return identity.chat_id
-
-    env_id = os.environ.get(CHAT_ID_ENV_VAR)
     if env_id is not None and env_id.strip():
         return env_id.strip()
     return None


### PR DESCRIPTION
## Summary
- Follow-up to #2058 (merged before this landed). Trims the `TurnIdentity` dataclass to just `message_id` — the only field the CLI consumes and the only value that goes stale in a persistent process environment.
- Drops the unused optional fields (`chat_id`, `user_id`, `company_id`, `assistant_id`, `turn`) and the unused `resolve_chat_id` helper; extra JSON keys written by the runner are simply ignored.
- Reader stays strict on what it relies on (non-empty `message_id`, fail-loud on a configured-but-unusable file) and tolerant of everything else.

## Test plan
- [x] `pytest unique_sdk/tests/cli/test_identity.py` — 11 passed
- [x] ruff check / format clean

Refs: UN-22947

Made with [Cursor](https://cursor.com)