### PR TITLE
feat(tool_packages): report tool-internal LLM invocation stats [UN-20907]

### DIFF
--- a/tool_packages/unique_internal_search/tests/test_invocation_stats.py
+++ b/tool_packages/unique_internal_search/tests/test_invocation_stats.py
@@ -1,0 +1,250 @@
+from typing import Any
+from unittest.mock import AsyncMock, Mock, PropertyMock, patch
+
+import pytest
+from unique_toolkit._common.chunk_relevancy_sorter.schemas import (
+    ChunkRelevancy,
+    ChunkRelevancySorterResult,
+)
+from unique_toolkit.agentic.evaluation.schemas import (
+    EvaluationMetricName,
+    EvaluationMetricResult,
+)
+from unique_toolkit.agentic.tools.schemas import ToolCallResponse
+from unique_toolkit.content.schemas import ContentChunk
+from unique_toolkit.content.service import ContentService
+from unique_toolkit.language_model.default_language_model import DEFAULT_GPT_4o
+from unique_toolkit.language_model.infos import LanguageModelInfo
+from unique_toolkit.language_model.invocation_stats import LanguageModelInvocationStats
+from unique_toolkit.language_model.schemas import LanguageModelTokenUsage
+
+from unique_internal_search.config import InternalSearchConfig
+from unique_internal_search.service import (
+    INTERNAL_SEARCH_CHUNK_RELEVANCY_FALLBACK_SOURCE,
+    INTERNAL_SEARCH_CHUNK_RELEVANCY_SOURCE,
+    InternalSearchService,
+    InternalSearchTool,
+    _append_chunk_relevancy_invocation_stats,
+)
+
+
+def _usage(total: int = 3) -> LanguageModelTokenUsage:
+    return LanguageModelTokenUsage(
+        completion_tokens=1,
+        prompt_tokens=total - 1,
+        total_tokens=total,
+    )
+
+
+def _relevancy_result(
+    *,
+    model_name: str = DEFAULT_GPT_4o,
+    total_tokens: int = 3,
+) -> EvaluationMetricResult:
+    return EvaluationMetricResult(
+        value="high",
+        name=EvaluationMetricName.CONTEXT_RELEVANCY,
+        reason="Test reason",
+        invocation_stats=[
+            LanguageModelInvocationStats.from_usage(
+                model_name,
+                _usage(total_tokens),
+                source="context_relevancy",
+            )
+        ],
+    )
+
+
+class TestAppendChunkRelevancyInvocationStats:
+    def test_remaps_primary_and_fallback_sources(
+        self,
+        base_internal_search_config: InternalSearchConfig,
+        sample_content_chunks: list[ContentChunk],
+    ) -> None:
+        config = base_internal_search_config.chunk_relevancy_sort_config.model_copy(
+            deep=True
+        )
+        config.language_model = LanguageModelInfo.from_name(DEFAULT_GPT_4o)
+        config.fallback_language_model = LanguageModelInfo.from_name("gpt-4o-mini")
+        primary = config.language_model.name
+        fallback = config.fallback_language_model.name
+        sorter_result = ChunkRelevancySorterResult(
+            relevancies=[
+                ChunkRelevancy(
+                    chunk=sample_content_chunks[0],
+                    relevancy=_relevancy_result(model_name=primary, total_tokens=5),
+                ),
+                ChunkRelevancy(
+                    chunk=sample_content_chunks[1],
+                    relevancy=_relevancy_result(model_name=fallback, total_tokens=7),
+                ),
+            ]
+        )
+        accumulator: list[LanguageModelInvocationStats] = []
+
+        _append_chunk_relevancy_invocation_stats(sorter_result, config, accumulator)
+
+        assert len(accumulator) == 2
+        assert accumulator[0].source == INTERNAL_SEARCH_CHUNK_RELEVANCY_SOURCE
+        assert accumulator[0].model_name == primary
+        assert accumulator[0].token_usage.total_tokens == 5
+        assert accumulator[1].source == INTERNAL_SEARCH_CHUNK_RELEVANCY_FALLBACK_SOURCE
+        assert accumulator[1].model_name == fallback
+        assert accumulator[1].token_usage.total_tokens == 7
+
+    def test_identical_model_names__uses_primary_source(
+        self,
+        base_internal_search_config: InternalSearchConfig,
+        sample_content_chunks: list[ContentChunk],
+    ) -> None:
+        config = base_internal_search_config.chunk_relevancy_sort_config
+        model_name = config.language_model.name
+        sorter_result = ChunkRelevancySorterResult(
+            relevancies=[
+                ChunkRelevancy(
+                    chunk=sample_content_chunks[0],
+                    relevancy=_relevancy_result(model_name=model_name),
+                )
+            ]
+        )
+        accumulator: list[LanguageModelInvocationStats] = []
+
+        _append_chunk_relevancy_invocation_stats(sorter_result, config, accumulator)
+
+        assert len(accumulator) == 1
+        assert accumulator[0].source == INTERNAL_SEARCH_CHUNK_RELEVANCY_SOURCE
+
+
+class TestInternalSearchInvocationStats:
+    @pytest.mark.ai
+    @pytest.mark.asyncio
+    async def test_search__relevancy_enabled__records_stats_on_accumulator(
+        self,
+        base_internal_search_config: InternalSearchConfig,
+        mock_content_service: ContentService,
+        mock_chunk_relevancy_sorter: Any,
+        mock_logger: Any,
+        sample_content_chunks: list[ContentChunk],
+    ) -> None:
+        base_internal_search_config.chunk_relevancy_sort_config.enabled = True
+        config = base_internal_search_config.chunk_relevancy_sort_config
+        service = InternalSearchService(
+            config=base_internal_search_config,
+            content_service=mock_content_service,
+            chunk_relevancy_sorter=mock_chunk_relevancy_sorter,
+            chat_id="chat_123",
+            logger=mock_logger,
+        )
+        mock_content_service.search_contents_async = AsyncMock(return_value=[])
+        mock_content_service.search_content_chunks_async = AsyncMock(
+            return_value=sample_content_chunks
+        )
+        mock_chunk_relevancy_sorter.run = AsyncMock(
+            return_value=ChunkRelevancySorterResult(
+                relevancies=[
+                    ChunkRelevancy(
+                        chunk=chunk,
+                        relevancy=_relevancy_result(
+                            model_name=config.language_model.name
+                        ),
+                    )
+                    for chunk in sample_content_chunks
+                ]
+            )
+        )
+
+        invocation_stats: list[LanguageModelInvocationStats] = []
+        await service.search("test query", invocation_stats=invocation_stats)
+
+        mock_chunk_relevancy_sorter.run.assert_called_once()
+        assert len(invocation_stats) == len(sample_content_chunks)
+        assert all(
+            stat.source == INTERNAL_SEARCH_CHUNK_RELEVANCY_SOURCE
+            for stat in invocation_stats
+        )
+
+    @pytest.mark.ai
+    @pytest.mark.asyncio
+    async def test_search__relevancy_disabled__leaves_accumulator_empty(
+        self,
+        base_internal_search_config: InternalSearchConfig,
+        mock_content_service: ContentService,
+        mock_chunk_relevancy_sorter: Any,
+        mock_logger: Any,
+        sample_content_chunks: list[ContentChunk],
+    ) -> None:
+        base_internal_search_config.chunk_relevancy_sort_config.enabled = False
+        service = InternalSearchService(
+            config=base_internal_search_config,
+            content_service=mock_content_service,
+            chunk_relevancy_sorter=mock_chunk_relevancy_sorter,
+            chat_id="chat_123",
+            logger=mock_logger,
+        )
+        mock_content_service.search_contents_async = AsyncMock(return_value=[])
+        mock_content_service.search_content_chunks_async = AsyncMock(
+            return_value=sample_content_chunks
+        )
+
+        invocation_stats: list[LanguageModelInvocationStats] = []
+        await service.search("test query", invocation_stats=invocation_stats)
+
+        assert invocation_stats == []
+        mock_chunk_relevancy_sorter.run.assert_not_called()
+
+    @pytest.mark.ai
+    @pytest.mark.asyncio
+    async def test_run__returns_invocation_stats_on_tool_response(
+        self,
+        base_internal_search_config: InternalSearchConfig,
+        mock_chat_event: Any,
+        mock_language_model_function: Any,
+        sample_content_chunks: list[ContentChunk],
+    ) -> None:
+        base_internal_search_config.chunk_relevancy_sort_config.enabled = True
+        recorded = [
+            LanguageModelInvocationStats.from_usage(
+                DEFAULT_GPT_4o,
+                _usage(4),
+                source=INTERNAL_SEARCH_CHUNK_RELEVANCY_SOURCE,
+            )
+        ]
+
+        async def _search_side_effect(*args: Any, **kwargs: Any) -> list[ContentChunk]:
+            stats = kwargs.get("invocation_stats")
+            if stats is not None:
+                stats.extend(recorded)
+            return sample_content_chunks
+
+        with (
+            patch(
+                "unique_internal_search.service.ContentService.from_event"
+            ) as mock_content_service_cls,
+            patch(
+                "unique_internal_search.service.ChunkRelevancySorter.from_event"
+            ) as mock_sorter_cls,
+            patch.object(
+                InternalSearchTool,
+                "search",
+                new_callable=AsyncMock,
+                side_effect=_search_side_effect,
+            ),
+            patch(
+                "unique_internal_search.service.feature_flags.enable_new_answers_ui_un_14411.is_enabled",
+                return_value=False,
+            ),
+            patch(
+                "unique_internal_search.service.Tool.tool_progress_reporter",
+                new_callable=PropertyMock,
+                return_value=None,
+            ),
+        ):
+            mock_content_service_cls.return_value = Mock()
+            mock_sorter_cls.return_value = Mock()
+            tool = InternalSearchTool(base_internal_search_config, mock_chat_event)
+            tool._message_step_logger = None
+
+            response = await tool.run(mock_language_model_function)
+
+        assert isinstance(response, ToolCallResponse)
+        assert response.invocation_stats == recorded

--- a/tool_packages/unique_internal_search/tests/test_invocation_stats.py
+++ b/tool_packages/unique_internal_search/tests/test_invocation_stats.py
@@ -20,8 +20,6 @@ from unique_toolkit.language_model.schemas import LanguageModelTokenUsage
 
 from unique_internal_search.config import InternalSearchConfig
 from unique_internal_search.service import (
-    INTERNAL_SEARCH_CHUNK_RELEVANCY_FALLBACK_SOURCE,
-    INTERNAL_SEARCH_CHUNK_RELEVANCY_SOURCE,
     InternalSearchService,
     InternalSearchTool,
     _append_chunk_relevancy_invocation_stats,
@@ -85,10 +83,10 @@ class TestAppendChunkRelevancyInvocationStats:
         _append_chunk_relevancy_invocation_stats(sorter_result, config, accumulator)
 
         assert len(accumulator) == 2
-        assert accumulator[0].source == INTERNAL_SEARCH_CHUNK_RELEVANCY_SOURCE
+        assert accumulator[0].source == "internal_search_chunk_relevancy"
         assert accumulator[0].model_name == primary
         assert accumulator[0].token_usage.total_tokens == 5
-        assert accumulator[1].source == INTERNAL_SEARCH_CHUNK_RELEVANCY_FALLBACK_SOURCE
+        assert accumulator[1].source == "internal_search_chunk_relevancy_fallback"
         assert accumulator[1].model_name == fallback
         assert accumulator[1].token_usage.total_tokens == 7
 
@@ -112,7 +110,7 @@ class TestAppendChunkRelevancyInvocationStats:
         _append_chunk_relevancy_invocation_stats(sorter_result, config, accumulator)
 
         assert len(accumulator) == 1
-        assert accumulator[0].source == INTERNAL_SEARCH_CHUNK_RELEVANCY_SOURCE
+        assert accumulator[0].source == "internal_search_chunk_relevancy"
 
 
 class TestInternalSearchInvocationStats:
@@ -159,7 +157,7 @@ class TestInternalSearchInvocationStats:
         mock_chunk_relevancy_sorter.run.assert_called_once()
         assert len(invocation_stats) == len(sample_content_chunks)
         assert all(
-            stat.source == INTERNAL_SEARCH_CHUNK_RELEVANCY_SOURCE
+            stat.source == "internal_search_chunk_relevancy"
             for stat in invocation_stats
         )
 
@@ -206,7 +204,7 @@ class TestInternalSearchInvocationStats:
             LanguageModelInvocationStats.from_usage(
                 DEFAULT_GPT_4o,
                 _usage(4),
-                source=INTERNAL_SEARCH_CHUNK_RELEVANCY_SOURCE,
+                source="internal_search_chunk_relevancy",
             )
         ]
 

--- a/tool_packages/unique_internal_search/unique_internal_search/service.py
+++ b/tool_packages/unique_internal_search/unique_internal_search/service.py
@@ -8,8 +8,14 @@ from unique_toolkit.agentic.message_log_manager.service import MessageStepLogger
 
 if TYPE_CHECKING:
     from unique_toolkit.language_model.infos import LanguageModelInfo
+from unique_toolkit._common.chunk_relevancy_sorter.config import (
+    ChunkRelevancySortConfig,
+)
 from unique_toolkit._common.chunk_relevancy_sorter.exception import (
     ChunkRelevancySorterException,
+)
+from unique_toolkit._common.chunk_relevancy_sorter.schemas import (
+    ChunkRelevancySorterResult,
 )
 from unique_toolkit._common.chunk_relevancy_sorter.service import ChunkRelevancySorter
 from unique_toolkit.agentic.evaluation.schemas import EvaluationMetricName
@@ -29,6 +35,9 @@ from unique_toolkit.content.utils import (
     merge_content_chunks,
     pick_content_chunks_for_token_window,
     sort_content_chunks,
+)
+from unique_toolkit.language_model.invocation_stats import (
+    LanguageModelInvocationStats,
 )
 from unique_toolkit.language_model.schemas import (
     LanguageModelFunction,
@@ -51,10 +60,53 @@ from unique_internal_search.utils import (
 
 AVERAGE_TOKENS_PER_CHUNK = 500
 TOKEN_BUDGET_SAFETY_FACTOR = 1.3
+INTERNAL_SEARCH_CHUNK_RELEVANCY_SOURCE = "internal_search_chunk_relevancy"
+INTERNAL_SEARCH_CHUNK_RELEVANCY_FALLBACK_SOURCE = (
+    "internal_search_chunk_relevancy_fallback"
+)
 
 
 async def _noop_log_progress(message: str) -> None:
     pass
+
+
+def _append_chunk_relevancy_invocation_stats(
+    sorter_result: ChunkRelevancySorterResult,
+    config: ChunkRelevancySortConfig,
+    accumulator: list[LanguageModelInvocationStats],
+) -> None:
+    """Remap per-chunk relevancy stats onto InternalSearch source names."""
+    primary_name = config.language_model.name
+    fallback_name = (
+        config.fallback_language_model.name
+        if config.fallback_language_model is not None
+        else None
+    )
+    for chunk_relevancy in sorter_result.relevancies:
+        relevancy = chunk_relevancy.relevancy
+        if relevancy is None:
+            continue
+        for stat in relevancy.invocation_stats:
+            if stat.token_usage is None:
+                continue
+            # Only label fallback when the configured models differ; identical
+            # names cannot distinguish primary vs fallback after the fact.
+            is_fallback = (
+                fallback_name is not None
+                and fallback_name != primary_name
+                and stat.model_name == fallback_name
+            )
+            accumulator.append(
+                LanguageModelInvocationStats.from_usage(
+                    stat.model_name,
+                    stat.token_usage,
+                    source=(
+                        INTERNAL_SEARCH_CHUNK_RELEVANCY_FALLBACK_SOURCE
+                        if is_fallback
+                        else INTERNAL_SEARCH_CHUNK_RELEVANCY_SOURCE
+                    ),
+                )
+            )
 
 
 class InternalSearchService:
@@ -118,6 +170,7 @@ class InternalSearchService:
         log_progress: Callable[[str], Awaitable[None]] = _noop_log_progress,
         content_ids: list[str] | None = None,
         metadata_filter: dict | None = None,
+        invocation_stats: list[LanguageModelInvocationStats] | None = None,
         **kwargs,
     ) -> list[ContentChunk]:
         """
@@ -127,6 +180,7 @@ class InternalSearchService:
             search_string: List of search strings or single search string
             content_ids: List of content IDs
             metadata_filter: Metadata filter
+            invocation_stats: Optional run-scoped accumulator for LLM usage
             log_progress: Async callable invoked at key progress points. Defaults
                 to a no-op so callers that don't need progress updates require no
                 changes.
@@ -204,6 +258,7 @@ class InternalSearchService:
                 result.chunks = await self._resort_found_chunks_if_enabled(
                     found_chunks=result.chunks,
                     search_string=result.query,
+                    invocation_stats=invocation_stats,
                 )
 
         ###
@@ -301,7 +356,10 @@ class InternalSearchService:
         return successful_results
 
     async def _resort_found_chunks_if_enabled(
-        self, found_chunks: list[ContentChunk], search_string: str
+        self,
+        found_chunks: list[ContentChunk],
+        search_string: str,
+        invocation_stats: list[LanguageModelInvocationStats] | None = None,
     ) -> list[ContentChunk]:
         try:
             total_chunks = len(found_chunks)
@@ -311,6 +369,12 @@ class InternalSearchService:
                 chunks=found_chunks,
                 config=self.config.chunk_relevancy_sort_config,
             )
+            if invocation_stats is not None:
+                _append_chunk_relevancy_invocation_stats(
+                    chunk_relevancy_sorter_result,
+                    self.config.chunk_relevancy_sort_config,
+                    invocation_stats,
+                )
             found_chunks = chunk_relevancy_sorter_result.content_chunks
         except ChunkRelevancySorterException as e:
             self.logger.warning(f"Error while sorting chunks: {e.error_message}")
@@ -524,10 +588,12 @@ class InternalSearchTool(Tool[InternalSearchConfig], InternalSearchService):
                 f"{'; '.join(search_strings_list)}", tool_call
             )
 
+        invocation_stats: list[LanguageModelInvocationStats] = []
         selected_chunks = await self.search(
             **tool_call.arguments,
             log_progress=message_logger.log_progress,
             tool_call=tool_call,
+            invocation_stats=invocation_stats,
         )
 
         await message_logger.log_chunks(selected_chunks)
@@ -545,6 +611,7 @@ class InternalSearchTool(Tool[InternalSearchConfig], InternalSearchService):
             content_chunks=selected_chunks,
             debug_info=self.debug_info,
             system_reminder=self.config.experimental_features.tool_response_system_reminder.get_reminder_prompt,
+            invocation_stats=invocation_stats,
         )
 
         if (

--- a/tool_packages/unique_internal_search/unique_internal_search/service.py
+++ b/tool_packages/unique_internal_search/unique_internal_search/service.py
@@ -60,10 +60,6 @@ from unique_internal_search.utils import (
 
 AVERAGE_TOKENS_PER_CHUNK = 500
 TOKEN_BUDGET_SAFETY_FACTOR = 1.3
-INTERNAL_SEARCH_CHUNK_RELEVANCY_SOURCE = "internal_search_chunk_relevancy"
-INTERNAL_SEARCH_CHUNK_RELEVANCY_FALLBACK_SOURCE = (
-    "internal_search_chunk_relevancy_fallback"
-)
 
 
 async def _noop_log_progress(message: str) -> None:
@@ -101,9 +97,9 @@ def _append_chunk_relevancy_invocation_stats(
                     stat.model_name,
                     stat.token_usage,
                     source=(
-                        INTERNAL_SEARCH_CHUNK_RELEVANCY_FALLBACK_SOURCE
+                        "internal_search_chunk_relevancy_fallback"
                         if is_fallback
-                        else INTERNAL_SEARCH_CHUNK_RELEVANCY_SOURCE
+                        else "internal_search_chunk_relevancy"
                     ),
                 )
             )

--- a/tool_packages/unique_swot/unique_swot/service.py
+++ b/tool_packages/unique_swot/unique_swot/service.py
@@ -18,6 +18,7 @@ from unique_toolkit.language_model import (
     LanguageModelMessage,
     LanguageModelMessageRole,
 )
+from unique_toolkit.language_model.invocation_stats import LanguageModelInvocationStats
 from unique_toolkit.language_model.schemas import LanguageModelToolDescription
 from unique_toolkit.services.knowledge_base import KnowledgeBaseService
 
@@ -131,6 +132,7 @@ class SwotAnalysisTool(Tool[SwotAnalysisToolConfig]):
             )
         company_name = session_config.swot_analysis.company_listing.name
         progress_notifier = self._get_progress_notifier(company_name=company_name)
+        invocation_stats: list[LanguageModelInvocationStats] = []
 
         try:
             plan = SWOTPlan.model_validate(tool_call.arguments)
@@ -191,7 +193,9 @@ class SwotAnalysisTool(Tool[SwotAnalysisToolConfig]):
             )
 
             # Generate markdown report
-            result = await orchestrator.run(plan=plan)
+            result = await orchestrator.run(
+                plan=plan, invocation_stats=invocation_stats
+            )
 
             if result.is_empty():
                 await progress_notifier.finish()
@@ -204,6 +208,7 @@ class SwotAnalysisTool(Tool[SwotAnalysisToolConfig]):
                     name=self.name,
                     content="No SWOT analysis results found for the company. Please try again with a different company or configuration.",
                     content_chunks=[],
+                    invocation_stats=invocation_stats,
                 )
 
             await progress_notifier.update(progress=90)
@@ -222,7 +227,9 @@ class SwotAnalysisTool(Tool[SwotAnalysisToolConfig]):
             )
 
             summarization_result = await summarization_agent.summarize(
-                company_name=company_name, markdown_report=executive_summary
+                company_name=company_name,
+                markdown_report=executive_summary,
+                invocation_stats=invocation_stats,
             )
 
             report_handler.deliver_report(
@@ -243,6 +250,7 @@ class SwotAnalysisTool(Tool[SwotAnalysisToolConfig]):
                 name=self.name,
                 content=summarization_result,
                 content_chunks=citation_manager.get_referenced_content_chunks(),
+                invocation_stats=invocation_stats,
             )
 
         except Exception as e:
@@ -257,6 +265,7 @@ class SwotAnalysisTool(Tool[SwotAnalysisToolConfig]):
                 name=self.name,
                 content=f"Error running SWOT plan: {e}",
                 content_chunks=[],
+                invocation_stats=invocation_stats,
             )
 
         finally:

--- a/tool_packages/unique_swot/unique_swot/services/generation/agentic/agent.py
+++ b/tool_packages/unique_swot/unique_swot/services/generation/agentic/agent.py
@@ -7,6 +7,7 @@ from tqdm.asyncio import tqdm
 from unique_toolkit import LanguageModelService
 from unique_toolkit._common.validators import LMI
 from unique_toolkit.content import Content
+from unique_toolkit.language_model.invocation_stats import LanguageModelInvocationStats
 
 from unique_swot.services.generation.agentic.config import AgenticGeneratorConfig
 from unique_swot.services.generation.agentic.exceptions import (
@@ -85,6 +86,7 @@ class GenerationAgent:
         source_registry: SourceRegistry,
         step_notifier: StepNotifier,
         progress_notifier: ProgressNotifier,
+        invocation_stats: list[LanguageModelInvocationStats] | None = None,
     ) -> SWOTReportComponents:
         match self._generation_mode:
             case GenerationMode.INTERLEAVED:
@@ -96,6 +98,7 @@ class GenerationAgent:
                     source_registry=source_registry,
                     step_notifier=step_notifier,
                     progress_notifier=progress_notifier,
+                    invocation_stats=invocation_stats,
                 )
             case GenerationMode.EXTRACT_FIRST:
                 return await self._generate_extract_first(
@@ -106,6 +109,7 @@ class GenerationAgent:
                     source_registry=source_registry,
                     step_notifier=step_notifier,
                     progress_notifier=progress_notifier,
+                    invocation_stats=invocation_stats,
                 )
             case _:
                 raise ValueError(
@@ -126,6 +130,7 @@ class GenerationAgent:
         source_registry: SourceRegistry,
         step_notifier: StepNotifier,
         progress_notifier: ProgressNotifier,
+        invocation_stats: list[LanguageModelInvocationStats] | None = None,
     ) -> SWOTReportComponents:
         step_size, progress_sequence = create_progress_sequence(
             start=10, stop=80, steps=total_steps
@@ -143,6 +148,7 @@ class GenerationAgent:
                 company_name=self._company_name,
                 content=content,
                 step_notifier=step_notifier,
+                invocation_stats=invocation_stats,
             )
 
             if not source_selection_result.should_select:
@@ -157,6 +163,7 @@ class GenerationAgent:
                 step_notifier=step_notifier,
                 source_registry=source_registry,
                 progress_notifier=progress_notifier,
+                invocation_stats=invocation_stats,
             )
 
         return self._get_swot_report_components()
@@ -175,6 +182,7 @@ class GenerationAgent:
         source_registry: SourceRegistry,
         step_notifier: StepNotifier,
         progress_notifier: ProgressNotifier,
+        invocation_stats: list[LanguageModelInvocationStats] | None = None,
     ) -> SWOTReportComponents:
         step_size, progress_sequence = create_progress_sequence(
             start=10, stop=60, steps=total_steps
@@ -194,6 +202,7 @@ class GenerationAgent:
                 company_name=self._company_name,
                 content=content,
                 step_notifier=step_notifier,
+                invocation_stats=invocation_stats,
             )
 
             if not source_selection_result.should_select:
@@ -257,6 +266,7 @@ class GenerationAgent:
                             notification_title=self.notification_title,
                             prompts_config=self._config.prompts_config.extraction_prompt_config,
                             component_definition_prompt_config=self._config.prompts_config.definition_prompt_config,
+                            invocation_stats=invocation_stats,
                         )
                         accumulated_facts[component].extend(facts)
                     except FailedToExtractFactsException:
@@ -313,6 +323,7 @@ class GenerationAgent:
                 swot_report_registry=self._swot_report_registry,
                 executor=self._executor,
                 config=self._config,
+                invocation_stats=invocation_stats,
             )
 
             await progress_notifier.increment(
@@ -336,6 +347,7 @@ class GenerationAgent:
         plan: SWOTPlan,
         step_notifier: StepNotifier,
         progress_notifier: ProgressNotifier,
+        invocation_stats: list[LanguageModelInvocationStats] | None = None,
     ):
         _LOGGER.info("Starting SWOT Analysis generation Agent")
         # Prepare the source splits
@@ -399,6 +411,7 @@ class GenerationAgent:
                             swot_report_registry=self._swot_report_registry,
                             executor=self._executor,
                             config=self._config,
+                            invocation_stats=invocation_stats,
                         )
                     case SWOTOperation.MODIFY:
                         _LOGGER.warning(
@@ -415,6 +428,7 @@ class GenerationAgent:
                             swot_report_registry=self._swot_report_registry,
                             executor=self._executor,
                             config=self._config,
+                            invocation_stats=invocation_stats,
                         )
                     case SWOTOperation.NOT_REQUESTED:
                         continue

--- a/tool_packages/unique_swot/unique_swot/services/generation/agentic/commands.py
+++ b/tool_packages/unique_swot/unique_swot/services/generation/agentic/commands.py
@@ -4,6 +4,7 @@ from logging import getLogger
 from jinja2 import Template
 from unique_toolkit import LanguageModelService
 from unique_toolkit._common.validators import LMI
+from unique_toolkit.language_model.invocation_stats import LanguageModelInvocationStats
 
 from unique_swot.services.generation.agentic.exceptions import (
     FailedToCreateNewSectionException,
@@ -23,7 +24,7 @@ from unique_swot.services.generation.models.base import (
 )
 from unique_swot.services.generation.models.plan import GenerationPlanCommand
 from unique_swot.services.generation.models.registry import SWOTReportRegistry
-from unique_swot.utils import generate_structured_output
+from unique_swot.utils import SWOT_GENERATION, generate_structured_output
 
 _LOGGER = getLogger(__name__)
 
@@ -38,6 +39,7 @@ async def create_new_section(
     command: GenerationPlanCommand,
     fact_id_map: dict[str, str],
     prompts_config: CreateNewSectionPromptConfig,
+    invocation_stats: list[LanguageModelInvocationStats] | None = None,
 ) -> SWOTReportComponentSection:
     ## Prepare a fact view for the prompt
     facts = {
@@ -67,6 +69,8 @@ async def create_new_section(
         llm_service=llm_service,
         llm=llm,
         output_model=SWOTReportComponentSection,
+        invocation_stats=invocation_stats,
+        source=SWOT_GENERATION,
     )
 
     ## Validate the result
@@ -91,6 +95,7 @@ async def update_existing_section(
     fact_id_map: dict[str, str],
     swot_report_registry: SWOTReportRegistry,
     prompts_config: UpdateExistingSectionPromptConfig,
+    invocation_stats: list[LanguageModelInvocationStats] | None = None,
 ) -> SWOTReportComponentSection:
     ## Validate the command
     if command.target_section_id is None:
@@ -139,6 +144,8 @@ async def update_existing_section(
         llm_service=llm_service,
         llm=llm,
         output_model=SWOTReportComponentSection,
+        invocation_stats=invocation_stats,
+        source=SWOT_GENERATION,
     )
     ## Validate the result
     if updated_section is None:

--- a/tool_packages/unique_swot/unique_swot/services/generation/agentic/operations.py
+++ b/tool_packages/unique_swot/unique_swot/services/generation/agentic/operations.py
@@ -5,6 +5,7 @@ from typing import Any, Sequence
 from jinja2 import Template
 from unique_toolkit import LanguageModelService
 from unique_toolkit._common.validators import LMI
+from unique_toolkit.language_model.invocation_stats import LanguageModelInvocationStats
 
 from unique_swot.services.generation.agentic.commands import (
     create_new_section,
@@ -39,7 +40,11 @@ from unique_swot.services.generation.models.plan import (
 )
 from unique_swot.services.generation.models.registry import SWOTReportRegistry
 from unique_swot.services.orchestrator.service import StepNotifier
-from unique_swot.utils import generate_structured_output, generate_unique_id
+from unique_swot.utils import (
+    SWOT_GENERATION,
+    generate_structured_output,
+    generate_unique_id,
+)
 
 _LOGGER = getLogger(__name__)
 
@@ -56,6 +61,7 @@ async def handle_generate_operation(
     swot_report_registry: SWOTReportRegistry,
     executor: AgenticPlanExecutor,
     config: AgenticGeneratorConfig,
+    invocation_stats: list[LanguageModelInvocationStats] | None = None,
 ) -> None:
     try:
         # Extract the items for the component
@@ -69,6 +75,7 @@ async def handle_generate_operation(
             notification_title=notification_title,
             prompts_config=config.prompts_config.extraction_prompt_config,
             component_definition_prompt_config=config.prompts_config.definition_prompt_config,
+            invocation_stats=invocation_stats,
         )
 
         # Skip if list of facts is empty
@@ -91,6 +98,7 @@ async def handle_generate_operation(
             notification_title=notification_title,
             swot_report_registry=swot_report_registry,
             prompts_config=config.prompts_config.plan_prompt_config,
+            invocation_stats=invocation_stats,
         )
 
         # Execute the generation for the component
@@ -104,6 +112,7 @@ async def handle_generate_operation(
             company_name=company_name,
             executor=executor,
             prompts_config=config.prompts_config.commands_prompt_config,
+            invocation_stats=invocation_stats,
         )
         # Register or update the sections in the registry
         _handle_execution_results(
@@ -150,6 +159,7 @@ async def extract_facts(
     notification_title: str,
     prompts_config: ExtractionPromptConfig,
     component_definition_prompt_config: ComponentDefinitionPromptConfig,
+    invocation_stats: list[LanguageModelInvocationStats] | None = None,
 ) -> list[str]:
     component_definition = get_component_definition(
         component, component_definition_prompt_config
@@ -172,6 +182,8 @@ async def extract_facts(
         llm_service=llm_service,
         llm=llm,
         output_model=SWOTExtractionFactsList,
+        invocation_stats=invocation_stats,
+        source=SWOT_GENERATION,
     )
 
     if extracted_facts is None:
@@ -198,6 +210,7 @@ async def _generate_plan(
     notification_title: str,
     swot_report_registry: SWOTReportRegistry,
     prompts_config: PlanPromptConfig,
+    invocation_stats: list[LanguageModelInvocationStats] | None = None,
 ) -> GenerationPlan:
     system_prompt = Template(prompts_config.system_prompt).render(
         company_name=company_name,
@@ -222,6 +235,8 @@ async def _generate_plan(
         llm_service=llm_service,
         llm=llm,
         output_model=GenerationPlan,
+        invocation_stats=invocation_stats,
+        source=SWOT_GENERATION,
     )
     if plan is None:
         _LOGGER.error(f"Failed to generate plan for component {component}")
@@ -248,6 +263,7 @@ async def _execute_plan(
     company_name: str,
     executor: AgenticPlanExecutor,
     prompts_config: CommandsPromptConfig,
+    invocation_stats: list[LanguageModelInvocationStats] | None = None,
 ) -> Sequence[Exception | Any]:
     for command in plan.commands:
         match command.command:
@@ -262,6 +278,7 @@ async def _execute_plan(
                     command=command,
                     fact_id_map=fact_id_map,
                     prompts_config=prompts_config.create_new_section_prompt_config,
+                    invocation_stats=invocation_stats,
                 )
 
             case GenerationPlanCommandType.UPDATE_SECTION:
@@ -276,6 +293,7 @@ async def _execute_plan(
                     fact_id_map=fact_id_map,
                     swot_report_registry=swot_report_registry,
                     prompts_config=prompts_config.update_existing_section_prompt_config,
+                    invocation_stats=invocation_stats,
                 )
             case _:
                 raise InvalidCommandException(f"Invalid command: {command.command}")
@@ -330,6 +348,7 @@ async def _generate_cluster_plan(
     llm_service: LanguageModelService,
     notification_title: str,
     prompts_config: ClusterPlanPromptConfig,
+    invocation_stats: list[LanguageModelInvocationStats] | None = None,
 ) -> GenerationPlan:
     """One-shot clustering planner that groups all accumulated facts into sections."""
     system_prompt = Template(prompts_config.system_prompt).render(
@@ -349,6 +368,8 @@ async def _generate_cluster_plan(
         llm_service=llm_service,
         llm=llm,
         output_model=GenerationPlan,
+        invocation_stats=invocation_stats,
+        source=SWOT_GENERATION,
     )
     if plan is None:
         _LOGGER.error(f"Failed to generate cluster plan for component {component}")
@@ -376,6 +397,7 @@ async def handle_accumulated_generate_operation(
     swot_report_registry: SWOTReportRegistry,
     executor: AgenticPlanExecutor,
     config: AgenticGeneratorConfig,
+    invocation_stats: list[LanguageModelInvocationStats] | None = None,
 ) -> None:
     """Plan and generate sections from pre-accumulated facts (extract-first mode)."""
     try:
@@ -388,6 +410,7 @@ async def handle_accumulated_generate_operation(
             llm_service=llm_service,
             notification_title=notification_title,
             prompts_config=config.prompts_config.cluster_plan_prompt_config,
+            invocation_stats=invocation_stats,
         )
 
         results = await _execute_plan(
@@ -400,6 +423,7 @@ async def handle_accumulated_generate_operation(
             company_name=company_name,
             executor=executor,
             prompts_config=config.prompts_config.commands_prompt_config,
+            invocation_stats=invocation_stats,
         )
 
         _handle_execution_results(

--- a/tool_packages/unique_swot/unique_swot/services/orchestrator/service.py
+++ b/tool_packages/unique_swot/unique_swot/services/orchestrator/service.py
@@ -3,6 +3,7 @@ from typing import AsyncIterator, Protocol
 
 from unique_toolkit.chat.service import ChatService
 from unique_toolkit.content import Content, ContentChunk, ContentReference
+from unique_toolkit.language_model.invocation_stats import LanguageModelInvocationStats
 
 from unique_swot.services.generation.models.base import SWOTReportComponents
 from unique_swot.services.memory.base import SwotMemoryService
@@ -51,7 +52,12 @@ class SourceSelector(Protocol):
     """This class is responsible for selecting the sources that are most relevant to the SWOT analysis."""
 
     async def select(
-        self, *, company_name: str, content: Content, step_notifier: StepNotifier
+        self,
+        *,
+        company_name: str,
+        content: Content,
+        step_notifier: StepNotifier,
+        invocation_stats: list[LanguageModelInvocationStats] | None = None,
     ) -> SourceSelectionResult: ...
 
 
@@ -59,7 +65,11 @@ class SourceIterator(Protocol):
     """This class is responsible for prioritizing the sources that are most relevant to the SWOT analysis."""
 
     async def iterate(
-        self, *, contents: list[Content], step_notifier: StepNotifier
+        self,
+        *,
+        contents: list[Content],
+        step_notifier: StepNotifier,
+        invocation_stats: list[LanguageModelInvocationStats] | None = None,
     ) -> AsyncIterator[Content]: ...
 
 
@@ -84,6 +94,7 @@ class ReportingAgent(Protocol):
         source_registry: SourceRegistry,
         step_notifier: StepNotifier,
         progress_notifier: ProgressNotifier,
+        invocation_stats: list[LanguageModelInvocationStats] | None = None,
     ) -> SWOTReportComponents: ...
 
 
@@ -110,7 +121,12 @@ class SWOTOrchestrator:
         self._progress_notifier = progress_notifier
         self._chat_service = chat_service
 
-    async def run(self, *, plan: SWOTPlan) -> SWOTReportComponents:
+    async def run(
+        self,
+        *,
+        plan: SWOTPlan,
+        invocation_stats: list[LanguageModelInvocationStats] | None = None,
+    ) -> SWOTReportComponents:
         contents = await self._source_collector.collect(
             step_notifier=self._step_notifier
         )
@@ -118,7 +134,9 @@ class SWOTOrchestrator:
         await self._progress_notifier.update(progress=5)
 
         source_iterator = await self._source_iterator.iterate(
-            contents=contents, step_notifier=self._step_notifier
+            contents=contents,
+            step_notifier=self._step_notifier,
+            invocation_stats=invocation_stats,
         )
 
         await self._progress_notifier.update(progress=10)
@@ -138,6 +156,7 @@ class SWOTOrchestrator:
             step_notifier=self._step_notifier,
             source_registry=self._source_registry,
             progress_notifier=self._progress_notifier,
+            invocation_stats=invocation_stats,
         )
 
         return reports

--- a/tool_packages/unique_swot/unique_swot/services/source_management/iteration/agent.py
+++ b/tool_packages/unique_swot/unique_swot/services/source_management/iteration/agent.py
@@ -15,7 +15,6 @@ from unique_swot.services.source_management.iteration.schema import (
     SourceIterationResults,
 )
 from unique_swot.utils import (
-    SWOT_SOURCE_ITERATION,
     generate_structured_output,
     generate_unique_id,
     get_content_chunk_title,
@@ -62,7 +61,7 @@ class SourceIterationAgent:
             llm_service=self._llm_service,
             output_model=SourceIterationResults,
             invocation_stats=invocation_stats,
-            source=SWOT_SOURCE_ITERATION,
+            source="swot_source_iteration",
         )
 
         fallback_notification_message = (

--- a/tool_packages/unique_swot/unique_swot/services/source_management/iteration/agent.py
+++ b/tool_packages/unique_swot/unique_swot/services/source_management/iteration/agent.py
@@ -5,6 +5,7 @@ from jinja2 import Template
 from unique_toolkit import LanguageModelService
 from unique_toolkit._common.validators import LMI
 from unique_toolkit.content import Content
+from unique_toolkit.language_model.invocation_stats import LanguageModelInvocationStats
 
 from unique_swot.services.orchestrator.service import StepNotifier
 from unique_swot.services.source_management.iteration.config import (
@@ -14,6 +15,7 @@ from unique_swot.services.source_management.iteration.schema import (
     SourceIterationResults,
 )
 from unique_swot.utils import (
+    SWOT_SOURCE_ITERATION,
     generate_structured_output,
     generate_unique_id,
     get_content_chunk_title,
@@ -36,7 +38,11 @@ class SourceIterationAgent:
         self._content_map = {}
 
     async def iterate(
-        self, *, contents: list[Content], step_notifier: StepNotifier
+        self,
+        *,
+        contents: list[Content],
+        step_notifier: StepNotifier,
+        invocation_stats: list[LanguageModelInvocationStats] | None = None,
     ) -> AsyncIterator[Content]:
         system_prompt = self._compose_system_prompt(
             objective=self._source_iteration_config.prompt_config.objective
@@ -55,6 +61,8 @@ class SourceIterationAgent:
             llm=self._llm,
             llm_service=self._llm_service,
             output_model=SourceIterationResults,
+            invocation_stats=invocation_stats,
+            source=SWOT_SOURCE_ITERATION,
         )
 
         fallback_notification_message = (

--- a/tool_packages/unique_swot/unique_swot/services/source_management/selection/agent.py
+++ b/tool_packages/unique_swot/unique_swot/services/source_management/selection/agent.py
@@ -14,7 +14,6 @@ from unique_swot.services.source_management.selection.schema import (
     SourceSelectionResult,
 )
 from unique_swot.utils import (
-    SWOT_SOURCE_SELECTION,
     generate_structured_output,
     get_content_chunk_title,
 )
@@ -61,7 +60,7 @@ class SourceSelectionAgent:
             llm_service=self._llm_service,
             output_model=SourceSelectionResult,
             invocation_stats=invocation_stats,
-            source=SWOT_SOURCE_SELECTION,
+            source="swot_source_selection",
         )
 
         if response is None:

--- a/tool_packages/unique_swot/unique_swot/services/source_management/selection/agent.py
+++ b/tool_packages/unique_swot/unique_swot/services/source_management/selection/agent.py
@@ -4,6 +4,7 @@ from jinja2 import Template
 from unique_toolkit import LanguageModelService
 from unique_toolkit._common.validators import LMI
 from unique_toolkit.content import Content
+from unique_toolkit.language_model.invocation_stats import LanguageModelInvocationStats
 
 from unique_swot.services.orchestrator.service import StepNotifier
 from unique_swot.services.source_management.selection.config import (
@@ -12,7 +13,11 @@ from unique_swot.services.source_management.selection.config import (
 from unique_swot.services.source_management.selection.schema import (
     SourceSelectionResult,
 )
-from unique_swot.utils import generate_structured_output, get_content_chunk_title
+from unique_swot.utils import (
+    SWOT_SOURCE_SELECTION,
+    generate_structured_output,
+    get_content_chunk_title,
+)
 
 _LOGGER = getLogger(__name__)
 
@@ -30,7 +35,12 @@ class SourceSelectionAgent:
         self._source_selection_config = source_selection_config
 
     async def select(
-        self, *, company_name: str, content: Content, step_notifier: StepNotifier
+        self,
+        *,
+        company_name: str,
+        content: Content,
+        step_notifier: StepNotifier,
+        invocation_stats: list[LanguageModelInvocationStats] | None = None,
     ) -> SourceSelectionResult:
         _LOGGER.info(f"Selecting sources for {company_name}")
         system_prompt = self._compose_system_prompt(company_name=company_name)
@@ -50,6 +60,8 @@ class SourceSelectionAgent:
             llm=self._llm,
             llm_service=self._llm_service,
             output_model=SourceSelectionResult,
+            invocation_stats=invocation_stats,
+            source=SWOT_SOURCE_SELECTION,
         )
 
         if response is None:

--- a/tool_packages/unique_swot/unique_swot/services/summarization/agent.py
+++ b/tool_packages/unique_swot/unique_swot/services/summarization/agent.py
@@ -7,7 +7,6 @@ from unique_toolkit.language_model.builder import MessagesBuilder
 from unique_toolkit.language_model.invocation_stats import LanguageModelInvocationStats
 
 from unique_swot.services.summarization.config import SummarizationConfig
-from unique_swot.utils import SWOT_SUMMARIZATION
 
 _LOGGER = getLogger(__name__)
 
@@ -58,7 +57,7 @@ class SummarizationAgent:
                     LanguageModelInvocationStats.from_usage(
                         self._llm.name,
                         response.usage,
-                        source=SWOT_SUMMARIZATION,
+                        source="swot_summarization",
                     )
                 )
 

--- a/tool_packages/unique_swot/unique_swot/services/summarization/agent.py
+++ b/tool_packages/unique_swot/unique_swot/services/summarization/agent.py
@@ -4,8 +4,10 @@ from jinja2 import Template
 from unique_toolkit import LanguageModelService
 from unique_toolkit._common.validators import LMI
 from unique_toolkit.language_model.builder import MessagesBuilder
+from unique_toolkit.language_model.invocation_stats import LanguageModelInvocationStats
 
 from unique_swot.services.summarization.config import SummarizationConfig
+from unique_swot.utils import SWOT_SUMMARIZATION
 
 _LOGGER = getLogger(__name__)
 
@@ -27,6 +29,7 @@ class SummarizationAgent:
         *,
         company_name: str,
         markdown_report: str,
+        invocation_stats: list[LanguageModelInvocationStats] | None = None,
     ) -> str:
         # Render the report with compatible citations for streaming
         user_prompt = Template(
@@ -49,6 +52,15 @@ class SummarizationAgent:
                 model_name=self._llm.name,
                 messages=messages,
             )
+
+            if invocation_stats is not None and response.usage is not None:
+                invocation_stats.append(
+                    LanguageModelInvocationStats.from_usage(
+                        self._llm.name,
+                        response.usage,
+                        source=SWOT_SUMMARIZATION,
+                    )
+                )
 
             if not isinstance(response.choices[0].message.content, str):
                 raise ValueError("Invalid response content received from the LLM")

--- a/tool_packages/unique_swot/unique_swot/tests/services/test_orchestrator.py
+++ b/tool_packages/unique_swot/unique_swot/tests/services/test_orchestrator.py
@@ -79,7 +79,7 @@ def _make_source_iterator():
         for content in contents:
             yield content
 
-    async def _iterate(contents, step_notifier):
+    async def _iterate(contents, step_notifier, invocation_stats=None):
         return _iterate_impl(contents, step_notifier)
 
     source_iterator.iterate = _iterate

--- a/tool_packages/unique_swot/unique_swot/tests/services/test_summarization.py
+++ b/tool_packages/unique_swot/unique_swot/tests/services/test_summarization.py
@@ -12,7 +12,6 @@ from unique_swot.services.generation.models.base import (
     SWOTReportSectionEntry,
 )
 from unique_swot.services.summarization.agent import SummarizationAgent
-from unique_swot.utils import SWOT_SUMMARIZATION
 
 
 def _make_report_components():
@@ -78,7 +77,7 @@ async def test_summarization_agent_records_invocation_stats_with_model(
     assert summary == "Summary text"
     assert len(invocation_stats) == 1
     assert invocation_stats[0].model_name == "summarization-model"
-    assert invocation_stats[0].source == SWOT_SUMMARIZATION
+    assert invocation_stats[0].source == "swot_summarization"
     assert invocation_stats[0].token_usage.total_tokens == 30
 
 

--- a/tool_packages/unique_swot/unique_swot/tests/services/test_summarization.py
+++ b/tool_packages/unique_swot/unique_swot/tests/services/test_summarization.py
@@ -1,8 +1,10 @@
 """Tests for the SummarizationAgent."""
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
 import pytest
+from unique_toolkit.language_model.schemas import LanguageModelTokenUsage
 
 from unique_swot.services.generation.models.base import (
     SWOTReportComponents,
@@ -10,6 +12,7 @@ from unique_swot.services.generation.models.base import (
     SWOTReportSectionEntry,
 )
 from unique_swot.services.summarization.agent import SummarizationAgent
+from unique_swot.utils import SWOT_SUMMARIZATION
 
 
 def _make_report_components():
@@ -39,6 +42,44 @@ def _make_report_components():
         opportunities=[],
         threats=[],
     )
+
+
+@pytest.mark.asyncio
+async def test_summarization_agent_records_invocation_stats_with_model(
+    mock_language_model_service,
+):
+    """Summarization should record usage with the configured model and source."""
+    config = Mock()
+    config.prompt_config.system_prompt = "System prompt"
+    config.prompt_config.user_prompt = "User prompt for {{company_name}}: {{report}}"
+
+    llm = SimpleNamespace(name="summarization-model", encoder_name="cl100k_base")
+    agent = SummarizationAgent(
+        llm=llm,
+        llm_service=mock_language_model_service,
+        summarization_config=config,
+    )
+
+    mock_response = Mock()
+    mock_response.choices = [Mock()]
+    mock_response.choices[0].message.content = "Summary text"
+    mock_response.usage = LanguageModelTokenUsage(
+        prompt_tokens=20, completion_tokens=10, total_tokens=30
+    )
+    mock_language_model_service.complete_async = AsyncMock(return_value=mock_response)
+
+    invocation_stats = []
+    summary = await agent.summarize(
+        company_name="ACME Corp",
+        markdown_report="Full report content",
+        invocation_stats=invocation_stats,
+    )
+
+    assert summary == "Summary text"
+    assert len(invocation_stats) == 1
+    assert invocation_stats[0].model_name == "summarization-model"
+    assert invocation_stats[0].source == SWOT_SUMMARIZATION
+    assert invocation_stats[0].token_usage.total_tokens == 30
 
 
 @pytest.mark.asyncio

--- a/tool_packages/unique_swot/unique_swot/tests/test_utils.py
+++ b/tool_packages/unique_swot/unique_swot/tests/test_utils.py
@@ -3,17 +3,28 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 from pydantic import BaseModel
+from unique_toolkit.language_model.invocation_stats import LanguageModelInvocationStats
+from unique_toolkit.language_model.schemas import LanguageModelTokenUsage
 
-from unique_swot.utils import generate_structured_output
+from unique_swot.utils import (
+    SWOT_GENERATION,
+    generate_structured_output,
+)
 
 
 class DummyOutput(BaseModel):
     value: str
 
 
-def _build_llm():
-    # Minimal LMI-like object with the encoder name
-    return SimpleNamespace(name="dummy-model", encoder_name="cl100k_base")
+def _build_llm(name: str = "dummy-model"):
+    return SimpleNamespace(name=name, encoder_name="cl100k_base")
+
+
+def _build_response(*, parsed: dict, usage: LanguageModelTokenUsage | None = None):
+    message = Mock(parsed=parsed)
+    response = Mock(choices=[Mock(message=message)])
+    response.usage = usage
+    return response
 
 
 @pytest.mark.asyncio
@@ -25,8 +36,7 @@ async def test_generate_structured_output_retries_and_succeeds(monkeypatch):
         if call_counter["count"] < 2:
             call_counter["count"] += 1
             raise RuntimeError("temporary failure")
-        message = Mock(parsed={"value": "ok"})
-        return Mock(choices=[Mock(message=message)])
+        return _build_response(parsed={"value": "ok"})
 
     call_counter = {"count": 0}
     llm_service = Mock()
@@ -62,3 +72,98 @@ async def test_generate_structured_output_returns_none_after_max_retries():
 
     assert result is None
     assert llm_service.complete_async.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_generate_structured_output__records_invocation_stats_on_success():
+    invocation_stats: list[LanguageModelInvocationStats] = []
+    usage = LanguageModelTokenUsage(
+        prompt_tokens=10, completion_tokens=5, total_tokens=15
+    )
+    llm_service = Mock()
+    llm_service.complete_async = AsyncMock(
+        return_value=_build_response(parsed={"value": "ok"}, usage=usage)
+    )
+
+    result = await generate_structured_output(
+        user_message="hi",
+        system_prompt="sys",
+        llm=_build_llm("generation-model"),
+        output_model=DummyOutput,
+        llm_service=llm_service,
+        invocation_stats=invocation_stats,
+        source=SWOT_GENERATION,
+    )
+
+    assert result is not None
+    assert len(invocation_stats) == 1
+    assert invocation_stats[0].model_name == "generation-model"
+    assert invocation_stats[0].source == SWOT_GENERATION
+    assert invocation_stats[0].token_usage == usage
+
+
+@pytest.mark.asyncio
+async def test_generate_structured_output__retry_skips_failed_attempts():
+    invocation_stats: list[LanguageModelInvocationStats] = []
+    usage = LanguageModelTokenUsage(
+        prompt_tokens=1, completion_tokens=1, total_tokens=2
+    )
+    call_counter = {"count": 0}
+
+    async def _raise_then_succeed(*_, **__):
+        if call_counter["count"] < 2:
+            call_counter["count"] += 1
+            raise RuntimeError("temporary failure")
+        return _build_response(parsed={"value": "ok"}, usage=usage)
+
+    llm_service = Mock()
+    llm_service.complete_async = AsyncMock(side_effect=_raise_then_succeed)
+
+    result = await generate_structured_output(
+        user_message="hi",
+        system_prompt="sys",
+        llm=_build_llm(),
+        output_model=DummyOutput,
+        llm_service=llm_service,
+        invocation_stats=invocation_stats,
+        source=SWOT_GENERATION,
+    )
+
+    assert result is not None
+    assert len(invocation_stats) == 1
+    assert llm_service.complete_async.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_generate_structured_output__mixed_models_preserved():
+    invocation_stats: list[LanguageModelInvocationStats] = []
+    llm_service = Mock()
+
+    async def _complete(*_, model_name: str, **__):
+        usage = LanguageModelTokenUsage(
+            prompt_tokens=1, completion_tokens=1, total_tokens=2
+        )
+        return _build_response(parsed={"value": "ok"}, usage=usage)
+
+    llm_service.complete_async = AsyncMock(side_effect=_complete)
+
+    await generate_structured_output(
+        user_message="hi",
+        system_prompt="sys",
+        llm=_build_llm("model-a"),
+        output_model=DummyOutput,
+        llm_service=llm_service,
+        invocation_stats=invocation_stats,
+        source=SWOT_GENERATION,
+    )
+    await generate_structured_output(
+        user_message="hi",
+        system_prompt="sys",
+        llm=_build_llm("model-b"),
+        output_model=DummyOutput,
+        llm_service=llm_service,
+        invocation_stats=invocation_stats,
+        source=SWOT_GENERATION,
+    )
+
+    assert [entry.model_name for entry in invocation_stats] == ["model-a", "model-b"]

--- a/tool_packages/unique_swot/unique_swot/utils.py
+++ b/tool_packages/unique_swot/unique_swot/utils.py
@@ -14,10 +14,7 @@ _LOGGER = getLogger(__name__)
 _MAX_RETRIES = 3
 T = TypeVar("T", bound=BaseModel)
 
-SWOT_SOURCE_ITERATION = "swot_source_iteration"
-SWOT_SOURCE_SELECTION = "swot_source_selection"
 SWOT_GENERATION = "swot_generation"
-SWOT_SUMMARIZATION = "swot_summarization"
 
 
 def generate_unique_id(prefix: str) -> str:

--- a/tool_packages/unique_swot/unique_swot/utils.py
+++ b/tool_packages/unique_swot/unique_swot/utils.py
@@ -8,10 +8,16 @@ from unique_toolkit import LanguageModelService
 from unique_toolkit._common.validators import LMI
 from unique_toolkit.content import Content, ContentChunk, ContentReference
 from unique_toolkit.language_model.builder import MessagesBuilder
+from unique_toolkit.language_model.invocation_stats import LanguageModelInvocationStats
 
 _LOGGER = getLogger(__name__)
 _MAX_RETRIES = 3
 T = TypeVar("T", bound=BaseModel)
+
+SWOT_SOURCE_ITERATION = "swot_source_iteration"
+SWOT_SOURCE_SELECTION = "swot_source_selection"
+SWOT_GENERATION = "swot_generation"
+SWOT_SUMMARIZATION = "swot_summarization"
 
 
 def generate_unique_id(prefix: str) -> str:
@@ -47,6 +53,8 @@ async def generate_structured_output(
     llm: LMI,
     output_model: type[T],
     llm_service: LanguageModelService,
+    invocation_stats: list[LanguageModelInvocationStats] | None = None,
+    source: str | None = None,
 ) -> T | None:
     """
     Call the LLM to produce a structured Pydantic model with retries.
@@ -76,7 +84,20 @@ async def generate_structured_output(
                 structured_output_model=output_model,
                 structured_output_enforce_schema=True,
             )
-            return output_model.model_validate(response.choices[0].message.parsed)
+            parsed = output_model.model_validate(response.choices[0].message.parsed)
+            if (
+                invocation_stats is not None
+                and source is not None
+                and response.usage is not None
+            ):
+                invocation_stats.append(
+                    LanguageModelInvocationStats.from_usage(
+                        llm.name,
+                        response.usage,
+                        source=source,
+                    )
+                )
+            return parsed
         except Exception as exc:
             last_error = str(exc)
             _LOGGER.exception(

--- a/tool_packages/unique_web_search/src/unique_web_search/schema.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/schema.py
@@ -16,9 +16,6 @@ from unique_toolkit.language_model.invocation_stats import (
 )
 from unique_toolkit.language_model.schemas import LanguageModelTokenUsage
 
-WEB_SEARCH_CHUNK_RELEVANCY_SOURCE = "web_search_chunk_relevancy"
-WEB_SEARCH_CHUNK_RELEVANCY_FALLBACK_SOURCE = "web_search_chunk_relevancy_fallback"
-
 
 class StepDebugInfo(BaseModel):
     step_name: str

--- a/tool_packages/unique_web_search/src/unique_web_search/schema.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/schema.py
@@ -10,6 +10,14 @@ from __future__ import annotations
 from pydantic import BaseModel, Field
 from unidecode import unidecode
 from unique_toolkit.content.schemas import ContentChunk
+from unique_toolkit.language_model.infos import LanguageModelName
+from unique_toolkit.language_model.invocation_stats import (
+    LanguageModelInvocationStats,
+)
+from unique_toolkit.language_model.schemas import LanguageModelTokenUsage
+
+WEB_SEARCH_CHUNK_RELEVANCY_SOURCE = "web_search_chunk_relevancy"
+WEB_SEARCH_CHUNK_RELEVANCY_FALLBACK_SOURCE = "web_search_chunk_relevancy_fallback"
 
 
 class StepDebugInfo(BaseModel):
@@ -53,12 +61,29 @@ class WebSearchDebugInfo(BaseModel):
     web_page_chunks: list[WebPageChunk] = []
     execution_time: float | None = None
     num_chunks_in_final_prompts: int = 0
+    invocation_stats: list[LanguageModelInvocationStats] = Field(default_factory=list)
+
+    def add_invocation(
+        self,
+        model_name: LanguageModelName | str,
+        usage: LanguageModelTokenUsage | None,
+        source: str | None = None,
+    ) -> None:
+        if usage is None or not isinstance(usage, LanguageModelTokenUsage):
+            return
+        # Safe under concurrent process_single_page calls: a plain `append`
+        # with no `await` in between, so asyncio can't interleave mid-update.
+        self.invocation_stats.append(
+            LanguageModelInvocationStats.from_usage(model_name, usage, source=source)
+        )
 
     def model_dump(self, *, with_debug_details: bool = True, **kwargs):
         """
         Dump the model, dropping `additional_info` in steps when debug=False.
         """
         exclude = kwargs.pop("exclude", {})
+        # stats surface via ToolCallResponse.invocation_stats; don't duplicate here.
+        exclude = {"invocation_stats": True} | exclude
         if not with_debug_details:
             # Build an exclude structure that applies to all steps
             exclude = {

--- a/tool_packages/unique_web_search/src/unique_web_search/service.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/service.py
@@ -94,7 +94,6 @@ class WebSearchTool(Tool[WebSearchConfig]):
         self._mode_strategy = get_mode_strategy(self.config.web_search_mode_config)
 
         def content_reducer(web_page_chunks: list[WebPageChunk]) -> list[WebPageChunk]:
-
             return reduce_sources_to_token_limit(
                 web_page_chunks,
                 self.config.language_model_max_input_tokens,
@@ -168,7 +167,7 @@ class WebSearchTool(Tool[WebSearchConfig]):
         try:
             if screening_service is not None:
                 screening_result = await screening_service(
-                    parameters_dump, web_search_message_logger
+                    parameters_dump, web_search_message_logger, debug_info=debug_info
                 )
 
                 debug_info.steps.append(
@@ -185,6 +184,7 @@ class WebSearchTool(Tool[WebSearchConfig]):
                         content=screening_service.build_rejection_response(
                             screening_result
                         ),
+                        invocation_stats=debug_info.invocation_stats,
                     )
 
             with metric_scope(
@@ -214,6 +214,7 @@ class WebSearchTool(Tool[WebSearchConfig]):
                 debug_info=debug_info.model_dump(with_debug_details=self.debug),
                 content_chunks=content_chunks,
                 system_reminder=self.config.experimental_features.tool_response_system_reminder.get_reminder_prompt,
+                invocation_stats=debug_info.invocation_stats,
             )
 
         except Exception as e:
@@ -233,6 +234,7 @@ class WebSearchTool(Tool[WebSearchConfig]):
                 name=self.name,
                 debug_info=debug_info.model_dump(with_debug_details=self.debug),
                 error_message=str(e),
+                invocation_stats=debug_info.invocation_stats,
             )
 
     def _get_executor(

--- a/tool_packages/unique_web_search/src/unique_web_search/services/argument_screening/service.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/argument_screening/service.py
@@ -15,7 +15,7 @@ from unique_toolkit._common.utils.structured_output.schema import StructuredOutp
 from unique_toolkit._common.validators import LMI
 from unique_toolkit.language_model import LanguageModelService
 
-from unique_web_search.schema import StepDebugInfo
+from unique_web_search.schema import StepDebugInfo, WebSearchDebugInfo
 from unique_web_search.services.argument_screening.config import (
     ArgumentScreeningConfig,
 )
@@ -63,12 +63,17 @@ class ArgumentScreeningService:
         self._config = config
 
     async def __call__(
-        self, arguments: dict, message_log_callback: WebSearchMessageLogger
+        self,
+        arguments: dict,
+        message_log_callback: WebSearchMessageLogger,
+        debug_info: WebSearchDebugInfo | None = None,
     ) -> ArgumentScreeningResult:
         """Screen tool call arguments; raises on rejection.
 
         Args:
             arguments: The raw tool call arguments dict.
+            debug_info: when given, receives per-invocation usage stats from the
+                screening LLM call via `debug_info.add_invocation(...)`.
 
         Raises:
             ArgumentScreeningException: If the screening agent flags the arguments.
@@ -81,7 +86,7 @@ class ArgumentScreeningService:
         await message_log_callback.log_progress("PII Detection running...")
 
         start_time = time()
-        result = await self._screen_arguments(arguments)
+        result = await self._screen_arguments(arguments, debug_info)
         result._execution_time = time() - start_time
 
         if not result.go:
@@ -91,7 +96,9 @@ class ArgumentScreeningService:
 
         return result
 
-    async def _screen_arguments(self, arguments: dict) -> ArgumentScreeningResult:
+    async def _screen_arguments(
+        self, arguments: dict, debug_info: WebSearchDebugInfo | None = None
+    ) -> ArgumentScreeningResult:
         _LOGGER.info("Running argument screening agent...")
 
         serialized_args = json.dumps(arguments, indent=2, default=str)
@@ -116,6 +123,7 @@ class ArgumentScreeningService:
                 system_message=self._config.system_prompt,
                 user_message=user_prompt,
                 response_model=ArgumentScreeningResult,
+                debug_info=debug_info,
             )
         except StructuredLlmUnparseableResponseError as e:
             raise ArgumentScreeningUnparseableResponseException(

--- a/tool_packages/unique_web_search/src/unique_web_search/services/content_processing/processing_strategies/base.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/content_processing/processing_strategies/base.py
@@ -1,11 +1,13 @@
-from typing import Protocol, TypedDict, Unpack
+from typing import NotRequired, Protocol, TypedDict, Unpack
 
+from unique_web_search.schema import WebSearchDebugInfo
 from unique_web_search.services.search_engine.schema import WebSearchResult
 
 
 class ProcessingStrategyKwargs(TypedDict):
     page: WebSearchResult
     query: str
+    debug_info: NotRequired[WebSearchDebugInfo | None]
 
 
 class ProcessingStrategy(Protocol):

--- a/tool_packages/unique_web_search/src/unique_web_search/services/content_processing/processing_strategies/llm_guard_judge.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/content_processing/processing_strategies/llm_guard_judge.py
@@ -6,6 +6,7 @@ from unique_toolkit._common.utils.jinja.render import render_template
 from unique_toolkit.language_model import LanguageModelService
 from unique_toolkit.language_model.builder import MessagesBuilder
 
+from unique_web_search.schema import WebSearchDebugInfo
 from unique_web_search.services.content_processing.processing_strategies.base import (
     ProcessingStrategyKwargs,
     WebSearchResult,
@@ -208,7 +209,9 @@ class LLMGuardJudge:
             sanitize=True,
         )
 
-        parsed = await self._complete(LLMGuardResponse, system_prompt, user_prompt)
+        parsed = await self._complete(
+            LLMGuardResponse, system_prompt, user_prompt, kwargs.get("debug_info")
+        )
         return parsed.apply_to_page(page, self._config.privacy_filter.flag_message)
 
     async def judge_only(
@@ -235,7 +238,9 @@ class LLMGuardJudge:
             task_description=_JUDGE_TASK_PREFIX,
         )
 
-        parsed = await self._complete(JudgeResponse, system_prompt, user_prompt)
+        parsed = await self._complete(
+            JudgeResponse, system_prompt, user_prompt, kwargs.get("debug_info")
+        )
 
         _LOGGER.info(
             f"Judge result for {page.url}: needs_sanitization={parsed.needs_sanitization}"
@@ -268,7 +273,10 @@ class LLMGuardJudge:
         )
 
         parsed = await self._complete(
-            JudgeAndSanitizeResponse, system_prompt, user_prompt
+            JudgeAndSanitizeResponse,
+            system_prompt,
+            user_prompt,
+            kwargs.get("debug_info"),
         )
 
         _LOGGER.info(
@@ -289,6 +297,7 @@ class LLMGuardJudge:
         response_model: type[_T],
         system_prompt: str,
         user_prompt: str,
+        debug_info: WebSearchDebugInfo | None = None,
     ) -> _T:
         """Build messages, call the LLM, and return the parsed structured response."""
         messages = (
@@ -309,6 +318,13 @@ class LLMGuardJudge:
             structured_output_model=response_model,
             structured_output_enforce_schema=True,
         )
+
+        if debug_info is not None:
+            debug_info.add_invocation(
+                self._config.language_model.name,
+                response.usage,
+                source="web_search_llm_guard_judge",
+            )
 
         if response.choices[0].message.parsed is None:
             raise ValueError("Judge call returned no parsed response")

--- a/tool_packages/unique_web_search/src/unique_web_search/services/content_processing/processing_strategies/llm_keyword_redact.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/content_processing/processing_strategies/llm_keyword_redact.py
@@ -184,6 +184,14 @@ class LLMKeywordRedact:
         if response.choices[0].message.parsed is None:
             raise ValueError("Keyword extraction call returned no parsed response")
 
+        debug_info = kwargs.get("debug_info")
+        if debug_info is not None:
+            debug_info.add_invocation(
+                self._config.language_model.name,
+                response.usage,
+                source="web_search_llm_keyword_redact",
+            )
+
         parsed = KeywordRedactResponse.model_validate(
             response.choices[0].message.parsed
         )

--- a/tool_packages/unique_web_search/src/unique_web_search/services/content_processing/processing_strategies/llm_process.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/content_processing/processing_strategies/llm_process.py
@@ -320,6 +320,14 @@ class LLMProcess:
         if response.choices[0].message.parsed is None:
             raise ValueError("Failed to parse response")
 
+        debug_info = kwargs.get("debug_info")
+        if debug_info is not None:
+            debug_info.add_invocation(
+                self._config.language_model.name,
+                response.usage,
+                source="web_search_llm_process",
+            )
+
         parsed = LLMProcessorResponse.model_validate(response.choices[0].message.parsed)
         return parsed.apply_to_page(page)
 

--- a/tool_packages/unique_web_search/src/unique_web_search/services/content_processing/service.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/content_processing/service.py
@@ -5,6 +5,7 @@ from unique_toolkit._common.execution import SafeTaskExecutor
 from unique_toolkit._common.utils.jinja.render import render_template
 from unique_toolkit.language_model import LanguageModelService, TypeDecoder, TypeEncoder
 
+from unique_web_search.schema import WebSearchDebugInfo
 from unique_web_search.services.content_processing.cleaning import (
     CharacterSanitize,
     LineRemoval,
@@ -84,12 +85,16 @@ class ContentProcessor:
         self,
         query: str,
         pages: list[WebSearchResult],
+        debug_info: WebSearchDebugInfo | None = None,
     ) -> list[WebPageChunk]:
         """
         Preprocess the pages content.
         Args:
             query: The search query.
             pages: list of pages.
+            debug_info: when given, receives per-invocation usage stats from any
+                LLM processing strategy (summarization, guard/judge, keyword
+                privacy filtering) via `debug_info.add_invocation(...)`.
         Returns:
             list[WebPageChunk]: List of processed webpage chunks.
         """
@@ -98,7 +103,7 @@ class ContentProcessor:
         pages = [self._clean_content(page) for page in pages]
 
         ## Apply Processing Strategies
-        processed_pages = await self._process_pages(query, pages)
+        processed_pages = await self._process_pages(query, pages, debug_info)
 
         ## Split pages to chunks
         pages_chunks = self._split_pages_to_chunks(processed_pages)
@@ -124,6 +129,7 @@ class ContentProcessor:
         self,
         query: str,
         pages: list[WebSearchResult],
+        debug_info: WebSearchDebugInfo | None = None,
     ) -> list[WebSearchResult]:
         # Apply processing strategy with regex preprocessing as baseline
         active_strategies = [
@@ -137,7 +143,7 @@ class ContentProcessor:
         async def process_single_page(page: WebSearchResult) -> WebSearchResult:
             for strategy in self._processing_strategies:
                 if strategy.is_enabled:
-                    page = await strategy(page=page, query=query)
+                    page = await strategy(page=page, query=query, debug_info=debug_info)
             return page
 
         safe_task_executor = SafeTaskExecutor(logger=_LOGGER)

--- a/tool_packages/unique_web_search/src/unique_web_search/services/executors/base_executor.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/executors/base_executor.py
@@ -21,8 +21,6 @@ from unique_toolkit.monitoring import metric_scope
 
 from unique_web_search.metrics import llm_duration, llm_errors
 from unique_web_search.schema import (
-    WEB_SEARCH_CHUNK_RELEVANCY_FALLBACK_SOURCE,
-    WEB_SEARCH_CHUNK_RELEVANCY_SOURCE,
     StepDebugInfo,
     WebPageChunk,
 )
@@ -211,8 +209,8 @@ class BaseWebSearchExecutor(ABC, Generic[T]):
                 sorted_chunks,
                 self.chunk_relevancy_sort_config,
                 self.debug_info.invocation_stats,
-                source=WEB_SEARCH_CHUNK_RELEVANCY_SOURCE,
-                fallback_source=WEB_SEARCH_CHUNK_RELEVANCY_FALLBACK_SOURCE,
+                source="web_search_chunk_relevancy",
+                fallback_source="web_search_chunk_relevancy_fallback",
             )
             _LOGGER.info(f"Sorting chunks message: {sorted_chunks.user_message}")
             return sorted_chunks.content_chunks

--- a/tool_packages/unique_web_search/src/unique_web_search/services/executors/base_executor.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/executors/base_executor.py
@@ -5,15 +5,24 @@ from typing import Generic, TypeVar
 
 from pydantic import BaseModel
 from unique_search_proxy_core.param_policy.exposed_params import ExposedParams
+from unique_toolkit._common.chunk_relevancy_sorter.config import (
+    ChunkRelevancySortConfig,
+)
+from unique_toolkit._common.chunk_relevancy_sorter.schemas import (
+    ChunkRelevancySorterResult,
+)
 from unique_toolkit.agentic.tools.tool_progress_reporter import (
     ProgressState,
 )
 from unique_toolkit.content import ContentChunk
 from unique_toolkit.language_model import LanguageModelFunction
+from unique_toolkit.language_model.invocation_stats import LanguageModelInvocationStats
 from unique_toolkit.monitoring import metric_scope
 
 from unique_web_search.metrics import llm_duration, llm_errors
 from unique_web_search.schema import (
+    WEB_SEARCH_CHUNK_RELEVANCY_FALLBACK_SOURCE,
+    WEB_SEARCH_CHUNK_RELEVANCY_SOURCE,
     StepDebugInfo,
     WebPageChunk,
 )
@@ -30,6 +39,44 @@ _LOGGER = logging.getLogger(__name__)
 
 
 T = TypeVar("T", bound=BaseModel)
+
+
+def _append_chunk_relevancy_invocation_stats(
+    sorter_result: ChunkRelevancySorterResult,
+    config: ChunkRelevancySortConfig,
+    accumulator: list[LanguageModelInvocationStats],
+    *,
+    source: str,
+    fallback_source: str,
+) -> None:
+    """Remap per-chunk relevancy stats onto tool-scoped source names."""
+    primary_name = config.language_model.name
+    fallback_name = (
+        config.fallback_language_model.name
+        if config.fallback_language_model is not None
+        else None
+    )
+    for chunk_relevancy in sorter_result.relevancies:
+        relevancy = chunk_relevancy.relevancy
+        if relevancy is None:
+            continue
+        for stat in relevancy.invocation_stats:
+            if stat.token_usage is None:
+                continue
+            # Only label fallback when the configured models differ; identical
+            # names cannot distinguish primary vs fallback after the fact.
+            is_fallback = (
+                fallback_name is not None
+                and fallback_name != primary_name
+                and stat.model_name == fallback_name
+            )
+            accumulator.append(
+                LanguageModelInvocationStats.from_usage(
+                    stat.model_name,
+                    stat.token_usage,
+                    source=fallback_source if is_fallback else source,
+                )
+            )
 
 
 class BaseWebSearchExecutor(ABC, Generic[T]):
@@ -121,7 +168,7 @@ class BaseWebSearchExecutor(ABC, Generic[T]):
         )
         with metric_scope(llm_duration, llm_errors, purpose="content_processing"):
             content_results = await self.content_processor.run(
-                objective, web_search_results
+                objective, web_search_results, debug_info=self.debug_info
             )
         end_time = time()
         delta_time = end_time - start_time
@@ -159,6 +206,13 @@ class BaseWebSearchExecutor(ABC, Generic[T]):
                 input_text=objective,
                 chunks=content,
                 config=self.chunk_relevancy_sort_config,
+            )
+            _append_chunk_relevancy_invocation_stats(
+                sorted_chunks,
+                self.chunk_relevancy_sort_config,
+                self.debug_info.invocation_stats,
+                source=WEB_SEARCH_CHUNK_RELEVANCY_SOURCE,
+                fallback_source=WEB_SEARCH_CHUNK_RELEVANCY_FALLBACK_SOURCE,
             )
             _LOGGER.info(f"Sorting chunks message: {sorted_chunks.user_message}")
             return sorted_chunks.content_chunks

--- a/tool_packages/unique_web_search/src/unique_web_search/services/executors/v1/executor.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/executors/v1/executor.py
@@ -21,7 +21,7 @@ from unique_web_search.metrics import (
     search_errors,
     search_total,
 )
-from unique_web_search.schema import StepDebugInfo
+from unique_web_search.schema import StepDebugInfo, WebSearchDebugInfo
 from unique_web_search.services.executors.base_executor import (
     BaseWebSearchExecutor,
 )
@@ -93,6 +93,7 @@ async def query_generation_agent(
     language_model: LMI,
     system_prompt: str,
     mode: RefineQueryMode,
+    debug_info: WebSearchDebugInfo | None = None,
 ) -> RefinedQuery | RefinedQueries:
     """Refine the query to be more specific and relevant to the user's question."""
     match mode:
@@ -124,6 +125,13 @@ async def query_generation_agent(
         structured_output_model=structured_output_model,
         structured_output_enforce_schema=True,
     )
+
+    if debug_info is not None:
+        debug_info.add_invocation(
+            language_model.name,
+            response.usage,
+            source="web_search_query_refinement",
+        )
 
     parsed_response = response.choices[0].message.parsed
     if parsed_response is None:
@@ -238,6 +246,7 @@ class WebSearchV1Executor(BaseWebSearchExecutor[WebSearchToolParameters]):
                 self.refine_query_language_model,
                 self.refine_query_system_prompt,
                 self.mode,
+                debug_info=self.debug_info,
             )
         end_time = time()
         delta_time = end_time - start_time
@@ -275,7 +284,11 @@ class WebSearchV1Executor(BaseWebSearchExecutor[WebSearchToolParameters]):
         _LOGGER.info(f"Company {self.company_id} Searching with {engine}")
         with metric_scope(search_duration, search_errors, engine=engine):
             search_total.labels(engine=engine).inc()
-            search_results = await self.search_service.search(query, params=params)
+            search_results = await self.search_service.search(
+                query,
+                params=params,
+                invocation_stats=self.debug_info.invocation_stats,
+            )
         end_time = time()
         delta_time = end_time - start_time
         _LOGGER.info(f"Searched with {engine} completed in {delta_time} seconds")

--- a/tool_packages/unique_web_search/src/unique_web_search/services/executors/v2/executor.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/executors/v2/executor.py
@@ -129,7 +129,10 @@ class WebSearchV2Executor(BaseWebSearchExecutor[WebSearchPlan]):
         await self._message_log_callback.log_queries([step.query_or_url])
         with metric_scope(search_duration, search_errors, engine=engine):
             search_total.labels(engine=engine).inc()
-            results = await self.search_service.search(step.query_or_url)
+            results = await self.search_service.search(
+                step.query_or_url,
+                invocation_stats=self.debug_info.invocation_stats,
+            )
 
         await self._message_log_callback.log_web_search_results(results)
 

--- a/tool_packages/unique_web_search/src/unique_web_search/services/executors/v3/executor.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/executors/v3/executor.py
@@ -108,7 +108,11 @@ class WebSearchV3Executor(BaseWebSearchExecutor[WebSearchV3ToolParameters]):
         await self._message_log_callback.log_queries([query])
         with metric_scope(search_duration, search_errors, engine=engine):
             search_total.labels(engine=engine).inc()
-            results = await self.search_service.search(query, params=params)
+            results = await self.search_service.search(
+                query,
+                params=params,
+                invocation_stats=self.debug_info.invocation_stats,
+            )
         await self._message_log_callback.log_web_search_results(results)
 
         delta_time = time() - time_start

--- a/tool_packages/unique_web_search/src/unique_web_search/services/search_engine/base.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/search_engine/base.py
@@ -12,6 +12,7 @@ from unique_search_proxy_core.search_engines.base import (
     BaseSearchEngineConfig,
     SearchEngineType,
 )
+from unique_toolkit.language_model.invocation_stats import LanguageModelInvocationStats
 
 from unique_web_search.services.proxy.bridge import (
     open_search_proxy_client,
@@ -88,26 +89,53 @@ class SearchEngine(ABC, Generic[SearchEngineConfig]):
             return engine
         return None
 
+    def _response_parsers_for(
+        self,
+        invocation_stats: list[LanguageModelInvocationStats] | None,
+    ) -> list[ResponseParser]:
+        """Clone agent parsers so LLM fallback usage can bind to a run-scoped list."""
+        parsers = getattr(self, "response_parsers", None)
+        if not parsers:
+            return []
+        if invocation_stats is None:
+            return list(parsers)
+        return [
+            parser.with_invocation_stats(invocation_stats)
+            if hasattr(parser, "with_invocation_stats")
+            else parser
+            for parser in parsers
+        ]
+
     async def search(
         self,
         query: str,
         params: ExposedParams | None = None,
+        *,
+        invocation_stats: list[LanguageModelInvocationStats] | None = None,
     ) -> list[WebSearchResult]:
         """Search the web for the given query using the search engine."""
         proxy_engine = self._proxy_engine
         if search_proxy_client_enabled and proxy_engine is not None:
-            return await self._proxy_search(query, params, proxy_engine)
-        return await self._legacy_search(query=query, params=params)
+            return await self._proxy_search(
+                query, params, proxy_engine, invocation_stats=invocation_stats
+            )
+        return await self._legacy_search(
+            query=query, params=params, invocation_stats=invocation_stats
+        )
 
     async def _proxy_search(
         self,
         query: str,
         params: ExposedParams | None,
         engine: ProxyEngineType,
+        *,
+        invocation_stats: list[LanguageModelInvocationStats] | None = None,
     ) -> list[WebSearchResult]:
         """Dispatch to the appropriate proxy path for the given engine."""
         if isinstance(engine, AgentEngineType):
-            return await self._agent_proxy_search(query, params, engine)
+            return await self._agent_proxy_search(
+                query, params, engine, invocation_stats=invocation_stats
+            )
         return await self._standard_proxy_search(query, params, engine)
 
     async def _standard_proxy_search(
@@ -143,6 +171,8 @@ class SearchEngine(ABC, Generic[SearchEngineConfig]):
         query: str,
         params: ExposedParams | None,
         engine: AgentEngineType,
+        *,
+        invocation_stats: list[LanguageModelInvocationStats] | None = None,
     ) -> list[WebSearchResult]:
         """Dispatch a grounded agent search via the proxy SDK and parse the answer."""
         del params  # Agent engines do not expose LLM knobs today.
@@ -157,7 +187,7 @@ class SearchEngine(ABC, Generic[SearchEngineConfig]):
             )
         results = await map_agent_answer(
             agent_answer_text(response),
-            self.response_parsers,
+            self._response_parsers_for(invocation_stats),
         )
         return await self._postprocess_results(results)
 
@@ -190,5 +220,7 @@ class SearchEngine(ABC, Generic[SearchEngineConfig]):
         self,
         query: str,
         params: ExposedParams | None,
+        *,
+        invocation_stats: list[LanguageModelInvocationStats] | None = None,
     ) -> list[WebSearchResult]:
         """Search the web directly without the search proxy."""

--- a/tool_packages/unique_web_search/src/unique_web_search/services/search_engine/bing.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/search_engine/bing.py
@@ -93,6 +93,8 @@ class BingSearch(SearchEngine[BingSearchConfig]):
         self,
         query: str,
         params: ExposedParams | None,
+        *,
+        invocation_stats=None,
     ) -> list[WebSearchResult]:
         del params
         agent_client = get_project_client(self.credentials, self.config.endpoint)
@@ -102,7 +104,7 @@ class BingSearch(SearchEngine[BingSearchConfig]):
             agent_id=self.config.agent_id,
             query=query,
             fetch_size=self.config.fetch_size,
-            response_parsers_strategies=self.response_parsers,
+            response_parsers_strategies=self._response_parsers_for(invocation_stats),
             generation_instructions=self.config.generation_instructions,
         )
 

--- a/tool_packages/unique_web_search/src/unique_web_search/services/search_engine/brave.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/search_engine/brave.py
@@ -38,5 +38,8 @@ class BraveSearch(SearchEngine[BraveConfig]):
         self,
         query: str,
         params: ExposedParams | None,
+        *,
+        invocation_stats=None,
     ) -> list[WebSearchResult]:
+        del query, params, invocation_stats
         raise NotImplementedError("Brave search is not supported in the legacy mode")

--- a/tool_packages/unique_web_search/src/unique_web_search/services/search_engine/custom_api.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/search_engine/custom_api.py
@@ -106,8 +106,10 @@ class CustomAPI(SearchEngine[CustomAPIConfig]):
         self,
         query: str,
         params: ExposedParams | None,
+        *,
+        invocation_stats=None,
     ) -> list[WebSearchResult]:
-        del params
+        del params, invocation_stats
         params_dict, body = self._prepare_request_params_and_body(query)
         async_client_params = self._client_config | {
             "timeout": self.config.timeout,

--- a/tool_packages/unique_web_search/src/unique_web_search/services/search_engine/google.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/search_engine/google.py
@@ -39,8 +39,11 @@ class GoogleSearch(SearchEngine[GoogleConfig]):
         self,
         query: str,
         params: ExposedParams | None,
+        *,
+        invocation_stats=None,
     ) -> list[WebSearchResult]:
         """Search the web for the given query."""
+        del invocation_stats
         try:
             search_results = await self._paginated_url_extraction(
                 query=query,

--- a/tool_packages/unique_web_search/src/unique_web_search/services/search_engine/perplexity.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/search_engine/perplexity.py
@@ -37,7 +37,10 @@ class PerplexitySearch(SearchEngine[PerplexityConfig]):
         self,
         query: str,
         params: ExposedParams | None,
+        *,
+        invocation_stats=None,
     ) -> list[WebSearchResult]:
+        del query, params, invocation_stats
         raise NotImplementedError(
             "Perplexity search is not supported in the legacy mode"
         )

--- a/tool_packages/unique_web_search/src/unique_web_search/services/search_engine/utils/grounding/__init__.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/search_engine/utils/grounding/__init__.py
@@ -5,6 +5,7 @@ from unique_web_search.services.search_engine.utils.grounding.models import (
     ResultItem,
 )
 from unique_web_search.services.search_engine.utils.grounding.response_parsing import (
+    WEB_SEARCH_GROUNDING_PARSER_SOURCE,
     JsonConversionStrategy,
     LLMParserStrategy,
     ResponseParser,
@@ -19,5 +20,6 @@ __all__ = [
     "JsonConversionStrategy",
     "LLMParserStrategy",
     "ResponseParser",
+    "WEB_SEARCH_GROUNDING_PARSER_SOURCE",
     "convert_response_to_search_results",
 ]

--- a/tool_packages/unique_web_search/src/unique_web_search/services/search_engine/utils/grounding/__init__.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/search_engine/utils/grounding/__init__.py
@@ -5,7 +5,6 @@ from unique_web_search.services.search_engine.utils.grounding.models import (
     ResultItem,
 )
 from unique_web_search.services.search_engine.utils.grounding.response_parsing import (
-    WEB_SEARCH_GROUNDING_PARSER_SOURCE,
     JsonConversionStrategy,
     LLMParserStrategy,
     ResponseParser,
@@ -20,6 +19,5 @@ __all__ = [
     "JsonConversionStrategy",
     "LLMParserStrategy",
     "ResponseParser",
-    "WEB_SEARCH_GROUNDING_PARSER_SOURCE",
     "convert_response_to_search_results",
 ]

--- a/tool_packages/unique_web_search/src/unique_web_search/services/search_engine/utils/grounding/response_parsing.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/search_engine/utils/grounding/response_parsing.py
@@ -15,7 +15,6 @@ from unique_web_search.services.search_engine.utils.grounding.models import (
 
 _LOGGER = logging.getLogger(__name__)
 _JSON_PATTERN = re.compile(r"```json\s*([\s\S]*?)\s*```")
-WEB_SEARCH_GROUNDING_PARSER_SOURCE = "web_search_grounding_parser"
 
 
 class ResponseParser(Protocol):
@@ -120,7 +119,7 @@ class LLMParserStrategy(ResponseParser):
                 LanguageModelInvocationStats.from_usage(
                     self.llm.name,
                     llm_response.usage,
-                    source=WEB_SEARCH_GROUNDING_PARSER_SOURCE,
+                    source="web_search_grounding_parser",
                 )
             )
 

--- a/tool_packages/unique_web_search/src/unique_web_search/services/search_engine/utils/grounding/response_parsing.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/search_engine/utils/grounding/response_parsing.py
@@ -1,9 +1,11 @@
 import logging
 import re
-from typing import Protocol
+from typing import Protocol, Self
 
 from unique_toolkit._common.validators import LMI
 from unique_toolkit.language_model.builder import MessagesBuilder
+from unique_toolkit.language_model.invocation_stats import LanguageModelInvocationStats
+from unique_toolkit.language_model.schemas import LanguageModelTokenUsage
 from unique_toolkit.language_model.service import LanguageModelService
 
 from unique_web_search.services.search_engine.schema import WebSearchResult
@@ -13,6 +15,7 @@ from unique_web_search.services.search_engine.utils.grounding.models import (
 
 _LOGGER = logging.getLogger(__name__)
 _JSON_PATTERN = re.compile(r"```json\s*([\s\S]*?)\s*```")
+WEB_SEARCH_GROUNDING_PARSER_SOURCE = "web_search_grounding_parser"
 
 
 class ResponseParser(Protocol):
@@ -73,9 +76,26 @@ class LLMParserStrategy(ResponseParser):
         ValueError: If the LLM response does not contain a valid parsed result.
     """
 
-    def __init__(self, llm: LMI, llm_service: LanguageModelService):
+    def __init__(
+        self,
+        llm: LMI,
+        llm_service: LanguageModelService,
+        *,
+        invocation_stats: list[LanguageModelInvocationStats] | None = None,
+    ):
         self.llm = llm
         self.llm_service = llm_service
+        self.invocation_stats = invocation_stats
+
+    def with_invocation_stats(
+        self, invocation_stats: list[LanguageModelInvocationStats]
+    ) -> Self:
+        """Return a copy bound to a run-scoped stats accumulator."""
+        return LLMParserStrategy(
+            self.llm,
+            self.llm_service,
+            invocation_stats=invocation_stats,
+        )
 
     async def __call__(self, response: str) -> list[WebSearchResult]:
         system_prompt = """You are a helpful assistant that converts an non-structured response to a structured response."""
@@ -92,6 +112,17 @@ class LLMParserStrategy(ResponseParser):
             structured_output_model=GroundingSearchResults,
             structured_output_enforce_schema=True,
         )
+
+        if self.invocation_stats is not None and isinstance(
+            llm_response.usage, LanguageModelTokenUsage
+        ):
+            self.invocation_stats.append(
+                LanguageModelInvocationStats.from_usage(
+                    self.llm.name,
+                    llm_response.usage,
+                    source=WEB_SEARCH_GROUNDING_PARSER_SOURCE,
+                )
+            )
 
         if not llm_response.choices[0].message.parsed:
             raise ValueError("No JSON found in the response")

--- a/tool_packages/unique_web_search/src/unique_web_search/services/search_engine/vertexai.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/search_engine/vertexai.py
@@ -98,6 +98,8 @@ class VertexAI(SearchEngine[VertexAIConfig]):
         self,
         query: str,
         params: ExposedParams | None,
+        *,
+        invocation_stats=None,
     ) -> list[WebSearchResult]:
         del params
         assert self._client is not None, "VertexAI client is not configured"
@@ -115,7 +117,7 @@ class VertexAI(SearchEngine[VertexAIConfig]):
         answer_with_citations = add_citations(response)
 
         results = await convert_response_to_search_results(
-            answer_with_citations, self.response_parsers
+            answer_with_citations, self._response_parsers_for(invocation_stats)
         )
 
         return await self._postprocess_results(results)

--- a/tool_packages/unique_web_search/src/unique_web_search/services/structured_llm.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/structured_llm.py
@@ -7,6 +7,8 @@ from unique_toolkit._common.validators import LMI
 from unique_toolkit.language_model import LanguageModelService
 from unique_toolkit.language_model.builder import MessagesBuilder
 
+from unique_web_search.schema import WebSearchDebugInfo
+
 T = TypeVar("T", bound=BaseModel)
 
 
@@ -22,6 +24,8 @@ async def complete_structured_llm(
     user_message: str,
     response_model: type[T],
     structured_output_enforce_schema: bool = True,
+    debug_info: WebSearchDebugInfo | None = None,
+    source: str = "web_search_argument_screening",
 ) -> T:
     """Run a structured completion and return a validated model instance."""
     messages = (
@@ -37,6 +41,13 @@ async def complete_structured_llm(
         structured_output_model=response_model,
         structured_output_enforce_schema=structured_output_enforce_schema,
     )
+
+    if debug_info is not None:
+        debug_info.add_invocation(
+            language_model.name,
+            response.usage,
+            source=source,
+        )
 
     parsed = response.choices[0].message.parsed
     if parsed is None:

--- a/tool_packages/unique_web_search/tests/test_argument_screening.py
+++ b/tool_packages/unique_web_search/tests/test_argument_screening.py
@@ -1,7 +1,9 @@
 from unittest.mock import AsyncMock, Mock
 
 import pytest
+from unique_toolkit.language_model.schemas import LanguageModelTokenUsage
 
+from unique_web_search.schema import WebSearchDebugInfo
 from unique_web_search.services.argument_screening import (
     DEFAULT_GUIDELINES,
     DEFAULT_REJECTION_RESPONSE_TEMPLATE,
@@ -171,6 +173,63 @@ class TestArgumentScreeningService:
 
         assert result.go is False
         assert "credit card number" in result.reason
+
+    @pytest.mark.asyncio
+    async def test_carries_usage_into_debug_info(
+        self,
+        enabled_config,
+        mock_language_model_service,
+        mock_language_model,
+        mock_message_log_callback,
+    ):
+        mock_response = Mock()
+        mock_response.choices = [
+            Mock(message=Mock(parsed={"go": True, "reason": "Safe query"}))
+        ]
+        mock_response.usage = LanguageModelTokenUsage(
+            completion_tokens=5, prompt_tokens=42, total_tokens=47
+        )
+        mock_language_model_service.complete_async.return_value = mock_response
+
+        service = ArgumentScreeningService(
+            language_model_service=mock_language_model_service,
+            language_model=mock_language_model,
+            config=enabled_config,
+        )
+        debug_info = WebSearchDebugInfo(parameters={})
+        await service(
+            {"query": "Python best practices"},
+            mock_message_log_callback,
+            debug_info=debug_info,
+        )
+
+        assert len(debug_info.invocation_stats) == 1
+        stat = debug_info.invocation_stats[0]
+        assert stat.model_name == "test-model"
+        assert stat.token_usage == LanguageModelTokenUsage(
+            completion_tokens=5, prompt_tokens=42, total_tokens=47
+        )
+        assert stat.source == "web_search_argument_screening"
+
+    @pytest.mark.asyncio
+    async def test_debug_info_usage_untouched_when_screening_disabled(
+        self,
+        disabled_config,
+        mock_language_model_service,
+        mock_language_model,
+        mock_message_log_callback,
+    ):
+        service = ArgumentScreeningService(
+            language_model_service=mock_language_model_service,
+            language_model=mock_language_model,
+            config=disabled_config,
+        )
+        debug_info = WebSearchDebugInfo(parameters={})
+        await service(
+            {"query": "test query"}, mock_message_log_callback, debug_info=debug_info
+        )
+
+        assert debug_info.invocation_stats == []
 
     @pytest.mark.asyncio
     async def test_raises_when_response_unparseable(

--- a/tool_packages/unique_web_search/tests/test_bing_runner.py
+++ b/tool_packages/unique_web_search/tests/test_bing_runner.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from azure.ai.agents.models import MessageTextContent, MessageTextUrlCitationAnnotation
 from pydantic import ValidationError
+from unique_toolkit.language_model.schemas import LanguageModelTokenUsage
 
 from unique_web_search.services.search_engine.schema import (
     WebSearchResult,
@@ -24,6 +25,9 @@ from unique_web_search.services.search_engine.utils.grounding.bing.runner import
     create_and_process_run,
     get_bing_grounding_tool,
     get_or_create_agent_id,
+)
+from unique_web_search.services.search_engine.utils.grounding.response_parsing import (
+    WEB_SEARCH_GROUNDING_PARSER_SOURCE,
 )
 
 # ---------------------------------------------------------------------------
@@ -327,6 +331,7 @@ class TestLLMParserStrategy:
         mock_choice.message.parsed = parsed_data.model_dump()
         mock_response = MagicMock()
         mock_response.choices = [mock_choice]
+        mock_response.usage = None
         mock_service.complete_async = AsyncMock(return_value=mock_response)
 
         strategy = LLMParserStrategy(llm=mock_lmi, llm_service=mock_service)
@@ -339,6 +344,49 @@ class TestLLMParserStrategy:
         assert results[0].url == "https://llm-parsed.com"
         assert results[0].title == "LLM Parsed"
         mock_service.complete_async.assert_called_once()
+
+    @pytest.mark.ai
+    @pytest.mark.asyncio
+    async def test_call__records_invocation_stats_when_accumulator_bound(self) -> None:
+        """
+        Purpose: Verify successful LMS usage is appended to a run-scoped accumulator.
+        Why this matters: Bing/Vertex grounding fallback was an untracked live LLM call.
+        Setup summary: Bind an empty list and return LanguageModelTokenUsage on the mock.
+        """
+        mock_lmi = MagicMock()
+        mock_lmi.name = "gpt-4o"
+        mock_service = MagicMock()
+
+        parsed_data = GroundingWithBingResults(
+            results=[
+                ResultItem(
+                    source_url="https://llm-parsed.com",
+                    source_title="LLM Parsed",
+                    detailed_answer="Parsed content",
+                    key_facts=["Parsed snippet"],
+                )
+            ]
+        )
+        mock_choice = MagicMock()
+        mock_choice.message.parsed = parsed_data.model_dump()
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+        mock_response.usage = LanguageModelTokenUsage(
+            completion_tokens=3, prompt_tokens=7, total_tokens=10
+        )
+        mock_service.complete_async = AsyncMock(return_value=mock_response)
+
+        invocation_stats: list = []
+        strategy = LLMParserStrategy(
+            llm=mock_lmi, llm_service=mock_service, invocation_stats=invocation_stats
+        )
+
+        await strategy("Some unstructured agent response text")
+
+        assert len(invocation_stats) == 1
+        assert invocation_stats[0].model_name == "gpt-4o"
+        assert invocation_stats[0].source == WEB_SEARCH_GROUNDING_PARSER_SOURCE
+        assert invocation_stats[0].token_usage.total_tokens == 10
 
     @pytest.mark.ai
     @pytest.mark.asyncio
@@ -357,6 +405,7 @@ class TestLLMParserStrategy:
         mock_choice.message.parsed = None
         mock_response = MagicMock()
         mock_response.choices = [mock_choice]
+        mock_response.usage = None
         mock_service.complete_async = AsyncMock(return_value=mock_response)
 
         strategy = LLMParserStrategy(llm=mock_lmi, llm_service=mock_service)
@@ -393,6 +442,7 @@ class TestLLMParserStrategy:
         mock_choice.message.parsed = parsed_data.model_dump()
         mock_response = MagicMock()
         mock_response.choices = [mock_choice]
+        mock_response.usage = None
         mock_service.complete_async = AsyncMock(return_value=mock_response)
 
         strategy = LLMParserStrategy(llm=mock_lmi, llm_service=mock_service)

--- a/tool_packages/unique_web_search/tests/test_bing_runner.py
+++ b/tool_packages/unique_web_search/tests/test_bing_runner.py
@@ -26,9 +26,6 @@ from unique_web_search.services.search_engine.utils.grounding.bing.runner import
     get_bing_grounding_tool,
     get_or_create_agent_id,
 )
-from unique_web_search.services.search_engine.utils.grounding.response_parsing import (
-    WEB_SEARCH_GROUNDING_PARSER_SOURCE,
-)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -385,7 +382,7 @@ class TestLLMParserStrategy:
 
         assert len(invocation_stats) == 1
         assert invocation_stats[0].model_name == "gpt-4o"
-        assert invocation_stats[0].source == WEB_SEARCH_GROUNDING_PARSER_SOURCE
+        assert invocation_stats[0].source == "web_search_grounding_parser"
         assert invocation_stats[0].token_usage.total_tokens == 10
 
     @pytest.mark.ai

--- a/tool_packages/unique_web_search/tests/test_content_processor_service.py
+++ b/tool_packages/unique_web_search/tests/test_content_processor_service.py
@@ -1,9 +1,11 @@
 """Tests for ContentProcessor service — cleaning, processing, and chunking."""
 
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
+from unique_toolkit.language_model.schemas import LanguageModelTokenUsage
 
+from unique_web_search.schema import WebSearchDebugInfo
 from unique_web_search.services.content_processing.config import (
     ContentProcessorConfig,
 )
@@ -258,3 +260,108 @@ class TestContentProcessorRun:
     ) -> None:
         chunks = await processor.run("test query", [])
         assert chunks == []
+
+
+class TestContentProcessorUsage:
+    @pytest.fixture
+    def llm_service_with_usage(self) -> Mock:
+        service = Mock()
+        response = Mock()
+        response.choices = [
+            Mock(
+                message=Mock(
+                    parsed={"snippet": "Sum snippet", "summary": "Sum content"}
+                )
+            )
+        ]
+        response.usage = LanguageModelTokenUsage(
+            completion_tokens=2, prompt_tokens=3, total_tokens=5
+        )
+        service.complete_async = AsyncMock(return_value=response)
+        return service
+
+    @pytest.fixture
+    def processor_with_llm(self, llm_service_with_usage: Mock) -> ContentProcessor:
+        config = ContentProcessorConfig()
+        config.processing_strategies.llm_processor.enabled = True
+        config.processing_strategies.llm_processor.min_tokens = 0
+        return ContentProcessor(
+            language_model_service=llm_service_with_usage,
+            config=config,
+            encoder=_simple_encoder,
+            decoder=_simple_decoder,
+        )
+
+    @pytest.mark.ai
+    @pytest.mark.asyncio
+    async def test_run__single_page__usage_recorded_on_debug_info(
+        self, processor_with_llm: ContentProcessor, fake_page: WebSearchResult
+    ) -> None:
+        debug_info = WebSearchDebugInfo(parameters={})
+
+        await processor_with_llm.run("test query", [fake_page], debug_info=debug_info)
+
+        assert len(debug_info.invocation_stats) == 1
+        stat = debug_info.invocation_stats[0]
+        assert (
+            stat.model_name
+            == processor_with_llm.config.processing_strategies.llm_processor.language_model.name
+        )
+        assert stat.token_usage == LanguageModelTokenUsage(
+            completion_tokens=2, prompt_tokens=3, total_tokens=5
+        )
+        assert stat.source == "web_search_llm_process"
+
+    @pytest.mark.ai
+    @pytest.mark.asyncio
+    async def test_run__multiple_concurrent_pages__usage_summed(
+        self, processor_with_llm: ContentProcessor
+    ) -> None:
+        """process_single_page runs concurrently across pages via
+        asyncio.gather -- each page's usage must be recorded as its own
+        invocation_stats entry on debug_info, not lost or overwritten by a
+        race."""
+        pages = [
+            WebSearchResult(
+                url=f"https://example.com/{i}",
+                title=f"Page {i}",
+                snippet=f"Snippet {i}",
+                content=f"Content {i}",
+            )
+            for i in range(5)
+        ]
+        debug_info = WebSearchDebugInfo(parameters={})
+
+        await processor_with_llm.run("test query", pages, debug_info=debug_info)
+
+        expected_model = processor_with_llm.config.processing_strategies.llm_processor.language_model.name
+        assert len(debug_info.invocation_stats) == 5
+        for stat in debug_info.invocation_stats:
+            assert stat.model_name == expected_model
+            assert stat.token_usage == LanguageModelTokenUsage(
+                completion_tokens=2, prompt_tokens=3, total_tokens=5
+            )
+            assert stat.source == "web_search_llm_process"
+
+        summed = LanguageModelTokenUsage(
+            completion_tokens=sum(
+                s.token_usage.completion_tokens for s in debug_info.invocation_stats
+            ),
+            prompt_tokens=sum(
+                s.token_usage.prompt_tokens for s in debug_info.invocation_stats
+            ),
+            total_tokens=sum(
+                s.token_usage.total_tokens for s in debug_info.invocation_stats
+            ),
+        )
+        assert summed == LanguageModelTokenUsage(
+            completion_tokens=10, prompt_tokens=15, total_tokens=25
+        )
+
+    @pytest.mark.ai
+    @pytest.mark.asyncio
+    async def test_run__no_debug_info__does_not_raise(
+        self, processor_with_llm: ContentProcessor, fake_page: WebSearchResult
+    ) -> None:
+        chunks = await processor_with_llm.run("test query", [fake_page])
+        assert len(chunks) >= 1

--- a/tool_packages/unique_web_search/tests/test_executors.py
+++ b/tool_packages/unique_web_search/tests/test_executors.py
@@ -17,7 +17,6 @@ from unique_toolkit.language_model.invocation_stats import LanguageModelInvocati
 from unique_toolkit.language_model.schemas import LanguageModelTokenUsage
 
 from unique_web_search.schema import (
-    WEB_SEARCH_CHUNK_RELEVANCY_SOURCE,
     WebPageChunk,
     WebSearchDebugInfo,
 )
@@ -1481,5 +1480,5 @@ class TestSelectRelevantSourcesInvocationStats:
         assert len(executor.debug_info.invocation_stats) == 1
         assert (
             executor.debug_info.invocation_stats[0].source
-            == WEB_SEARCH_CHUNK_RELEVANCY_SOURCE
+            == "web_search_chunk_relevancy"
         )

--- a/tool_packages/unique_web_search/tests/test_executors.py
+++ b/tool_packages/unique_web_search/tests/test_executors.py
@@ -4,7 +4,23 @@ from typing import Any
 from unittest.mock import AsyncMock, Mock
 
 import pytest
+from unique_toolkit._common.chunk_relevancy_sorter.schemas import (
+    ChunkRelevancy,
+    ChunkRelevancySorterResult,
+)
+from unique_toolkit.agentic.evaluation.schemas import (
+    EvaluationMetricName,
+    EvaluationMetricResult,
+)
+from unique_toolkit.content.schemas import ContentChunk
+from unique_toolkit.language_model.invocation_stats import LanguageModelInvocationStats
+from unique_toolkit.language_model.schemas import LanguageModelTokenUsage
 
+from unique_web_search.schema import (
+    WEB_SEARCH_CHUNK_RELEVANCY_SOURCE,
+    WebPageChunk,
+    WebSearchDebugInfo,
+)
 from unique_web_search.services.crawlers.url_safety import (
     CrawlTargetValidationError,
     UrlSafetyService,
@@ -165,6 +181,66 @@ class TestQueryGenerationAgent:
                 system_prompt="test prompt",
                 mode=RefineQueryMode.BASIC,
             )
+
+    @pytest.mark.ai
+    @pytest.mark.asyncio
+    async def test_query_generation_agent__records_usage_on_debug_info__when_mode_is_basic(
+        self,
+    ) -> None:
+        mock_lm_service = Mock()
+        mock_lm = Mock()
+        mock_lm.name = "test-model"
+
+        mock_response = Mock()
+        mock_response.choices = [Mock()]
+        mock_response.choices[0].message.parsed = {
+            "objective": "Find test info",
+            "refined_query": "optimized test query",
+        }
+        mock_response.usage = LanguageModelTokenUsage(
+            completion_tokens=3, prompt_tokens=7, total_tokens=10
+        )
+        mock_lm_service.complete_async = AsyncMock(return_value=mock_response)
+
+        debug_info = WebSearchDebugInfo(parameters={})
+        await query_generation_agent(
+            query="test query",
+            language_model_service=mock_lm_service,
+            language_model=mock_lm,
+            system_prompt="test prompt",
+            mode=RefineQueryMode.BASIC,
+            debug_info=debug_info,
+        )
+
+        assert len(debug_info.invocation_stats) == 1
+        stat = debug_info.invocation_stats[0]
+        assert stat.model_name == "test-model"
+        assert stat.token_usage == LanguageModelTokenUsage(
+            completion_tokens=3, prompt_tokens=7, total_tokens=10
+        )
+        assert stat.source == "web_search_query_refinement"
+
+    @pytest.mark.ai
+    @pytest.mark.asyncio
+    async def test_query_generation_agent__no_usage_when_deactivated(
+        self,
+    ) -> None:
+        debug_info = WebSearchDebugInfo(parameters={})
+        mock_lm_service = Mock()
+        mock_lm = Mock()
+        mock_lm.name = "test-model"
+
+        await query_generation_agent(
+            query="test query",
+            language_model_service=mock_lm_service,
+            language_model=mock_lm,
+            system_prompt="test prompt",
+            mode=RefineQueryMode.DEACTIVATED,
+            debug_info=debug_info,
+        )
+
+        assert debug_info.invocation_stats == []
+        mock_lm_service.complete_async.assert_not_called()
 
 
 class TestWebSearchV1ExecutorInit:
@@ -415,6 +491,48 @@ class TestWebSearchV1ExecutorRefineQuery:
         assert queries[0] == "query1"
         assert queries[1] == "query2"
         assert objective == "test objective"
+
+    @pytest.mark.ai
+    @pytest.mark.asyncio
+    async def test_refine_query__records_usage_on_debug_info(
+        self,
+        executor_context_objects: dict,
+        mock_executor_dependencies: dict,
+    ) -> None:
+        tool_parameters = WebSearchToolParameters(query="test")
+
+        mock_response = Mock()
+        mock_response.choices = [Mock()]
+        mock_response.choices[0].message.parsed = {
+            "objective": "test objective",
+            "refined_query": "refined test",
+        }
+        mock_response.usage = LanguageModelTokenUsage(
+            completion_tokens=4, prompt_tokens=6, total_tokens=10
+        )
+        mock_executor_dependencies["language_model_service"].complete_async = AsyncMock(
+            return_value=mock_response
+        )
+
+        executor = WebSearchV1Executor(
+            services=executor_context_objects["services"],
+            config=executor_context_objects["config"],
+            callbacks=executor_context_objects["callbacks"],
+            tool_call=mock_executor_dependencies["tool_call"],
+            tool_parameters=tool_parameters,
+            refine_query_system_prompt="test prompt",
+            refine_query_language_model=mock_executor_dependencies["language_model"],
+            mode=RefineQueryMode.BASIC,
+        )
+
+        await executor._refine_query("test query")
+
+        assert len(executor.debug_info.invocation_stats) == 1
+        stat = executor.debug_info.invocation_stats[0]
+        assert stat.source == "web_search_query_refinement"
+        assert stat.token_usage == LanguageModelTokenUsage(
+            completion_tokens=4, prompt_tokens=6, total_tokens=10
+        )
 
 
 class TestWebSearchV1ExecutorEnforceMaxQueries:
@@ -1282,3 +1400,86 @@ class TestWebSearchV2ExecutorDebugInfo:
         )
         assert search_step is not None
         assert search_step.extra["query"] == "test query"
+
+
+class TestSelectRelevantSourcesInvocationStats:
+    @pytest.mark.ai
+    @pytest.mark.asyncio
+    async def test_select_relevant_sources__chunk_relevancy_enabled__records_stats(
+        self,
+        executor_context_objects: dict,
+        mock_executor_dependencies: dict,
+    ) -> None:
+        mock_config = mock_executor_dependencies["chunk_relevancy_sort_config"]
+        mock_config.enabled = True
+        primary_model = Mock()
+        primary_model.name = "gpt-4o"
+        fallback_model = Mock()
+        fallback_model.name = "gpt-4o-mini"
+        mock_config.language_model = primary_model
+        mock_config.fallback_language_model = fallback_model
+        mock_chunk = ContentChunk(
+            id="chunk_1",
+            order=1,
+            chunk_id="chunk_1",
+            text="content",
+        )
+        mock_executor_dependencies["chunk_relevancy_sorter"].run = AsyncMock(
+            return_value=ChunkRelevancySorterResult(
+                relevancies=[
+                    ChunkRelevancy(
+                        chunk=mock_chunk,
+                        relevancy=EvaluationMetricResult(
+                            value="high",
+                            name=EvaluationMetricName.CONTEXT_RELEVANCY,
+                            reason="ok",
+                            invocation_stats=[
+                                LanguageModelInvocationStats.from_usage(
+                                    primary_model.name,
+                                    LanguageModelTokenUsage(
+                                        completion_tokens=1,
+                                        prompt_tokens=2,
+                                        total_tokens=3,
+                                    ),
+                                    source="context_relevancy",
+                                )
+                            ],
+                        ),
+                    )
+                ]
+            )
+        )
+
+        executor = WebSearchV1Executor(
+            services=executor_context_objects["services"],
+            config=executor_context_objects["config"],
+            callbacks=executor_context_objects["callbacks"],
+            tool_call=mock_executor_dependencies["tool_call"],
+            tool_parameters=WebSearchToolParameters(query="test"),
+            refine_query_system_prompt="test prompt",
+            refine_query_language_model=mock_executor_dependencies["language_model"],
+        )
+        executor.content_reducer = lambda chunks: chunks
+
+        web_page_chunks = [
+            WebPageChunk(
+                url="https://example.com",
+                display_link="example.com",
+                title="Title",
+                snippet="snippet",
+                content="body",
+                order="1",
+            )
+        ]
+
+        await executor._select_relevant_sources("objective", web_page_chunks)
+
+        mock_executor_dependencies["chunk_relevancy_sorter"].run.assert_called_once()
+        assert "invocation_stats_source" not in (
+            mock_executor_dependencies["chunk_relevancy_sorter"].run.call_args.kwargs
+        )
+        assert len(executor.debug_info.invocation_stats) == 1
+        assert (
+            executor.debug_info.invocation_stats[0].source
+            == WEB_SEARCH_CHUNK_RELEVANCY_SOURCE
+        )

--- a/tool_packages/unique_web_search/tests/test_llm_guard_judge.py
+++ b/tool_packages/unique_web_search/tests/test_llm_guard_judge.py
@@ -3,7 +3,9 @@
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from unique_toolkit.language_model.schemas import LanguageModelTokenUsage
 
+from unique_web_search.schema import WebSearchDebugInfo
 from unique_web_search.services.content_processing.processing_strategies.llm_guard_judge import (
     JudgeAndSanitizeResponse,
     LLMGuardJudge,
@@ -50,10 +52,13 @@ def _make_config(
     )
 
 
-def _mock_llm_service(parsed_response: dict) -> Mock:
+def _mock_llm_service(
+    parsed_response: dict, usage: LanguageModelTokenUsage | None = None
+) -> Mock:
     service = Mock()
     mock_resp = Mock()
     mock_resp.choices = [Mock(message=Mock(parsed=parsed_response))]
+    mock_resp.usage = usage
     service.complete_async = AsyncMock(return_value=mock_resp)
     return service
 
@@ -414,3 +419,151 @@ class TestLLMGuardJudgeComplete:
 
         with pytest.raises(ValueError, match="no parsed response"):
             await judge.sanitize_page(page=fake_page, query=fake_query)
+
+
+class TestLLMGuardJudgeUsage:
+    @pytest.mark.ai
+    @pytest.mark.asyncio
+    async def test_always_sanitize__usage_recorded_on_debug_info(
+        self, fake_page: WebSearchResult, fake_query: str
+    ) -> None:
+        config = _make_config(SanitizeMode.ALWAYS_SANITIZE)
+        llm_service = _mock_llm_service(
+            {"reasoning": "Clean.", "sanitized_content": "Sanitized."},
+            usage=LanguageModelTokenUsage(
+                completion_tokens=1, prompt_tokens=2, total_tokens=3
+            ),
+        )
+        judge = LLMGuardJudge(config=config, llm_service=llm_service)
+        debug_info = WebSearchDebugInfo(parameters={})
+
+        await judge(page=fake_page, query=fake_query, debug_info=debug_info)
+
+        assert len(debug_info.invocation_stats) == 1
+        stat = debug_info.invocation_stats[0]
+        assert stat.model_name == config.language_model.name
+        assert stat.token_usage == LanguageModelTokenUsage(
+            completion_tokens=1, prompt_tokens=2, total_tokens=3
+        )
+        assert stat.source == "web_search_llm_guard_judge"
+
+    @pytest.mark.ai
+    @pytest.mark.asyncio
+    async def test_judge_only__usage_recorded_on_debug_info(
+        self, fake_page: WebSearchResult, fake_query: str
+    ) -> None:
+        config = _make_config(SanitizeMode.JUDGE_ONLY)
+        llm_service = _mock_llm_service(
+            {"reasoning": "Clean.", "needs_sanitization": False},
+            usage=LanguageModelTokenUsage(
+                completion_tokens=1, prompt_tokens=1, total_tokens=2
+            ),
+        )
+        judge = LLMGuardJudge(config=config, llm_service=llm_service)
+        debug_info = WebSearchDebugInfo(parameters={})
+
+        await judge(page=fake_page, query=fake_query, debug_info=debug_info)
+
+        assert len(debug_info.invocation_stats) == 1
+        stat = debug_info.invocation_stats[0]
+        assert stat.model_name == config.language_model.name
+        assert stat.token_usage == LanguageModelTokenUsage(
+            completion_tokens=1, prompt_tokens=1, total_tokens=2
+        )
+        assert stat.source == "web_search_llm_guard_judge"
+
+    @pytest.mark.ai
+    @pytest.mark.asyncio
+    async def test_judge_then_sanitize__flagged__sums_usage_from_both_calls(
+        self, fake_page: WebSearchResult, fake_query: str
+    ) -> None:
+        config = _make_config(sanitize_mode=SanitizeMode.JUDGE_THEN_SANITIZE)
+        judge = LLMGuardJudge(config=config, llm_service=Mock())
+
+        judge_response = Mock()
+        judge_response.choices = [
+            Mock(
+                message=Mock(
+                    parsed={"reasoning": "Flagged.", "needs_sanitization": True}
+                )
+            )
+        ]
+        judge_response.usage = LanguageModelTokenUsage(
+            completion_tokens=1, prompt_tokens=1, total_tokens=2
+        )
+
+        sanitize_response = Mock()
+        sanitize_response.choices = [
+            Mock(
+                message=Mock(
+                    parsed={
+                        "reasoning": "Sanitized.",
+                        "sanitized_content": "Redacted.",
+                    }
+                )
+            )
+        ]
+        sanitize_response.usage = LanguageModelTokenUsage(
+            completion_tokens=10, prompt_tokens=20, total_tokens=30
+        )
+
+        judge._llm_service.complete_async = AsyncMock(
+            side_effect=[judge_response, sanitize_response]
+        )
+        debug_info = WebSearchDebugInfo(parameters={})
+
+        result = await judge(page=fake_page, query=fake_query, debug_info=debug_info)
+
+        assert result.content == "Redacted."
+        assert len(debug_info.invocation_stats) == 2
+        judge_stat, sanitize_stat = debug_info.invocation_stats
+        assert judge_stat.model_name == config.language_model.name
+        assert judge_stat.token_usage == LanguageModelTokenUsage(
+            completion_tokens=1, prompt_tokens=1, total_tokens=2
+        )
+        assert judge_stat.source == "web_search_llm_guard_judge"
+        assert sanitize_stat.model_name == config.language_model.name
+        assert sanitize_stat.token_usage == LanguageModelTokenUsage(
+            completion_tokens=10, prompt_tokens=20, total_tokens=30
+        )
+        assert sanitize_stat.source == "web_search_llm_guard_judge"
+
+    @pytest.mark.ai
+    @pytest.mark.asyncio
+    async def test_judge_then_sanitize__not_flagged__usage_from_judge_call_only(
+        self, fake_page: WebSearchResult, fake_query: str
+    ) -> None:
+        config = _make_config(sanitize_mode=SanitizeMode.JUDGE_THEN_SANITIZE)
+        llm_service = _mock_llm_service(
+            {"reasoning": "Clean.", "needs_sanitization": False},
+            usage=LanguageModelTokenUsage(
+                completion_tokens=1, prompt_tokens=1, total_tokens=2
+            ),
+        )
+        judge = LLMGuardJudge(config=config, llm_service=llm_service)
+        debug_info = WebSearchDebugInfo(parameters={})
+
+        await judge(page=fake_page, query=fake_query, debug_info=debug_info)
+
+        assert len(debug_info.invocation_stats) == 1
+        stat = debug_info.invocation_stats[0]
+        assert stat.model_name == config.language_model.name
+        assert stat.token_usage == LanguageModelTokenUsage(
+            completion_tokens=1, prompt_tokens=1, total_tokens=2
+        )
+        assert stat.source == "web_search_llm_guard_judge"
+
+    @pytest.mark.ai
+    @pytest.mark.asyncio
+    async def test_no_debug_info__does_not_raise(
+        self, fake_page: WebSearchResult, fake_query: str
+    ) -> None:
+        config = _make_config(SanitizeMode.ALWAYS_SANITIZE)
+        llm_service = _mock_llm_service(
+            {"reasoning": "Clean.", "sanitized_content": "Sanitized."}
+        )
+        judge = LLMGuardJudge(config=config, llm_service=llm_service)
+
+        result = await judge(page=fake_page, query=fake_query)
+
+        assert result.content == "Sanitized."

--- a/tool_packages/unique_web_search/tests/test_llm_keyword_redact.py
+++ b/tool_packages/unique_web_search/tests/test_llm_keyword_redact.py
@@ -3,7 +3,9 @@
 from unittest.mock import AsyncMock, Mock
 
 import pytest
+from unique_toolkit.language_model.schemas import LanguageModelTokenUsage
 
+from unique_web_search.schema import WebSearchDebugInfo
 from unique_web_search.services.content_processing.processing_strategies.llm_keyword_redact import (
     KeywordRedactResponse,
     LLMKeywordRedact,
@@ -224,5 +226,59 @@ class TestLLMKeywordRedact:
 
         redactor = LLMKeywordRedact(config=config, llm_service=llm_service)
         result = await redactor(page=fake_page, query="")
+
+        assert result.content == fake_page.content
+
+
+class TestLLMKeywordRedactUsage:
+    @pytest.mark.ai
+    @pytest.mark.asyncio
+    async def test_usage_recorded_on_debug_info(
+        self, fake_page: WebSearchResult
+    ) -> None:
+        config = LLMProcessorConfig(
+            enabled=True,
+            privacy_filter=PrivacyFilterConfig(sanitize=True),
+        )
+        llm_service = Mock()
+        mock_resp = Mock()
+        mock_resp.choices = [Mock(message=Mock(parsed={"sensitive_keywords": []}))]
+        mock_resp.usage = LanguageModelTokenUsage(
+            completion_tokens=6, prompt_tokens=9, total_tokens=15
+        )
+        llm_service.complete_async = AsyncMock(return_value=mock_resp)
+
+        redactor = LLMKeywordRedact(config=config, llm_service=llm_service)
+        debug_info = WebSearchDebugInfo(parameters={})
+
+        await redactor(page=fake_page, query="patient info", debug_info=debug_info)
+
+        assert len(debug_info.invocation_stats) == 1
+        stat = debug_info.invocation_stats[0]
+        assert stat.model_name == config.language_model.name
+        assert stat.token_usage == LanguageModelTokenUsage(
+            completion_tokens=6, prompt_tokens=9, total_tokens=15
+        )
+        assert stat.source == "web_search_llm_keyword_redact"
+
+    @pytest.mark.ai
+    @pytest.mark.asyncio
+    async def test_no_debug_info__does_not_raise(
+        self, fake_page: WebSearchResult
+    ) -> None:
+        config = LLMProcessorConfig(
+            enabled=True,
+            privacy_filter=PrivacyFilterConfig(sanitize=True),
+        )
+        llm_service = Mock()
+        mock_resp = Mock()
+        mock_resp.choices = [Mock(message=Mock(parsed={"sensitive_keywords": []}))]
+        mock_resp.usage = LanguageModelTokenUsage(
+            completion_tokens=1, prompt_tokens=1, total_tokens=2
+        )
+        llm_service.complete_async = AsyncMock(return_value=mock_resp)
+
+        redactor = LLMKeywordRedact(config=config, llm_service=llm_service)
+        result = await redactor(page=fake_page, query="patient info")
 
         assert result.content == fake_page.content

--- a/tool_packages/unique_web_search/tests/test_llm_process_dispatch.py
+++ b/tool_packages/unique_web_search/tests/test_llm_process_dispatch.py
@@ -3,7 +3,9 @@
 from unittest.mock import AsyncMock, Mock
 
 import pytest
+from unique_toolkit.language_model.schemas import LanguageModelTokenUsage
 
+from unique_web_search.schema import WebSearchDebugInfo
 from unique_web_search.services.content_processing.processing_strategies.llm_process import (
     LLMProcess,
     LLMProcessorConfig,
@@ -297,3 +299,86 @@ class TestLLMProcessDispatch:
         )
         result = await processor(page=fake_page, query="test query")
         assert result.url == fake_page.url
+
+
+# ---------------------------------------------------------------------------
+# Token usage capture (via the debug_info side-channel)
+# ---------------------------------------------------------------------------
+
+
+class TestLLMProcessUsage:
+    @pytest.mark.ai
+    @pytest.mark.asyncio
+    async def test_summarize__usage_recorded_on_debug_info(
+        self, fake_page: WebSearchResult
+    ) -> None:
+        config = LLMProcessorConfig(
+            enabled=True,
+            min_tokens=0,
+            privacy_filter=PrivacyFilterConfig(sanitize=False),
+        )
+        mock_llm_service = Mock()
+        mock_resp = Mock()
+        mock_resp.choices = [
+            Mock(
+                message=Mock(
+                    parsed={"snippet": "Sum snippet", "summary": "Sum content"}
+                )
+            )
+        ]
+        mock_resp.usage = LanguageModelTokenUsage(
+            completion_tokens=4, prompt_tokens=8, total_tokens=12
+        )
+        mock_llm_service.complete_async = AsyncMock(return_value=mock_resp)
+
+        processor = LLMProcess(
+            config=config,
+            llm_service=mock_llm_service,
+            encoder=_simple_encoder,
+            decoder=_simple_decoder,
+        )
+        debug_info = WebSearchDebugInfo(parameters={})
+
+        await processor(page=fake_page, query="test query", debug_info=debug_info)
+
+        assert len(debug_info.invocation_stats) == 1
+        stat = debug_info.invocation_stats[0]
+        assert stat.model_name == config.language_model.name
+        assert stat.token_usage == LanguageModelTokenUsage(
+            completion_tokens=4, prompt_tokens=8, total_tokens=12
+        )
+        assert stat.source == "web_search_llm_process"
+
+    @pytest.mark.ai
+    @pytest.mark.asyncio
+    async def test_no_debug_info__does_not_raise(
+        self, fake_page: WebSearchResult
+    ) -> None:
+        config = LLMProcessorConfig(
+            enabled=True,
+            min_tokens=0,
+            privacy_filter=PrivacyFilterConfig(sanitize=False),
+        )
+        mock_llm_service = Mock()
+        mock_resp = Mock()
+        mock_resp.choices = [
+            Mock(
+                message=Mock(
+                    parsed={"snippet": "Sum snippet", "summary": "Sum content"}
+                )
+            )
+        ]
+        mock_resp.usage = LanguageModelTokenUsage(
+            completion_tokens=1, prompt_tokens=1, total_tokens=2
+        )
+        mock_llm_service.complete_async = AsyncMock(return_value=mock_resp)
+
+        processor = LLMProcess(
+            config=config,
+            llm_service=mock_llm_service,
+            encoder=_simple_encoder,
+            decoder=_simple_decoder,
+        )
+        result = await processor(page=fake_page, query="test query")
+
+        assert result.content == "Sum content"

--- a/tool_packages/unique_web_search/tests/test_service.py
+++ b/tool_packages/unique_web_search/tests/test_service.py
@@ -2,7 +2,10 @@ from typing import Any
 from unittest.mock import AsyncMock, Mock
 
 import pytest
+from unique_toolkit.language_model.invocation_stats import LanguageModelInvocationStats
+from unique_toolkit.language_model.schemas import LanguageModelTokenUsage
 
+from unique_web_search.schema import WebSearchDebugInfo
 from unique_web_search.service import WebSearchTool
 from unique_web_search.services.executors.modes import get_mode_strategy
 from unique_web_search.services.executors.v1.schema import WebSearchToolParameters
@@ -976,3 +979,82 @@ class TestWebSearchToolRun:
         assert len(args) == 4  # tool_call, name, message, state
         assert args[1] == "test-name"  # name argument
         assert args[2] == "test-message"  # message argument
+
+
+class TestWebSearchToolInvocationStats:
+    @pytest.mark.ai
+    @pytest.mark.asyncio
+    async def test_run__passes_invocation_stats_on_tool_call_response(
+        self,
+        mock_web_search_config_v1: Mock,
+        sample_web_search_tool_parameters: WebSearchToolParameters,
+        sample_content_chunks: list,
+        mocker: Any,
+    ) -> None:
+        mock_executor = AsyncMock()
+        mock_executor.run = AsyncMock(return_value=sample_content_chunks)
+        mock_executor.notify_name = "test-name"
+        mock_executor.notify_message = "test-message"
+
+        mocker.patch("unique_web_search.service.get_search_engine_service")
+        mocker.patch("unique_web_search.service.get_crawler_service")
+        mocker.patch("unique_web_search.service.ChunkRelevancySorter")
+        mocker.patch("unique_web_search.service.ContentProcessor")
+
+        mocker.patch.object(
+            WebSearchTool, "__init__", lambda self, config, *args, **kwargs: None
+        )
+        mocker.patch.object(WebSearchTool, "_get_executor", return_value=mock_executor)
+
+        tool = WebSearchTool.__new__(WebSearchTool)
+        tool.config = mock_web_search_config_v1
+        tool.exposed_params_cls = None
+        tool._mode_strategy = get_mode_strategy(tool.config.web_search_mode_config)
+        tool.tool_parameter_calls = WebSearchToolParameters
+        tool.logger = Mock()
+        tool._message_step_logger = Mock()
+        tool._tool_progress_reporter = None
+        tool._display_name = "WebSearch"
+        tool.company_id = "test-company"
+        tool.debug = False
+        tool.name = "WebSearch"
+        tool.settings = Mock()
+        tool.settings.display_name = "WebSearch"
+        tool._get_argument_screening_service_if_ff_enabled = AsyncMock(
+            return_value=None
+        )
+
+        expected_stats = [
+            LanguageModelInvocationStats.from_usage(
+                "gpt-4-test",
+                LanguageModelTokenUsage(
+                    completion_tokens=1, prompt_tokens=2, total_tokens=3
+                ),
+                source="web_search_llm_process",
+            )
+        ]
+
+        real_debug_info = WebSearchDebugInfo(parameters={"query": "test"})
+        real_debug_info.invocation_stats = expected_stats
+
+        mocker.patch(
+            "unique_web_search.service.WebSearchDebugInfo",
+            return_value=real_debug_info,
+        )
+
+        mock_message_logger = Mock()
+        mock_message_logger.finished = AsyncMock()
+        mock_message_logger.failed = AsyncMock()
+        mocker.patch(
+            "unique_web_search.service.WebSearchMessageLogger",
+            return_value=mock_message_logger,
+        )
+
+        tool_call = Mock()
+        tool_call.id = "test-id"
+        tool_call.arguments = {"query": "test"}
+
+        response = await tool.run(tool_call)
+
+        assert response.invocation_stats == expected_stats
+        assert "invocation_stats" not in response.debug_info


### PR DESCRIPTION
## Summary
- Report per-invocation LLM usage from `unique_web_search` (screening, content processing, executors, search engines) on tool responses.
- Surface chunk-relevancy invocation stats from `unique_internal_search`.
- Aggregate per-phase LLM invocation stats across `unique_swot` orchestration, generation, source management, and summarization.
- Builds on orchestrator/toolkit work already on main (#2051, #2077, #2078).
- **Deferred:** DeepResearch invocation-stats follow-up (doc left untracked for a later PR).

## Test plan
- [ ] `unique_web_search` unit tests for screening, content processors, executors, and service aggregation
- [ ] `unique_internal_search` invocation-stats tests
- [ ] `unique_swot` utils/orchestrator/summarization tests covering stats propagation
- [ ] Manual/smoke: run a Space chat that uses web search / internal search / SWOT and confirm tool-message token usage appears as expected