### PR TITLE
feat(search-proxy): enforce tenant context headers and enrich request logs

### DIFF
--- a/.github/actions/run-min-tests-and-deptry/action.yml
+++ b/.github/actions/run-min-tests-and-deptry/action.yml
@@ -96,7 +96,12 @@ runs:
         sys.exit(0 if dev is not None else 1)
         EOF
         then
-          uv export --frozen --only-group dev --no-hashes | uv pip install -r -
+          # Export from repo root so workspace editable paths (e.g.
+          # ./connectors/unique_search_proxy/unique_search_proxy_core)
+          # resolve correctly; uv export emits repo-root-relative paths.
+          PACKAGE_NAME=$(python3 -c "import tomllib, pathlib; print(tomllib.loads(pathlib.Path('pyproject.toml').read_text())['project']['name'])")
+          uv export --directory "$REPO_ROOT" --package "$PACKAGE_NAME" --frozen --only-group dev --no-hashes \
+            | (cd "$REPO_ROOT" && uv pip install -r -)
         fi
 
     - name: Show installed packages

--- a/connectors/unique_search_proxy/unique_search_proxy_client/.env.example
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/.env.example
@@ -6,10 +6,12 @@
 # Prefixes: HTTP_CLIENT_, PROMETHEUS_, BING_AGENT_, VERTEXAI_AGENT_; Google vars have no prefix.
 
 # ── Request context headers (tenant identity on /v1/* routes) ────────────────
-# When true (default), POST /v1/search, /v1/agent-search, and /v1/crawl require
+# When true, POST /v1/search, /v1/agent-search, and /v1/crawl require
 # x-unique-company-id, x-unique-user-id, and x-unique-chat-id headers.
-# Set to false for local notebooks / curl without tenant context.
-REQUIRE_CONTEXT_HEADERS=true
+# Default in code is true (production). Local .env uses false so /docs and
+# scripts/try_presets.py work without extra setup; both send local/* headers
+# when enforcement is enabled.
+REQUIRE_CONTEXT_HEADERS=false
 
 # ── Google Custom Search (required for POST /v1/search with engine=google) ───
 # Create API key + Programmable Search Engine (cx) in Google Cloud Console.

--- a/connectors/unique_search_proxy/unique_search_proxy_client/.env.example
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/.env.example
@@ -5,6 +5,12 @@
 # Loaded via pydantic-settings (see unique_search_proxy/web/settings/base.py).
 # Prefixes: HTTP_CLIENT_, PROMETHEUS_, BING_AGENT_, VERTEXAI_AGENT_; Google vars have no prefix.
 
+# ── Request context headers (tenant identity on /v1/* routes) ────────────────
+# When true (default), POST /v1/search, /v1/agent-search, and /v1/crawl require
+# x-unique-company-id, x-unique-user-id, and x-unique-chat-id headers.
+# Set to false for local notebooks / curl without tenant context.
+REQUIRE_CONTEXT_HEADERS=true
+
 # ── Google Custom Search (required for POST /v1/search with engine=google) ───
 # Create API key + Programmable Search Engine (cx) in Google Cloud Console.
 # Use real values in deployment. NOT_PROVIDED (or empty) means the provider is unavailable.

--- a/connectors/unique_search_proxy/unique_search_proxy_client/README.md
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/README.md
@@ -249,9 +249,9 @@ uv run python scripts/generate_sdk.py
 
 ## 8. Dev testing
 
-1. Start the server and configure `.env`.
-2. **Swagger** — `/docs` → **Try it out** on `/v1/search` or `/v1/crawl` → pick an **Examples** preset.
-3. **CLI** — same presets from the terminal:
+1. Start the server and configure `.env` (`.env.example` sets `REQUIRE_CONTEXT_HEADERS=false` for local use; production keeps enforcement enabled).
+2. **Swagger** — `/docs` → **Try it out** on `/v1/search` or `/v1/crawl` → pick an **Examples** preset. Context headers default to `local` in the UI.
+3. **CLI** — same presets from the terminal (`scripts/try_presets.py` sends the same local context headers):
 
 ```bash
 uv run python scripts/try_presets.py list

--- a/connectors/unique_search_proxy/unique_search_proxy_client/openapi.json
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Unique Search Proxy",
-    "description": "Unified web egress proxy for search engines and crawlers. Use **Try it out** on `/v1/search` and `/v1/crawl` \u2014 pick an example from the request-body dropdown (snippets-only Google search, crawl with HTML markdown, etc.). Requires provider env vars (e.g. `GOOGLE_SEARCH_API_KEY`, `GOOGLE_SEARCH_ENGINE_ID`) for live calls.",
+    "description": "Unified web egress proxy for search engines and crawlers. Use **Try it out** on `/v1/search` and `/v1/crawl` \u2014 pick an example from the request-body dropdown (snippets-only Google search, crawl with HTML markdown, etc.). `/v1/*` routes accept tenant context headers (`x-unique-company-id`, `x-unique-user-id`, `x-unique-chat-id`; defaults `local` in Swagger). Requires provider env vars (e.g. `GOOGLE_SEARCH_API_KEY`, `GOOGLE_SEARCH_ENGINE_ID`) for live calls.",
     "version": "0.2.0"
   },
   "paths": {
@@ -61,6 +61,44 @@
         ],
         "summary": "List registered search engines and crawlers",
         "operationId": "list_providers_v1_configuration_providers_get",
+        "parameters": [
+          {
+            "name": "x-unique-company-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Tenant company identifier.",
+              "default": "local",
+              "title": "X-Unique-Company-Id"
+            },
+            "description": "Tenant company identifier."
+          },
+          {
+            "name": "x-unique-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Tenant user identifier.",
+              "default": "local",
+              "title": "X-Unique-User-Id"
+            },
+            "description": "Tenant user identifier."
+          },
+          {
+            "name": "x-unique-chat-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Tenant chat or session identifier.",
+              "default": "local",
+              "title": "X-Unique-Chat-Id"
+            },
+            "description": "Tenant chat or session identifier."
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -68,6 +106,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ProvidersListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -82,7 +130,46 @@
         ],
         "summary": "Run a search engine with a typed call payload",
         "operationId": "search_v1_search_post",
+        "parameters": [
+          {
+            "name": "x-unique-company-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Tenant company identifier.",
+              "default": "local",
+              "title": "X-Unique-Company-Id"
+            },
+            "description": "Tenant company identifier."
+          },
+          {
+            "name": "x-unique-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Tenant user identifier.",
+              "default": "local",
+              "title": "X-Unique-User-Id"
+            },
+            "description": "Tenant user identifier."
+          },
+          {
+            "name": "x-unique-chat-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Tenant chat or session identifier.",
+              "default": "local",
+              "title": "X-Unique-Chat-Id"
+            },
+            "description": "Tenant chat or session identifier."
+          }
+        ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -146,8 +233,7 @@
                 }
               }
             }
-          },
-          "required": true
+          }
         },
         "responses": {
           "200": {
@@ -180,7 +266,46 @@
         ],
         "summary": "Run an agent-based grounded search",
         "operationId": "agent_search_v1_agent_search_post",
+        "parameters": [
+          {
+            "name": "x-unique-company-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Tenant company identifier.",
+              "default": "local",
+              "title": "X-Unique-Company-Id"
+            },
+            "description": "Tenant company identifier."
+          },
+          {
+            "name": "x-unique-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Tenant user identifier.",
+              "default": "local",
+              "title": "X-Unique-User-Id"
+            },
+            "description": "Tenant user identifier."
+          },
+          {
+            "name": "x-unique-chat-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Tenant chat or session identifier.",
+              "default": "local",
+              "title": "X-Unique-Chat-Id"
+            },
+            "description": "Tenant chat or session identifier."
+          }
+        ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -215,8 +340,7 @@
                 }
               }
             }
-          },
-          "required": true
+          }
         },
         "responses": {
           "200": {
@@ -249,7 +373,46 @@
         ],
         "summary": "Stream an agent-based grounded search (SSE)",
         "operationId": "agent_search_stream_v1_agent_search_stream_post",
+        "parameters": [
+          {
+            "name": "x-unique-company-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Tenant company identifier.",
+              "default": "local",
+              "title": "X-Unique-Company-Id"
+            },
+            "description": "Tenant company identifier."
+          },
+          {
+            "name": "x-unique-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Tenant user identifier.",
+              "default": "local",
+              "title": "X-Unique-User-Id"
+            },
+            "description": "Tenant user identifier."
+          },
+          {
+            "name": "x-unique-chat-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Tenant chat or session identifier.",
+              "default": "local",
+              "title": "X-Unique-Chat-Id"
+            },
+            "description": "Tenant chat or session identifier."
+          }
+        ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -284,8 +447,7 @@
                 }
               }
             }
-          },
-          "required": true
+          }
         },
         "responses": {
           "200": {
@@ -316,7 +478,46 @@
         ],
         "summary": "Crawl URLs with a configured crawler",
         "operationId": "crawl_v1_crawl_post",
+        "parameters": [
+          {
+            "name": "x-unique-company-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Tenant company identifier.",
+              "default": "local",
+              "title": "X-Unique-Company-Id"
+            },
+            "description": "Tenant company identifier."
+          },
+          {
+            "name": "x-unique-user-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Tenant user identifier.",
+              "default": "local",
+              "title": "X-Unique-User-Id"
+            },
+            "description": "Tenant user identifier."
+          },
+          {
+            "name": "x-unique-chat-id",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Tenant chat or session identifier.",
+              "default": "local",
+              "title": "X-Unique-Chat-Id"
+            },
+            "description": "Tenant chat or session identifier."
+          }
+        ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -518,8 +719,7 @@
                 }
               }
             }
-          },
-          "required": true
+          }
         },
         "responses": {
           "200": {
@@ -592,10 +792,13 @@
             "type": "string",
             "const": "Basic",
             "title": "Crawler",
+            "description": "Provider discriminator; must be `Basic` for this config.",
             "default": "Basic"
           },
           "timeout": {
             "type": "integer",
+            "maximum": 600.0,
+            "minimum": 1.0,
             "title": "Timeout",
             "description": "Request timeout in seconds",
             "default": 30
@@ -614,12 +817,13 @@
           },
           "maxConcurrentRequests": {
             "type": "integer",
+            "maximum": 50.0,
+            "minimum": 1.0,
             "title": "Maximum concurrent HTTP fetches",
             "description": "Maximum concurrent HTTP fetches",
             "default": 10
           }
         },
-        "additionalProperties": false,
         "type": "object",
         "required": [
           "urls"
@@ -649,12 +853,16 @@
           },
           "timeout": {
             "type": "integer",
+            "maximum": 600.0,
+            "minimum": 1.0,
             "title": "Timeout",
             "description": "Request timeout in seconds (agent runs can be slow).",
             "default": 120
           },
           "fetchSize": {
             "type": "integer",
+            "maximum": 50.0,
+            "minimum": 1.0,
             "title": "Fetch Size",
             "description": "Maximum number of Bing grounding results per query",
             "default": 5
@@ -695,12 +903,16 @@
           },
           "fetchSize": {
             "type": "integer",
+            "maximum": 100.0,
+            "minimum": 1.0,
             "title": "Fetch Size",
             "description": "Default result count merged into each search request",
             "default": 10
           },
           "timeout": {
             "type": "integer",
+            "maximum": 600.0,
+            "minimum": 1.0,
             "title": "Timeout",
             "description": "Request timeout in seconds",
             "default": 30
@@ -888,13 +1100,7 @@
           "freshness": {
             "anyOf": [
               {
-                "type": "string",
-                "title": "String"
-              },
-              {
-                "type": "null",
-                "title": "Deactivated",
-                "description": "None"
+                "type": "string"
               },
               {
                 "type": "null"
@@ -985,13 +1191,7 @@
                     "locations"
                   ]
                 },
-                "type": "array",
-                "title": "Result Filter"
-              },
-              {
-                "type": "null",
-                "title": "Deactivated",
-                "description": "None"
+                "type": "array"
               },
               {
                 "type": "null"
@@ -1138,10 +1338,13 @@
             "type": "string",
             "const": "Firecrawl",
             "title": "Crawler",
+            "description": "Provider discriminator; must be `Firecrawl` for this config.",
             "default": "Firecrawl"
           },
           "timeout": {
             "type": "integer",
+            "maximum": 600.0,
+            "minimum": 1.0,
             "title": "Timeout",
             "description": "Request timeout in seconds",
             "default": 30
@@ -1178,6 +1381,7 @@
           },
           "waitFor": {
             "type": "integer",
+            "minimum": 0.0,
             "title": "Wait for",
             "description": "Extra delay in milliseconds before fetching page content.",
             "default": 0
@@ -1269,7 +1473,6 @@
             "description": "Return cached page content younger than this age in milliseconds."
           }
         },
-        "additionalProperties": false,
         "type": "object",
         "required": [
           "urls"
@@ -1293,12 +1496,16 @@
           },
           "fetchSize": {
             "type": "integer",
+            "maximum": 100.0,
+            "minimum": 1.0,
             "title": "Fetch Size",
             "description": "Default result count merged into each search request",
             "default": 10
           },
           "timeout": {
             "type": "integer",
+            "maximum": 600.0,
+            "minimum": 1.0,
             "title": "Timeout",
             "description": "Request timeout in seconds",
             "default": 30
@@ -1328,13 +1535,7 @@
           "gl": {
             "anyOf": [
               {
-                "type": "string",
-                "title": "String"
-              },
-              {
-                "type": "null",
-                "title": "Deactivated",
-                "description": "None"
+                "type": "string"
               },
               {
                 "type": "null"
@@ -1346,13 +1547,7 @@
           "hl": {
             "anyOf": [
               {
-                "type": "string",
-                "title": "String"
-              },
-              {
-                "type": "null",
-                "title": "Deactivated",
-                "description": "None"
+                "type": "string"
               },
               {
                 "type": "null"
@@ -1364,13 +1559,7 @@
           "lr": {
             "anyOf": [
               {
-                "type": "string",
-                "title": "String"
-              },
-              {
-                "type": "null",
-                "title": "Deactivated",
-                "description": "None"
+                "type": "string"
               },
               {
                 "type": "null"
@@ -1382,13 +1571,7 @@
           "dateRestrict": {
             "anyOf": [
               {
-                "type": "string",
-                "title": "String"
-              },
-              {
-                "type": "null",
-                "title": "Deactivated",
-                "description": "None"
+                "type": "string"
               },
               {
                 "type": "null"
@@ -1400,13 +1583,7 @@
           "exactTerms": {
             "anyOf": [
               {
-                "type": "string",
-                "title": "String"
-              },
-              {
-                "type": "null",
-                "title": "Deactivated",
-                "description": "None"
+                "type": "string"
               },
               {
                 "type": "null"
@@ -1418,13 +1595,7 @@
           "excludeTerms": {
             "anyOf": [
               {
-                "type": "string",
-                "title": "String"
-              },
-              {
-                "type": "null",
-                "title": "Deactivated",
-                "description": "None"
+                "type": "string"
               },
               {
                 "type": "null"
@@ -1436,13 +1607,7 @@
           "fileType": {
             "anyOf": [
               {
-                "type": "string",
-                "title": "String"
-              },
-              {
-                "type": "null",
-                "title": "Deactivated",
-                "description": "None"
+                "type": "string"
               },
               {
                 "type": "null"
@@ -1454,13 +1619,7 @@
           "siteSearch": {
             "anyOf": [
               {
-                "type": "string",
-                "title": "String"
-              },
-              {
-                "type": "null",
-                "title": "Deactivated",
-                "description": "None"
+                "type": "string"
               },
               {
                 "type": "null"
@@ -1476,13 +1635,7 @@
                 "enum": [
                   "e",
                   "i"
-                ],
-                "title": "Site Search Filter"
-              },
-              {
-                "type": "null",
-                "title": "Deactivated",
-                "description": "None"
+                ]
               },
               {
                 "type": "null"
@@ -1494,13 +1647,7 @@
           "sort": {
             "anyOf": [
               {
-                "type": "string",
-                "title": "String"
-              },
-              {
-                "type": "null",
-                "title": "Deactivated",
-                "description": "None"
+                "type": "string"
               },
               {
                 "type": "null"
@@ -1544,10 +1691,13 @@
             "type": "string",
             "const": "Jina",
             "title": "Crawler",
+            "description": "Provider discriminator; must be `Jina` for this config.",
             "default": "Jina"
           },
           "timeout": {
             "type": "integer",
+            "maximum": 600.0,
+            "minimum": 1.0,
             "title": "Timeout",
             "description": "Request timeout in seconds",
             "default": 30
@@ -1591,6 +1741,8 @@
           },
           "maxConcurrentRequests": {
             "type": "integer",
+            "maximum": 50.0,
+            "minimum": 1.0,
             "title": "Maximum concurrent reader requests",
             "description": "Maximum concurrent Jina Reader POST requests.",
             "default": 10
@@ -1732,7 +1884,6 @@
             "default": true
           }
         },
-        "additionalProperties": false,
         "type": "object",
         "required": [
           "urls"
@@ -1774,12 +1925,16 @@
           },
           "fetchSize": {
             "type": "integer",
+            "maximum": 100.0,
+            "minimum": 1.0,
             "title": "Fetch Size",
             "description": "Default result count merged into each search request",
             "default": 10
           },
           "timeout": {
             "type": "integer",
+            "maximum": 600.0,
+            "minimum": 1.0,
             "title": "Timeout",
             "description": "Request timeout in seconds",
             "default": 30
@@ -1822,13 +1977,7 @@
           "country": {
             "anyOf": [
               {
-                "type": "string",
-                "title": "String"
-              },
-              {
-                "type": "null",
-                "title": "Deactivated",
-                "description": "None"
+                "type": "string"
               },
               {
                 "type": "null"
@@ -1843,13 +1992,7 @@
                 "items": {
                   "type": "string"
                 },
-                "type": "array",
-                "title": "Language Filter"
-              },
-              {
-                "type": "null",
-                "title": "Deactivated",
-                "description": "None"
+                "type": "array"
               },
               {
                 "type": "null"
@@ -1864,13 +2007,7 @@
                 "items": {
                   "type": "string"
                 },
-                "type": "array",
-                "title": "Domain Filter"
-              },
-              {
-                "type": "null",
-                "title": "Deactivated",
-                "description": "None"
+                "type": "array"
               },
               {
                 "type": "null"
@@ -1889,13 +2026,7 @@
                   "week",
                   "month",
                   "year"
-                ],
-                "title": "Recency Filter"
-              },
-              {
-                "type": "null",
-                "title": "Deactivated",
-                "description": "None"
+                ]
               },
               {
                 "type": "null"
@@ -1907,13 +2038,7 @@
           "lastUpdatedAfterFilter": {
             "anyOf": [
               {
-                "type": "string",
-                "title": "String"
-              },
-              {
-                "type": "null",
-                "title": "Deactivated",
-                "description": "None"
+                "type": "string"
               },
               {
                 "type": "null"
@@ -1925,13 +2050,7 @@
           "lastUpdatedBeforeFilter": {
             "anyOf": [
               {
-                "type": "string",
-                "title": "String"
-              },
-              {
-                "type": "null",
-                "title": "Deactivated",
-                "description": "None"
+                "type": "string"
               },
               {
                 "type": "null"
@@ -1943,13 +2062,7 @@
           "searchAfterDateFilter": {
             "anyOf": [
               {
-                "type": "string",
-                "title": "String"
-              },
-              {
-                "type": "null",
-                "title": "Deactivated",
-                "description": "None"
+                "type": "string"
               },
               {
                 "type": "null"
@@ -1961,13 +2074,7 @@
           "searchBeforeDateFilter": {
             "anyOf": [
               {
-                "type": "string",
-                "title": "String"
-              },
-              {
-                "type": "null",
-                "title": "Deactivated",
-                "description": "None"
+                "type": "string"
               },
               {
                 "type": "null"
@@ -2063,10 +2170,13 @@
             "type": "string",
             "const": "Tavily",
             "title": "Crawler",
+            "description": "Provider discriminator; must be `Tavily` for this config.",
             "default": "Tavily"
           },
           "timeout": {
             "type": "integer",
+            "maximum": 600.0,
+            "minimum": 1.0,
             "title": "Timeout",
             "description": "Request timeout in seconds",
             "default": 30
@@ -2134,7 +2244,6 @@
             "default": false
           }
         },
-        "additionalProperties": false,
         "type": "object",
         "required": [
           "urls"
@@ -2197,6 +2306,8 @@
           },
           "timeout": {
             "type": "integer",
+            "maximum": 600.0,
+            "minimum": 1.0,
             "title": "Timeout",
             "description": "Request timeout in seconds (agent runs can be slow).",
             "default": 120

--- a/connectors/unique_search_proxy/unique_search_proxy_client/scripts/try_presets.py
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/scripts/try_presets.py
@@ -10,6 +10,7 @@ import time
 from typing import Any
 
 import httpx
+from unique_search_proxy_core.context import LOCAL_REQUEST_CONTEXT
 
 from unique_search_proxy_client.web.presets import (
     PresetDefinition,
@@ -61,7 +62,11 @@ def _run_preset(
     payload = preset.build_payload()
     path = _endpoint_for_kind(preset.kind)
     started = time.perf_counter()
-    response = client.post(f"{base_url.rstrip('/')}{path}", json=payload)
+    response = client.post(
+        f"{base_url.rstrip('/')}{path}",
+        json=payload,
+        headers=LOCAL_REQUEST_CONTEXT.to_headers(),
+    )
     elapsed_ms = (time.perf_counter() - started) * 1000
     try:
         body = response.json()

--- a/connectors/unique_search_proxy/unique_search_proxy_client/tests/conftest.py
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/tests/conftest.py
@@ -9,6 +9,19 @@ import unique_search_proxy_core.url_safety.dns as url_safety_dns
 
 
 @pytest.fixture(autouse=True)
+def disable_context_header_enforcement_for_legacy_tests(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Keep existing TestClient integration tests working without tenant headers."""
+    from unique_search_proxy_client.web.settings.app import AppSettings
+
+    monkeypatch.setattr(
+        "unique_search_proxy_client.web.middleware.context.app_settings",
+        AppSettings(require_context_headers=False),
+    )
+
+
+@pytest.fixture(autouse=True)
 def stable_public_dns_for_tests(monkeypatch: pytest.MonkeyPatch) -> None:
     """Return a deterministic public IP for dotted hostnames during unit tests."""
 

--- a/connectors/unique_search_proxy/unique_search_proxy_client/tests/test_logging_config.py
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/tests/test_logging_config.py
@@ -21,6 +21,18 @@ class TestLoggingConfig:
         assert config["formatters"]["default"]["()"] == (
             "uvicorn.logging.DefaultFormatter"
         )
+        assert config["formatters"]["default"]["fmt"] == (
+            "%(levelprefix)s "
+            "company=%(company_id)s user=%(user_id)s chat=%(chat_id)s "
+            "%(message)s"
+        )
+        assert config["formatters"]["access"]["fmt"] == (
+            "%(levelprefix)s "
+            "company=%(company_id)s user=%(user_id)s chat=%(chat_id)s "
+            '%(client_addr)s - "%(request_line)s" %(status_code)s'
+        )
+        assert config["handlers"]["default"]["filters"] == ["request_context"]
+        assert config["handlers"]["access"]["filters"] == ["request_context"]
 
     @pytest.mark.ai
     def test_configure_logging_uses_uvicorn_formatter(

--- a/connectors/unique_search_proxy/unique_search_proxy_client/tests/test_request_context.py
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/tests/test_request_context.py
@@ -5,13 +5,22 @@ from __future__ import annotations
 import pytest
 from fastapi.testclient import TestClient
 from unique_search_proxy_core.context import (
+    CHAT_ID_HEADER,
+    COMPANY_ID_HEADER,
     LOCAL_REQUEST_CONTEXT,
+    USER_ID_HEADER,
     RequestContext,
 )
 from unique_search_proxy_core.schema import ProxyErrorCode
 
 from unique_search_proxy_client.web.app import create_app
 from unique_search_proxy_client.web.settings.app import AppSettings
+
+_CONTEXT_HEADER_NAMES = (
+    COMPANY_ID_HEADER,
+    USER_ID_HEADER,
+    CHAT_ID_HEADER,
+)
 
 
 def _context_headers(
@@ -178,3 +187,37 @@ class TestRequestContextMiddleware:
             json={"engine": "google", "query": "test", "fetchSize": 1},
         )
         assert response.status_code == 200
+
+
+@pytest.mark.ai
+class TestRequestContextOpenAPI:
+    def test_v1_post_routes_declare_context_headers(self) -> None:
+        schema = create_app().openapi()
+        for path in ("/v1/search", "/v1/crawl", "/v1/agent-search"):
+            header_names = [
+                parameter["name"]
+                for parameter in schema["paths"][path]["post"].get("parameters", [])
+                if parameter.get("in") == "header"
+            ]
+            assert header_names == list(_CONTEXT_HEADER_NAMES)
+
+        for path in ("/v1/agent-search/stream",):
+            header_names = [
+                parameter["name"]
+                for parameter in schema["paths"][path]["post"].get("parameters", [])
+                if parameter.get("in") == "header"
+            ]
+            assert header_names == list(_CONTEXT_HEADER_NAMES)
+
+    def test_openapi_context_headers_default_to_local(self) -> None:
+        schema = create_app().openapi()
+        search_headers = {
+            parameter["name"]: parameter.get("schema", {}).get("default")
+            for parameter in schema["paths"]["/v1/search"]["post"].get("parameters", [])
+            if parameter.get("in") == "header"
+        }
+        assert search_headers == {
+            COMPANY_ID_HEADER: LOCAL_REQUEST_CONTEXT.company_id,
+            USER_ID_HEADER: LOCAL_REQUEST_CONTEXT.user_id,
+            CHAT_ID_HEADER: LOCAL_REQUEST_CONTEXT.chat_id,
+        }

--- a/connectors/unique_search_proxy/unique_search_proxy_client/tests/test_request_context.py
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/tests/test_request_context.py
@@ -1,0 +1,180 @@
+"""Tests for request context middleware and logging."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+from unique_search_proxy_core.context import (
+    LOCAL_REQUEST_CONTEXT,
+    RequestContext,
+)
+from unique_search_proxy_core.schema import ProxyErrorCode
+
+from unique_search_proxy_client.web.app import create_app
+from unique_search_proxy_client.web.settings.app import AppSettings
+
+
+def _context_headers(
+    *,
+    company_id: str = "company-1",
+    user_id: str = "user-1",
+    chat_id: str = "chat-1",
+) -> dict[str, str]:
+    return RequestContext(
+        company_id=company_id,
+        user_id=user_id,
+        chat_id=chat_id,
+    ).to_headers()
+
+
+@pytest.fixture
+def enforcement_client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    monkeypatch.setattr(
+        "unique_search_proxy_client.web.middleware.context.app_settings",
+        AppSettings(require_context_headers=True),
+    )
+    with TestClient(create_app()) as test_client:
+        yield test_client
+
+
+@pytest.fixture
+def relaxed_client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    monkeypatch.setattr(
+        "unique_search_proxy_client.web.middleware.context.app_settings",
+        AppSettings(require_context_headers=False),
+    )
+    with TestClient(create_app()) as test_client:
+        yield test_client
+
+
+@pytest.mark.ai
+class TestRequestContextMiddleware:
+    def test_missing_headers_rejected_when_enforcement_enabled(
+        self,
+        enforcement_client: TestClient,
+    ) -> None:
+        response = enforcement_client.post(
+            "/v1/search",
+            json={"engine": "google", "query": "test", "fetchSize": 1},
+        )
+        assert response.status_code == 422
+        body = response.json()
+        assert body["error"]["code"] == ProxyErrorCode.VALIDATION_ERROR.value
+        assert "Missing required context headers" in body["error"]["message"]
+
+    def test_present_headers_accepted_when_enforcement_enabled(
+        self,
+        enforcement_client: TestClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("GOOGLE_SEARCH_API_KEY", "test-key")
+        monkeypatch.setenv("GOOGLE_SEARCH_ENGINE_ID", "test-cx")
+
+        from unique_search_proxy_core.schema import (
+            SearchEngineRaw,
+            WebSearchResult,
+            WebSearchResults,
+        )
+        from unique_search_proxy_core.search_engines.google.schema import (
+            GoogleSearchRequest,
+        )
+
+        async def fake_search(
+            self: object,
+            request: GoogleSearchRequest,
+        ) -> tuple[SearchEngineRaw, WebSearchResults]:
+            return SearchEngineRaw(pages=[]), WebSearchResults(
+                results=[
+                    WebSearchResult(url="https://example.com", title="t", snippet="s"),
+                ],
+            )
+
+        monkeypatch.setattr(
+            "unique_search_proxy_client.web.core.search_engines.google.service.GoogleSearchService.search",
+            fake_search,
+        )
+
+        response = enforcement_client.post(
+            "/v1/search",
+            headers=_context_headers(),
+            json={"engine": "google", "query": "test", "fetchSize": 1},
+        )
+        assert response.status_code == 200
+        assert response.json()["engine"] == "google"
+
+    def test_missing_headers_accepted_when_enforcement_disabled(
+        self,
+        relaxed_client: TestClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("GOOGLE_SEARCH_API_KEY", "test-key")
+        monkeypatch.setenv("GOOGLE_SEARCH_ENGINE_ID", "test-cx")
+
+        from unique_search_proxy_core.schema import (
+            SearchEngineRaw,
+            WebSearchResult,
+            WebSearchResults,
+        )
+        from unique_search_proxy_core.search_engines.google.schema import (
+            GoogleSearchRequest,
+        )
+
+        async def fake_search(
+            self: object,
+            request: GoogleSearchRequest,
+        ) -> tuple[SearchEngineRaw, WebSearchResults]:
+            return SearchEngineRaw(pages=[]), WebSearchResults(
+                results=[
+                    WebSearchResult(url="https://example.com", title="t", snippet="s"),
+                ],
+            )
+
+        monkeypatch.setattr(
+            "unique_search_proxy_client.web.core.search_engines.google.service.GoogleSearchService.search",
+            fake_search,
+        )
+
+        response = relaxed_client.post(
+            "/v1/search",
+            json={"engine": "google", "query": "test", "fetchSize": 1},
+        )
+        assert response.status_code == 200
+
+    def test_local_default_headers_accepted_when_enforcement_enabled(
+        self,
+        enforcement_client: TestClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("GOOGLE_SEARCH_API_KEY", "test-key")
+        monkeypatch.setenv("GOOGLE_SEARCH_ENGINE_ID", "test-cx")
+
+        from unique_search_proxy_core.schema import (
+            SearchEngineRaw,
+            WebSearchResult,
+            WebSearchResults,
+        )
+        from unique_search_proxy_core.search_engines.google.schema import (
+            GoogleSearchRequest,
+        )
+
+        async def fake_search(
+            self: object,
+            request: GoogleSearchRequest,
+        ) -> tuple[SearchEngineRaw, WebSearchResults]:
+            return SearchEngineRaw(pages=[]), WebSearchResults(
+                results=[
+                    WebSearchResult(url="https://example.com", title="t", snippet="s"),
+                ],
+            )
+
+        monkeypatch.setattr(
+            "unique_search_proxy_client.web.core.search_engines.google.service.GoogleSearchService.search",
+            fake_search,
+        )
+
+        response = enforcement_client.post(
+            "/v1/search",
+            headers=LOCAL_REQUEST_CONTEXT.to_headers(),
+            json={"engine": "google", "query": "test", "fetchSize": 1},
+        )
+        assert response.status_code == 200

--- a/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/api/v1/__init__.py
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/api/v1/__init__.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
 from unique_search_proxy_client.web.api.v1.agent_search import (
     router as agent_search_router,
@@ -6,10 +6,16 @@ from unique_search_proxy_client.web.api.v1.agent_search import (
 from unique_search_proxy_client.web.api.v1.configuration import (
     router as configuration_router,
 )
+from unique_search_proxy_client.web.api.v1.context_headers import (
+    document_request_context_headers,
+)
 from unique_search_proxy_client.web.api.v1.crawl import router as crawl_router
 from unique_search_proxy_client.web.api.v1.search import router as search_router
 
-v1_router = APIRouter(prefix="/v1")
+v1_router = APIRouter(
+    prefix="/v1",
+    dependencies=[Depends(document_request_context_headers)],
+)
 v1_router.include_router(configuration_router)
 v1_router.include_router(search_router)
 v1_router.include_router(agent_search_router)

--- a/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/api/v1/agent_search.py
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/api/v1/agent_search.py
@@ -82,7 +82,6 @@ async def agent_search(
         engine_id,
         timeout,
     )
-    _LOGGER.debug("agent-search query=%r", body.query)
 
     try:
         engine_service = get_agent_engine_service(
@@ -161,7 +160,6 @@ async def agent_search_stream(
         engine_id,
         timeout,
     )
-    _LOGGER.debug("agent-search query=%r", body.query)
 
     try:
         engine_service = get_agent_engine_service(

--- a/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/api/v1/agent_search.py
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/api/v1/agent_search.py
@@ -77,6 +77,12 @@ async def agent_search(
     engine_id = engine.value if hasattr(engine, "value") else str(engine)
     timeout = body.timeout
     started = time.perf_counter()
+    _LOGGER.info(
+        "agent-search start mode=sync engine=%s timeout=%ss",
+        engine_id,
+        timeout,
+    )
+    _LOGGER.debug("agent-search query=%r", body.query)
 
     try:
         engine_service = get_agent_engine_service(
@@ -90,6 +96,12 @@ async def agent_search(
             ProxyErrorCode.UPSTREAM_TIMEOUT.value,
             time.perf_counter() - started,
         )
+        _LOGGER.warning(
+            "agent-search timeout mode=sync engine=%s timeout=%ss duration=%.0fms",
+            engine_id,
+            timeout,
+            (time.perf_counter() - started) * 1000,
+        )
         raise _agent_search_request_context(
             UpstreamTimeoutError(
                 f"Agent engine '{engine_id}' timed out after {timeout}s",
@@ -102,6 +114,12 @@ async def agent_search(
             exc.code.value if hasattr(exc.code, "value") else str(exc.code),
             time.perf_counter() - started,
         )
+        _LOGGER.warning(
+            "agent-search failed mode=sync engine=%s code=%s duration=%.0fms",
+            engine_id,
+            exc.code.value if hasattr(exc.code, "value") else exc.code,
+            (time.perf_counter() - started) * 1000,
+        )
         raise _agent_search_request_context(exc, engine_id=engine_id) from exc
     except Exception:
         record_agent_search_error(
@@ -109,10 +127,20 @@ async def agent_search(
             "INTERNAL_ERROR",
             time.perf_counter() - started,
         )
+        _LOGGER.exception(
+            "agent-search error mode=sync engine=%s duration=%.0fms",
+            engine_id,
+            (time.perf_counter() - started) * 1000,
+        )
         raise
 
     duration = time.perf_counter() - started
     record_agent_search_success(engine_id, duration)
+    _LOGGER.info(
+        "agent-search success mode=sync engine=%s duration=%.0fms",
+        engine_id,
+        duration * 1000,
+    )
     return result
 
 
@@ -128,6 +156,12 @@ async def agent_search_stream(
     engine_id = engine.value if hasattr(engine, "value") else str(engine)
     timeout = body.timeout
     started = time.perf_counter()
+    _LOGGER.info(
+        "agent-search start mode=stream engine=%s timeout=%ss",
+        engine_id,
+        timeout,
+    )
+    _LOGGER.debug("agent-search query=%r", body.query)
 
     try:
         engine_service = get_agent_engine_service(
@@ -135,6 +169,10 @@ async def agent_search_stream(
         )
     except Exception as exc:
         record_agent_search_error(engine_id, "INTERNAL_ERROR", 0.0)
+        _LOGGER.exception(
+            "agent-search setup error mode=stream engine=%s",
+            engine_id,
+        )
         raise _agent_search_request_context(
             UpstreamError(str(exc)),
             engine_id=engine_id,
@@ -147,11 +185,22 @@ async def agent_search_stream(
                 async for event in engine_service.stream(body):
                     yield _format_sse_event(event)
             record_agent_search_success(engine_id, time.perf_counter() - started)
+            _LOGGER.info(
+                "agent-search success mode=stream engine=%s duration=%.0fms",
+                engine_id,
+                (time.perf_counter() - started) * 1000,
+            )
         except TimeoutError:
             record_agent_search_error(
                 engine_id,
                 ProxyErrorCode.UPSTREAM_TIMEOUT.value,
                 time.perf_counter() - started,
+            )
+            _LOGGER.warning(
+                "agent-search timeout mode=stream engine=%s timeout=%ss duration=%.0fms",
+                engine_id,
+                timeout,
+                (time.perf_counter() - started) * 1000,
             )
             error = _agent_search_request_context(
                 UpstreamTimeoutError(
@@ -166,6 +215,12 @@ async def agent_search_stream(
                 exc.code.value if hasattr(exc.code, "value") else str(exc.code),
                 time.perf_counter() - started,
             )
+            _LOGGER.warning(
+                "agent-search failed mode=stream engine=%s code=%s duration=%.0fms",
+                engine_id,
+                exc.code.value if hasattr(exc.code, "value") else exc.code,
+                (time.perf_counter() - started) * 1000,
+            )
             yield _format_sse_error(
                 _agent_search_request_context(exc, engine_id=engine_id)
             )
@@ -175,7 +230,11 @@ async def agent_search_stream(
                 "INTERNAL_ERROR",
                 time.perf_counter() - started,
             )
-            _LOGGER.exception("Agent search stream failed")
+            _LOGGER.exception(
+                "agent-search error mode=stream engine=%s duration=%.0fms",
+                engine_id,
+                (time.perf_counter() - started) * 1000,
+            )
             yield _format_sse_error(
                 _agent_search_request_context(
                     UpstreamError(str(exc)),

--- a/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/api/v1/context_headers.py
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/api/v1/context_headers.py
@@ -1,0 +1,43 @@
+"""OpenAPI documentation for tenant context headers enforced by middleware."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import Header
+from unique_search_proxy_core.context import (
+    CHAT_ID_HEADER,
+    COMPANY_ID_HEADER,
+    LOCAL_REQUEST_CONTEXT,
+    USER_ID_HEADER,
+)
+
+
+async def document_request_context_headers(
+    x_unique_company_id: Annotated[
+        str,
+        Header(
+            alias=COMPANY_ID_HEADER,
+            description="Tenant company identifier.",
+        ),
+    ] = LOCAL_REQUEST_CONTEXT.company_id,
+    x_unique_user_id: Annotated[
+        str,
+        Header(
+            alias=USER_ID_HEADER,
+            description="Tenant user identifier.",
+        ),
+    ] = LOCAL_REQUEST_CONTEXT.user_id,
+    x_unique_chat_id: Annotated[
+        str,
+        Header(
+            alias=CHAT_ID_HEADER,
+            description="Tenant chat or session identifier.",
+        ),
+    ] = LOCAL_REQUEST_CONTEXT.chat_id,
+) -> None:
+    """Declare context headers on /v1 routes for Swagger; enforcement is in middleware."""
+    return None
+
+
+__all__ = ["document_request_context_headers"]

--- a/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/api/v1/crawl.py
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/api/v1/crawl.py
@@ -54,15 +54,30 @@ async def crawl(
     crawler_id = body.crawler
     timeout = body.timeout
     started = time.perf_counter()
+    _LOGGER.info(
+        "crawl start crawler=%s urls=%d timeout=%ss",
+        crawler_id,
+        len(body.urls),
+        timeout,
+    )
+    _LOGGER.debug("crawl urls=%r", body.urls)
 
     try:
         async with asyncio.timeout(timeout):
             gate = await apply_url_safety_gate(body.urls)
             if not gate.allowed_targets:
+                duration = time.perf_counter() - started
                 record_crawl_success(
                     crawler_id,
                     len(body.urls),
-                    time.perf_counter() - started,
+                    duration,
+                )
+                _LOGGER.info(
+                    "crawl success crawler=%s urls=%d blocked=%d results=0 duration=%.0fms",
+                    crawler_id,
+                    len(body.urls),
+                    len(gate.blocked_by_index),
+                    duration * 1000,
                 )
                 return CrawlResponse(
                     crawler=crawler_id,
@@ -94,6 +109,12 @@ async def crawl(
             ProxyErrorCode.UPSTREAM_TIMEOUT.value,
             time.perf_counter() - started,
         )
+        _LOGGER.warning(
+            "crawl timeout crawler=%s timeout=%ss duration=%.0fms",
+            crawler_id,
+            timeout,
+            (time.perf_counter() - started) * 1000,
+        )
         raise _crawl_request_context(
             UpstreamTimeoutError(
                 f"Crawler '{crawler_id}' timed out after {timeout}s",
@@ -101,6 +122,12 @@ async def crawl(
             crawler_id=crawler_id,
         ) from exc
     except ProxyError as exc:
+        _LOGGER.warning(
+            "crawl failed crawler=%s code=%s duration=%.0fms",
+            crawler_id,
+            exc.code.value if hasattr(exc.code, "value") else exc.code,
+            (time.perf_counter() - started) * 1000,
+        )
         raise _crawl_request_context(exc, crawler_id=crawler_id) from exc
     except Exception:
         record_crawl_error(
@@ -108,14 +135,29 @@ async def crawl(
             "INTERNAL_ERROR",
             time.perf_counter() - started,
         )
+        _LOGGER.exception(
+            "crawl error crawler=%s duration=%.0fms",
+            crawler_id,
+            (time.perf_counter() - started) * 1000,
+        )
         raise
 
-    record_crawl_success(crawler_id, len(body.urls), time.perf_counter() - started)
+    duration = time.perf_counter() - started
+    record_crawl_success(crawler_id, len(body.urls), duration)
+    merged_results = merge_crawl_results(
+        body.urls,
+        blocked_by_index=gate.blocked_by_index,
+        crawler_results=crawler_results,
+    )
+    _LOGGER.info(
+        "crawl success crawler=%s urls=%d blocked=%d results=%d duration=%.0fms",
+        crawler_id,
+        len(body.urls),
+        len(gate.blocked_by_index),
+        len(merged_results),
+        duration * 1000,
+    )
     return CrawlResponse(
         crawler=crawler_id,
-        results=merge_crawl_results(
-            body.urls,
-            blocked_by_index=gate.blocked_by_index,
-            crawler_results=crawler_results,
-        ),
+        results=merged_results,
     )

--- a/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/api/v1/crawl.py
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/api/v1/crawl.py
@@ -60,7 +60,6 @@ async def crawl(
         len(body.urls),
         timeout,
     )
-    _LOGGER.debug("crawl urls=%r", body.urls)
 
     try:
         async with asyncio.timeout(timeout):

--- a/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/api/v1/search.py
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/api/v1/search.py
@@ -65,7 +65,6 @@ async def search(
     timeout = body.timeout
     started = time.perf_counter()
     _LOGGER.info("search start engine=%s timeout=%ss", engine_id, timeout)
-    _LOGGER.debug("search query=%r", body.query)
 
     try:
         pool = get_http_client_pool(request.app)

--- a/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/api/v1/search.py
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/api/v1/search.py
@@ -64,6 +64,8 @@ async def search(
     engine_id = engine.value if hasattr(engine, "value") else str(engine)
     timeout = body.timeout
     started = time.perf_counter()
+    _LOGGER.info("search start engine=%s timeout=%ss", engine_id, timeout)
+    _LOGGER.debug("search query=%r", body.query)
 
     try:
         pool = get_http_client_pool(request.app)
@@ -79,6 +81,12 @@ async def search(
             ProxyErrorCode.UPSTREAM_TIMEOUT.value,
             time.perf_counter() - started,
         )
+        _LOGGER.warning(
+            "search timeout engine=%s timeout=%ss duration=%.0fms",
+            engine_id,
+            timeout,
+            (time.perf_counter() - started) * 1000,
+        )
         raise _search_request_context(
             UpstreamTimeoutError(
                 f"Search engine '{engine_id}' timed out after {timeout}s",
@@ -86,6 +94,12 @@ async def search(
             engine_id=engine_id,
         ) from exc
     except ProxyError as exc:
+        _LOGGER.warning(
+            "search failed engine=%s code=%s duration=%.0fms",
+            engine_id,
+            exc.code.value if hasattr(exc.code, "value") else exc.code,
+            (time.perf_counter() - started) * 1000,
+        )
         raise _search_request_context(exc, engine_id=engine_id) from exc
     except Exception:
         record_search_error(
@@ -93,14 +107,26 @@ async def search(
             "INTERNAL_ERROR",
             time.perf_counter() - started,
         )
+        _LOGGER.exception(
+            "search error engine=%s duration=%.0fms",
+            engine_id,
+            (time.perf_counter() - started) * 1000,
+        )
         raise
 
     duration = time.perf_counter() - started
     record_search_success(engine_id, duration)
+    curated = _curated_results(curated)
+    _LOGGER.info(
+        "search success engine=%s results=%d duration=%.0fms",
+        engine_id,
+        len(curated),
+        duration * 1000,
+    )
 
     return SearchResponse(
         engine=engine_id,
         query=body.query,
         raw=raw,
-        curated=_curated_results(curated),
+        curated=curated,
     )

--- a/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/app.py
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/app.py
@@ -17,6 +17,7 @@ from unique_search_proxy_client.web.logging_config import (
     build_logging_config,
     configure_logging,
 )
+from unique_search_proxy_client.web.middleware.context import RequestContextMiddleware
 from unique_search_proxy_client.web.monitoring import setup_prometheus
 from unique_search_proxy_client.web.startup_report import (
     log_startup_settings_report,
@@ -82,6 +83,7 @@ def create_app() -> FastAPI:
     )
     register_exception_handlers(application)
     setup_prometheus(application)
+    application.add_middleware(RequestContextMiddleware)
     application.include_router(health_router)
     application.include_router(v1_router)
     return application

--- a/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/app.py
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/app.py
@@ -68,7 +68,9 @@ def create_app() -> FastAPI:
             "Unified web egress proxy for search engines and crawlers. "
             "Use **Try it out** on `/v1/search` and `/v1/crawl` — pick an example "
             "from the request-body dropdown (snippets-only Google search, crawl with "
-            "HTML markdown, etc.). Requires provider env vars (e.g. "
+            "HTML markdown, etc.). `/v1/*` routes accept tenant context headers "
+            "(`x-unique-company-id`, `x-unique-user-id`, `x-unique-chat-id`; "
+            "defaults `local` in Swagger). Requires provider env vars (e.g. "
             "`GOOGLE_SEARCH_API_KEY`, `GOOGLE_SEARCH_ENGINE_ID`) for live calls."
         ),
         version="0.2.0",

--- a/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/context.py
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/context.py
@@ -1,0 +1,49 @@
+"""Request-scoped tenant context for logging and diagnostics."""
+
+from __future__ import annotations
+
+import logging
+from contextvars import ContextVar, Token
+from typing import Final
+
+from unique_search_proxy_core.context import LOCAL_REQUEST_CONTEXT, RequestContext
+
+_REQUEST_CONTEXT: ContextVar[RequestContext] = ContextVar(
+    "request_context",
+    default=LOCAL_REQUEST_CONTEXT,
+)
+
+_CONTEXT_FIELDS: Final[tuple[str, ...]] = ("company_id", "user_id", "chat_id")
+
+
+def bind_request_context(context: RequestContext) -> Token[RequestContext]:
+    """Bind tenant context for the current async task."""
+    return _REQUEST_CONTEXT.set(context)
+
+
+def reset_request_context(token: Token[RequestContext]) -> None:
+    """Restore the previous tenant context."""
+    _REQUEST_CONTEXT.reset(token)
+
+
+def get_request_context() -> RequestContext:
+    """Return the tenant context for the current async task."""
+    return _REQUEST_CONTEXT.get()
+
+
+class RequestContextLogFilter(logging.Filter):
+    """Inject tenant context fields into every log record."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        context = get_request_context()
+        for field_name in _CONTEXT_FIELDS:
+            setattr(record, field_name, getattr(context, field_name))
+        return True
+
+
+__all__ = [
+    "RequestContextLogFilter",
+    "bind_request_context",
+    "get_request_context",
+    "reset_request_context",
+]

--- a/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/error_handlers.py
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/error_handlers.py
@@ -47,7 +47,13 @@ def register_exception_handlers(app: FastAPI) -> None:
             record_search_error(exc.provider, exc.code.value, 0.0)
         if exc.request == "crawl" and exc.provider is not None:
             record_crawl_error(exc.provider, exc.code.value, 0.0)
-        _LOGGER.warning("Proxy error [%s]: %s", exc.code.value, exc.message)
+        _LOGGER.warning(
+            "Proxy error [%s] request=%s provider=%s: %s",
+            exc.code.value,
+            exc.request or "-",
+            exc.provider or "-",
+            exc.message,
+        )
         return proxy_error_response(exc)
 
     @app.exception_handler(RequestValidationError)

--- a/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/logging_config.py
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/logging_config.py
@@ -8,9 +8,23 @@ from typing import Any
 
 from uvicorn.config import LOG_LEVELS, LOGGING_CONFIG
 
+from unique_search_proxy_client.web.context import RequestContextLogFilter
+
 _APP_LOGGER_NAMES = (
     "unique_search_proxy_client",
     "unique_search_proxy_core",
+)
+
+_CONTEXT_LOG_FORMAT = (
+    "%(levelprefix)s "
+    "company=%(company_id)s user=%(user_id)s chat=%(chat_id)s "
+    "%(message)s"
+)
+
+_ACCESS_CONTEXT_LOG_FORMAT = (
+    "%(levelprefix)s "
+    "company=%(company_id)s user=%(user_id)s chat=%(chat_id)s "
+    '%(client_addr)s - "%(request_line)s" %(status_code)s'
 )
 
 
@@ -22,6 +36,14 @@ def build_logging_config(log_level: str | None = None) -> dict[str, Any]:
     level_name = level_key.upper()
 
     config = copy.deepcopy(LOGGING_CONFIG)
+    config.setdefault("filters", {})
+    config["filters"]["request_context"] = {
+        "()": RequestContextLogFilter,
+    }
+    config["formatters"]["default"]["fmt"] = _CONTEXT_LOG_FORMAT
+    config["formatters"]["access"]["fmt"] = _ACCESS_CONTEXT_LOG_FORMAT
+    config["handlers"]["default"]["filters"] = ["request_context"]
+    config["handlers"]["access"]["filters"] = ["request_context"]
     for logger_name in _APP_LOGGER_NAMES:
         config["loggers"][logger_name] = {
             "handlers": ["default"],

--- a/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/middleware/context.py
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/middleware/context.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from starlette.types import ASGIApp, Receive, Scope, Send
+from unique_search_proxy_core.context import LOCAL_REQUEST_CONTEXT, RequestContext
+from unique_search_proxy_core.errors import ValidationProxyError
+
+from unique_search_proxy_client.web.context import (
+    bind_request_context,
+    reset_request_context,
+)
+from unique_search_proxy_client.web.error_handlers import proxy_error_response
+from unique_search_proxy_client.web.settings.app import app_settings
+
+_CONTEXT_EXCLUDED_PATHS = frozenset(
+    {
+        "/",
+        "/health",
+        "/ready",
+        "/metrics",
+        "/docs",
+        "/redoc",
+        "/openapi.json",
+    }
+)
+
+
+def _headers_from_scope(scope: Scope) -> dict[str, str]:
+    return {
+        key.decode("latin-1").lower(): value.decode("latin-1")
+        for key, value in scope.get("headers", [])
+    }
+
+
+class RequestContextMiddleware:
+    """Enforce tenant context headers on /v1 routes and bind them for logging.
+
+    Implemented as pure ASGI middleware (not ``BaseHTTPMiddleware``) so the
+    bound context stays active for the whole request lifecycle — including
+    response send, which is when Uvicorn emits its access log line.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        path = scope.get("path", "")
+        if not path.startswith("/v1") or path in _CONTEXT_EXCLUDED_PATHS:
+            await self.app(scope, receive, send)
+            return
+
+        headers = _headers_from_scope(scope)
+        missing = RequestContext.missing_headers(headers)
+        if missing and app_settings.require_context_headers:
+            details = [
+                {
+                    "loc": ["header", header_name],
+                    "msg": "Field required",
+                    "type": "missing",
+                }
+                for header_name in missing
+            ]
+            response = proxy_error_response(
+                ValidationProxyError(
+                    f"Missing required context headers: {', '.join(missing)}",
+                    details=details,
+                ),
+            )
+            await response(scope, receive, send)
+            return
+
+        context = RequestContext.from_headers(
+            headers,
+            fallback=LOCAL_REQUEST_CONTEXT,
+        )
+        token = bind_request_context(context)
+        try:
+            await self.app(scope, receive, send)
+        finally:
+            reset_request_context(token)
+
+
+__all__ = ["RequestContextMiddleware"]

--- a/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/settings/app.py
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/settings/app.py
@@ -1,0 +1,30 @@
+from pydantic_settings import BaseSettings
+
+from unique_search_proxy_client.web.helm.metadata import helm_settings
+from unique_search_proxy_client.web.settings.base import get_settings
+
+APP_ENV_PREFIX = ""
+
+
+@helm_settings(
+    title="Application",
+    helm_key=None,
+    kind="internal",
+    egress=None,
+    env_prefix=APP_ENV_PREFIX,
+)
+class AppSettings(BaseSettings):
+    require_context_headers: bool = True
+
+
+def get_app_settings() -> AppSettings:
+    return get_settings(AppSettings, env_prefix=APP_ENV_PREFIX)
+
+
+app_settings: AppSettings = get_app_settings()
+
+__all__ = [
+    "AppSettings",
+    "app_settings",
+    "get_app_settings",
+]

--- a/connectors/unique_search_proxy/unique_search_proxy_core/tests/test_context.py
+++ b/connectors/unique_search_proxy/unique_search_proxy_core/tests/test_context.py
@@ -1,0 +1,48 @@
+"""Tests for tenant context header contract."""
+
+from __future__ import annotations
+
+import pytest
+
+from unique_search_proxy_core.context import (
+    CHAT_ID_HEADER,
+    COMPANY_ID_HEADER,
+    LOCAL_REQUEST_CONTEXT,
+    USER_ID_HEADER,
+    RequestContext,
+)
+
+
+@pytest.mark.ai
+class TestRequestContext:
+    def test_to_headers(self) -> None:
+        context = RequestContext(
+            company_id="company-1",
+            user_id="user-1",
+            chat_id="chat-1",
+        )
+        assert context.to_headers() == {
+            COMPANY_ID_HEADER: "company-1",
+            USER_ID_HEADER: "user-1",
+            CHAT_ID_HEADER: "chat-1",
+        }
+
+    def test_missing_headers_detects_absent_values(self) -> None:
+        missing = RequestContext.missing_headers(
+            {
+                COMPANY_ID_HEADER: "company-1",
+                USER_ID_HEADER: "",
+            }
+        )
+        assert USER_ID_HEADER in missing
+        assert CHAT_ID_HEADER in missing
+        assert COMPANY_ID_HEADER not in missing
+
+    def test_from_headers_uses_fallback_for_missing(self) -> None:
+        context = RequestContext.from_headers(
+            {COMPANY_ID_HEADER: "company-1"},
+            fallback=LOCAL_REQUEST_CONTEXT,
+        )
+        assert context.company_id == "company-1"
+        assert context.user_id == "local"
+        assert context.chat_id == "local"

--- a/connectors/unique_search_proxy/unique_search_proxy_core/unique_search_proxy_core/__init__.py
+++ b/connectors/unique_search_proxy/unique_search_proxy_core/unique_search_proxy_core/__init__.py
@@ -1,5 +1,12 @@
 """Shared types for Unique Search Proxy (no FastAPI / server dependencies)."""
 
+from unique_search_proxy_core.context import (
+    CHAT_ID_HEADER,
+    COMPANY_ID_HEADER,
+    LOCAL_REQUEST_CONTEXT,
+    USER_ID_HEADER,
+    RequestContext,
+)
 from unique_search_proxy_core.errors import (
     BadRequestProxyError,
     EmptySearchResultsError,
@@ -22,6 +29,11 @@ from unique_search_proxy_core.schema import (
 )
 
 __all__ = [
+    "CHAT_ID_HEADER",
+    "COMPANY_ID_HEADER",
+    "LOCAL_REQUEST_CONTEXT",
+    "RequestContext",
+    "USER_ID_HEADER",
     "BadRequestProxyError",
     "CrawlResponse",
     "EmptySearchResultsError",

--- a/connectors/unique_search_proxy/unique_search_proxy_core/unique_search_proxy_core/context.py
+++ b/connectors/unique_search_proxy/unique_search_proxy_core/unique_search_proxy_core/context.py
@@ -1,0 +1,81 @@
+"""Tenant context propagated via HTTP headers between SDK callers and the proxy."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+COMPANY_ID_HEADER = "x-unique-company-id"
+USER_ID_HEADER = "x-unique-user-id"
+CHAT_ID_HEADER = "x-unique-chat-id"
+
+_CONTEXT_HEADER_FIELDS: tuple[tuple[str, str], ...] = (
+    ("company_id", COMPANY_ID_HEADER),
+    ("user_id", USER_ID_HEADER),
+    ("chat_id", CHAT_ID_HEADER),
+)
+
+
+class RequestContext(BaseModel):
+    """Caller identity for search-proxy requests."""
+
+    model_config = ConfigDict(frozen=True)
+
+    company_id: str
+    user_id: str
+    chat_id: str
+
+    def to_headers(self) -> dict[str, str]:
+        """Serialize context to the canonical HTTP header names."""
+        return {
+            COMPANY_ID_HEADER: self.company_id,
+            USER_ID_HEADER: self.user_id,
+            CHAT_ID_HEADER: self.chat_id,
+        }
+
+    @classmethod
+    def missing_headers(cls, headers: Mapping[str, Any]) -> list[str]:
+        """Return header names that are absent or blank."""
+        normalized = {key.lower(): value for key, value in headers.items()}
+        missing: list[str] = []
+        for _field, header_name in _CONTEXT_HEADER_FIELDS:
+            value = normalized.get(header_name.lower())
+            if value is None or (isinstance(value, str) and not value.strip()):
+                missing.append(header_name)
+        return missing
+
+    @classmethod
+    def from_headers(
+        cls,
+        headers: Mapping[str, Any],
+        *,
+        fallback: RequestContext,
+    ) -> RequestContext:
+        """Build context from headers, using ``fallback`` for any missing values."""
+        normalized = {key.lower(): value for key, value in headers.items()}
+        values: dict[str, str] = {}
+        for field_name, header_name in _CONTEXT_HEADER_FIELDS:
+            raw = normalized.get(header_name.lower())
+            if raw is None or (isinstance(raw, str) and not raw.strip()):
+                values[field_name] = getattr(fallback, field_name)
+            else:
+                values[field_name] = str(raw)
+        return cls(**values)
+
+
+LOCAL_REQUEST_CONTEXT = RequestContext(
+    company_id="local",
+    user_id="local",
+    chat_id="local",
+)
+
+
+__all__ = [
+    "CHAT_ID_HEADER",
+    "COMPANY_ID_HEADER",
+    "LOCAL_REQUEST_CONTEXT",
+    "RequestContext",
+    "USER_ID_HEADER",
+]

--- a/connectors/unique_search_proxy/unique_search_proxy_sdk/tests/test_sdk_client.py
+++ b/connectors/unique_search_proxy/unique_search_proxy_sdk/tests/test_sdk_client.py
@@ -340,3 +340,27 @@ class TestSubclientTypes:
         assert callable(sdk_client.search.google)
         assert callable(sdk_client.crawl.basic)
         assert callable(sdk_client.agent_search.bing_stream)
+
+
+class TestRequestContextHeaders:
+    @pytest.mark.ai
+    def test_client_sends_context_headers(self) -> None:
+        from unique_search_proxy_core.context import (
+            CHAT_ID_HEADER,
+            COMPANY_ID_HEADER,
+            USER_ID_HEADER,
+            RequestContext,
+        )
+
+        from unique_search_proxy_sdk._transport import OpenapiTransport
+
+        context = RequestContext(
+            company_id="company-1",
+            user_id="user-1",
+            chat_id="chat-1",
+        )
+        transport = OpenapiTransport("http://test", context=context)
+        headers = transport.openapi.get_async_httpx_client().headers
+        assert headers[COMPANY_ID_HEADER] == "company-1"
+        assert headers[USER_ID_HEADER] == "user-1"
+        assert headers[CHAT_ID_HEADER] == "chat-1"

--- a/connectors/unique_search_proxy/unique_search_proxy_sdk/unique_search_proxy_sdk/_transport.py
+++ b/connectors/unique_search_proxy/unique_search_proxy_sdk/unique_search_proxy_sdk/_transport.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 import httpx
+from unique_search_proxy_core.context import LOCAL_REQUEST_CONTEXT, RequestContext
 from unique_search_proxy_core.logging import suppress_httpx_request_logs
 
 from unique_search_proxy_sdk._generated.api.health import (
@@ -26,6 +27,7 @@ class OpenapiTransport:
         *,
         http_client: httpx.AsyncClient | None = None,
         timeout: float = _DEFAULT_TIMEOUT_SECONDS,
+        context: RequestContext = LOCAL_REQUEST_CONTEXT,
     ) -> None:
         suppress_httpx_request_logs()
         self._base_url = base_url.rstrip("/")
@@ -33,8 +35,10 @@ class OpenapiTransport:
         self._openapi = OpenAPIClient(
             base_url=self._base_url,
             timeout=httpx.Timeout(timeout),
+            headers=context.to_headers(),
         )
         if http_client is not None:
+            http_client.headers.update(context.to_headers())
             self._openapi.set_async_httpx_client(http_client)
 
     @property

--- a/connectors/unique_search_proxy/unique_search_proxy_sdk/unique_search_proxy_sdk/client.py
+++ b/connectors/unique_search_proxy/unique_search_proxy_sdk/unique_search_proxy_sdk/client.py
@@ -11,6 +11,7 @@ live in ``unique_search_proxy_core`` — not in this SDK.
 from __future__ import annotations
 
 import httpx
+from unique_search_proxy_core.context import LOCAL_REQUEST_CONTEXT, RequestContext
 
 from unique_search_proxy_sdk._generated.client import Client as OpenAPIClient
 from unique_search_proxy_sdk._transport import OpenapiTransport
@@ -34,11 +35,13 @@ class UniqueSearchProxyClient:
         *,
         http_client: httpx.AsyncClient | None = None,
         timeout: float = _DEFAULT_TIMEOUT_SECONDS,
+        context: RequestContext = LOCAL_REQUEST_CONTEXT,
     ) -> None:
         self._transport = OpenapiTransport(
             base_url,
             http_client=http_client,
             timeout=timeout,
+            context=context,
         )
         self.search = SearchClient(self._transport)
         self.agent_search = AgentSearchClient(self._transport)

--- a/tool_packages/unique_web_search/src/unique_web_search/service.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/service.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from time import time
 
 from typing_extensions import override
+from unique_search_proxy_core.context import RequestContext
 from unique_search_proxy_core.param_policy.exposed_params import ExposedParams
 from unique_search_proxy_core.search_engines.base import BaseSearchEngineConfig
 from unique_toolkit._common.chunk_relevancy_sorter.service import ChunkRelevancySorter
@@ -72,13 +73,22 @@ class WebSearchTool(Tool[WebSearchConfig]):
             language_model_orchestrator or configuration.token_counting_language_model
         )
 
+        self.chunk_relevancy_sorter = ChunkRelevancySorter(self.event)
+        self.company_id = self.event.company_id
+        self.request_context = RequestContext(
+            company_id=self.event.company_id,
+            user_id=self.event.user_id,
+            chat_id=self.event.payload.chat_id,
+        )
         self.search_engine_service = get_search_engine_service(
             self.config.search_engine_config,
             self.language_model_service,
+            request_context=self.request_context,
         )
-        self.crawler_service = get_crawler_service(self.config.crawler_config)
-        self.chunk_relevancy_sorter = ChunkRelevancySorter(self.event)
-        self.company_id = self.event.company_id
+        self.crawler_service = get_crawler_service(
+            self.config.crawler_config,
+            request_context=self.request_context,
+        )
         self.chat_history_token_length = 0
         self.chat_history_chat_messages = self._chat_service.get_full_history()
 

--- a/tool_packages/unique_web_search/src/unique_web_search/services/crawlers/base.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/crawlers/base.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Generic, TypeVar
 
+from unique_search_proxy_core.context import LOCAL_REQUEST_CONTEXT, RequestContext
 from unique_search_proxy_core.crawlers.base import BaseCrawlerConfig
 from unique_search_proxy_core.url_safety import (
     CrawlTargetValidationError,
@@ -30,8 +31,14 @@ class BaseCrawler(ABC, Generic[CrawlerConfig]):
     the direct ``_legacy_crawl`` implementation used when the proxy is disabled.
     """
 
-    def __init__(self, config: CrawlerConfig):
+    def __init__(
+        self,
+        config: CrawlerConfig,
+        *,
+        request_context: RequestContext = LOCAL_REQUEST_CONTEXT,
+    ):
         self.config = config
+        self._request_context = request_context
 
     async def crawl(self, urls: list[str]) -> list[str]:
         if search_proxy_client_enabled:
@@ -49,7 +56,8 @@ class BaseCrawler(ABC, Generic[CrawlerConfig]):
         """Dump deployment config fields into the generic proxy crawl call."""
         params = self.config.model_dump(exclude={"crawler"}, exclude_none=True)
         async with open_search_proxy_client(
-            timeout=float(self.config.timeout)
+            timeout=float(self.config.timeout),
+            context=self._request_context,
         ) as client:
             response = await client.crawl.crawl(
                 urls=urls,

--- a/tool_packages/unique_web_search/src/unique_web_search/services/crawlers/basic.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/crawlers/basic.py
@@ -8,6 +8,7 @@ from httpx import AsyncClient, Timeout
 from markdownify import markdownify
 from pydantic import Field
 from typing_extensions import override
+from unique_search_proxy_core.context import LOCAL_REQUEST_CONTEXT, RequestContext
 from unique_search_proxy_core.crawlers.base import CrawlerType
 from unique_search_proxy_core.crawlers.basic.content_types import (
     CONTENT_TYPE_TOGGLE_TO_MIME,
@@ -54,8 +55,13 @@ class BasicConfig(CoreBasicConfig):
     config_display_name="Basic",
 )
 class BasicCrawler(BaseCrawler[BasicConfig]):
-    def __init__(self, config: BasicConfig):
-        super().__init__(config)
+    def __init__(
+        self,
+        config: BasicConfig,
+        *,
+        request_context: RequestContext = LOCAL_REQUEST_CONTEXT,
+    ):
+        super().__init__(config, request_context=request_context)
 
         self.semaphore: asyncio.Semaphore = asyncio.Semaphore(
             self.config.max_concurrent_requests
@@ -69,7 +75,8 @@ class BasicCrawler(BaseCrawler[BasicConfig]):
             exclude_none=True,
         )
         async with open_search_proxy_client(
-            timeout=float(self.config.timeout)
+            timeout=float(self.config.timeout),
+            context=self._request_context,
         ) as client:
             response = await client.crawl.crawl(
                 urls=urls,

--- a/tool_packages/unique_web_search/src/unique_web_search/services/crawlers/firecrawl.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/crawlers/firecrawl.py
@@ -19,9 +19,6 @@ from unique_web_search.services.crawlers.url_safety import ResolvedCrawlTarget
     config_display_name="Firecrawl",
 )
 class FirecrawlCrawler(BaseCrawler[FirecrawlConfig]):
-    def __init__(self, config: FirecrawlConfig):
-        super().__init__(config)
-
     @override
     async def _legacy_crawl(self, targets: list[ResolvedCrawlTarget]) -> list[str]:
         urls = [target.normalized_url for target in targets]

--- a/tool_packages/unique_web_search/src/unique_web_search/services/crawlers/jina.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/crawlers/jina.py
@@ -39,9 +39,6 @@ class ReaderResponse(BaseModel):
     config_display_name="Jina",
 )
 class JinaCrawler(BaseCrawler[JinaConfig]):
-    def __init__(self, config: JinaConfig):
-        super().__init__(config)
-
     @override
     async def _legacy_crawl(self, targets: list[ResolvedCrawlTarget]) -> list[str]:
         urls = [target.normalized_url for target in targets]

--- a/tool_packages/unique_web_search/src/unique_web_search/services/crawlers/registry.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/crawlers/registry.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 
 from pydantic import BaseModel
+from unique_search_proxy_core.context import LOCAL_REQUEST_CONTEXT, RequestContext
 from unique_search_proxy_core.crawlers.base import CrawlerType
 
 from unique_web_search.services._registry import BaseSpec, Registry
@@ -37,9 +38,16 @@ def register_crawler(
     )
 
 
-def get_crawler_service(crawler_config: object):
+def get_crawler_service(
+    crawler_config: object,
+    *,
+    request_context: RequestContext = LOCAL_REQUEST_CONTEXT,
+):
     crawler = getattr(crawler_config, "crawler")
-    return CRAWLER_REGISTRY[crawler].impl_cls(crawler_config)
+    return CRAWLER_REGISTRY[crawler].impl_cls(
+        crawler_config,
+        request_context=request_context,
+    )
 
 
 __all__ = [

--- a/tool_packages/unique_web_search/src/unique_web_search/services/crawlers/tavily.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/crawlers/tavily.py
@@ -18,9 +18,6 @@ from unique_web_search.services.crawlers.url_safety import ResolvedCrawlTarget
     config_display_name="Tavily",
 )
 class TavilyCrawler(BaseCrawler[TavilyConfig]):
-    def __init__(self, config: TavilyConfig):
-        super().__init__(config)
-
     @override
     async def _legacy_crawl(self, targets: list[ResolvedCrawlTarget]) -> list[str]:
         urls = [target.normalized_url for target in targets]

--- a/tool_packages/unique_web_search/src/unique_web_search/services/proxy/bridge.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/proxy/bridge.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
+from unique_search_proxy_core.context import LOCAL_REQUEST_CONTEXT, RequestContext
 from unique_search_proxy_sdk import UniqueSearchProxyClient
 
 from unique_web_search.settings import env_settings
@@ -13,6 +14,7 @@ search_proxy_client_enabled = env_settings.search_proxy_base_url is not None
 @asynccontextmanager
 async def open_search_proxy_client(
     timeout: float,
+    context: RequestContext = LOCAL_REQUEST_CONTEXT,
 ) -> AsyncIterator[UniqueSearchProxyClient]:
     base_url = env_settings.search_proxy_base_url
     assert base_url is not None, "Unique Search Proxy base URL is not configured"
@@ -20,6 +22,7 @@ async def open_search_proxy_client(
     async with UniqueSearchProxyClient(
         base_url=base_url,
         timeout=timeout,
+        context=context,
     ) as client:
         yield client
 

--- a/tool_packages/unique_web_search/src/unique_web_search/services/search_engine/base.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/search_engine/base.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, Generic, TypeVar
 from pydantic import BaseModel
 from unique_search_proxy_core.agent_engines.base import AgentEngineType
 from unique_search_proxy_core.agent_engines.config_types import ENGINE_NAME_TO_CONFIG
+from unique_search_proxy_core.context import LOCAL_REQUEST_CONTEXT, RequestContext
 from unique_search_proxy_core.param_policy.exposed_params import ExposedParams
 from unique_search_proxy_core.search_engines.base import (
     BaseSearchEngineConfig,
@@ -72,8 +73,14 @@ class SearchEngine(ABC, Generic[SearchEngineConfig]):
     # Set by agent engines (Bing/VertexAI) and consumed by the agent proxy path.
     response_parsers: list[ResponseParser]
 
-    def __init__(self, config: SearchEngineConfig):
+    def __init__(
+        self,
+        config: SearchEngineConfig,
+        *,
+        request_context: RequestContext = LOCAL_REQUEST_CONTEXT,
+    ):
         self.config = config
+        self._request_context = request_context
 
     @property
     def requires_scraping(self) -> bool:
@@ -129,7 +136,10 @@ class SearchEngine(ABC, Generic[SearchEngineConfig]):
         invocation = request.model_dump(by_alias=False, exclude_none=True)
         invocation.pop("engine", None)
         invocation.pop("query", None)
-        async with open_search_proxy_client(timeout=_STANDARD_PROXY_TIMEOUT) as client:
+        async with open_search_proxy_client(
+            timeout=_STANDARD_PROXY_TIMEOUT,
+            context=self._request_context,
+        ) as client:
             response = await client.search.search(
                 query=query,
                 engine=engine.value,
@@ -148,7 +158,8 @@ class SearchEngine(ABC, Generic[SearchEngineConfig]):
         del params  # Agent engines do not expose LLM knobs today.
         invocation = self._agent_proxy_invocation(engine)
         async with open_search_proxy_client(
-            timeout=float(self.config.timeout)
+            timeout=float(self.config.timeout),
+            context=self._request_context,
         ) as client:
             response = await client.agent_search.search(
                 query=query,

--- a/tool_packages/unique_web_search/src/unique_web_search/services/search_engine/bing.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/search_engine/bing.py
@@ -4,6 +4,7 @@ from typing import override
 from pydantic import Field
 from unique_search_proxy_core.agent_engines.base import AgentEngineType
 from unique_search_proxy_core.agent_engines.bing.schema import BingAgentConfig
+from unique_search_proxy_core.context import LOCAL_REQUEST_CONTEXT, RequestContext
 from unique_search_proxy_core.param_policy.exposed_params import ExposedParams
 from unique_toolkit._common.default_language_model import DEFAULT_LANGUAGE_MODEL
 from unique_toolkit._common.validators import LMI, get_LMI_default_field
@@ -62,8 +63,10 @@ class BingSearch(SearchEngine[BingSearchConfig]):
         self,
         config: BingSearchConfig,
         language_model_service: LanguageModelService,
+        *,
+        request_context: RequestContext = LOCAL_REQUEST_CONTEXT,
     ):
-        super().__init__(config)
+        super().__init__(config, request_context=request_context)
         self.credentials = get_credentials()
 
         self.response_parsers = [

--- a/tool_packages/unique_web_search/src/unique_web_search/services/search_engine/custom_api.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/search_engine/custom_api.py
@@ -4,6 +4,7 @@ from typing import Any, Literal, TypeVar, override
 from httpx import AsyncClient
 from pydantic import BaseModel, Field
 from pydantic.json_schema import SkipJsonSchema
+from unique_search_proxy_core.context import LOCAL_REQUEST_CONTEXT, RequestContext
 from unique_search_proxy_core.param_policy.exposed_params import ExposedParams
 from unique_toolkit.agentic.tools.config import get_configuration_dict
 
@@ -96,8 +97,13 @@ class CustomAPIConfig(BaseModel):
     config_display_name="Customized API",
 )
 class CustomAPI(SearchEngine[CustomAPIConfig]):
-    def __init__(self, config: CustomAPIConfig):
-        super().__init__(config)
+    def __init__(
+        self,
+        config: CustomAPIConfig,
+        *,
+        request_context: RequestContext = LOCAL_REQUEST_CONTEXT,
+    ):
+        super().__init__(config, request_context=request_context)
         self.api_endpoint = config.api_endpoint
         self.is_configured = True  # No possibility to check if the API is configured from our side. So we assume it is configured.
 

--- a/tool_packages/unique_web_search/src/unique_web_search/services/search_engine/registry.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/search_engine/registry.py
@@ -8,6 +8,7 @@ from typing import cast
 
 from pydantic import BaseModel, ConfigDict, create_model
 from unique_search_proxy_core.agent_engines.base import AgentEngineType
+from unique_search_proxy_core.context import LOCAL_REQUEST_CONTEXT, RequestContext
 from unique_search_proxy_core.search_engines.base import SearchEngineType
 from unique_toolkit.agentic.tools.config import get_configuration_dict
 from unique_toolkit.language_model import LanguageModelService
@@ -71,12 +72,21 @@ def register_search_engine(
 def get_search_engine_service(
     search_engine_config: object,
     language_model_service: LanguageModelService,
+    *,
+    request_context: RequestContext = LOCAL_REQUEST_CONTEXT,
 ):
     engine = getattr(search_engine_config, "engine")
     spec = SEARCH_ENGINE_REGISTRY[engine]
     if spec.needs_language_model:
-        return spec.impl_cls(search_engine_config, language_model_service)
-    return spec.impl_cls(search_engine_config)
+        return spec.impl_cls(
+            search_engine_config,
+            language_model_service,
+            request_context=request_context,
+        )
+    return spec.impl_cls(
+        search_engine_config,
+        request_context=request_context,
+    )
 
 
 def get_search_engine_mode(

--- a/tool_packages/unique_web_search/src/unique_web_search/services/search_engine/vertexai.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/search_engine/vertexai.py
@@ -7,6 +7,7 @@ from httpx import HTTPError
 from pydantic import Field
 from unique_search_proxy_core.agent_engines.base import AgentEngineType
 from unique_search_proxy_core.agent_engines.vertexai.schema import VertexAIAgentConfig
+from unique_search_proxy_core.context import LOCAL_REQUEST_CONTEXT, RequestContext
 from unique_search_proxy_core.param_policy.exposed_params import ExposedParams
 from unique_toolkit._common.default_language_model import DEFAULT_LANGUAGE_MODEL
 from unique_toolkit._common.validators import LMI, get_LMI_default_field
@@ -66,8 +67,10 @@ class VertexAI(SearchEngine[VertexAIConfig]):
         self,
         config: VertexAIConfig,
         language_model_service: LanguageModelService,
+        *,
+        request_context: RequestContext = LOCAL_REQUEST_CONTEXT,
     ):
-        super().__init__(config=config)
+        super().__init__(config=config, request_context=request_context)
         self._client = get_vertex_client()
         self.is_configured = search_proxy_client_enabled or self._client is not None
 

--- a/tool_packages/unique_web_search/tests/test_google.py
+++ b/tool_packages/unique_web_search/tests/test_google.py
@@ -1,6 +1,7 @@
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from unique_search_proxy_core.context import RequestContext
 from unique_search_proxy_core.param_policy.exposable_param import ExposableParam
 from unique_search_proxy_core.search_engines.google.schema import (
     ExposableStrOrNone,
@@ -20,7 +21,12 @@ class TestGoogleSearch:
             gl=ExposableParam(expose=False, value="us"),
             site_search=ExposableParam(expose=False, value="example.com"),
         )
-        search = GoogleSearch(config)
+        request_context = RequestContext(
+            company_id="company-1",
+            user_id="user-1",
+            chat_id="chat-1",
+        )
+        search = GoogleSearch(config, request_context=request_context)
 
         mock_response = Mock()
         mock_response.curated = [
@@ -48,6 +54,10 @@ class TestGoogleSearch:
 
             results = await search.search("test query")
 
+        mock_open_client.assert_called_once_with(
+            timeout=30.0,
+            context=request_context,
+        )
         mock_search.assert_awaited_once()
         call_kwargs = mock_search.await_args.kwargs
         assert call_kwargs["query"] == "test query"


### PR DESCRIPTION
ref: UN-23120
## Summary

- Add a shared `RequestContext` contract (`x-unique-company-id`, `x-unique-user-id`, `x-unique-chat-id`) in `unique_search_proxy_core`, sent by the SDK and enforced by the search proxy on `/v1/*` routes when `REQUIRE_CONTEXT_HEADERS=true` (default).
- Thread context from `WebSearchTool` (`ChatEvent`) through search/crawler services into every proxy client call.
- Enrich proxy logging: application logs and Uvicorn access logs now include tenant context; search/agent-search/crawl routes log engine/crawler metadata at INFO and query/URLs at DEBUG.

## Test plan

- [x] `uv run ruff format . && uv run ruff check .` in `connectors/unique_search_proxy`
- [x] `uv run pytest` in `unique_search_proxy_core`, `unique_search_proxy_sdk`, and `unique_search_proxy_client` (420 tests)
- [x] `uv run poe lint`, `uv run poe format`, and `uv run poe test` in `tool_packages/unique_web_search` (659 tests)
- [x] Manual smoke test: access log line includes `company=... user=... chat=...` for `POST /v1/search`

## Notes for reviewers

- `REQUIRE_CONTEXT_HEADERS=false` is intended for local/notebook use only; documented in `.env.example`.
- SDK defaults to `LOCAL_REQUEST_CONTEXT` (`local/local/local`) so notebooks can call the proxy without explicit ids when enforcement is disabled.
- Middleware is pure ASGI (not `BaseHTTPMiddleware`) so context stays bound through response send when Uvicorn writes access logs.


Made with [Cursor](https://cursor.com)