### PR TITLE
fix(security): bump mcp and starlette via constraint-dependencies

### DIFF
--- a/connectors/unique_search_proxy/unique_search_proxy_client/pyproject.toml
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/pyproject.toml
@@ -6,8 +6,8 @@ authors = [{ name = "ThePhilAz", email = "rami.azouz@philico.com" }]
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "fastapi>=0.115.0,<1.0.0",
-    "starlette>=0.41.0,<1.0.0",
+    "fastapi>=0.133.0,<1.0.0",
+    "starlette>=1.3.1,<2.0.0",
     "uvicorn[standard]>=0.32.0,<1.0.0",
     "pydantic>=2.12.5,<3.0.0",
     "httpx>=0.28.0,<0.29.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ constraint-dependencies = [
     # 1.83.14 relaxes it; 1.84+ relaxes openai==2.24.0.
     "litellm>=1.84.0",
     "lxml>=6.1.0",
+    "mcp>=1.28.1",
     "pillow>=12.2.0",
     "pydantic-settings>=2.14.2",
     "pygments>=2.20.0",
@@ -84,6 +85,7 @@ constraint-dependencies = [
     "pytest>=9.0.3",
     "python-multipart>=0.0.31",
     "requests>=2.33.0",
+    "starlette>=1.3.1",
     "tornado>=6.5.5",
     "urllib3>=2.7.0",
 ]
@@ -110,10 +112,6 @@ override-dependencies = [
 "unique-search-proxy-core" = false
 "unique-search-proxy-sdk" = false
 "unique-quartr" = false
-# Security fixes published within the exclude-newer window. Remove once older than 2 weeks.
-"crawl4ai" = "2026-06-19"
-"langsmith" = "2026-06-20"
-"pydantic-settings" = "2026-06-20"
 
 [tool.uv.sources]
 unique-sdk = { workspace = true }

--- a/unique_toolkit/pyproject.toml
+++ b/unique_toolkit/pyproject.toml
@@ -55,8 +55,8 @@ langchain = [
     "langchain-core>=1.0.0,<2",
 ]
 fastapi = [
-    "fastapi>=0.121.0,<0.122",
-    "starlette>=0.49.1",
+    "fastapi>=0.133.0,<1.0.0",
+    "starlette>=1.3.1,<2.0.0",
     "uvicorn>=0.37.0,<0.38",
 ]
 monitoring = [
@@ -77,7 +77,6 @@ dev = [
 [tool.uv]
 exclude-newer = "2 weeks"
 constraint-dependencies = [
-    "starlette>=0.49.1",
     "lxml>=6.1.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -12,13 +12,12 @@ conflicts = [[
 ]]
 
 [options]
-exclude-newer = "2026-07-03T08:40:02.30686491Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P2W"
 
 [options.exclude-newer-package]
 unique-toolkit = false
 unique-internal-search = false
-crawl4ai = "2026-06-19T22:00:00Z"
 unique-swot = false
 unique-sdk = false
 unique-search-proxy-core = false
@@ -26,9 +25,7 @@ unique-mcp = false
 unique-orchestrator = false
 unique-follow-up-questions = false
 unique-user-memory = false
-langsmith = "2026-06-20T22:00:00Z"
 unique-six = false
-pydantic-settings = "2026-06-20T22:00:00Z"
 unique-search-proxy = false
 unique-web-search = false
 unique-deep-research = false
@@ -74,6 +71,7 @@ constraints = [
     { name = "langsmith", specifier = ">=0.8.18" },
     { name = "litellm", specifier = ">=1.84.0" },
     { name = "lxml", specifier = ">=6.1.0" },
+    { name = "mcp", specifier = ">=1.28.1" },
     { name = "pillow", specifier = ">=12.2.0" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "pygments", specifier = ">=2.20.0" },
@@ -81,6 +79,7 @@ constraints = [
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "python-multipart", specifier = ">=0.0.31" },
     { name = "requests", specifier = ">=2.33.0" },
+    { name = "starlette", specifier = ">=1.3.1" },
     { name = "tornado", specifier = ">=6.5.5" },
     { name = "urllib3", specifier = ">=2.7.0" },
 ]
@@ -1060,17 +1059,18 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.121.3"
+version = "0.139.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
     { name = "pydantic" },
     { name = "starlette" },
     { name = "typing-extensions" },
+    { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/80/f0/086c442c6516195786131b8ca70488c6ef11d2f2e33c9a893576b2b0d3f7/fastapi-0.121.3.tar.gz", hash = "sha256:0055bc24fe53e56a40e9e0ad1ae2baa81622c406e548e501e717634e2dfbc40b", size = 344501, upload-time = "2025-11-19T16:53:39.243Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/af/a5f50ccfa659ec1802cb4ca842c23f06d906a8cc9aef6016a2caeea3d4ed/fastapi-0.139.0.tar.gz", hash = "sha256:99ab7b2d92223c76d6cf10757ab3f89d45b38267fc20b2a136cf02f6beac3145", size = 423016, upload-time = "2026-07-01T16:35:33.436Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/b6/4f620d7720fc0a754c8c1b7501d73777f6ba43b57c8ab99671f4d7441eb8/fastapi-0.121.3-py3-none-any.whl", hash = "sha256:0c78fc87587fcd910ca1bbf5bc8ba37b80e119b388a7206b39f0ecc95ebf53e9", size = 109801, upload-time = "2025-11-19T16:53:37.918Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/7c/8e3c6ad324ea5cb36604fc3f968554887891c316d9dfde57761611d907ad/fastapi-0.139.0-py3-none-any.whl", hash = "sha256:cf15e1e9e667ddb0ad63811e60bd11390d1aac838ca4a7a23f421807b2308189", size = 130339, upload-time = "2026-07-01T16:35:32.19Z" },
 ]
 
 [[package]]
@@ -2648,7 +2648,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.27.2"
+version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2666,9 +2666,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten' or (extra == 'group-11-ai-monorepo-dev' and extra == 'group-11-ai-monorepo-docs')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/27/3c/347cf965d313f5d41764e7d46bea6ffe7d9ef13b983cc429b0340962a082/mcp-1.27.2.tar.gz", hash = "sha256:8e02db104096d1c25b28e64bde29a5c32b31bc241710213e12fd4d84985bdfef", size = 621116, upload-time = "2026-05-29T17:16:04.039Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/11/252c6f971dc4f16af1d98a1c469d8ba523aab00d1bb76b4d3bc1ff32eacc/mcp-1.27.2-py3-none-any.whl", hash = "sha256:d6ff5160c6ca65d93013626efb3fc249de683c30b2d8570755ceddd490344de5", size = 220498, upload-time = "2026-05-29T17:16:02.442Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
 ]
 
 [[package]]
@@ -4799,15 +4799,15 @@ sdist = { url = "https://files.pythonhosted.org/packages/cf/6c/fa601216344952be8
 
 [[package]]
 name = "starlette"
-version = "0.50.0"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'group-11-ai-monorepo-dev' and extra == 'group-11-ai-monorepo-docs')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/b8/73a0e6a6e079a9d9cfa64113d771e421640b6f679a52eeb9b32f72d871a1/starlette-0.50.0.tar.gz", hash = "sha256:a2a17b22203254bcbc2e1f926d2d55f3f9497f769416b3190768befe598fa3ca", size = 2646985, upload-time = "2025-11-01T15:25:27.516Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/52/1064f510b141bd54025f9b55105e26d1fa970b9be67ad766380a3c9b74b0/starlette-0.50.0-py3-none-any.whl", hash = "sha256:9e5391843ec9b6e472eed1365a78c8098cfceb7a74bfd4d6b1c0c0095efb3bca", size = 74033, upload-time = "2025-11-01T15:25:25.461Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
 ]
 
 [[package]]
@@ -5368,7 +5368,7 @@ requires-dist = [
     { name = "azure-core", specifier = ">=1.36.0,<2" },
     { name = "azure-identity", specifier = ">=1.25.0,<2" },
     { name = "certifi", specifier = ">=2025.11.12,<2027" },
-    { name = "fastapi", specifier = ">=0.115.0,<1.0.0" },
+    { name = "fastapi", specifier = ">=0.133.0,<1.0.0" },
     { name = "google-auth", specifier = ">=2.43.0,<3" },
     { name = "google-genai", specifier = ">=1.73.0,<2" },
     { name = "httpx", specifier = ">=0.28.0,<0.29.0" },
@@ -5377,7 +5377,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.12.5,<3.0.0" },
     { name = "pydantic-settings", specifier = ">=2.12.0,<3.0.0" },
     { name = "python-dotenv", specifier = ">=1.2.1,<2.0.0" },
-    { name = "starlette", specifier = ">=0.41.0,<1.0.0" },
+    { name = "starlette", specifier = ">=1.3.1,<2.0.0" },
     { name = "unique-search-proxy-core", editable = "connectors/unique_search_proxy/unique_search_proxy_core" },
     { name = "unique-toolkit", extras = ["monitoring"], editable = "unique_toolkit" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0,<1.0.0" },
@@ -5643,7 +5643,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.1.0,<9" },
     { name = "deepdiff", specifier = ">=8.6.1,<9" },
     { name = "docxtpl", specifier = ">=0.20.1,<0.21" },
-    { name = "fastapi", marker = "extra == 'fastapi'", specifier = ">=0.121.0,<0.122" },
+    { name = "fastapi", marker = "extra == 'fastapi'", specifier = ">=0.133.0,<1.0.0" },
     { name = "httpx", specifier = ">=0.28.0,<0.29" },
     { name = "jambo", specifier = ">=0.1.2,<0.2" },
     { name = "jinja2", specifier = ">=3.1.6,<4" },
@@ -5667,7 +5667,7 @@ requires-dist = [
     { name = "rapidfuzz", specifier = ">=3.0,<4" },
     { name = "requests", specifier = ">=2.32.0,<3" },
     { name = "sseclient", specifier = ">=0.0.27,<0.0.28" },
-    { name = "starlette", marker = "extra == 'fastapi'", specifier = ">=0.49.1" },
+    { name = "starlette", marker = "extra == 'fastapi'", specifier = ">=1.3.1,<2.0.0" },
     { name = "tenacity", specifier = ">=9.1.4" },
     { name = "tiktoken", specifier = ">=0.12.0,<0.13" },
     { name = "tokenizers", specifier = ">=0.21.0,<0.23" },


### PR DESCRIPTION
## Summary
- Clears the 6 remaining open Dependabot alerts on the root workspace `uv.lock` by adding security floors for `mcp>=1.28.1` and `starlette>=1.3.1`.
- Prunes stale `exclude-newer-package` timestamps (`crawl4ai`, `langsmith`, `pydantic-settings`) that are older than the 2-week rolling window.
- Raises FastAPI pins in `unique_toolkit` and `unique-search-proxy` so Starlette 1.x resolves (FastAPI `<0.133` caps Starlette at `<0.51`).

## Changes
- **`pyproject.toml`**: add `mcp` / `starlette` constraint-dependencies; remove expired exclude-newer overrides.
- **`unique_toolkit`**: bump `[fastapi]` extra to `fastapi>=0.133.0`, `starlette>=1.3.1`; drop redundant local `starlette>=0.49.1` constraint.
- **`unique_search_proxy_client`**: align `fastapi` / `starlette` lower bounds with the workspace floor.
- **`uv.lock`**: `mcp` 1.27.2 → 1.28.1, `starlette` 0.50.0 → 1.3.1, `fastapi` 0.121.3 → 0.139.0.

## Context
152 ghost alerts on deleted sub-project lockfiles were bulk-dismissed separately (manifests removed from `main` in April 2026; dependency graph snapshots were stale).

## Test plan
- [x] `uv lock --refresh` resolves cleanly
- [ ] CI: lint, typecheck, pytest, dependency checks

## Risk / rollout
- Starlette 0.x → 1.3.1 and FastAPI 0.121 → 0.139 are non-trivial bumps; watch FastAPI/Starlette integration tests and search-proxy deploy path.
- Dependabot alerts should auto-close after merge + rescan; no manual version/changelog edits (release-please owns those).

🤖 AI assist: medium

Made with [Cursor](https://cursor.com)