### PR TITLE
feat(unique_follow_up_questions): report per-invocation LLM usage [UN-20907]

### DIFF
--- a/postprocessors/unique_follow_up_questions/pyproject.toml
+++ b/postprocessors/unique_follow_up_questions/pyproject.toml
@@ -17,11 +17,6 @@ dependencies = [
     "unique-toolkit>=2026.28.0",
 ]
 
-[dependency-groups]
-dev = [
-    "unique-sdk>=0.11.12",
-]
-
 [build-system]
 requires = ["uv_build>=0.7.19,<0.8"]
 build-backend = "uv_build"
@@ -34,11 +29,9 @@ exclude-newer = "2 weeks"
 constraint-dependencies = ["lxml>=6.1.0"]
 
 [tool.uv.exclude-newer-package]
-"unique-sdk" = false
 "unique-toolkit" = false
 
 [tool.uv.sources]
-unique-sdk = { workspace = true }
 unique-toolkit = { workspace = true }
 
 [tool.poe.tasks]

--- a/postprocessors/unique_follow_up_questions/unique_follow_up_questions/follow_up_postprocessor.py
+++ b/postprocessors/unique_follow_up_questions/unique_follow_up_questions/follow_up_postprocessor.py
@@ -186,17 +186,16 @@ class FollowUpPostprocessor(Postprocessor):
                     model_name=self._config.language_model.name,
                     structured_output_model=FollowUpQuestionsOutput,
                 )
-                parsed_content = response.choices[0].message.parsed
             else:
                 response = await language_model_service.complete_async(
                     messages=messages,
                     model_name=self._config.language_model.name,
                 )
-                content = response.choices[0].message.content
-                if not isinstance(content, str):
-                    raise ValueError("Language model response content must be a string")
-                parsed_content = convert_string_to_json(content)
 
+            # Record usage as soon as the (billable) LLM call itself succeeds,
+            # before any parsing/validation below that could raise -- an
+            # already-billed call must not be dropped just because the
+            # response content failed to parse.
             if response.usage is not None:
                 self._invocation_stats.append(
                     LanguageModelInvocationStats.from_usage(
@@ -205,6 +204,15 @@ class FollowUpPostprocessor(Postprocessor):
                         source="follow_up_questions",
                     )
                 )
+
+            if self._config.use_structured_output:
+                parsed_content = response.choices[0].message.parsed
+            else:
+                content = response.choices[0].message.content
+                if not isinstance(content, str):
+                    raise ValueError("Language model response content must be a string")
+                parsed_content = convert_string_to_json(content)
+
             return FollowUpQuestionsOutput.model_validate(parsed_content)
 
         except Exception as e:

--- a/postprocessors/unique_follow_up_questions/unique_follow_up_questions/follow_up_postprocessor.py
+++ b/postprocessors/unique_follow_up_questions/unique_follow_up_questions/follow_up_postprocessor.py
@@ -4,6 +4,9 @@ from unique_toolkit.agentic.history_manager.history_manager import HistoryManage
 from unique_toolkit.agentic.postprocessor.postprocessor_manager import Postprocessor
 from unique_toolkit.app.schemas import ChatEvent
 from unique_toolkit.language_model.builder import MessagesBuilder
+from unique_toolkit.language_model.invocation_stats import (
+    LanguageModelInvocationStats,
+)
 from unique_toolkit.language_model.schemas import (
     LanguageModelMessage,
     LanguageModelMessages,
@@ -42,8 +45,15 @@ class FollowUpPostprocessor(Postprocessor):
         self._language = event.payload.user_message.language
         self._historyManager = historyManager
         self._llm_service = llm_service
+        self._invocation_stats: list[LanguageModelInvocationStats] = []
+
+    @property
+    def invocation_stats(self) -> list[LanguageModelInvocationStats]:
+        return list(self._invocation_stats)
 
     async def run(self, loop_response: LanguageModelStreamResponse) -> None:
+        # Reset so a re-run reports one entry per actual LLM call of this run.
+        self._invocation_stats = []
         history = await self._historyManager.get_user_visible_chat_history(
             loop_response.message.text,
             self.remove_from_text,
@@ -187,6 +197,14 @@ class FollowUpPostprocessor(Postprocessor):
                     raise ValueError("Language model response content must be a string")
                 parsed_content = convert_string_to_json(content)
 
+            if response.usage is not None:
+                self._invocation_stats.append(
+                    LanguageModelInvocationStats.from_usage(
+                        self._config.language_model.name,
+                        response.usage,
+                        source="follow_up_questions",
+                    )
+                )
             return FollowUpQuestionsOutput.model_validate(parsed_content)
 
         except Exception as e:

--- a/postprocessors/unique_follow_up_questions/unique_follow_up_questions/tests/test_follow_up_postprocessor.py
+++ b/postprocessors/unique_follow_up_questions/unique_follow_up_questions/tests/test_follow_up_postprocessor.py
@@ -1,0 +1,103 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from unique_toolkit.language_model.schemas import LanguageModelTokenUsage
+
+from unique_follow_up_questions.follow_up_postprocessor import FollowUpPostprocessor
+
+
+def _make_postprocessor(*, use_structured_output: bool) -> FollowUpPostprocessor:
+    """Builds a FollowUpPostprocessor with only the attributes
+    `_generate_follow_up_questions` touches, skipping the full constructor's
+    heavy dependencies (ChatEvent, HistoryManager, ...)."""
+    postprocessor = object.__new__(FollowUpPostprocessor)
+    config = MagicMock()
+    config.use_structured_output = use_structured_output
+    config.language_model.name = "gpt-4o"
+    postprocessor._config = config  # type: ignore[attr-defined]
+    postprocessor._logger = MagicMock()  # type: ignore[attr-defined]
+    postprocessor._invocation_stats = []  # type: ignore[attr-defined]
+    return postprocessor
+
+
+def _make_response(
+    *, content: object, usage: LanguageModelTokenUsage | None
+) -> MagicMock:
+    response = MagicMock()
+    response.usage = usage
+    response.choices[0].message.content = content
+    response.choices[0].message.parsed = content
+    return response
+
+
+@pytest.mark.asyncio
+async def test_generate_follow_up_questions__non_string_content__usage_still_captured() -> (
+    None
+):
+    """Tokens are spent even if the model's response content is not a string
+    (non-structured path) -- the usage must still be recorded even though
+    question generation itself falls back to an empty result."""
+    postprocessor = _make_postprocessor(use_structured_output=False)
+    usage = LanguageModelTokenUsage(
+        completion_tokens=10, prompt_tokens=20, total_tokens=30
+    )
+    llm_service = AsyncMock()
+    llm_service.complete_async = AsyncMock(
+        return_value=_make_response(content=None, usage=usage)
+    )
+
+    result = await postprocessor._generate_follow_up_questions(
+        language_model_service=llm_service,
+        messages=MagicMock(),
+    )
+
+    assert result.questions == []
+    assert len(postprocessor.invocation_stats) == 1
+    assert postprocessor.invocation_stats[0].token_usage == usage
+
+
+@pytest.mark.asyncio
+async def test_generate_follow_up_questions__json_parse_failure__usage_still_captured() -> (
+    None
+):
+    """Same as above, but the failure is JSON-parsing valid string content
+    that isn't valid JSON."""
+    postprocessor = _make_postprocessor(use_structured_output=False)
+    usage = LanguageModelTokenUsage(
+        completion_tokens=5, prompt_tokens=15, total_tokens=20
+    )
+    llm_service = AsyncMock()
+    llm_service.complete_async = AsyncMock(
+        return_value=_make_response(content="not-json{{{", usage=usage)
+    )
+
+    result = await postprocessor._generate_follow_up_questions(
+        language_model_service=llm_service,
+        messages=MagicMock(),
+    )
+
+    assert result.questions == []
+    assert len(postprocessor.invocation_stats) == 1
+    assert postprocessor.invocation_stats[0].token_usage == usage
+
+
+@pytest.mark.asyncio
+async def test_generate_follow_up_questions__success__usage_captured_once() -> None:
+    postprocessor = _make_postprocessor(use_structured_output=False)
+    usage = LanguageModelTokenUsage(
+        completion_tokens=5, prompt_tokens=15, total_tokens=20
+    )
+    llm_service = AsyncMock()
+    content = '{"questions": [{"category": "clarification", "question": "a?"}]}'
+    llm_service.complete_async = AsyncMock(
+        return_value=_make_response(content=content, usage=usage)
+    )
+
+    result = await postprocessor._generate_follow_up_questions(
+        language_model_service=llm_service,
+        messages=MagicMock(),
+    )
+
+    assert [q.question for q in result.questions] == ["a?"]
+    assert len(postprocessor.invocation_stats) == 1
+    assert postprocessor.invocation_stats[0].token_usage == usage

--- a/uv.lock
+++ b/uv.lock
@@ -12,13 +12,13 @@ conflicts = [[
 ]]
 
 [options]
-exclude-newer = "2026-06-29T11:26:51.762116Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P2W"
 
 [options.exclude-newer-package]
 unique-toolkit = false
 unique-internal-search = false
-crawl4ai = "2026-06-19T23:00:00Z"
+crawl4ai = "2026-06-19T22:00:00Z"
 unique-swot = false
 unique-sdk = false
 unique-search-proxy-core = false
@@ -26,9 +26,9 @@ unique-mcp = false
 unique-orchestrator = false
 unique-follow-up-questions = false
 unique-user-memory = false
-langsmith = "2026-06-20T23:00:00Z"
+langsmith = "2026-06-20T22:00:00Z"
 unique-six = false
-pydantic-settings = "2026-06-20T23:00:00Z"
+pydantic-settings = "2026-06-20T22:00:00Z"
 unique-search-proxy = false
 unique-web-search = false
 unique-deep-research = false
@@ -5166,20 +5166,12 @@ dependencies = [
     { name = "unique-toolkit" },
 ]
 
-[package.dev-dependencies]
-dev = [
-    { name = "unique-sdk" },
-]
-
 [package.metadata]
 requires-dist = [
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "pydantic", specifier = ">=2.8.2" },
     { name = "unique-toolkit", editable = "unique_toolkit" },
 ]
-
-[package.metadata.requires-dev]
-dev = [{ name = "unique-sdk", editable = "unique_sdk" }]
 
 [[package]]
 name = "unique-internal-search"


### PR DESCRIPTION
## Summary
Part 2/3 of the UN-20907 PR split (see #2051 for part 1/3, the `unique_toolkit`/`unique_sdk` foundation this depends on).

- Wires `FollowUpPostprocessor` into the `invocation_stats` mechanism added in `unique_toolkit`.
- Resets its stats list at the start of each `run()` and appends per LLM call, so a re-run reports one honest entry per actual call instead of overwriting the previous one.
- Exposes the stats via the `invocation_stats` property (per review feedback on the parent PR).

**Base**: this PR targets `feat/UN-20907-space-token-usage` (part 1/3), not `main` — merge part 1 first.

## Test plan
- [x] `postprocessors/unique_follow_up_questions` test suite passes (12 passed)
- [x] ruff clean