### PR TITLE
feat(orchestrator): apply per-model temperature on model choice

### DIFF
--- a/unique_orchestrator/tests/test_unique_ai_builder_model_choice.py
+++ b/unique_orchestrator/tests/test_unique_ai_builder_model_choice.py
@@ -165,6 +165,75 @@ def test_model_choice_uses_selected_model_when_selection_is_enabled() -> None:
 
 
 @pytest.mark.ai
+def test_model_choice_applies_switchable_temperature_when_defined() -> None:
+    """
+    Purpose: Verify per-model temperature from switchable_language_models is applied.
+    Why this matters: Admins can configure different temperatures per selectable model.
+    Setup summary: Configure an allowlisted model with temperature 0.3; assert experimental temp updates.
+    """
+    default_model = _make_model("default-model")
+    selected_model = _make_model("selected-model")
+    config = UniqueAIConfig(
+        space=UniqueAISpaceConfig(
+            allow_model_switching=True,
+            switchable_language_models=[
+                {
+                    "displayName": "Selected Model",
+                    "languageModel": selected_model,
+                    "temperature": 0.3,
+                }
+            ],
+            language_model=default_model,
+            tools=[],
+        ),
+        agent={"experimental": {"temperature": 0.5}},
+    )
+
+    config = _apply_model_choice_override(
+        event=_make_event(selected_model, has_model_choice_override=True),
+        logger=MagicMock(),
+        config=config,
+    )
+
+    assert config.space.language_model == selected_model
+    assert config.agent.experimental.temperature == 0.3
+
+
+@pytest.mark.ai
+def test_model_choice_keeps_experimental_temperature_when_switchable_has_none() -> None:
+    """
+    Purpose: Verify space default temperature remains when the chosen model has no override.
+    Why this matters: Fallback behavior must preserve existing spaces without per-model temps.
+    Setup summary: Allowlisted model without temperature; assert experimental temp unchanged.
+    """
+    default_model = _make_model("default-model")
+    selected_model = _make_model("selected-model")
+    config = UniqueAIConfig(
+        space=UniqueAISpaceConfig(
+            allow_model_switching=True,
+            switchable_language_models=[
+                {
+                    "displayName": "Selected Model",
+                    "languageModel": selected_model,
+                }
+            ],
+            language_model=default_model,
+            tools=[],
+        ),
+        agent={"experimental": {"temperature": 0.5}},
+    )
+
+    config = _apply_model_choice_override(
+        event=_make_event(selected_model, has_model_choice_override=True),
+        logger=MagicMock(),
+        config=config,
+    )
+
+    assert config.space.language_model == selected_model
+    assert config.agent.experimental.temperature == 0.5
+
+
+@pytest.mark.ai
 def test_record_language_model_debug_info_uses_effective_model() -> None:
     """
     Purpose: Verify debug info records the active language model.
@@ -186,13 +255,17 @@ def test_record_language_model_debug_info_uses_effective_model() -> None:
         config=config,
     )
 
-    debug_info_manager.add.assert_called_once_with(
+    debug_info_manager.add.assert_any_call(
         "language_model",
         {
             "name": "selected-model",
             "provider": "AZURE",
             "family": "unknown",
         },
+    )
+    debug_info_manager.add.assert_any_call(
+        "temperature_requested",
+        config.agent.experimental.temperature,
     )
 
 

--- a/unique_orchestrator/tests/test_unique_ai_builder_model_choice.py
+++ b/unique_orchestrator/tests/test_unique_ai_builder_model_choice.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 import pytest
+from pydantic import ValidationError
 from unique_internal_search.config import InternalSearchConfig
 from unique_internal_search.service import InternalSearchTool
 from unique_toolkit.agentic.tools.experimental.open_file_tool.config import (
@@ -197,6 +198,30 @@ def test_model_choice_applies_switchable_temperature_when_defined() -> None:
 
     assert config.space.language_model == selected_model
     assert config.agent.experimental.temperature == 0.3
+
+
+@pytest.mark.ai
+def test_switchable_temperature_out_of_bounds_is_rejected() -> None:
+    """
+    Purpose: Verify an out-of-range per-model temperature fails at config load.
+    Why this matters: The value is copied into agent.experimental.temperature (0.0–10.0);
+    matching bounds surface the error early instead of on user model selection.
+    Setup summary: Build a space config with temperature 15.0; assert ValidationError.
+    """
+    selected_model = _make_model("selected-model")
+    with pytest.raises(ValidationError):
+        UniqueAISpaceConfig(
+            allow_model_switching=True,
+            switchable_language_models=[
+                {
+                    "displayName": "Selected Model",
+                    "languageModel": selected_model,
+                    "temperature": 15.0,
+                }
+            ],
+            language_model=_make_model("default-model"),
+            tools=[],
+        )
 
 
 @pytest.mark.ai

--- a/unique_orchestrator/tests/test_unique_ai_builder_model_choice.py
+++ b/unique_orchestrator/tests/test_unique_ai_builder_model_choice.py
@@ -255,17 +255,13 @@ def test_record_language_model_debug_info_uses_effective_model() -> None:
         config=config,
     )
 
-    debug_info_manager.add.assert_any_call(
+    debug_info_manager.add.assert_called_once_with(
         "language_model",
         {
             "name": "selected-model",
             "provider": "AZURE",
             "family": "unknown",
         },
-    )
-    debug_info_manager.add.assert_any_call(
-        "temperature_requested",
-        config.agent.experimental.temperature,
     )
 
 

--- a/unique_orchestrator/unique_orchestrator/config.py
+++ b/unique_orchestrator/unique_orchestrator/config.py
@@ -98,9 +98,12 @@ class SwitchableLanguageModelConfig(BaseToolConfig):
     )
     temperature: float | None = Field(
         default=None,
+        ge=0.0,
+        le=10.0,
         description=(
             "Optional per-model temperature override applied when chat users "
-            "select this model."
+            "select this model. Bounds mirror agent.experimental.temperature so "
+            "the value validates when copied on model choice."
         ),
     )
 

--- a/unique_orchestrator/unique_orchestrator/config.py
+++ b/unique_orchestrator/unique_orchestrator/config.py
@@ -96,6 +96,13 @@ class SwitchableLanguageModelConfig(BaseToolConfig):
             "`languageModel`."
         ),
     )
+    temperature: float | None = Field(
+        default=None,
+        description=(
+            "Optional per-model temperature override applied when chat users "
+            "select this model."
+        ),
+    )
 
 
 class SpaceConfigBase(BaseToolConfig, Generic[T]):

--- a/unique_orchestrator/unique_orchestrator/tests/test_unique_ai_execution_timing.py
+++ b/unique_orchestrator/unique_orchestrator/tests/test_unique_ai_execution_timing.py
@@ -33,6 +33,7 @@ def _build_unique_ai(**overrides):
 
     mock_config = MagicMock()
     mock_config.agent.prompt_config.user_metadata = []
+    mock_config.space.language_model.resolve_temp_and_reasoning.return_value = (0.0, None)
 
     mock_debug_info_manager = MagicMock()
     mock_debug_info_manager.get.return_value = {}
@@ -658,6 +659,10 @@ class TestRunExecutionTimingIntegration:
         mock_config = MagicMock()
         mock_config.effective_max_loop_iterations = 1
         mock_config.agent.prompt_config.user_metadata = []
+        mock_config.space.language_model.resolve_temp_and_reasoning.return_value = (
+            0.0,
+            None,
+        )
 
         mock_history_manager = MagicMock()
         mock_history_manager.get_history_for_model_call = AsyncMock(

--- a/unique_orchestrator/unique_orchestrator/tests/test_unique_ai_execution_timing.py
+++ b/unique_orchestrator/unique_orchestrator/tests/test_unique_ai_execution_timing.py
@@ -33,7 +33,10 @@ def _build_unique_ai(**overrides):
 
     mock_config = MagicMock()
     mock_config.agent.prompt_config.user_metadata = []
-    mock_config.space.language_model.resolve_temp_and_reasoning.return_value = (0.0, None)
+    mock_config.space.language_model.resolve_temp_and_reasoning.return_value = (
+        0.0,
+        None,
+    )
 
     mock_debug_info_manager = MagicMock()
     mock_debug_info_manager.get.return_value = {}

--- a/unique_orchestrator/unique_orchestrator/tests/test_unique_ai_loop_debug_params.py
+++ b/unique_orchestrator/unique_orchestrator/tests/test_unique_ai_loop_debug_params.py
@@ -44,6 +44,7 @@ def _build_unique_ai(**overrides):
 
     mock_config = MagicMock()
     mock_config.agent.prompt_config.user_metadata = []
+    mock_config.space.language_model.resolve_temp_and_reasoning.return_value = (0.0, None)
 
     mock_debug_info_manager = MagicMock()
     mock_debug_info_manager.get.return_value = {}
@@ -287,6 +288,10 @@ class TestRunLoopDebugParams:
         mock_config.space.language_model.name = "AZURE_GPT_5_2025_0807"
         mock_config.space.language_model.family = "openai"
         mock_config.space.language_model.provider = "AZURE"
+        mock_config.space.language_model.resolve_temp_and_reasoning.return_value = (
+            0.0,
+            None,
+        )
 
         mock_history_manager = MagicMock()
         mock_history_manager.get_history_for_model_call = AsyncMock(

--- a/unique_orchestrator/unique_orchestrator/tests/test_unique_ai_loop_debug_params.py
+++ b/unique_orchestrator/unique_orchestrator/tests/test_unique_ai_loop_debug_params.py
@@ -44,7 +44,10 @@ def _build_unique_ai(**overrides):
 
     mock_config = MagicMock()
     mock_config.agent.prompt_config.user_metadata = []
-    mock_config.space.language_model.resolve_temp_and_reasoning.return_value = (0.0, None)
+    mock_config.space.language_model.resolve_temp_and_reasoning.return_value = (
+        0.0,
+        None,
+    )
 
     mock_debug_info_manager = MagicMock()
     mock_debug_info_manager.get.return_value = {}

--- a/unique_orchestrator/unique_orchestrator/tests/test_unique_ai_reference_order.py
+++ b/unique_orchestrator/unique_orchestrator/tests/test_unique_ai_reference_order.py
@@ -38,6 +38,7 @@ async def test_history_updated_before_reference_extraction(monkeypatch):
     mock_config = MagicMock()
     mock_config.agent.max_loop_iterations = 1
     mock_config.space.language_model.name = "dummy-model"
+    mock_config.space.language_model.resolve_temp_and_reasoning.return_value = (0.0, None)
     mock_config.agent.experimental.temperature = 0.0
     mock_config.agent.experimental.additional_llm_options = {}
 

--- a/unique_orchestrator/unique_orchestrator/tests/test_unique_ai_reference_order.py
+++ b/unique_orchestrator/unique_orchestrator/tests/test_unique_ai_reference_order.py
@@ -38,7 +38,10 @@ async def test_history_updated_before_reference_extraction(monkeypatch):
     mock_config = MagicMock()
     mock_config.agent.max_loop_iterations = 1
     mock_config.space.language_model.name = "dummy-model"
-    mock_config.space.language_model.resolve_temp_and_reasoning.return_value = (0.0, None)
+    mock_config.space.language_model.resolve_temp_and_reasoning.return_value = (
+        0.0,
+        None,
+    )
     mock_config.agent.experimental.temperature = 0.0
     mock_config.agent.experimental.additional_llm_options = {}
 

--- a/unique_orchestrator/unique_orchestrator/tests/test_unique_ai_token_usage.py
+++ b/unique_orchestrator/unique_orchestrator/tests/test_unique_ai_token_usage.py
@@ -56,6 +56,7 @@ def _build_run_ua(loop_responses: list[MagicMock], max_iterations: int):
     mock_config.effective_max_loop_iterations = max_iterations
     mock_config.agent.prompt_config.user_metadata = []
     mock_config.space.language_model.name = MODEL_NAME
+    mock_config.space.language_model.resolve_temp_and_reasoning.return_value = (0.0, None)
 
     mock_history_manager = MagicMock()
     mock_history_manager.get_history_for_model_call = AsyncMock(

--- a/unique_orchestrator/unique_orchestrator/tests/test_unique_ai_token_usage.py
+++ b/unique_orchestrator/unique_orchestrator/tests/test_unique_ai_token_usage.py
@@ -56,7 +56,10 @@ def _build_run_ua(loop_responses: list[MagicMock], max_iterations: int):
     mock_config.effective_max_loop_iterations = max_iterations
     mock_config.agent.prompt_config.user_metadata = []
     mock_config.space.language_model.name = MODEL_NAME
-    mock_config.space.language_model.resolve_temp_and_reasoning.return_value = (0.0, None)
+    mock_config.space.language_model.resolve_temp_and_reasoning.return_value = (
+        0.0,
+        None,
+    )
 
     mock_history_manager = MagicMock()
     mock_history_manager.get_history_for_model_call = AsyncMock(

--- a/unique_orchestrator/unique_orchestrator/unique_ai.py
+++ b/unique_orchestrator/unique_orchestrator/unique_ai.py
@@ -444,17 +444,24 @@ class UniqueAI:
 
     def _record_loop_debug_params(self, other_options: dict) -> None:
         reasoning = other_options.get("reasoning")
-        thinking_level: str = (
+        reasoning_effort = (
             other_options.get("reasoning_effort")
             if not isinstance(reasoning, dict)
             else reasoning.get("effort")
-        ) or "None"
+        )
+        thinking_level: str = reasoning_effort or "None"
         self._loop_debug_params.append(
             {
                 "loop_number": self.current_iteration_index,
                 "thinking_level": thinking_level,
             }
         )
+        model_info = self._config.space.language_model
+        resolved_temperature, _ = model_info.resolve_temp_and_reasoning(
+            self._config.agent.experimental.temperature,
+            reasoning_effort=reasoning_effort,
+        )
+        self._debug_info_manager.add("temperature", resolved_temperature)
 
     def _get_activated_skills_debug_info(self) -> list[dict[str, str | bool]]:
         skill_tool = self._tool_manager.get_tool_by_name(SkillTool.name)

--- a/unique_orchestrator/unique_orchestrator/unique_ai.py
+++ b/unique_orchestrator/unique_orchestrator/unique_ai.py
@@ -443,12 +443,7 @@ class UniqueAI:
         return round((assistant_completed_at - user_created_at).total_seconds() * 1000)
 
     def _record_loop_debug_params(self, other_options: dict) -> None:
-        reasoning = other_options.get("reasoning")
-        reasoning_effort = (
-            other_options.get("reasoning_effort")
-            if not isinstance(reasoning, dict)
-            else reasoning.get("effort")
-        )
+        reasoning_effort = self._resolve_effective_reasoning_effort(other_options)
         thinking_level: str = reasoning_effort or "None"
         self._loop_debug_params.append(
             {
@@ -462,6 +457,24 @@ class UniqueAI:
             reasoning_effort=reasoning_effort,
         )
         self._debug_info_manager.add("temperature", resolved_temperature)
+
+    def _resolve_effective_reasoning_effort(self, other_options: dict) -> str | None:
+        """Read the reasoning effort from the same source the active LLM API uses.
+
+        Mirrors ``resolve_other_options``: the completions API reads the flat
+        ``reasoning_effort`` key, while the responses API prefers the nested
+        ``reasoning.effort`` and falls back to the flat key. Keeping this in sync
+        ensures the debug temperature matches what is actually sent to the model.
+        """
+        use_responses_api = (
+            self._config.agent.experimental.responses_api_config.use_responses_api
+            or self._config.agent.experimental.use_responses_api
+        )
+        if use_responses_api:
+            reasoning = other_options.get("reasoning")
+            if isinstance(reasoning, dict) and reasoning.get("effort") is not None:
+                return reasoning.get("effort")
+        return other_options.get("reasoning_effort")
 
     def _get_activated_skills_debug_info(self) -> list[dict[str, str | bool]]:
         skill_tool = self._tool_manager.get_tool_by_name(SkillTool.name)

--- a/unique_orchestrator/unique_orchestrator/unique_ai_builder.py
+++ b/unique_orchestrator/unique_orchestrator/unique_ai_builder.py
@@ -268,10 +268,6 @@ def _record_language_model_debug_info(
             include={"name", "provider", "family"},
         ),
     )
-    debug_info_manager.add(
-        "temperature_requested",
-        config.agent.experimental.temperature,
-    )
 
 
 def _find_switchable_language_model_entry(

--- a/unique_orchestrator/unique_orchestrator/unique_ai_builder.py
+++ b/unique_orchestrator/unique_orchestrator/unique_ai_builder.py
@@ -234,6 +234,18 @@ def _apply_model_choice_override(
 
     config_data = config.model_dump()
     config_data["space"]["language_model"] = selected_model
+
+    switchable_entry = _find_switchable_language_model_entry(
+        selected_model=selected_model,
+        switchable_language_models=config.space.switchable_language_models,
+    )
+    if switchable_entry is not None and switchable_entry.temperature is not None:
+        config_data.setdefault("agent", {})
+        config_data["agent"].setdefault("experimental", {})
+        config_data["agent"]["experimental"]["temperature"] = (
+            switchable_entry.temperature
+        )
+
     validated_config = UniqueAIConfig.model_validate(config_data)
 
     logger.info(
@@ -256,6 +268,21 @@ def _record_language_model_debug_info(
             include={"name", "provider", "family"},
         ),
     )
+    debug_info_manager.add(
+        "temperature_requested",
+        config.agent.experimental.temperature,
+    )
+
+
+def _find_switchable_language_model_entry(
+    *,
+    selected_model: LanguageModelInfo,
+    switchable_language_models: list[SwitchableLanguageModelConfig],
+) -> SwitchableLanguageModelConfig | None:
+    for switchable_model in switchable_language_models:
+        if selected_model == switchable_model.language_model:
+            return switchable_model
+    return None
 
 
 def _is_switchable_language_model_choice(


### PR DESCRIPTION
## Summary
- Apply admin-configured per-model temperature when a chat user picks a switchable model
- Surface the requested vs resolved temperature in message debug info

## Changes
- `config.py`: add optional `temperature` to `SwitchableLanguageModelConfig`
- `unique_ai_builder.py`: apply the chosen entry's temperature to `agent.experimental.temperature`; record `temperature_requested`
- `unique_ai.py`: record the resolved (post `resolve_temp_and_reasoning`) `temperature` per loop
- tests: cover apply/ignore behaviour

## Test plan
- [x] `uv run pytest tests/test_unique_ai_builder_model_choice.py`
- [x] Manual: Test with Unique AI switchable models with distinct temps → debug shows `temperature`; GPT-5 clamps to 1.0
- [x] Manual: Test with External knowledge module (Chat with GPT) switchable models with distinct temps → debug in node shows temperature set in database

Refs: ITK-215