### PR TITLE
fix(toolkit): allow MessageLogEvent type "Todo" with status field

### DIFF
--- a/unique_toolkit/tests/chat/test_message_log_schemas.py
+++ b/unique_toolkit/tests/chat/test_message_log_schemas.py
@@ -1,0 +1,56 @@
+"""Tests for the MessageLog/MessageLogEvent schemas in unique_toolkit.chat.schemas.
+
+Covers the "Todo" event type regression (UN-23253): the backend's ``details``
+column is untyped JSON, so a write with an unsupported ``type`` value succeeds
+server-side but previously failed when re-parsing the response into
+``MessageLog`` (see ``create_message_log_async`` / ``update_message_log_async``
+in ``unique_toolkit.chat.functions``, both of which do
+``return MessageLog(**message_log)`` right after the write).
+"""
+
+from unique_toolkit.chat.schemas import (
+    MessageLog,
+    MessageLogDetails,
+    MessageLogEvent,
+)
+
+
+def test_message_log_event_accepts_todo_type_with_status():
+    event = MessageLogEvent(type="Todo", text="Set up project", status="done")
+
+    assert event.type == "Todo"
+    assert event.status == "done"
+
+
+def test_message_log_event_status_defaults_to_none():
+    event = MessageLogEvent(type="ToolCall", text="Calling a tool")
+
+    assert event.status is None
+
+
+def test_message_log_round_trips_todo_event_like_functions_return_path():
+    """Regression test for UN-23253.
+
+    Mirrors the exact pattern used by ``create_message_log_async`` /
+    ``update_message_log_async``: build a ``MessageLogEvent``/``MessageLogDetails``,
+    dump it (as if sending it over the wire), then re-parse the raw response
+    dict via ``MessageLog(**message_log)``. Before the fix, this raised a
+    pydantic ``ValidationError`` because ``"Todo"`` wasn't a valid ``type``.
+    """
+    event = MessageLogEvent(type="Todo", text="Set up project", status="done")
+    details = MessageLogDetails(data=[event])
+
+    raw = {
+        "id": "row-1",
+        "status": "RUNNING",
+        "order": 1,
+        "details": details.model_dump(),
+    }
+
+    parsed = MessageLog(**raw)
+
+    assert parsed.message_log_id == "row-1"
+    assert parsed.details is not None
+    assert parsed.details.data is not None
+    assert parsed.details.data[0].type == "Todo"
+    assert parsed.details.data[0].status == "done"

--- a/unique_toolkit/unique_toolkit/chat/schemas.py
+++ b/unique_toolkit/unique_toolkit/chat/schemas.py
@@ -216,9 +216,15 @@ class MessageLogUncitedReferences(BaseModel):
 
 class MessageLogEvent(BaseModel):
     model_config = model_config
-    type: Literal["WebSearch", "InternalSearch", "Elicitation", "Thinking", "ToolCall"]
+    type: Literal[
+        "WebSearch", "InternalSearch", "Elicitation", "Thinking", "ToolCall", "Todo"
+    ]
     text: str
     step_type: str | None = None
+    status: Literal["todo", "done"] | None = Field(
+        default=None,
+        description="Checklist item state for 'Todo' events; unused for other event types",
+    )
 
 
 class MessageLogDetails(BaseModel):


### PR DESCRIPTION
## Summary

`unique_sdk.MessageLog.create_async`/`update_async` writes succeed against the untyped `details` JSON column in the backend, but the toolkit then re-parses the response into its own strict `MessageLog` pydantic model (`return MessageLog(**message_log)` in `create_message_log_async`/`update_message_log_async`). This raised a `ValidationError` for any `MessageLogEvent.type` not in the existing `Literal`.

The monorepo's `swappable_intelligence` `TodoWrite` integration ([PR #26867](https://github.com/Unique-AG/monorepo/pull/26867)) emits `"Todo"`-typed `MessageLogEvent`s so the chat frontend can render an inline checklist. Because the toolkit didn't know about `"Todo"`, the re-parse raised *after* the write already succeeded — callers never got back a `message_log_id`, so every subsequent `TodoWrite` call created a brand-new row instead of updating the existing one (the root cause of the "duplicated todo checklist" bug).

- Widen `MessageLogEvent.type` to include `"Todo"` alongside the existing five values.
- Add an optional `status: Literal["todo", "done"] | None = None` field for checklist item state (matches the only two values the monorepo side currently sends via its local `_TodoMessageLogEvent` workaround).
- Purely additive — no breaking changes, no other fields/routes touched.

This is scoped to `unique_toolkit` only, per UN-23253. The monorepo-side follow-up (bump the pin in `assistants-core`, remove the local `_TodoMessageLogEvent` widening) is a separate, out-of-scope step once this ships.

Refs: UN-23253 (blocks UN-21677)

## Test plan

- [x] `poetry run pytest tests/chat/test_message_log_schemas.py tests/agentic/test_logger_service.py -q` — 33 passed (includes the new regression test that constructs a `"Todo"` event and round-trips it through `MessageLog(**message_log)` the same way `functions.py` does)
- [x] `poetry run ruff check` / `ruff format` — clean
- [x] `poetry run basedpyright` on changed files — 0 errors
- [x] Confirmed unrelated pre-existing test failures elsewhere in the suite (tiktoken download blocked by sandbox proxy) are present with or without this change

Made with [Cursor](https://cursor.com)