### PR TITLE
refactor(web_search): extract default URL blocked patterns constant

### DIFF
--- a/tool_packages/unique_web_search/src/unique_web_search/services/crawlers/basic.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/crawlers/basic.py
@@ -31,6 +31,8 @@ from unique_web_search.services.proxy.mappers import map_crawl_response
 
 _LOGGER = logging.getLogger(__name__)
 
+_DEFAULT_URL_BLOCKED_PATTERNS = [r".*\.pdf$"]
+
 
 class BasicConfig(CoreBasicConfig):
     """Tool-local Basic crawler config; extends proxy-core with legacy URL filters."""
@@ -39,7 +41,7 @@ class BasicConfig(CoreBasicConfig):
         list[str],
         RJSFMetaTag({"ui:options": {"orderable": False}}),
     ] = Field(
-        default_factory=lambda: [r".*\.pdf$"],
+        default=_DEFAULT_URL_BLOCKED_PATTERNS,
         title="URL blocked patterns",
         description=(
             "List of URL regex patterns to skip when crawling. "


### PR DESCRIPTION
## Summary
- Extract the basic crawler's default URL blocked patterns (`[r".*\.pdf$"]`) into a module-level `_DEFAULT_URL_BLOCKED_PATTERNS` constant.
- Reference the constant from the `BasicConfig.url_blocked_patterns` field default. No behavior change.

## Changes
- `tool_packages/unique_web_search/src/unique_web_search/services/crawlers/basic.py`: introduce `_DEFAULT_URL_BLOCKED_PATTERNS` and use it as the field `default` (replacing the inline `default_factory` lambda).

## Test plan
- [ ] `poetry run poe lint` (ruff) on the touched package
- [ ] Verify `BasicConfig().url_blocked_patterns == [r".*\.pdf$"]`

## Risk / rollout
- Low risk; pure refactor with no functional change.

Made with [Cursor](https://cursor.com)