### PR TITLE
feat(unique_mcp): async per-request identity resolver, OIDC scope advertisement

### DIFF
--- a/unique_mcp/README.md
+++ b/unique_mcp/README.md
@@ -32,8 +32,14 @@ flowchart TD
     B -- yes --> C[Use _meta identity]
     B -- no --> D{Zitadel JWT has sub\n+ company claim?}
     D -- yes --> E[Use Zitadel JWT claims]
-    D -- no --> F[Use env-loaded UniqueSettings auth]
-    C & E --> G[Build UniqueSettings → tool executes]
+    D -- no --> H{Async resolver?\nget_unique_settings_async}
+    H -- yes --> I{Zitadel /userinfo\nyields sub + company?}
+    I -- yes --> J[Use userinfo identity]
+    I -- no --> K{Access token present?}
+    K -- yes --> L([Raise: refuse env fallback])
+    K -- no --> F[Use env-loaded UniqueSettings auth]
+    H -- no, sync --> F
+    C & E & J --> G[Build UniqueSettings → tool executes]
     F --> G
 ```
 
@@ -156,17 +162,20 @@ sequenceDiagram
 
     Client->>MCP: tools/call + Authorization: Bearer <FastMCP JWT>
     MCP->>MCP: token swap → retrieve Zitadel JWT
-    Note over MCP: JWT incomplete for get_unique_settings → env auth
-    opt Tool calls get_unique_userinfo
-        MCP->>Zitadel: GET /oidc/v1/userinfo (Bearer Zitadel JWT)
+    Note over MCP: JWT incomplete for get_unique_settings (sync) → env auth
+    MCP->>Zitadel: get_unique_settings_async: GET /oidc/v1/userinfo (Bearer Zitadel JWT)
+    alt userinfo has sub + company
         Zitadel-->>MCP: sub, urn:zitadel:...:id, email, ...
+        Note over MCP: Use userinfo identity
+    else userinfo incomplete
+        Note over MCP: Raise — refuse env fallback for a logged-in request
     end
     MCP-->>Client: tool result
 ```
 
 ### 3 — Trusted internal caller with `_meta` override
 
-An internal service calls the tool on behalf of a known user by passing identity directly in the MCP `_meta` field. This takes highest priority — but **only works if both `unique.app/user-id` and `unique.app/company-id` are present**. If either is missing, the provider falls through to JWT/env resolution, which will use env auth if the JWT is also incomplete.
+An internal service calls the tool on behalf of a known user by passing identity directly in the MCP `_meta` field. This takes highest priority — but **only works if both `unique.app/auth/user-id` and `unique.app/auth/company-id` are present**. If either is missing, the provider falls through to JWT/env resolution, which will use env auth if the JWT is also incomplete.
 
 > **Security:** The server takes `_meta` values as-is without further validation. Only use this from callers you fully trust — never expose it to external users.
 
@@ -177,8 +186,8 @@ An internal service calls the tool on behalf of a known user by passing identity
     "name": "search",
     "arguments": { "query": "hello" },
     "_meta": {
-      "unique.app/user-id": "user-abc123",
-      "unique.app/company-id": "company-xyz456"
+      "unique.app/auth/user-id": "user-abc123",
+      "unique.app/auth/company-id": "company-xyz456"
     }
   }
 }

--- a/unique_mcp/README.md
+++ b/unique_mcp/README.md
@@ -10,17 +10,21 @@ MCP tools must call Unique APIs on behalf of the requesting user — every tool 
 
 The MCP server acts as an OAuth proxy: clients receive a FastMCP-issued JWT, which the server swaps server-side for the stored Zitadel token on every request. The Zitadel token _should_ contain `sub` and the company claim, but this depends on token configuration and can't be assumed.
 
-You wire a normal `FastMCP` instance with the Zitadel OAuth proxy (`create_zitadel_oauth_proxy`), then inject **`get_unique_settings`** (and optionally **`get_unique_userinfo`** / **`get_unique_service_factory`**) via `Depends()` into each tool. Those helpers resolve identity per request using a three-priority strategy:
+You wire a normal `FastMCP` instance with the Zitadel OAuth proxy (`create_zitadel_oauth_proxy`), then inject **`get_unique_settings`** / **`get_unique_settings_async`** (and optionally **`get_unique_userinfo`** / **`get_unique_service_factory`**) via `Depends()` into each tool.
+
+**`get_unique_settings` (sync)** — three-priority strategy:
 
 | Priority     | Source                          | Fields                                         | When it wins                                  |
 | ------------ | ------------------------------- | ---------------------------------------------- | --------------------------------------------- |
-| 1 (highest)  | `_meta` keys in the MCP request | `unique.app/user-id`, `unique.app/company-id`  | Trusted internal callers overriding identity  |
+| 1 (highest)  | `_meta` keys in the MCP request | `unique.app/auth/user-id`, `unique.app/auth/company-id` | Trusted internal callers overriding identity  |
 | 2            | Zitadel JWT claims (server-side token swap) | `sub`, `urn:zitadel:iam:user:resourceowner:id` | Normal OAuth flow with fully-configured token |
 | 3 (fallback) | Environment-loaded settings     | `UniqueSettings.from_env_auto_with_sdk_init()` | No usable `_meta` or complete JWT claims      |
 
-Both `user-id` and `company-id` must be present for priority 1 or 2 to apply. If JWT claims are incomplete, resolution falls through to env-based auth — `get_unique_settings` does **not** call Zitadel `/userinfo` automatically.
+Both `user-id` and `company-id` must be present for priority 1 or 2 to apply. The sync helper does **not** call Zitadel `/userinfo` — incomplete JWTs fall through to env `UNIQUE_AUTH_*`.
 
-**`get_unique_userinfo`** is a separate async helper: when a Bearer token is present, it performs `GET` on Zitadel’s userinfo endpoint and returns `UniqueUserInfo` (IDs + optional `email`). Use it when you need profile fields or an explicit userinfo round-trip; combine with `get_unique_settings` as needed.
+**`get_unique_settings_async`** — same as above, but inserts Zitadel `/userinfo` **before** the env fallback. Prefer this in tools that must act as the **logged-in** user. If an access token is present but neither JWT nor userinfo yield both IDs, it **raises** instead of using the fixed service user.
+
+**`get_unique_userinfo`** is also available on its own when you need profile fields (e.g. email).
 
 ```mermaid
 flowchart TD
@@ -96,7 +100,8 @@ if __name__ == "__main__":
 
 | Name                         | Role                                                                 |
 | ---------------------------- | -------------------------------------------------------------------- |
-| `get_unique_settings`        | Sync dependency: returns `UniqueSettings` with per-request auth      |
+| `get_unique_settings`        | Sync dependency: `_meta` → JWT → env auth                            |
+| `get_unique_settings_async`  | Async: `_meta` → JWT → userinfo → env; refuses env when logged in    |
 | `get_unique_service_factory` | Sync dependency: `UniqueServiceFactory` from resolved settings       |
 | `get_unique_userinfo`        | Async: Zitadel userinfo → `UniqueUserInfo` (requires access token)   |
 
@@ -137,11 +142,11 @@ sequenceDiagram
     MCP-->>Client: tool result
 ```
 
-### 2 — JWT without company claim (env fallback vs userinfo)
+### 2 — JWT without company claim (userinfo before env)
 
-If the Zitadel JWT carries `sub` but not the company claim, **`get_unique_settings`** does not apply JWT auth and falls back to **environment** identity from `UniqueSettings.from_env_auto_with_sdk_init()` (typical for local/dev with `UNIQUE_AUTH_*`).
+If the Zitadel JWT carries `sub` but not the company claim, **`get_unique_settings`** (sync) falls back to **environment** identity (`UNIQUE_AUTH_*`). That is wrong for multi-user servers.
 
-To obtain `sub` + company from Zitadel’s **userinfo** response explicitly, call **`await get_unique_userinfo(http_client)`** in the tool when you need that data (for example email or IDs from userinfo). Configure Zitadel so JWTs embed the resourceowner claim when possible — see [`docs/zitadel/README.md`](docs/zitadel/README.md) — to avoid relying on env or extra calls.
+Use **`await get_unique_settings_async()`** (or call **`get_unique_userinfo`**) so identity comes from Zitadel `/userinfo` instead. Configure Zitadel so JWTs embed the resourceowner claim when possible — see [`docs/zitadel/README.md`](docs/zitadel/README.md) — to avoid the extra userinfo round-trip.
 
 ```mermaid
 sequenceDiagram

--- a/unique_mcp/pyproject.toml
+++ b/unique_mcp/pyproject.toml
@@ -8,7 +8,9 @@ authors = [
 ]
 requires-python = ">=3.12"
 dependencies = [
-    "fastmcp>=3.1.1,<4",
+    # 3.3.0 is the floor: create_zitadel_oidc_proxy calls
+    # OAuthProxy.update_default_scopes, added in that release.
+    "fastmcp>=3.3.0,<4",
     "httpx>=0.28.0",
     "platformdirs>=4.0.0",
     "pydantic>=2.12.5",

--- a/unique_mcp/pyproject.toml
+++ b/unique_mcp/pyproject.toml
@@ -16,7 +16,9 @@ dependencies = [
     "pydantic>=2.12.5",
     "pydantic-settings>=2.0.0",
     "python-dotenv>=1.0.0",
-    "typing-extensions>=4.5.0",
+    # 4.6.0 is the floor: 4.4.0/4.5.0 fail to import on Python 3.12 (a
+    # TypeVar subclassing incompatibility, fixed in 4.6.0), verified locally.
+    "typing-extensions>=4.6.0",
     "unique-toolkit>=2026.30.0",
 ]
 

--- a/unique_mcp/pyproject.toml
+++ b/unique_mcp/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "pydantic>=2.12.5",
     "pydantic-settings>=2.0.0",
     "python-dotenv>=1.0.0",
+    "typing-extensions>=4.5.0",
     "unique-toolkit>=2026.30.0",
 ]
 

--- a/unique_mcp/src/unique_mcp/__init__.py
+++ b/unique_mcp/src/unique_mcp/__init__.py
@@ -15,6 +15,7 @@ from unique_mcp.unique_injectors import (
     get_request_meta,
     get_unique_service_factory,
     get_unique_settings,
+    get_unique_settings_async,
     get_unique_userinfo,
 )
 
@@ -32,6 +33,7 @@ __all__ = [
     "get_tool_config",
     "get_unique_service_factory",
     "get_unique_settings",
+    "get_unique_settings_async",
     "get_unique_userinfo",
     "merge_tool_meta",
 ]

--- a/unique_mcp/src/unique_mcp/auth/zitadel/oidc_proxy.py
+++ b/unique_mcp/src/unique_mcp/auth/zitadel/oidc_proxy.py
@@ -61,7 +61,12 @@ def create_zitadel_oidc_proxy(
     if "scope" not in extra_authorize_params:
         extra_authorize_params["scope"] = " ".join(ZITADEL_DEFAULT_MCP_SCOPES)
 
-    return OIDCProxy(
+    # Advertise / accept these scopes for DCR and /authorize. Do NOT pass them as
+    # ``required_scopes`` to OIDCProxy: that wires them into the JWT verifier, and
+    # Zitadel access tokens often omit scopes from the JWT → invalid_token loop.
+    valid_scopes = kwargs.pop("valid_scopes", ZITADEL_DEFAULT_MCP_SCOPES)
+
+    proxy = OIDCProxy(
         config_url=settings.config_url,
         client_id=settings.client_id,
         client_secret=settings.client_secret,
@@ -71,3 +76,8 @@ def create_zitadel_oidc_proxy(
         extra_authorize_params=extra_authorize_params,
         **kwargs,
     )
+    # OIDCProxy does not forward ``valid_scopes`` to OAuthProxy; set them after init
+    # so metadata ``scopes_supported`` and DCR accept openid/profile/mcp:* scopes.
+    if valid_scopes:
+        proxy.update_default_scopes(list(valid_scopes))
+    return proxy

--- a/unique_mcp/src/unique_mcp/unique_injectors.py
+++ b/unique_mcp/src/unique_mcp/unique_injectors.py
@@ -226,6 +226,9 @@ async def get_unique_settings_async() -> UniqueSettings:
     Use this in tools that must search/act as the **logged-in** user. When an
     access token is present but neither JWT nor userinfo yield both IDs, this
     raises instead of silently using ``UNIQUE_AUTH_*`` service credentials.
+    In practice that path currently surfaces as ``get_unique_userinfo``'s own
+    "Zitadel userinfo incomplete" ValueError, not the message below — see the
+    comment at the raise site.
     """
     settings = _base_settings()
 
@@ -243,6 +246,14 @@ async def get_unique_settings_async() -> UniqueSettings:
     if auth_context := await _userinfo_to_auth_context():
         return settings.with_auth(auth_context)
 
+    # Currently unreachable: with a real access token, get_unique_userinfo
+    # (called above via _userinfo_to_auth_context) either returns a complete
+    # UniqueUserInfo or raises its own "Zitadel userinfo incomplete" ValueError
+    # — it never falls through to return None while a token is present. Kept
+    # as a defensive guard for a future _userinfo_to_auth_context that
+    # swallows lookup failures and returns None instead of raising (e.g. an
+    # env-var-only / no-OIDC-proxy MCP deployment); without it, that case
+    # would silently fall through to the UNIQUE_AUTH_* return below.
     if get_access_token() is not None:
         raise ValueError(
             "Authenticated session could not be resolved to user_id and "

--- a/unique_mcp/src/unique_mcp/unique_injectors.py
+++ b/unique_mcp/src/unique_mcp/unique_injectors.py
@@ -19,6 +19,7 @@ except ImportError:
 
 
 from pydantic import BaseModel, SecretStr
+from typing_extensions import deprecated
 from unique_toolkit.agentic.feature_flags.feature_flags import feature_flags
 from unique_toolkit.app.unique_settings import (
     AuthContext,
@@ -182,8 +183,15 @@ def get_request_meta() -> dict[str, Any] | None:
     return _fastmcp_read_meta_dict()
 
 
+@deprecated(
+    "Use get_unique_settings_async: it also resolves Zitadel userinfo and "
+    "refuses the UNIQUE_AUTH_* env fallback for logged-in requests."
+)
 def get_unique_settings() -> UniqueSettings:
     """Resolve ``UniqueSettings`` for the current request (sync).
+
+    .. deprecated:: kept for callers that cannot await; new code should use
+       :func:`get_unique_settings_async`.
 
     Priority: ``_meta`` auth → JWT claims → env ``UNIQUE_AUTH_*``.
 
@@ -245,6 +253,10 @@ async def get_unique_settings_async() -> UniqueSettings:
     return settings
 
 
+@deprecated(
+    "Sync identity resolution; prefer get_unique_settings_async and build "
+    "services from the resolved settings."
+)
 def get_unique_service_factory() -> UniqueServiceFactory:
     settings = get_unique_settings()
     return UniqueServiceFactory(settings=settings)

--- a/unique_mcp/src/unique_mcp/unique_injectors.py
+++ b/unique_mcp/src/unique_mcp/unique_injectors.py
@@ -183,6 +183,14 @@ def get_request_meta() -> dict[str, Any] | None:
 
 
 def get_unique_settings() -> UniqueSettings:
+    """Resolve ``UniqueSettings`` for the current request (sync).
+
+    Priority: ``_meta`` auth → JWT claims → env ``UNIQUE_AUTH_*``.
+
+    This sync path does **not** call Zitadel ``/userinfo``. When a JWT omits
+    the company claim, callers that must not fall back to a fixed service
+    user should use :func:`get_unique_settings_async` instead.
+    """
     settings = _base_settings()
 
     meta = get_request_meta()
@@ -198,6 +206,41 @@ def get_unique_settings() -> UniqueSettings:
     # the already-bound chat context (see `UniqueSettings.with_auth`).
     if auth_context := _fastmcp_access_token_to_auth_context():
         return settings.with_auth(auth_context)
+
+    return settings
+
+
+async def get_unique_settings_async() -> UniqueSettings:
+    """Like :func:`get_unique_settings`, but try Zitadel userinfo before env.
+
+    Priority: ``_meta`` auth → JWT claims → Zitadel ``/userinfo`` → env.
+
+    Use this in tools that must search/act as the **logged-in** user. When an
+    access token is present but neither JWT nor userinfo yield both IDs, this
+    raises instead of silently using ``UNIQUE_AUTH_*`` service credentials.
+    """
+    settings = _base_settings()
+
+    meta = get_request_meta()
+
+    if meta is not None:
+        if chat_context := _chat_from_meta(meta):
+            settings = settings.with_chat(chat_context)
+        if auth_context := _auth_from_meta(meta):
+            return settings.with_auth(auth_context)
+
+    if auth_context := _fastmcp_access_token_to_auth_context():
+        return settings.with_auth(auth_context)
+
+    if auth_context := await _userinfo_to_auth_context():
+        return settings.with_auth(auth_context)
+
+    if get_access_token() is not None:
+        raise ValueError(
+            "Authenticated session could not be resolved to user_id and "
+            "company_id (JWT claims incomplete and userinfo unavailable). "
+            "Refusing UNIQUE_AUTH_* env fallback for a logged-in request."
+        )
 
     return settings
 

--- a/unique_mcp/tests/test_unique_injectors.py
+++ b/unique_mcp/tests/test_unique_injectors.py
@@ -247,8 +247,12 @@ async def test_get_unique_settings_async__raises__when_token_but_no_identity(
     base_settings: UniqueSettings,
 ) -> None:
     """
-    Purpose: With a Bearer token but no meta/JWT/userinfo, refuse env fallback.
-    Why this matters: Avoid silently acting as UNIQUE_AUTH_* for logged-in calls.
+    Purpose: exercise the defensive guard directly (mocking
+    _userinfo_to_auth_context to return None), since with the real
+    implementation a token present always makes it either succeed or raise
+    first — this exact call path is not reachable via real traffic today.
+    Why this matters: if a future _userinfo_to_auth_context swallows lookup
+    failures instead of raising, this guard must still refuse env fallback.
     Setup summary: get_access_token returns a token; all auth helpers return None.
     """
     with (

--- a/unique_mcp/tests/test_unique_injectors.py
+++ b/unique_mcp/tests/test_unique_injectors.py
@@ -26,6 +26,7 @@ from unique_mcp.unique_injectors import (
     get_request_meta,
     get_unique_service_factory,
     get_unique_settings,
+    get_unique_settings_async,
     get_unique_userinfo,
     get_zitadel_settings,
 )
@@ -209,6 +210,56 @@ def test_get_unique_settings__falls_back_to_env__when_no_meta_no_jwt(
         s = get_unique_settings()
     assert s.authcontext.get_confidential_user_id() == "dummy_user"
     assert s.authcontext.get_confidential_company_id() == "dummy_company"
+
+
+@pytest.mark.ai
+@pytest.mark.asyncio
+async def test_get_unique_settings_async__uses_userinfo__before_env(
+    base_settings: UniqueSettings,
+) -> None:
+    """
+    Purpose: Async resolver prefers Zitadel userinfo over UNIQUE_AUTH_* env.
+    Why this matters: Logged-in users must not search as the service account.
+    Setup summary: No meta/JWT; userinfo returns IDs; expect those IDs.
+    """
+    with (
+        patch(f"{_MOD}._base_settings", return_value=base_settings),
+        patch(f"{_MOD}.get_request_meta", return_value=None),
+        patch(f"{_MOD}._fastmcp_access_token_to_auth_context", return_value=None),
+        patch(
+            f"{_MOD}._userinfo_to_auth_context",
+            new=AsyncMock(
+                return_value=AuthContext(
+                    user_id=SecretStr("ui-user"),
+                    company_id=SecretStr("ui-company"),
+                )
+            ),
+        ),
+    ):
+        s = await get_unique_settings_async()
+    assert s.authcontext.get_confidential_user_id() == "ui-user"
+    assert s.authcontext.get_confidential_company_id() == "ui-company"
+
+
+@pytest.mark.ai
+@pytest.mark.asyncio
+async def test_get_unique_settings_async__raises__when_token_but_no_identity(
+    base_settings: UniqueSettings,
+) -> None:
+    """
+    Purpose: With a Bearer token but no meta/JWT/userinfo, refuse env fallback.
+    Why this matters: Avoid silently acting as UNIQUE_AUTH_* for logged-in calls.
+    Setup summary: get_access_token returns a token; all auth helpers return None.
+    """
+    with (
+        patch(f"{_MOD}._base_settings", return_value=base_settings),
+        patch(f"{_MOD}.get_request_meta", return_value=None),
+        patch(f"{_MOD}._fastmcp_access_token_to_auth_context", return_value=None),
+        patch(f"{_MOD}._userinfo_to_auth_context", new=AsyncMock(return_value=None)),
+        patch(f"{_MOD}.get_access_token", return_value=MagicMock()),
+        pytest.raises(ValueError, match="Refusing UNIQUE_AUTH_"),
+    ):
+        await get_unique_settings_async()
 
 
 @pytest.mark.ai

--- a/unique_mcp/tests/test_unique_injectors.py
+++ b/unique_mcp/tests/test_unique_injectors.py
@@ -552,3 +552,69 @@ def test_get_unique_service_factory__builds_factory_with_resolved_settings(
     mock_get_settings.assert_called_once()
     mock_factory_cls.assert_called_once_with(settings=base_settings)
     assert result is mock_instance
+
+
+@pytest.mark.ai
+@pytest.mark.asyncio
+async def test_get_unique_settings_async__uses_meta__before_jwt_and_userinfo(
+    base_settings: UniqueSettings,
+) -> None:
+    """
+    Purpose: Async resolver honors trusted _meta identity first.
+    Why this matters: Unique AI passes identity via _meta; it must win.
+    Setup summary: meta carries canonical user/company keys; expect them back.
+    """
+    meta = {MetaKeys.USER_ID: "meta-user", MetaKeys.COMPANY_ID: "meta-company"}
+    with (
+        patch(f"{_MOD}._base_settings", return_value=base_settings),
+        patch(f"{_MOD}.get_request_meta", return_value=meta),
+    ):
+        s = await get_unique_settings_async()
+    assert s.authcontext.get_confidential_user_id() == "meta-user"
+    assert s.authcontext.get_confidential_company_id() == "meta-company"
+
+
+@pytest.mark.ai
+@pytest.mark.asyncio
+async def test_get_unique_settings_async__uses_jwt__before_userinfo(
+    base_settings: UniqueSettings,
+) -> None:
+    """
+    Purpose: Async resolver uses JWT claims before calling userinfo.
+    Why this matters: avoids an extra Zitadel round-trip for complete tokens.
+    Setup summary: no meta; JWT auth context present; expect its ids.
+    """
+    with (
+        patch(f"{_MOD}._base_settings", return_value=base_settings),
+        patch(f"{_MOD}.get_request_meta", return_value=None),
+        patch(
+            f"{_MOD}._fastmcp_access_token_to_auth_context",
+            return_value=AuthContext(
+                user_id=SecretStr("jwt-user"),
+                company_id=SecretStr("jwt-company"),
+            ),
+        ),
+    ):
+        s = await get_unique_settings_async()
+    assert s.authcontext.get_confidential_user_id() == "jwt-user"
+
+
+@pytest.mark.ai
+@pytest.mark.asyncio
+async def test_get_unique_settings_async__falls_back_to_env__without_session(
+    base_settings: UniqueSettings,
+) -> None:
+    """
+    Purpose: Without any OAuth session, env-based settings are returned as-is.
+    Why this matters: local unauthenticated development must keep working.
+    Setup summary: no meta/JWT/userinfo/token; expect the base settings object.
+    """
+    with (
+        patch(f"{_MOD}._base_settings", return_value=base_settings),
+        patch(f"{_MOD}.get_request_meta", return_value=None),
+        patch(f"{_MOD}._fastmcp_access_token_to_auth_context", return_value=None),
+        patch(f"{_MOD}._userinfo_to_auth_context", new=AsyncMock(return_value=None)),
+        patch(f"{_MOD}.get_access_token", return_value=None),
+    ):
+        s = await get_unique_settings_async()
+    assert s is base_settings

--- a/unique_toolkit/tests/experimental/test_content_tree_unit.py
+++ b/unique_toolkit/tests/experimental/test_content_tree_unit.py
@@ -459,3 +459,24 @@ async def test_AI_search_visible_files_fuzzy_reuses_cached_snapshot() -> None:
         await svc.search_visible_files_fuzzy_async("a.pdf", min_score=0.0)
 
     assert mock_core.await_count == 1
+
+
+@pytest.mark.ai
+async def test_translate_scope_id_async__returns_none__when_folder_lookup_fails() -> (
+    None
+):
+    """A single failing folder lookup logs at debug and yields None so batch
+    resolution keeps going (callers fall back to the raw scope_id)."""
+    from unique_toolkit.experimental.components.content_tree.functions import (
+        translate_scope_id_async,
+    )
+
+    with patch(
+        "unique_toolkit.experimental.components.content_tree.functions.get_folder_info_async",
+        new=AsyncMock(side_effect=RuntimeError("folder service unavailable")),
+    ):
+        resolved = await translate_scope_id_async(
+            user_id="u", company_id="c", scope_id="scope_x"
+        )
+
+    assert resolved is None

--- a/unique_toolkit/unique_toolkit/experimental/components/content_tree/functions.py
+++ b/unique_toolkit/unique_toolkit/experimental/components/content_tree/functions.py
@@ -118,7 +118,7 @@ async def translate_scope_id_async(
         )
         return folder_info.name
     except Exception as e:
-        _LOGGER.debug("Could not resolve folder for scope_id %s: %s", scope_id, e)
+        _LOGGER.debug("Could not resolve folder for scope_id %s", scope_id, exc_info=e)
         return None
 
 

--- a/unique_toolkit/unique_toolkit/experimental/components/content_tree/functions.py
+++ b/unique_toolkit/unique_toolkit/experimental/components/content_tree/functions.py
@@ -107,9 +107,8 @@ async def translate_scope_id_async(
 ) -> str | None:
     """Resolve a single ``scope_id`` to a folder name.
 
-    Returns ``None`` (and logs a warning) if the folder lookup fails, so callers
-    can batch-resolve ids without a single missing folder aborting the whole
-    operation.
+    Returns ``None`` if the folder lookup fails (logged at debug; callers fall back
+    to the raw ``scope_id``), so batch resolution is not aborted by a single miss.
     """
     try:
         folder_info = await get_folder_info_async(
@@ -119,7 +118,7 @@ async def translate_scope_id_async(
         )
         return folder_info.name
     except Exception as e:
-        _LOGGER.warning(f"Could not resolve folder for scope_id {scope_id}", exc_info=e)
+        _LOGGER.debug("Could not resolve folder for scope_id %s: %s", scope_id, e)
         return None
 
 

--- a/unique_toolkit/unique_toolkit/services/knowledge_base.py
+++ b/unique_toolkit/unique_toolkit/services/knowledge_base.py
@@ -843,9 +843,7 @@ class KnowledgeBaseService:
             folder_info = await self.get_folder_info_async(scope_id=scope_id)
             return folder_info.name
         except Exception as e:
-            _LOGGER.warning(
-                f"Could not resolve folder for scope_id {scope_id}", exc_info=e
-            )
+            _LOGGER.debug("Could not resolve folder for scope_id %s: %s", scope_id, e)
             return None
 
     async def _translate_scope_ids_async(

--- a/unique_toolkit/unique_toolkit/services/knowledge_base.py
+++ b/unique_toolkit/unique_toolkit/services/knowledge_base.py
@@ -843,7 +843,9 @@ class KnowledgeBaseService:
             folder_info = await self.get_folder_info_async(scope_id=scope_id)
             return folder_info.name
         except Exception as e:
-            _LOGGER.debug("Could not resolve folder for scope_id %s: %s", scope_id, e)
+            _LOGGER.debug(
+                "Could not resolve folder for scope_id %s", scope_id, exc_info=e
+            )
             return None
 
     async def _translate_scope_ids_async(

--- a/uv.lock
+++ b/uv.lock
@@ -12,13 +12,13 @@ conflicts = [[
 ]]
 
 [options]
-exclude-newer = "2026-07-03T08:40:02.30686491Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P2W"
 
 [options.exclude-newer-package]
 unique-toolkit = false
 unique-internal-search = false
-crawl4ai = "2026-06-20T00:00:00Z"
+crawl4ai = "2026-06-19T22:00:00Z"
 unique-swot = false
 unique-sdk = false
 unique-search-proxy-core = false
@@ -26,9 +26,9 @@ unique-mcp = false
 unique-orchestrator = false
 unique-follow-up-questions = false
 unique-user-memory = false
-langsmith = "2026-06-21T00:00:00Z"
+langsmith = "2026-06-20T22:00:00Z"
 unique-six = false
-pydantic-settings = "2026-06-21T00:00:00Z"
+pydantic-settings = "2026-06-20T22:00:00Z"
 unique-search-proxy = false
 unique-web-search = false
 unique-deep-research = false
@@ -5210,7 +5210,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fastmcp", specifier = ">=3.1.1,<4" },
+    { name = "fastmcp", specifier = ">=3.3.0,<4" },
     { name = "httpx", specifier = ">=0.28.0" },
     { name = "platformdirs", specifier = ">=4.0.0" },
     { name = "pydantic", specifier = ">=2.12.5" },

--- a/uv.lock
+++ b/uv.lock
@@ -5204,6 +5204,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
+    { name = "typing-extensions" },
     { name = "unique-toolkit" },
 ]
 
@@ -5215,6 +5216,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
+    { name = "typing-extensions", specifier = ">=4.5.0" },
     { name = "unique-toolkit", editable = "unique_toolkit" },
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ conflicts = [[
 ]]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-07-03T08:40:02.30686491Z"
 exclude-newer-span = "P2W"
 
 [options.exclude-newer-package]
@@ -5216,7 +5216,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
-    { name = "typing-extensions", specifier = ">=4.5.0" },
+    { name = "typing-extensions", specifier = ">=4.6.0" },
     { name = "unique-toolkit", editable = "unique_toolkit" },
 ]
 


### PR DESCRIPTION
## Summary

Split out of #2023 per team decision — the `unique_mcp`/`unique_toolkit` changes land first, standalone, so `mcp_search`'s tools can depend on a released version instead of carrying unreleased library code in an application PR.

- **`get_unique_settings_async`**: per-request identity resolver that tries `_meta` → JWT claims → Zitadel `/userinfo` → env `UNIQUE_AUTH_*`, in that order, and **raises** instead of silently falling back to the fixed service user when an access token is present but identity can't be resolved. Existing `get_unique_settings` (sync) only goes `_meta` → JWT → env and never calls `/userinfo` — it's now marked `@deprecated` (same for `get_unique_service_factory`, which shares the limitation), kept for callers that can't await.
- **OIDC scope advertisement**: `create_zitadel_oidc_proxy` now advertises `openid`/`profile`/`mcp:*` scopes via `update_default_scopes` — not `required_scopes`, which would wire them into the JWT verifier and reintroduce `invalid_token` loops when Zitadel omits scopes from the access token (comment in the diff explains why).
- **Toolkit**: `content_tree`'s batch scope-id resolution now logs a missing folder at `debug` instead of `warning` — a single failed lookup is an expected, non-actionable per-item miss in batch resolution, not something worth spamming production logs over.
- Declares `typing-extensions` as a direct dependency (was only transitive; needed for `@deprecated`).

## Test plan

- [x] `uv run --directory unique_mcp python -m pytest tests/` — 82 passed
- [x] `uv run --directory unique_toolkit python -m pytest tests/experimental/test_content_tree_unit.py` — 24 passed
- [x] Verified via `git diff origin/main..HEAD --stat` that this touches only `unique_mcp/**` and the two `unique_toolkit` logging lines — no `mcp_search` files

## Follow-up

`mcp_search`'s tools (`search`, `content_tree`, `read_file`) already use `get_unique_settings_async`; that PR (#2023, being rebased) will depend on this merging and a `unique-mcp` release/dev-build containing it.
