### PR TITLE
fix(unique_sdk): chat-monotonic MCP source numbering and richer citation sources [UN-23199]

### DIFF
--- a/unique_sdk/tests/cli/test_mcp.py
+++ b/unique_sdk/tests/cli/test_mcp.py
@@ -20,6 +20,7 @@ from unique_sdk.cli.state import ShellState
 
 _OUTPUT_MANIFEST = Path(".unique") / "mcp-output.jsonl"
 _REFS_MANIFEST = Path(".unique") / "mcp-refs.jsonl"
+_REFS_SEED = Path(".unique") / "mcp-refs-seed.json"
 
 
 class _FakeMCPResponse:
@@ -810,6 +811,103 @@ def test_record_mcp_citations_concurrent_monotonic_numbers(
     # collisions despite concurrent writers (the per-turn flock serializes them).
     assert numbers == list(range(1, n + 1))
     assert len(_unique_lines(unique_dir, "mcp-output.jsonl")) == n
+
+
+# ── Chat-monotonic source numbering / seed file (UN-23199) ───────────────────
+#
+# The SI runner wipes ``mcp-refs.jsonl`` between turns, so manifest-derived
+# numbering would restart at 1 each turn. A persistent sibling seed file
+# (``mcp-refs-seed.json``) records the highest source number ever assigned in
+# the chat so numbering stays monotonic across the runner's per-turn reset.
+
+
+def test_seed_continues_numbering_after_manifest_wiped(tmp_path: Path) -> None:
+    # Turn 1: two items → sources 1, 2. The seed file records the max.
+    r1 = _FakeMCPResponse(
+        content=[
+            {"type": "resource_link", "uri": "https://e/a", "name": "Doc A"},
+            {"type": "resource_link", "uri": "https://e/b", "name": "Doc B"},
+        ]
+    )
+    _run("mcp__kb__search", r1)
+    first_max = max(r["sourceNumber"] for r in _lines(tmp_path, _REFS_MANIFEST))
+    assert first_max == 2
+
+    # Seed file exists with the contract body; manifest is wiped (runner reset).
+    seed_path = tmp_path / _REFS_SEED
+    assert seed_path.is_file()
+    assert json.loads(seed_path.read_text(encoding="utf-8")) == {"maxSourceNumber": 2}
+    (tmp_path / _REFS_MANIFEST).unlink()
+
+    # Turn 2: a fresh item must continue above the prior max, not restart at 1.
+    r2 = _FakeMCPResponse(
+        content=[{"type": "resource_link", "uri": "https://e/c", "name": "Doc C"}]
+    )
+    _run("mcp__kb__search", r2)
+    refs2 = _lines(tmp_path, _REFS_MANIFEST)
+    assert [r["sourceNumber"] for r in refs2] == [first_max + 1]
+    assert refs2[0]["title"] == "Doc C"
+    assert json.loads(seed_path.read_text(encoding="utf-8")) == {"maxSourceNumber": 3}
+
+
+def test_absent_seed_reproduces_pre_seed_numbering(tmp_path: Path) -> None:
+    # No seed file → seed 0 → numbering identical to today's behavior (starts 1).
+    response = _FakeMCPResponse(
+        content=[{"type": "resource_link", "uri": "https://e/a", "name": "Doc A"}]
+    )
+    _run("mcp__kb__fetch", response)
+    assert _lines(tmp_path, _REFS_MANIFEST)[0]["sourceNumber"] == 1
+
+
+# ── Sources block names the tool (UN-23199) ──────────────────────────────────
+
+
+def test_sources_block_includes_tool_name(tmp_path: Path) -> None:
+    response = _FakeMCPResponse(
+        content=[{"type": "resource_link", "uri": "https://e/a", "name": "Doc A"}]
+    )
+    out = _run("mcp__kb__fetch", response)
+    assert "[mcpsource1] Doc A — mcp__kb__fetch" in out
+
+
+def test_sources_block_titleless_uses_tool_name(tmp_path: Path) -> None:
+    response = _FakeMCPResponse(content=[{"type": "text", "text": "status: ok"}])
+    out = _run("mcp__crm__update", response)
+    assert "[mcpsource1] mcp__crm__update" in out
+
+
+# ── Title-less dedup by content hash (UN-23199) ──────────────────────────────
+
+
+def test_titleless_distinct_text_gets_distinct_numbers(tmp_path: Path) -> None:
+    # Two title-less fetches through one tool returning different bodies must not
+    # collapse onto one source number (content-hash in the dedup key).
+    _run(
+        "mcp__crm__update",
+        _FakeMCPResponse(content=[{"type": "text", "text": "a"}]),
+        formatted="alpha result",
+    )
+    _run(
+        "mcp__crm__update",
+        _FakeMCPResponse(content=[{"type": "text", "text": "b"}]),
+        formatted="beta result",
+    )
+    refs = _lines(tmp_path, _REFS_MANIFEST)
+    assert len(refs) == 2
+    assert {r["sourceNumber"] for r in refs} == {1, 2}
+
+
+def test_titleless_identical_text_still_merges(tmp_path: Path) -> None:
+    # Identical title-less bodies through one tool still merge onto one source.
+    for _ in range(2):
+        _run(
+            "mcp__crm__update",
+            _FakeMCPResponse(content=[{"type": "text", "text": "same"}]),
+            formatted="identical",
+        )
+    refs = _lines(tmp_path, _REFS_MANIFEST)
+    assert len(refs) == 1
+    assert refs[0]["sourceNumber"] == 1
 
 
 # ── reference_mapping override (per-tool list destructuring) ──────────────────

--- a/unique_sdk/tests/cli/test_mcp.py
+++ b/unique_sdk/tests/cli/test_mcp.py
@@ -878,6 +878,21 @@ def test_write_seed_refuses_symlinked_temp_path(tmp_path: Path) -> None:
     assert not seed_path.exists()
 
 
+def test_write_seed_without_o_nofollow_attr(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Bugbot regression: O_NOFOLLOW is POSIX-only. On a platform lacking it the
+    # write must still succeed (getattr → 0), not raise AttributeError that would
+    # bubble out of _annotate_mcp_results_for_citations and blank the Sources
+    # block.
+    monkeypatch.delattr(mcp_cmd.os, "O_NOFOLLOW", raising=False)
+    seed_path = tmp_path / ".unique" / "mcp-refs-seed.json"
+
+    mcp_cmd._write_mcp_refs_seed(seed_path, 4)
+
+    assert json.loads(seed_path.read_text(encoding="utf-8")) == {"maxSourceNumber": 4}
+
+
 # ── Sources block names the tool (UN-23199) ──────────────────────────────────
 
 

--- a/unique_sdk/tests/cli/test_mcp.py
+++ b/unique_sdk/tests/cli/test_mcp.py
@@ -859,6 +859,25 @@ def test_absent_seed_reproduces_pre_seed_numbering(tmp_path: Path) -> None:
     assert _lines(tmp_path, _REFS_MANIFEST)[0]["sourceNumber"] == 1
 
 
+def test_write_seed_refuses_symlinked_temp_path(tmp_path: Path) -> None:
+    # Bugbot security regression: the seed write must not follow a symlink
+    # pre-planted at the predictable temp path, so it cannot be redirected to
+    # overwrite a file outside the refs directory.
+    unique_dir = tmp_path / ".unique"
+    unique_dir.mkdir()
+    seed_path = unique_dir / "mcp-refs-seed.json"
+    outside = tmp_path / "outside.txt"
+    outside.write_text("SECRET", encoding="utf-8")
+    (unique_dir / "mcp-refs-seed.json.tmp").symlink_to(outside)
+
+    # Best-effort: the O_NOFOLLOW open fails and is swallowed (no raise).
+    mcp_cmd._write_mcp_refs_seed(seed_path, 5)
+
+    # The symlink target outside the refs dir is untouched, and no seed landed.
+    assert outside.read_text(encoding="utf-8") == "SECRET"
+    assert not seed_path.exists()
+
+
 # ── Sources block names the tool (UN-23199) ──────────────────────────────────
 
 
@@ -904,6 +923,25 @@ def test_titleless_identical_text_still_merges(tmp_path: Path) -> None:
             "mcp__crm__update",
             _FakeMCPResponse(content=[{"type": "text", "text": "same"}]),
             formatted="identical",
+        )
+    refs = _lines(tmp_path, _REFS_MANIFEST)
+    assert len(refs) == 1
+    assert refs[0]["sourceNumber"] == 1
+
+
+def test_titleless_oversized_identical_text_merges_across_calls(
+    tmp_path: Path,
+) -> None:
+    # Bugbot regression: the dedup key must hash the CAPPED text so the second
+    # call (rebuilding the key from the truncated manifest entry) still matches
+    # the first (full live text). An oversized identical title-less body must
+    # merge onto one source, not be re-assigned a duplicate number.
+    big = "x" * (mcp_cmd._MCP_REF_TEXT_CHAR_LIMIT + 50)
+    for _ in range(2):
+        _run(
+            "mcp__crm__update",
+            _FakeMCPResponse(content=[{"type": "text", "text": "plain"}]),
+            formatted=big,
         )
     refs = _lines(tmp_path, _REFS_MANIFEST)
     assert len(refs) == 1

--- a/unique_sdk/unique_sdk/cli/commands/mcp.py
+++ b/unique_sdk/unique_sdk/cli/commands/mcp.py
@@ -569,13 +569,18 @@ def _write_mcp_refs_seed(seed_path: Path, value: int) -> None:
     predictable temp path cannot redirect the write outside the refs directory
     (defense in depth on top of the per-user workspace sandbox). ``os.replace``
     operates on the directory entry and does not follow a symlink at the target.
+    ``O_NOFOLLOW`` is POSIX-only; on platforms lacking it (e.g. Windows) it
+    degrades to ``0`` via ``getattr`` rather than raising ``AttributeError`` —
+    which, being outside the ``OSError`` handler, would otherwise bubble out of
+    ``_annotate_mcp_results_for_citations`` after entries were written and blank
+    the Sources block.
     """
     try:
         if value <= _read_mcp_refs_seed(seed_path):
             return
         seed_path.parent.mkdir(parents=True, exist_ok=True)
         tmp_path = seed_path.with_suffix(seed_path.suffix + ".tmp")
-        flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW
+        flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_NOFOLLOW", 0)
         fd = os.open(tmp_path, flags, 0o600)
         with os.fdopen(fd, "w", encoding="utf-8") as handle:
             handle.write(json.dumps({"maxSourceNumber": value}))
@@ -631,8 +636,11 @@ def _annotate_mcp_results_for_citations(
     """Assign per-turn ``[mcpsourceN]`` numbers to each retrieved item and append
     the refs manifest. Returns ``[(sourceNumber, item)]`` for the Sources block.
 
-    Items dedup by title across the turn (same item keeps one number), or by
-    tool for the title-less fallback. Best-effort — returns ``[]`` on any failure
+    Items dedup by title across the turn (same item keeps one number); a
+    title-less item dedups by tool plus a content hash of its (capped) text, so
+    two distinct title-less results through one tool get distinct numbers while
+    identical bodies still merge (this weakens the search-then-fetch text-upgrade
+    merge for title-less items only). Best-effort — returns ``[]`` on any failure
     (the tool result is unaffected; only the citation Sources block is skipped).
     """
     refs_log_path = refs_log_path or (Path.cwd() / _MCP_REFS_LOG_RELATIVE_PATH)

--- a/unique_sdk/unique_sdk/cli/commands/mcp.py
+++ b/unique_sdk/unique_sdk/cli/commands/mcp.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import os
 import re
 import sys
 from pathlib import Path
@@ -563,14 +564,22 @@ def _write_mcp_refs_seed(seed_path: Path, value: int) -> None:
 
     Only writes when ``value`` exceeds the currently persisted seed, so numbers
     never regress across turns.
+
+    The temp file is opened with ``O_NOFOLLOW`` so a symlink pre-planted at the
+    predictable temp path cannot redirect the write outside the refs directory
+    (defense in depth on top of the per-user workspace sandbox). ``os.replace``
+    operates on the directory entry and does not follow a symlink at the target.
     """
     try:
         if value <= _read_mcp_refs_seed(seed_path):
             return
         seed_path.parent.mkdir(parents=True, exist_ok=True)
         tmp_path = seed_path.with_suffix(seed_path.suffix + ".tmp")
-        tmp_path.write_text(json.dumps({"maxSourceNumber": value}), encoding="utf-8")
-        tmp_path.replace(seed_path)
+        flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW
+        fd = os.open(tmp_path, flags, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(json.dumps({"maxSourceNumber": value}))
+        os.replace(tmp_path, seed_path)
     except OSError as exc:
         _LOGGER.warning("mcp: failed to write refs seed: %s", exc)
 
@@ -584,13 +593,19 @@ def _item_dedup_key(tool_name: str, item: dict[str, Any]) -> str:
     one number (identical bodies still merge). NOTE: this intentionally weakens
     the search-then-fetch text-upgrade merge for title-less items only — titled
     items still merge by title as before.
+
+    The text is capped at ``_MCP_REF_TEXT_CHAR_LIMIT`` BEFORE hashing — the same
+    cap the manifest stores under ``text``. Without it, the first call (live,
+    full-length item text) and a later call rebuilding this key from the
+    truncated manifest entry would hash to different values, so an oversized
+    title-less result would be re-assigned a duplicate ``[mcpsourceN]`` instead
+    of deduping.
     """
     title = item.get("title")
     if isinstance(title, str) and title.strip():
         return f"title:{tool_name}:{title.strip()}"
-    text_hash = hashlib.sha256((item.get("text") or "").encode("utf-8")).hexdigest()[
-        :12
-    ]
+    capped_text = (item.get("text") or "")[:_MCP_REF_TEXT_CHAR_LIMIT]
+    text_hash = hashlib.sha256(capped_text.encode("utf-8")).hexdigest()[:12]
     return f"tool:{tool_name}:{text_hash}"
 
 

--- a/unique_sdk/unique_sdk/cli/commands/mcp.py
+++ b/unique_sdk/unique_sdk/cli/commands/mcp.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import re
@@ -44,6 +45,14 @@ _MCP_OUTPUT_TEXT_CHAR_LIMIT = 200_000
 # the result carries no recognizable title.
 _MCP_REFS_LOG_RELATIVE_PATH = Path(".unique") / "mcp-refs.jsonl"
 _MCP_REFS_LOCK_FILENAME = "mcp-refs.lock"
+# Persistent per-chat seed for ``[mcpsourceN]`` numbering. The SI runner wipes
+# ``mcp-refs.jsonl`` between turns, so manifest-derived numbering restarts at 1
+# every turn; this sibling file records the highest source number ever assigned
+# in the chat so numbering stays monotonic across turns (UN-23199). Body is
+# ``{"maxSourceNumber": <int>}``; the monorepo runner preserves this file across
+# its per-turn reset. Absent/unreadable → seed 0 → identical to pre-seed
+# behavior (forward/backward compatible).
+_MCP_REFS_SEED_FILENAME = "mcp-refs-seed.json"
 _MCP_SNIPPET_CHAR_LIMIT = 300
 # Writer-side cap on the per-item ``text`` recorded in the refs manifest — the
 # cited item's underlying text, consumed by the runner's hallucination check to
@@ -533,12 +542,56 @@ def _next_mcp_source_number(entries: list[dict[str, Any]]) -> int:
     return max(numbers, default=0) + 1
 
 
+def _read_mcp_refs_seed(seed_path: Path) -> int:
+    """Read the persisted chat-wide ``maxSourceNumber`` from the seed file.
+
+    Best-effort: returns ``0`` when the file is absent, unreadable, or malformed
+    (never raises), so a missing seed reproduces the pre-seed numbering exactly.
+    """
+    try:
+        raw = seed_path.read_text(encoding="utf-8")
+        value = json.loads(raw).get("maxSourceNumber")
+        if isinstance(value, int) and not isinstance(value, bool):
+            return value
+    except (OSError, ValueError, TypeError, AttributeError):
+        return 0
+    return 0
+
+
+def _write_mcp_refs_seed(seed_path: Path, value: int) -> None:
+    """Persist the chat-wide ``maxSourceNumber`` seed (best-effort, never raises).
+
+    Only writes when ``value`` exceeds the currently persisted seed, so numbers
+    never regress across turns.
+    """
+    try:
+        if value <= _read_mcp_refs_seed(seed_path):
+            return
+        seed_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = seed_path.with_suffix(seed_path.suffix + ".tmp")
+        tmp_path.write_text(json.dumps({"maxSourceNumber": value}), encoding="utf-8")
+        tmp_path.replace(seed_path)
+    except OSError as exc:
+        _LOGGER.warning("mcp: failed to write refs seed: %s", exc)
+
+
 def _item_dedup_key(tool_name: str, item: dict[str, Any]) -> str:
-    """Dedup by title when present (same item = one chip), else by tool."""
+    """Dedup by title when present (same item = one chip), else by tool + a short
+    content hash of the item's text.
+
+    Two distinct title-less fetches through one tool return different bodies, so
+    hashing the text keeps them as separate sources instead of collapsing onto
+    one number (identical bodies still merge). NOTE: this intentionally weakens
+    the search-then-fetch text-upgrade merge for title-less items only — titled
+    items still merge by title as before.
+    """
     title = item.get("title")
     if isinstance(title, str) and title.strip():
         return f"title:{tool_name}:{title.strip()}"
-    return f"tool:{tool_name}"
+    text_hash = hashlib.sha256((item.get("text") or "").encode("utf-8")).hexdigest()[
+        :12
+    ]
+    return f"tool:{tool_name}:{text_hash}"
 
 
 def _ref_text(item: dict[str, Any]) -> str | None:
@@ -581,6 +634,14 @@ def _annotate_mcp_results_for_citations(
             refs_log_path, lock_filename=_MCP_REFS_LOCK_FILENAME
         ):
             entries = _read_turn_refs_manifest(refs_log_path)
+            # Chat-wide monotonic seed: the runner wipes ``mcp-refs.jsonl``
+            # between turns, so manifest-derived numbering restarts at 1 each
+            # turn. The seed file (preserved across the runner's per-turn reset)
+            # records the highest number ever assigned in the chat so a fresh
+            # number exceeds both the current manifest max AND the chat-wide max.
+            seed_path = refs_log_path.parent / _MCP_REFS_SEED_FILENAME
+            seed = _read_mcp_refs_seed(seed_path)
+            highest_assigned = seed
             numbers_by_key: dict[str, int] = {}
             for entry in entries:
                 if isinstance(entry.get("sourceNumber"), int):
@@ -598,7 +659,7 @@ def _annotate_mcp_results_for_citations(
                 key = _item_dedup_key(tool_name, item)
                 source_number = numbers_by_key.get(key)
                 if source_number is None:
-                    source_number = _next_mcp_source_number(entries)
+                    source_number = max(_next_mcp_source_number(entries), seed + 1)
                     manifest_entry = {
                         "sourceNumber": source_number,
                         "toolName": tool_name,
@@ -618,6 +679,7 @@ def _annotate_mcp_results_for_citations(
                     numbers_by_key[key] = source_number
                     entries.append(manifest_entry)
                     entries_by_number[source_number] = manifest_entry
+                    highest_assigned = max(highest_assigned, source_number)
                 else:
                     # Deduped: a prior call already claimed this source number.
                     # Backfill ``details`` the first call may have lacked (the
@@ -649,6 +711,10 @@ def _annotate_mcp_results_for_citations(
                     _LOGGER.warning(
                         "mcp: failed to backfill refs manifest enrichment: %s", exc
                     )
+            # Persist the chat-wide max so next turn's numbering continues above
+            # it even after the runner wipes ``mcp-refs.jsonl``.
+            if highest_assigned > seed:
+                _write_mcp_refs_seed(seed_path, highest_assigned)
     except (UnsafeRefsLogPathError, OSError) as exc:
         _LOGGER.warning("mcp: failed to append refs manifest: %s", exc)
         return []
@@ -658,13 +724,19 @@ def _annotate_mcp_results_for_citations(
     return annotated
 
 
-def _citation_sources_block(annotated: list[tuple[int, dict[str, Any]]]) -> str:
+def _citation_sources_block(
+    annotated: list[tuple[int, dict[str, Any]]], *, tool_name: str
+) -> str:
     """Tell the agent which marker to cite each retrieved item with.
 
     Rendered *before* the tool output (leading block, not a trailing footer):
     the agent harness spills oversized tool results to a file wholesale, and a
     partial or programmatic read of that file only reliably sees the head — a
     trailing marker list would be exactly what such reads miss (UN-22309).
+
+    Each line names the ``tool_name`` alongside the marker so the model has a
+    stronger anchor than a bare integer: ``{title} — {tool_name}`` when the item
+    carries a title, or ``{tool_name}`` for the title-less fallback.
     """
     if not annotated:
         return ""
@@ -674,7 +746,11 @@ def _citation_sources_block(annotated: list[tuple[int, dict[str, Any]]]) -> str:
         "will not be referenced in the answer:",
     ]
     for source_number, item in annotated:
-        label = item.get("title") or "this MCP tool result"
+        title = item.get("title")
+        if isinstance(title, str) and title.strip():
+            label = f"{title.strip()} — {tool_name}"
+        else:
+            label = tool_name
         lines.append(f"  [mcpsource{source_number}] {label}")
     return "\n".join(lines)
 
@@ -758,7 +834,7 @@ def record_mcp_citations(
         reference_mapping=reference_mapping,
         fallback_text=formatted_text,
     )
-    return _citation_sources_block(annotated)
+    return _citation_sources_block(annotated, tool_name=tool_name)
 
 
 def _read_payload(


### PR DESCRIPTION
## Context

Supports the runner-side fix for [UN-23199](https://unique-ch.atlassian.net/browse/UN-23199) (MCP references attributed to the wrong connector; dropped "X references"). `[mcpsourceN]` numbers restarted at 1 every turn because the SwappableIntelligence runner wipes `mcp-refs.jsonl` between turns, so a resumed session's stale numbers collided with fresh, unrelated slots.

Companion runner PR: **Unique-AG/monorepo#27143**.

## Changes (`unique_sdk/cli/commands/mcp.py`)

- **Chat-monotonic numbering**: persist the highest source number ever assigned in the chat to a sibling `.unique/mcp-refs-seed.json` (`{"maxSourceNumber": <int>}`), preserved by the runner across its per-turn reset. Fresh numbers are `max(next-manifest-number, seed + 1)`, so they never restart. Read/write are best-effort inside the existing manifest lock; an absent/malformed seed reproduces pre-seed numbering exactly (**forward/backward compatible** — safe to merge and publish before the runner pin bump).
- **Tool name in the Sources block**: `[mcpsourceN] <title> — <tool>` gives the model a stronger anchor than a bare integer.
- **Title-less dedup by content hash**: two distinct title-less fetches through one tool no longer collapse onto one source number (titled items still merge by title). *Trade-off:* weakens the search-then-fetch text-upgrade merge for title-less items only.

## Contract

`mcp-refs-seed.json` — sibling of `mcp-refs.jsonl` under `.unique/`, body `{"maxSourceNumber": <int>}`. SDK writes it; the runner preserves it across the per-turn reset (monorepo#27143).

## Testing

- `uv run pytest tests/cli/test_mcp.py` → **51 passed** (+7 new: seed continuation across a simulated manifest wipe, absent-seed reproduces pre-seed numbering, Sources block includes tool name, title-less distinct/identical dedup). All prior tests green.
- `ruff check` + `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[UN-23199]: https://unique-ch.atlassian.net/browse/UN-23199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ