### PR TITLE
feat(unique_toolkit): add artifact output size analytics

### DIFF
--- a/unique_orchestrator/unique_orchestrator/tests/test_unique_ai_async_modify.py
+++ b/unique_orchestrator/unique_orchestrator/tests/test_unique_ai_async_modify.py
@@ -143,7 +143,7 @@ async def test_handle_no_tool_calls_stores_returned_artifacts_for_analytics(
     monkeypatch,
 ):
     ua = _make_ua(monkeypatch)
-    artifacts = {"count": 1, "filetypes": ["csv"]}
+    artifacts = {"count": 1, "filetypes": ["csv"], "output_size": 0.25}
     ua._postprocessor_manager.run_postprocessors.return_value = {
         DisplayCodeInterpreterFilesPostProcessor.__name__: artifacts
     }

--- a/unique_orchestrator/unique_orchestrator/tests/test_unique_ai_loop_debug_params.py
+++ b/unique_orchestrator/unique_orchestrator/tests/test_unique_ai_loop_debug_params.py
@@ -505,7 +505,11 @@ class TestRunLoopDebugParams:
         """
         ua = self._build_run_ua(monkeypatch)
         # Leftover from a hypothetical previous run on the same instance.
-        ua._generated_files_info = {"count": 99, "filetypes": ["stale"]}
+        ua._generated_files_info = {
+            "count": 99,
+            "filetypes": ["stale"],
+            "output_size": 9.9,
+        }
         # Exit the loop as if a tool took control: _handle_no_tool_calls (which sets
         # _generated_files_info) is skipped, but finalization still calls add_analytics.
         ua._process_plan = AsyncMock(return_value=True)  # type: ignore[method-assign]

--- a/unique_toolkit/tests/agentic/test_debug_info_manager.py
+++ b/unique_toolkit/tests/agentic/test_debug_info_manager.py
@@ -513,6 +513,7 @@ class TestAddAnalytics:
         # Reserved placeholders — always present, populated in a later step.
         assert analytics["artifacts_created_count"] is None
         assert analytics["artifacts_created_filetype"] is None
+        assert analytics["output_size"] is None
 
     @pytest.mark.ai
     def test_add_analytics__total_time_to_answer_ms__always_present_as_null(
@@ -544,18 +545,23 @@ class TestAddAnalytics:
         Purpose: Verify the artifact fields are read from the artifacts argument.
         Why this matters: This is the wiring that makes the reserved keys carry real
         values once Code Interpreter has produced files.
-        Setup summary: Pass artifact metadata; assert both fields mirror it.
+        Setup summary: Pass artifact metadata; assert all fields mirror it.
         """
         debug_info_manager.add_analytics(
             [],
             language_model=self.language_model,
             tool_display_names=self.tool_display_names,
-            artifacts={"count": 2, "filetypes": ["csv", "png"]},
+            artifacts={
+                "count": 2,
+                "filetypes": ["csv", "png"],
+                "output_size": 1.5,
+            },
         )
 
         analytics = debug_info_manager.get()["analytics"]
         assert analytics["artifacts_created_count"] == 2
         assert analytics["artifacts_created_filetype"] == ["csv", "png"]
+        assert analytics["output_size"] == 1.5
 
     @pytest.mark.ai
     def test_add_analytics__artifacts__zero_when_code_interpreter_ran_but_empty(
@@ -563,32 +569,34 @@ class TestAddAnalytics:
     ) -> None:
         """
         Purpose: Verify a ran-but-produced-nothing Code Interpreter turn reports
-        count 0 / empty filetypes, distinct from the never-ran (None) case.
+        count 0 / empty filetypes / 0.0 size, distinct from the never-ran (None)
+        case.
         Why this matters: Consumers must be able to tell "0 files created" from
         "no Code Interpreter this turn" — the caller passes {count:0,
-        filetypes:[]} in the former case and None in the latter.
-        Setup summary: Pass empty artifact metadata; assert 0 / [] (not None).
+        filetypes:[], output_size:0.0} in the former case and None in the latter.
+        Setup summary: Pass empty artifact metadata; assert 0 / [] / 0.0 (not None).
         """
         debug_info_manager.add_analytics(
             [],
             language_model=self.language_model,
             tool_display_names=self.tool_display_names,
-            artifacts={"count": 0, "filetypes": []},
+            artifacts={"count": 0, "filetypes": [], "output_size": 0.0},
         )
 
         analytics = debug_info_manager.get()["analytics"]
         assert analytics["artifacts_created_count"] == 0
         assert analytics["artifacts_created_filetype"] == []
+        assert analytics["output_size"] == 0.0
 
     @pytest.mark.ai
     def test_add_analytics__artifacts__none_when_no_entry(
         self, debug_info_manager: DebugInfoManager
     ) -> None:
         """
-        Purpose: Verify both artifact fields are None when no Code Interpreter ran
+        Purpose: Verify artifact fields are None when no Code Interpreter ran
         (no debug_info["artifacts"] entry) — the always-present, null-when-unknown
         contract from doc 03.
-        Setup summary: No artifacts entry seeded; assert both keys present and None.
+        Setup summary: No artifacts entry seeded; assert all keys present and None.
         """
         debug_info_manager.add_analytics(
             [],
@@ -599,6 +607,7 @@ class TestAddAnalytics:
         analytics = debug_info_manager.get()["analytics"]
         assert analytics["artifacts_created_count"] is None
         assert analytics["artifacts_created_filetype"] is None
+        assert analytics["output_size"] is None
 
     @pytest.mark.ai
     def test_add_analytics__context_memory_updated__populated_from_argument(

--- a/unique_toolkit/tests/agentic/test_postprocessor_manager_execution_times.py
+++ b/unique_toolkit/tests/agentic/test_postprocessor_manager_execution_times.py
@@ -157,7 +157,7 @@ class TestPostprocessorManagerExecutionTimes:
         self, manager, mock_postprocessor
     ) -> None:
         mock_loop_response = MagicMock()
-        expected = {"count": 1, "filetypes": ["csv"]}
+        expected = {"count": 1, "filetypes": ["csv"], "output_size": 0.25}
         mock_postprocessor.run.return_value = expected
 
         result = await manager.execute_postprocessors(
@@ -172,7 +172,7 @@ class TestPostprocessorManagerExecutionTimes:
     async def test_run_postprocessors_returns_results_by_name(
         self, manager, mock_postprocessor
     ) -> None:
-        expected = {"count": 1, "filetypes": ["csv"]}
+        expected = {"count": 1, "filetypes": ["csv"], "output_size": 0.25}
         mock_postprocessor.get_name.return_value = "source_handler"
         mock_postprocessor.run.return_value = expected
         mock_postprocessor.apply_postprocessing_to_response.return_value = False

--- a/unique_toolkit/tests/agentic/tools/test_code_interpreter_postprocessors_generated_files.py
+++ b/unique_toolkit/tests/agentic/tools/test_code_interpreter_postprocessors_generated_files.py
@@ -2916,12 +2916,19 @@ def test_compute_artifacts_debug_info__excludes_failed_uploads() -> None:
     """
     Purpose: Verify only successful uploads (content_id is not None) are counted.
     Why this matters: artifacts_created_count means files the user actually got;
-    failed downloads must not inflate it (decision 2).
+    failed downloads must not inflate it (decision 2). Same gate applies to
+    output_size — failed files' bytes are ignored even if present in the size map.
     Setup summary: content_map with two successes and one failure; assert count 2
-    and the failed file's extension is absent.
+    and the failed file's extension/size are absent from the totals.
     """
     proc = _make_display_files_postprocessor()
     proc._content_map = {"a.png": "c1", "b.csv": "c2", "c.pdf": None}
+    # Failed upload still had downloaded bytes; must not count toward output_size.
+    proc._file_size_map = {
+        "a.png": 512 * 1024,  # 0.5 MiB
+        "b.csv": 512 * 1024,  # 0.5 MiB
+        "c.pdf": 10 * 1024 * 1024,  # would be 10 MiB if incorrectly counted
+    }
     response = _make_response(
         calls=[_make_ci_call("print('x')")],
         annotations=[
@@ -2936,6 +2943,7 @@ def test_compute_artifacts_debug_info__excludes_failed_uploads() -> None:
     assert artifacts is not None
     assert artifacts["count"] == 2
     assert artifacts["filetypes"] == ["csv", "png"]
+    assert artifacts["output_size"] == 1.0
 
 
 @pytest.mark.ai
@@ -2947,6 +2955,11 @@ def test_compute_artifacts_debug_info__filetypes_deduped_and_sorted() -> None:
     """
     proc = _make_display_files_postprocessor()
     proc._content_map = {"chart.png": "c1", "chart2.png": "c2", "data.csv": "c3"}
+    proc._file_size_map = {
+        "chart.png": 256 * 1024,
+        "chart2.png": 256 * 1024,
+        "data.csv": 512 * 1024,
+    }
     response = _make_response(
         calls=[_make_ci_call("print('x')")],
         annotations=[
@@ -2961,6 +2974,7 @@ def test_compute_artifacts_debug_info__filetypes_deduped_and_sorted() -> None:
     assert artifacts is not None
     assert artifacts["count"] == 3
     assert artifacts["filetypes"] == ["csv", "png"]
+    assert artifacts["output_size"] == 1.0
 
 
 @pytest.mark.ai
@@ -2969,7 +2983,7 @@ def test_compute_artifacts_debug_info__counts_only_this_turn_not_prior_files() -
     Purpose: Verify prior-message files in _content_map (loaded from short-term
     memory) are NOT counted — only this turn's container_files (decision 4).
     Why this matters: Guards the §2a accuracy trap; counting the whole content_map
-    would inflate the per-turn total across a long chat.
+    would inflate the per-turn total across a long chat. Same for output_size.
     Setup summary: content_map holds a prior file plus this turn's file; only this
     turn's annotation is on the response; assert just it is counted.
     """
@@ -2977,6 +2991,10 @@ def test_compute_artifacts_debug_info__counts_only_this_turn_not_prior_files() -
     # 'old.pdf' was created in an earlier message (present in content_map via
     # _load_previous_files) but is NOT in this response's container_files.
     proc._content_map = {"old.pdf": "c-old", "new.png": "c-new"}
+    proc._file_size_map = {
+        "old.pdf": 5 * 1024 * 1024,
+        "new.png": 512 * 1024,
+    }
     response = _make_response(
         calls=[_make_ci_call("print('x')")],
         annotations=[_make_annotation("new.png")],
@@ -2987,6 +3005,7 @@ def test_compute_artifacts_debug_info__counts_only_this_turn_not_prior_files() -
     assert artifacts is not None
     assert artifacts["count"] == 1
     assert artifacts["filetypes"] == ["png"]
+    assert artifacts["output_size"] == 0.5
 
 
 @pytest.mark.ai
@@ -2995,10 +3014,10 @@ def test_compute_artifacts_debug_info__ran_but_produced_no_files__returns_zero()
 ):
     """
     Purpose: Verify a turn where the interpreter ran but produced no files returns
-    count 0 / empty filetypes.
+    count 0 / empty filetypes / 0.0 size.
     Why this matters: This is the genuine "ran, created nothing" state — distinct
     from "did not run" (None). It requires code_interpreter_calls to be present.
-    Setup summary: One CI call, no container files; assert {count: 0, filetypes: []}.
+    Setup summary: One CI call, no container files; assert zeros.
     """
     proc = _make_display_files_postprocessor()
     proc._content_map = {}
@@ -3009,13 +3028,15 @@ def test_compute_artifacts_debug_info__ran_but_produced_no_files__returns_zero()
     assert artifacts is not None
     assert artifacts["count"] == 0
     assert artifacts["filetypes"] == []
+    assert artifacts["output_size"] == 0.0
 
 
 @pytest.mark.ai
 def test_compute_artifacts_debug_info__interpreter_not_invoked__returns_none() -> None:
     """
     Purpose: Verify None is returned when the Code Interpreter did not run this
-    turn, so analytics.artifacts_* stays null ("did not run") rather than 0/[].
+    turn, so analytics.artifacts_* / output_size stays null ("did not run") rather
+    than 0/[]/0.0.
     Why this matters: The postprocessor is registered whenever the tool is *enabled*,
     so run() fires even on turns the model never invoked it — returning 0/[] there
     would misreport "ran, created nothing" on every ordinary answer (Cursor bot,
@@ -3027,3 +3048,29 @@ def test_compute_artifacts_debug_info__interpreter_not_invoked__returns_none() -
     response = _make_response(calls=[], annotations=[])
 
     assert proc._compute_artifacts_debug_info(response) is None
+
+
+@pytest.mark.ai
+def test_compute_artifacts_debug_info__output_size_sums_successful_uploads() -> None:
+    """
+    Purpose: Verify output_size is the sum of this turn's successful upload sizes
+    in MiB (bytes / 1024**2).
+    Why this matters: Consumers report total agent-produced file volume per turn;
+    the unit must be MiB and only successful uploads count.
+    Setup summary: Two successful files totaling 1.5 MiB; assert output_size == 1.5.
+    """
+    proc = _make_display_files_postprocessor()
+    proc._content_map = {"a.png": "c1", "b.csv": "c2"}
+    proc._file_size_map = {
+        "a.png": 1024 * 1024,  # 1 MiB
+        "b.csv": 512 * 1024,  # 0.5 MiB
+    }
+    response = _make_response(
+        calls=[_make_ci_call("print('x')")],
+        annotations=[_make_annotation("a.png"), _make_annotation("b.csv")],
+    )
+
+    artifacts = proc._compute_artifacts_debug_info(response)
+
+    assert artifacts is not None
+    assert artifacts["output_size"] == 1.5

--- a/unique_toolkit/unique_toolkit/agentic/debug_info_manager/debug_info_manager.py
+++ b/unique_toolkit/unique_toolkit/agentic/debug_info_manager/debug_info_manager.py
@@ -48,6 +48,9 @@ class Analytics(TypedDict):
     language_model: AnalyticsLanguageModel
     loop_iteration_count: int
     mcp_tool_names_used: list[AnalyticsToolName]
+    # Total size of artifacts/files created this turn, in MiB. None when Code
+    # Interpreter did not run; 0.0 when it ran but produced nothing.
+    output_size: float | None
     references_count: int
     skills_used: list[AnalyticsSkill]
     subagent_names_used: list[AnalyticsToolName]
@@ -129,8 +132,8 @@ class DebugInfoManager:
         ]
         # Artifacts are recorded at the postprocessor seam (Code Interpreter's
         # DisplayCodeInterpreterFilesPostProcessor) into debug_info["artifacts"].
-        # Absent when no Code Interpreter ran this turn → both fields stay None,
-        # preserving the always-present, null-when-unknown contract.
+        # Absent when no Code Interpreter ran this turn → artifact fields stay
+        # None, preserving the always-present, null-when-unknown contract.
         analytics = Analytics(
             tools_used=analytics_tools,
             tool_call_count=len(analytics_tools),
@@ -152,6 +155,7 @@ class DebugInfoManager:
             total_time_to_answer_ms=total_time_to_answer_ms,
             artifacts_created_count=artifacts["count"] if artifacts else None,
             artifacts_created_filetype=artifacts["filetypes"] if artifacts else None,
+            output_size=artifacts["output_size"] if artifacts else None,
             # None when the user-memory postprocessor is not activated for this
             # turn; True/False when it ran and did/didn't update the profile.
             context_memory_updated=context_memory_updated,

--- a/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/postprocessors/generated_files.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/postprocessors/generated_files.py
@@ -46,16 +46,22 @@ from unique_toolkit.short_term_memory.service import ShortTermMemoryService
 logger = logging.getLogger(__name__)
 
 
+_BYTES_PER_MB = 1024 * 1024
+
+
 class ArtifactsDebugInfo(TypedDict):
     """This turn's successfully-created artifacts, for analytics.
 
-    Feeds analytics.artifacts_created_count / artifacts_created_filetype. The
-    postprocessor returns this to the orchestrator, which owns the
-    ``DebugInfoManager`` and records it.
+    Feeds analytics.artifacts_created_count / artifacts_created_filetype /
+    output_size. The postprocessor returns this to the orchestrator, which
+    owns the ``DebugInfoManager`` and records it.
     """
 
     count: int
     filetypes: list[str]
+    # Total size of this turn's successfully-created artifacts, in MiB
+    # (bytes / 1024**2). 0.0 when the interpreter ran but produced nothing.
+    output_size: float
 
 
 class _ChatLoggerAdapter(logging.LoggerAdapter[logging.Logger]):
@@ -380,6 +386,9 @@ class DisplayCodeInterpreterFilesPostProcessor(
                 chat_id=chat_id,
             )
 
+        # Cleared at the start of each run(); holds this-turn download sizes.
+        self._file_size_map: dict[str, int] = {}
+
     def _build_retry(self) -> AsyncRetrying:
         """Build a tenacity retry policy from the current config.
 
@@ -406,6 +415,10 @@ class DisplayCodeInterpreterFilesPostProcessor(
             len(container_files),
             [cf.filename for cf in container_files],
         )
+
+        # Per-turn byte sizes of successfully uploaded files. Not persisted to
+        # short-term memory — only feeds this turn's analytics.output_size.
+        self._file_size_map: dict[str, int] = {}
 
         phase_t0 = time.monotonic()
         try:
@@ -501,17 +514,19 @@ class DisplayCodeInterpreterFilesPostProcessor(
     ) -> ArtifactsDebugInfo | None:
         """Compute this turn's successfully-created artifacts.
 
-        Feeds analytics.artifacts_created_count / artifacts_created_filetype.
+        Feeds analytics.artifacts_created_count / artifacts_created_filetype /
+        output_size.
 
         Returns ``None`` when the Code Interpreter did not execute this turn
         (``code_interpreter_calls`` empty). The postprocessor is registered
         whenever the tool is *enabled*, so ``run()`` also fires on turns where the
         model never invoked it — returning ``None`` there keeps analytics.artifacts_*
-        as null ("did not run") rather than 0/[] ("ran, created nothing"). When it
-        did run, count is scoped to this response's ``container_files`` (not
-        ``self._content_map``, which also holds prior-message files from short-term
-        memory), successful uploads only, with a deduped, sorted set of file
-        extensions.
+        / output_size as null ("did not run") rather than 0/[]/0.0 ("ran, created
+        nothing"). When it did run, metrics are scoped to this response's
+        ``container_files`` (not ``self._content_map``, which also holds
+        prior-message files from short-term memory), successful uploads only, with
+        a deduped, sorted set of file extensions and total size in MiB from
+        ``self._file_size_map`` (populated at download time).
         """
         # Interpreter did not run this turn → leave artifacts null, not 0/[].
         if not loop_response.code_interpreter_calls:
@@ -522,9 +537,13 @@ class DisplayCodeInterpreterFilesPostProcessor(
             for cf in loop_response.container_files
             if self._content_map.get(cf.filename) is not None
         }
+        total_bytes = sum(
+            self._file_size_map.get(name, 0) for name in created_filenames
+        )
         return ArtifactsDebugInfo(
             count=len(created_filenames),
             filetypes=sorted({_artifact_filetype(name) for name in created_filenames}),
+            output_size=total_bytes / _BYTES_PER_MB,
         )
 
     @override
@@ -763,6 +782,9 @@ class DisplayCodeInterpreterFilesPostProcessor(
                 upload_ms,
                 pipeline_ms,
             )
+            # Record size only on successful upload so failed downloads don't
+            # inflate analytics.output_size (mirrors content_map success gating).
+            self._file_size_map[container_file.filename] = len(file_bytes)
             return _ContentInfo(filename=container_file.filename, content_id=content.id)
 
     async def _download_file_bytes_with_progress(

--- a/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/postprocessors/generated_files.py
+++ b/unique_toolkit/unique_toolkit/agentic/tools/openai_builtin/code_interpreter/postprocessors/generated_files.py
@@ -418,7 +418,7 @@ class DisplayCodeInterpreterFilesPostProcessor(
 
         # Per-turn byte sizes of successfully uploaded files. Not persisted to
         # short-term memory — only feeds this turn's analytics.output_size.
-        self._file_size_map: dict[str, int] = {}
+        self._file_size_map = {}
 
         phase_t0 = time.monotonic()
         try:


### PR DESCRIPTION
## Summary
- Adds `analytics.output_size` as the total size in MiB of artifacts/files successfully created by the agent in the current turn.
- Preserves the artifact analytics contract: `null` when Code Interpreter did not run and `0.0` when it ran without creating files.

## Changes
- Track downloaded byte sizes only after successful artifact uploads.
- Sum sizes for current-turn `container_files`, excluding failed uploads and files retained from prior turns.
- Pass `output_size` through `ArtifactsDebugInfo` into the analytics frame.
- Extend toolkit and orchestrator tests for populated, empty, failed-upload, prior-turn, and null behavior.

## Test plan
- [x] `cd unique_toolkit && uv run pytest tests/agentic/test_debug_info_manager.py tests/agentic/tools/test_code_interpreter_postprocessors_generated_files.py -k "artifacts or output_size or add_analytics" -q --tb=short`
- [x] `cd unique_orchestrator && uv run pytest unique_orchestrator/tests/test_unique_ai_async_modify.py unique_orchestrator/tests/test_unique_ai_loop_debug_params.py -k "artifacts or generated_files or add_analytics" -q --tb=short`
- [x] Ruff lint and format checks for changed toolkit files.

## Risk / rollout
- Additive analytics schema change with no migration required.
- Size is reported in MiB (`bytes / 1024²`) and includes successful current-turn uploads only.

Refs: #2076
