### PR TITLE
feat(search-proxy): per-URL crawl outcome metrics with HTTP status

### DIFF
--- a/connectors/unique_search_proxy/unique_search_proxy_client/deploy/helm-chart/files/grafana/dashboards/search-proxy.json
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/deploy/helm-chart/files/grafana/dashboards/search-proxy.json
@@ -41,384 +41,974 @@
   },
   "panels": [
     {
+      "id": 1,
       "type": "row",
-      "title": "HTTP",
+      "title": "Overview",
       "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
       "collapsed": false
     },
     {
-      "type": "timeseries",
-      "title": "HTTP request rate by path & status (req/s)",
+      "id": 2,
+      "type": "stat",
+      "title": "HTTP request rate",
+      "description": "All inbound HTTP requests per second.",
       "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 1 },
-      "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "fillOpacity": 10 } }, "overrides": [] },
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 1 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "decimals": 2,
+          "color": { "mode": "palette-classic" },
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "blue", "value": null } ] }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "graphMode": "area",
+        "colorMode": "value",
+        "textMode": "auto",
+        "orientation": "auto"
+      },
       "targets": [
         {
           "refId": "A",
           "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
-          "expr": "sum by (path, status_code) (rate(python_http_requests_total[1m]))",
-          "legendFormat": "{{path}} [{{status_code}}]"
+          "expr": "sum(rate(python_http_requests_total[$__rate_interval]))",
+          "legendFormat": "req/s"
         }
       ]
     },
     {
-      "type": "timeseries",
-      "title": "HTTP latency p50 / p95 / p99 by path (s)",
+      "id": 3,
+      "type": "stat",
+      "title": "HTTP 5xx ratio",
+      "description": "Share of HTTP responses with a 5xx status. Green < 1%, red > 5%.",
       "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 1 },
-      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 1 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 2,
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 0.01 },
+              { "color": "red", "value": 0.05 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "graphMode": "area",
+        "colorMode": "value",
+        "textMode": "auto",
+        "orientation": "auto"
+      },
       "targets": [
         {
           "refId": "A",
           "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
-          "expr": "histogram_quantile(0.50, sum by (le, path) (rate(python_http_request_duration_seconds_bucket[5m])))",
-          "legendFormat": "p50 {{path}}"
+          "expr": "sum(rate(python_http_requests_total{status_code=~\"5..\"}[$__rate_interval])) / sum(rate(python_http_requests_total[$__rate_interval]))",
+          "legendFormat": "5xx ratio"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "HTTP latency p95",
+      "description": "95th percentile latency across all endpoints.",
+      "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
+      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 1 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 5 },
+              { "color": "red", "value": 15 }
+            ]
+          }
         },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "graphMode": "area",
+        "colorMode": "value",
+        "textMode": "auto",
+        "orientation": "auto"
+      },
+      "targets": [
         {
-          "refId": "B",
+          "refId": "A",
           "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
-          "expr": "histogram_quantile(0.95, sum by (le, path) (rate(python_http_request_duration_seconds_bucket[5m])))",
-          "legendFormat": "p95 {{path}}"
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(python_http_request_duration_seconds_bucket[$__rate_interval])))",
+          "legendFormat": "p95"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "In-flight requests",
+      "description": "HTTP requests currently being processed.",
+      "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
+      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 1 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "blue", "value": null } ] }
         },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "graphMode": "area",
+        "colorMode": "value",
+        "textMode": "auto",
+        "orientation": "auto"
+      },
+      "targets": [
         {
-          "refId": "C",
+          "refId": "A",
           "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
-          "expr": "histogram_quantile(0.99, sum by (le, path) (rate(python_http_request_duration_seconds_bucket[5m])))",
-          "legendFormat": "p99 {{path}}"
+          "expr": "sum(python_http_requests_in_progress)",
+          "legendFormat": "in flight"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "stat",
+      "title": "Crawl URL success rate",
+      "description": "Share of individual crawled URLs that succeeded over the selected time range. Green > 98%, red < 90%.",
+      "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
+      "gridPos": { "h": 4, "w": 4, "x": 16, "y": 1 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 1,
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "orange", "value": 0.9 },
+              { "color": "green", "value": 0.98 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "graphMode": "none",
+        "colorMode": "background",
+        "textMode": "auto",
+        "orientation": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
+          "expr": "sum(increase(unique_search_proxy_crawl_url_outcomes_total{crawler=~\"$crawler\",outcome=\"success\"}[$__range])) / sum(increase(unique_search_proxy_crawl_url_outcomes_total{crawler=~\"$crawler\"}[$__range]))",
+          "instant": true,
+          "legendFormat": "success rate"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "stat",
+      "title": "Proxy API errors",
+      "description": "Top-level API errors returned to clients over the selected time range.",
+      "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
+      "gridPos": { "h": 4, "w": 4, "x": 20, "y": 1 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 1 },
+              { "color": "red", "value": 20 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "graphMode": "none",
+        "colorMode": "value",
+        "textMode": "auto",
+        "orientation": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
+          "expr": "sum(increase(unique_search_proxy_proxy_errors_total[$__range])) or vector(0)",
+          "instant": true,
+          "legendFormat": "errors"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "type": "stat",
+      "title": "Searches",
+      "description": "Search requests over the selected time range (successes; errors tracked separately).",
+      "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
+      "gridPos": { "h": 3, "w": 4, "x": 0, "y": 5 },
+      "fieldConfig": {
+        "defaults": { "unit": "short", "decimals": 0, "color": { "fixedColor": "blue", "mode": "fixed" } },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "graphMode": "none",
+        "colorMode": "value",
+        "textMode": "auto",
+        "orientation": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
+          "expr": "sum(increase(unique_search_proxy_search_total{engine=~\"$engine\"}[$__range])) or vector(0)",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "type": "stat",
+      "title": "Agent searches",
+      "description": "Agent (grounded) search requests over the selected time range.",
+      "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
+      "gridPos": { "h": 3, "w": 4, "x": 4, "y": 5 },
+      "fieldConfig": {
+        "defaults": { "unit": "short", "decimals": 0, "color": { "fixedColor": "purple", "mode": "fixed" } },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "graphMode": "none",
+        "colorMode": "value",
+        "textMode": "auto",
+        "orientation": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
+          "expr": "sum(increase(unique_search_proxy_agent_search_total{engine=~\"$engine\"}[$__range])) or vector(0)",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "stat",
+      "title": "Crawl batches",
+      "description": "Crawl batch requests over the selected time range.",
+      "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
+      "gridPos": { "h": 3, "w": 4, "x": 8, "y": 5 },
+      "fieldConfig": {
+        "defaults": { "unit": "short", "decimals": 0, "color": { "fixedColor": "blue", "mode": "fixed" } },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "graphMode": "none",
+        "colorMode": "value",
+        "textMode": "auto",
+        "orientation": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
+          "expr": "sum(increase(unique_search_proxy_crawl_total{crawler=~\"$crawler\"}[$__range])) or vector(0)",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 11,
+      "type": "stat",
+      "title": "URLs crawled",
+      "description": "Individual URLs submitted to crawlers over the selected time range.",
+      "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
+      "gridPos": { "h": 3, "w": 4, "x": 12, "y": 5 },
+      "fieldConfig": {
+        "defaults": { "unit": "short", "decimals": 0, "color": { "fixedColor": "blue", "mode": "fixed" } },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "graphMode": "none",
+        "colorMode": "value",
+        "textMode": "auto",
+        "orientation": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
+          "expr": "sum(increase(unique_search_proxy_crawl_urls_total{crawler=~\"$crawler\"}[$__range])) or vector(0)",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 12,
+      "type": "stat",
+      "title": "URL errors",
+      "description": "Individual URLs that failed (per-URL errors) over the selected time range.",
+      "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
+      "gridPos": { "h": 3, "w": 4, "x": 16, "y": 5 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 1 },
+              { "color": "red", "value": 50 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "graphMode": "none",
+        "colorMode": "value",
+        "textMode": "auto",
+        "orientation": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
+          "expr": "sum(increase(unique_search_proxy_crawl_url_outcomes_total{crawler=~\"$crawler\",outcome=\"error\"}[$__range])) or vector(0)",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 13,
+      "type": "stat",
+      "title": "URLs blocked (safety)",
+      "description": "URLs blocked by the URL safety policy over the selected time range.",
+      "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
+      "gridPos": { "h": 3, "w": 4, "x": 20, "y": 5 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 1 },
+              { "color": "red", "value": 50 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "graphMode": "none",
+        "colorMode": "value",
+        "textMode": "auto",
+        "orientation": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
+          "expr": "sum(increase(unique_search_proxy_crawl_blocked_total[$__range])) or vector(0)",
+          "instant": true
         }
       ]
     },
 
     {
+      "id": 20,
       "type": "row",
-      "title": "Search",
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 9 },
+      "title": "Crawl — per-URL outcomes",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 8 },
       "collapsed": false
     },
     {
+      "id": 21,
       "type": "timeseries",
-      "title": "Search request rate by engine (req/s, incl. errors)",
+      "title": "Per-URL outcomes (url/s)",
+      "description": "Individual URL outcomes per second, stacked. Success vs error per crawler — a batch with partial failures shows both series.",
       "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
-      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 10 },
-      "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "fillOpacity": 10 } }, "overrides": [] },
-      "targets": [
-        {
-          "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
-          "expr": "sum by (engine) (rate(unique_search_proxy_search_total[1m])) + sum by (engine) (rate(unique_search_proxy_search_errors_total[1m]))",
-          "legendFormat": "{{engine}}"
-        }
-      ]
-    },
-    {
-      "type": "timeseries",
-      "title": "Search errors by engine / code (err/s)",
-      "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
-      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 10 },
-      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
-      "targets": [
-        {
-          "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
-          "expr": "sum by (engine, error_code) (rate(unique_search_proxy_search_errors_total[1m]))",
-          "legendFormat": "{{engine}} [{{error_code}}]"
-        }
-      ]
-    },
-    {
-      "type": "timeseries",
-      "title": "Search latency p50 / p95 / p99 by engine (s)",
-      "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
-      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 10 },
-      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
-      "targets": [
-        {
-          "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
-          "expr": "histogram_quantile(0.50, sum by (le, engine) (rate(unique_search_proxy_search_duration_seconds_bucket[5m])))",
-          "legendFormat": "p50 {{engine}}"
-        },
-        {
-          "refId": "B",
-          "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
-          "expr": "histogram_quantile(0.95, sum by (le, engine) (rate(unique_search_proxy_search_duration_seconds_bucket[5m])))",
-          "legendFormat": "p95 {{engine}}"
-        },
-        {
-          "refId": "C",
-          "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
-          "expr": "histogram_quantile(0.99, sum by (le, engine) (rate(unique_search_proxy_search_duration_seconds_bucket[5m])))",
-          "legendFormat": "p99 {{engine}}"
-        }
-      ]
-    },
-    {
-      "type": "barchart",
-      "title": "Search latency distribution — $engine",
-      "description": "Standard histogram: x = latency bucket upper bound (le, seconds), y = request count over the selected range. The query's Heatmap format de-cumulates the classic histogram buckets, and the Time field is dropped so the bucket bounds become the x-axis categories. Repeats per engine.",
-      "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
-      "repeat": "engine",
-      "repeatDirection": "h",
-      "maxPerRow": 3,
-      "gridPos": { "h": 9, "w": 8, "x": 0, "y": 18 },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 9 },
       "fieldConfig": {
         "defaults": {
-          "unit": "short",
-          "color": { "mode": "continuous-BlPu" },
-          "custom": { "lineWidth": 1, "fillOpacity": 80, "gradientMode": "hue", "axisLabel": "requests" }
+          "unit": "reqps",
+          "custom": {
+            "fillOpacity": 35,
+            "lineWidth": 1,
+            "stacking": { "mode": "normal", "group": "A" },
+            "gradientMode": "opacity"
+          }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": { "id": "byRegexp", "options": ".*success.*" },
+            "properties": [ { "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } } ]
+          },
+          {
+            "matcher": { "id": "byRegexp", "options": ".*error.*" },
+            "properties": [ { "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } } ]
+          }
+        ]
       },
       "options": {
-        "xField": "Field",
-        "orientation": "vertical",
-        "xTickLabelRotation": -45,
-        "xTickLabelSpacing": 0,
-        "showValue": "auto",
-        "stacking": "none",
-        "groupWidth": 0.7,
-        "barWidth": 0.97,
-        "fullHighlight": false,
-        "legend": { "showLegend": false, "displayMode": "list", "placement": "bottom" },
+        "legend": { "showLegend": true, "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max", "lastNotNull"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
+          "expr": "sum by (crawler, outcome) (rate(unique_search_proxy_crawl_url_outcomes_total{crawler=~\"$crawler\"}[$__rate_interval]))",
+          "legendFormat": "{{crawler}} {{outcome}}"
+        }
+      ]
+    },
+    {
+      "id": 22,
+      "type": "piechart",
+      "title": "Error codes — share of failures",
+      "description": "Distribution of per-URL failures by normalized error code over the selected time range.",
+      "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
+      "gridPos": { "h": 9, "w": 6, "x": 12, "y": 9 },
+      "fieldConfig": { "defaults": { "unit": "short", "decimals": 0 }, "overrides": [] },
+      "options": {
+        "pieType": "donut",
+        "displayLabels": ["percent"],
+        "legend": { "showLegend": true, "displayMode": "table", "placement": "bottom", "values": ["value"] },
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
         "tooltip": { "mode": "single", "sort": "none" }
       },
       "targets": [
         {
           "refId": "A",
           "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
-          "expr": "sum by (le) (increase(unique_search_proxy_search_duration_seconds_bucket{engine=~\"$engine\"}[$__range]))",
-          "format": "heatmap",
+          "expr": "sum by (error_code) (increase(unique_search_proxy_crawl_url_outcomes_total{crawler=~\"$crawler\",outcome=\"error\"}[$__range]))",
           "instant": true,
-          "legendFormat": "{{le}}"
+          "legendFormat": "{{error_code}}"
         }
-      ],
-      "transformations": [
-        { "id": "reduce", "options": { "reducers": ["lastNotNull"], "mode": "seriesToRows" } }
       ]
     },
-
     {
-      "type": "row",
-      "title": "Crawl",
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 27 },
-      "collapsed": false
-    },
-    {
-      "type": "timeseries",
-      "title": "Crawl request rate by crawler (req/s, incl. errors)",
+      "id": 23,
+      "type": "bargauge",
+      "title": "Top upstream HTTP statuses",
+      "description": "Most frequent upstream HTTP statuses (403, 404, 500, ...) among per-URL failures over the selected time range. Only failures that received an HTTP response carry a status.",
       "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
-      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 28 },
-      "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "fillOpacity": 10 } }, "overrides": [] },
+      "gridPos": { "h": 9, "w": 6, "x": 18, "y": 9 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "color": { "mode": "continuous-RdYlGr" },
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "red", "value": null } ] }
+        },
+        "overrides": []
+      },
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "horizontal",
+        "valueMode": "color",
+        "showUnfilled": true,
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+      },
       "targets": [
         {
           "refId": "A",
           "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
-          "expr": "sum by (crawler) (rate(unique_search_proxy_crawl_total[1m])) + sum by (crawler) (rate(unique_search_proxy_crawl_errors_total[1m]))",
+          "expr": "topk(7, sum by (http_status) (increase(unique_search_proxy_crawl_url_outcomes_total{crawler=~\"$crawler\",outcome=\"error\",http_status!=\"\"}[$__range])))",
+          "instant": true,
+          "legendFormat": "HTTP {{http_status}}"
+        }
+      ]
+    },
+    {
+      "id": 24,
+      "type": "timeseries",
+      "title": "Per-URL errors by code & HTTP status (url/s)",
+      "description": "Failure rate broken down by normalized error code and upstream HTTP status. Spikes reveal which failure mode is growing.",
+      "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 18 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "fillOpacity": 10, "lineWidth": 1 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "showLegend": true, "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max", "lastNotNull"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
+          "expr": "sum by (crawler, error_code, http_status) (rate(unique_search_proxy_crawl_url_outcomes_total{crawler=~\"$crawler\",outcome=\"error\"}[$__rate_interval]))",
+          "legendFormat": "{{crawler}} {{error_code}} {{http_status}}"
+        }
+      ]
+    },
+    {
+      "id": 25,
+      "type": "table",
+      "title": "Error counts by code & HTTP status",
+      "description": "Total per-URL failures over the selected time range, grouped by crawler, error code and upstream HTTP status (blank status = no HTTP response: timeout, transport, blocked, processing). Footer sums the total.",
+      "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 18 },
+      "fieldConfig": {
+        "defaults": { "unit": "short", "decimals": 0, "custom": { "align": "auto", "filterable": true } },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Count" },
+            "properties": [
+              { "id": "custom.cellOptions", "value": { "type": "color-background", "mode": "gradient" } },
+              { "id": "color", "value": { "mode": "continuous-YlRd" } },
+              { "id": "custom.width", "value": 110 }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "sortBy": [ { "displayName": "Count", "desc": true } ],
+        "footer": { "show": true, "reducer": ["sum"], "countRows": false, "fields": ["Count"] }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
+          "expr": "sum by (crawler, error_code, http_status) (increase(unique_search_proxy_crawl_url_outcomes_total{crawler=~\"$crawler\",outcome=\"error\"}[$__range]))",
+          "format": "table",
+          "instant": true
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": { "Time": true },
+            "renameByName": { "Value #A": "Count", "Value": "Count", "crawler": "Crawler", "error_code": "Error code", "http_status": "HTTP status" }
+          }
+        },
+        { "id": "sortBy", "options": { "fields": "", "sort": [ { "field": "Count", "desc": true } ] } }
+      ]
+    },
+
+    {
+      "id": 30,
+      "type": "row",
+      "title": "Crawl — batches & URL safety",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 27 },
+      "collapsed": false
+    },
+    {
+      "id": 31,
+      "type": "timeseries",
+      "title": "Batch request rate (req/s, incl. errors)",
+      "description": "Crawl batch requests per second per crawler, including batches that failed outright.",
+      "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 28 },
+      "fieldConfig": {
+        "defaults": { "unit": "reqps", "custom": { "fillOpacity": 10, "lineWidth": 1 } },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "showLegend": true, "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
+          "expr": "(sum by (crawler) (rate(unique_search_proxy_crawl_total{crawler=~\"$crawler\"}[$__rate_interval])) or sum by (crawler) (rate(unique_search_proxy_crawl_errors_total{crawler=~\"$crawler\"}[$__rate_interval])) * 0) + (sum by (crawler) (rate(unique_search_proxy_crawl_errors_total{crawler=~\"$crawler\"}[$__rate_interval])) or sum by (crawler) (rate(unique_search_proxy_crawl_total{crawler=~\"$crawler\"}[$__rate_interval])) * 0)",
           "legendFormat": "{{crawler}}"
         }
       ]
     },
     {
+      "id": 32,
       "type": "timeseries",
-      "title": "Crawl errors & blocked (per/s)",
-      "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
-      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 28 },
-      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
-      "targets": [
-        {
-          "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
-          "expr": "sum by (crawler, error_code) (rate(unique_search_proxy_crawl_errors_total[1m]))",
-          "legendFormat": "err {{crawler}} [{{error_code}}]"
-        },
-        {
-          "refId": "B",
-          "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
-          "expr": "sum by (reason_category) (rate(unique_search_proxy_crawl_blocked_total[1m]))",
-          "legendFormat": "blocked [{{reason_category}}]"
-        }
-      ]
-    },
-    {
-      "type": "timeseries",
-      "title": "Crawl latency p50 / p95 / p99 by crawler (s)",
+      "title": "Batch latency p50 / p95 / p99 (s)",
+      "description": "End-to-end crawl batch latency percentiles per crawler.",
       "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
       "gridPos": { "h": 8, "w": 8, "x": 16, "y": 28 },
-      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "fieldConfig": {
+        "defaults": { "unit": "s", "custom": { "fillOpacity": 0, "lineWidth": 1 } },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "showLegend": true, "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max", "lastNotNull"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
       "targets": [
         {
           "refId": "A",
           "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
-          "expr": "histogram_quantile(0.50, sum by (le, crawler) (rate(unique_search_proxy_crawl_duration_seconds_bucket[5m])))",
+          "expr": "histogram_quantile(0.50, sum by (le, crawler) (rate(unique_search_proxy_crawl_duration_seconds_bucket{crawler=~\"$crawler\"}[$__rate_interval])))",
           "legendFormat": "p50 {{crawler}}"
         },
         {
           "refId": "B",
           "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
-          "expr": "histogram_quantile(0.95, sum by (le, crawler) (rate(unique_search_proxy_crawl_duration_seconds_bucket[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le, crawler) (rate(unique_search_proxy_crawl_duration_seconds_bucket{crawler=~\"$crawler\"}[$__rate_interval])))",
           "legendFormat": "p95 {{crawler}}"
         },
         {
           "refId": "C",
           "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
-          "expr": "histogram_quantile(0.99, sum by (le, crawler) (rate(unique_search_proxy_crawl_duration_seconds_bucket[5m])))",
+          "expr": "histogram_quantile(0.99, sum by (le, crawler) (rate(unique_search_proxy_crawl_duration_seconds_bucket{crawler=~\"$crawler\"}[$__rate_interval])))",
           "legendFormat": "p99 {{crawler}}"
         }
       ]
     },
     {
-      "type": "barchart",
-      "title": "Crawl latency distribution — $crawler",
-      "description": "Standard histogram: x = latency bucket upper bound (le, seconds), y = request count over the selected range. The query's Heatmap format de-cumulates the classic histogram buckets, and the Time field is dropped so the bucket bounds become the x-axis categories. Repeats per crawler.",
+      "id": 33,
+      "type": "timeseries",
+      "title": "Batch errors & safety blocks (per/s)",
+      "description": "Whole-batch failures by error code, plus URLs blocked by the URL safety policy by reason category.",
       "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
-      "repeat": "crawler",
-      "repeatDirection": "h",
-      "maxPerRow": 3,
-      "gridPos": { "h": 9, "w": 8, "x": 0, "y": 36 },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 28 },
       "fieldConfig": {
-        "defaults": {
-          "unit": "short",
-          "color": { "mode": "continuous-GrYlRd" },
-          "custom": { "lineWidth": 1, "fillOpacity": 80, "gradientMode": "hue", "axisLabel": "requests" }
-        },
+        "defaults": { "unit": "reqps", "custom": { "fillOpacity": 10, "lineWidth": 1 } },
         "overrides": []
       },
       "options": {
-        "xField": "Field",
-        "orientation": "vertical",
-        "xTickLabelRotation": -45,
-        "xTickLabelSpacing": 0,
-        "showValue": "auto",
-        "stacking": "none",
-        "groupWidth": 0.7,
-        "barWidth": 0.97,
-        "fullHighlight": false,
-        "legend": { "showLegend": false, "displayMode": "list", "placement": "bottom" },
-        "tooltip": { "mode": "single", "sort": "none" }
+        "legend": { "showLegend": true, "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
       },
       "targets": [
         {
           "refId": "A",
           "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
-          "expr": "sum by (le) (increase(unique_search_proxy_crawl_duration_seconds_bucket{crawler=~\"$crawler\"}[$__range]))",
-          "format": "heatmap",
-          "instant": true,
-          "legendFormat": "{{le}}"
+          "expr": "sum by (crawler, error_code) (rate(unique_search_proxy_crawl_errors_total{crawler=~\"$crawler\"}[$__rate_interval]))",
+          "legendFormat": "batch {{crawler}} [{{error_code}}]"
+        },
+        {
+          "refId": "B",
+          "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
+          "expr": "sum by (reason_category) (rate(unique_search_proxy_crawl_blocked_total[$__rate_interval]))",
+          "legendFormat": "blocked [{{reason_category}}]"
         }
-      ],
-      "transformations": [
-        { "id": "reduce", "options": { "reducers": ["lastNotNull"], "mode": "seriesToRows" } }
       ]
     },
 
     {
+      "id": 40,
+      "type": "row",
+      "title": "Search",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 36 },
+      "collapsed": false
+    },
+    {
+      "id": 41,
+      "type": "timeseries",
+      "title": "Search rate by engine (req/s, incl. errors)",
+      "description": "Search requests per second per engine, including failed requests.",
+      "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 37 },
+      "fieldConfig": {
+        "defaults": { "unit": "reqps", "custom": { "fillOpacity": 10, "lineWidth": 1 } },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "showLegend": true, "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
+          "expr": "(sum by (engine) (rate(unique_search_proxy_search_total{engine=~\"$engine\"}[$__rate_interval])) or sum by (engine) (rate(unique_search_proxy_search_errors_total{engine=~\"$engine\"}[$__rate_interval])) * 0) + (sum by (engine) (rate(unique_search_proxy_search_errors_total{engine=~\"$engine\"}[$__rate_interval])) or sum by (engine) (rate(unique_search_proxy_search_total{engine=~\"$engine\"}[$__rate_interval])) * 0)",
+          "legendFormat": "{{engine}}"
+        }
+      ]
+    },
+    {
+      "id": 42,
+      "type": "timeseries",
+      "title": "Search errors by engine / code (err/s)",
+      "description": "Failed search requests per second, by engine and normalized error code.",
+      "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 37 },
+      "fieldConfig": {
+        "defaults": { "unit": "reqps", "custom": { "fillOpacity": 10, "lineWidth": 1 } },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "showLegend": true, "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
+          "expr": "sum by (engine, error_code) (rate(unique_search_proxy_search_errors_total{engine=~\"$engine\"}[$__rate_interval]))",
+          "legendFormat": "{{engine}} [{{error_code}}]"
+        }
+      ]
+    },
+    {
+      "id": 43,
+      "type": "timeseries",
+      "title": "Search latency p50 / p95 / p99 (s)",
+      "description": "Search request latency percentiles per engine.",
+      "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 37 },
+      "fieldConfig": {
+        "defaults": { "unit": "s", "custom": { "fillOpacity": 0, "lineWidth": 1 } },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "showLegend": true, "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max", "lastNotNull"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
+          "expr": "histogram_quantile(0.50, sum by (le, engine) (rate(unique_search_proxy_search_duration_seconds_bucket{engine=~\"$engine\"}[$__rate_interval])))",
+          "legendFormat": "p50 {{engine}}"
+        },
+        {
+          "refId": "B",
+          "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
+          "expr": "histogram_quantile(0.95, sum by (le, engine) (rate(unique_search_proxy_search_duration_seconds_bucket{engine=~\"$engine\"}[$__rate_interval])))",
+          "legendFormat": "p95 {{engine}}"
+        },
+        {
+          "refId": "C",
+          "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
+          "expr": "histogram_quantile(0.99, sum by (le, engine) (rate(unique_search_proxy_search_duration_seconds_bucket{engine=~\"$engine\"}[$__rate_interval])))",
+          "legendFormat": "p99 {{engine}}"
+        }
+      ]
+    },
+
+    {
+      "id": 50,
       "type": "row",
       "title": "Agent search",
       "gridPos": { "h": 1, "w": 24, "x": 0, "y": 45 },
       "collapsed": false
     },
     {
+      "id": 51,
       "type": "timeseries",
       "title": "Agent search rate by engine (req/s, incl. errors)",
+      "description": "Agent (grounded) search requests per second per engine, including failed requests.",
       "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
       "gridPos": { "h": 8, "w": 8, "x": 0, "y": 46 },
-      "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "fillOpacity": 10 } }, "overrides": [] },
+      "fieldConfig": {
+        "defaults": { "unit": "reqps", "custom": { "fillOpacity": 10, "lineWidth": 1 } },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "showLegend": true, "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
       "targets": [
         {
           "refId": "A",
           "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
-          "expr": "sum by (engine) (rate(unique_search_proxy_agent_search_total[1m])) + sum by (engine) (rate(unique_search_proxy_agent_search_errors_total[1m]))",
+          "expr": "(sum by (engine) (rate(unique_search_proxy_agent_search_total{engine=~\"$engine\"}[$__rate_interval])) or sum by (engine) (rate(unique_search_proxy_agent_search_errors_total{engine=~\"$engine\"}[$__rate_interval])) * 0) + (sum by (engine) (rate(unique_search_proxy_agent_search_errors_total{engine=~\"$engine\"}[$__rate_interval])) or sum by (engine) (rate(unique_search_proxy_agent_search_total{engine=~\"$engine\"}[$__rate_interval])) * 0)",
           "legendFormat": "{{engine}}"
         }
       ]
     },
     {
+      "id": 52,
       "type": "timeseries",
-      "title": "Agent search & top-level proxy errors (err/s)",
+      "title": "Agent search errors by engine / code (err/s)",
+      "description": "Failed agent search requests per second, by engine and normalized error code.",
       "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
       "gridPos": { "h": 8, "w": 8, "x": 8, "y": 46 },
-      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "fieldConfig": {
+        "defaults": { "unit": "reqps", "custom": { "fillOpacity": 10, "lineWidth": 1 } },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "showLegend": true, "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
       "targets": [
         {
           "refId": "A",
           "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
-          "expr": "sum by (engine, error_code) (rate(unique_search_proxy_agent_search_errors_total[1m]))",
-          "legendFormat": "agent {{engine}} [{{error_code}}]"
-        },
-        {
-          "refId": "B",
-          "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
-          "expr": "sum by (error_code) (rate(unique_search_proxy_proxy_errors_total[1m]))",
-          "legendFormat": "proxy [{{error_code}}]"
+          "expr": "sum by (engine, error_code) (rate(unique_search_proxy_agent_search_errors_total{engine=~\"$engine\"}[$__rate_interval]))",
+          "legendFormat": "{{engine}} [{{error_code}}]"
         }
       ]
     },
     {
+      "id": 53,
       "type": "timeseries",
-      "title": "Agent search latency p50 / p95 / p99 by engine (s)",
+      "title": "Agent search latency p50 / p95 / p99 (s)",
+      "description": "Agent search latency percentiles per engine.",
       "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
       "gridPos": { "h": 8, "w": 8, "x": 16, "y": 46 },
-      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "fieldConfig": {
+        "defaults": { "unit": "s", "custom": { "fillOpacity": 0, "lineWidth": 1 } },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "showLegend": true, "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max", "lastNotNull"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
       "targets": [
         {
           "refId": "A",
           "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
-          "expr": "histogram_quantile(0.50, sum by (le, engine) (rate(unique_search_proxy_agent_search_duration_seconds_bucket[5m])))",
+          "expr": "histogram_quantile(0.50, sum by (le, engine) (rate(unique_search_proxy_agent_search_duration_seconds_bucket{engine=~\"$engine\"}[$__rate_interval])))",
           "legendFormat": "p50 {{engine}}"
         },
         {
           "refId": "B",
           "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
-          "expr": "histogram_quantile(0.95, sum by (le, engine) (rate(unique_search_proxy_agent_search_duration_seconds_bucket[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le, engine) (rate(unique_search_proxy_agent_search_duration_seconds_bucket{engine=~\"$engine\"}[$__rate_interval])))",
           "legendFormat": "p95 {{engine}}"
         },
         {
           "refId": "C",
           "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
-          "expr": "histogram_quantile(0.99, sum by (le, engine) (rate(unique_search_proxy_agent_search_duration_seconds_bucket[5m])))",
+          "expr": "histogram_quantile(0.99, sum by (le, engine) (rate(unique_search_proxy_agent_search_duration_seconds_bucket{engine=~\"$engine\"}[$__rate_interval])))",
           "legendFormat": "p99 {{engine}}"
         }
       ]
     },
+
     {
-      "type": "barchart",
-      "title": "Agent search latency distribution (all engines)",
-      "description": "Standard histogram: x = latency bucket upper bound (le, seconds), y = request count over the selected range. The query's Heatmap format de-cumulates the classic histogram buckets, and the Time field is dropped so the bucket bounds become the x-axis categories.",
+      "id": 60,
+      "type": "row",
+      "title": "HTTP / service health",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 54 },
+      "collapsed": false
+    },
+    {
+      "id": 61,
+      "type": "timeseries",
+      "title": "HTTP request rate by path & status (req/s)",
+      "description": "Inbound HTTP traffic per endpoint and response status.",
       "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
-      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 54 },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 55 },
       "fieldConfig": {
-        "defaults": {
-          "unit": "short",
-          "color": { "mode": "continuous-BlPu" },
-          "custom": { "lineWidth": 1, "fillOpacity": 80, "gradientMode": "hue", "axisLabel": "requests" }
-        },
-        "overrides": []
+        "defaults": { "unit": "reqps", "custom": { "fillOpacity": 10, "lineWidth": 1 } },
+        "overrides": [
+          {
+            "matcher": { "id": "byRegexp", "options": ".*\\[5..\\]" },
+            "properties": [ { "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } } ]
+          }
+        ]
       },
       "options": {
-        "xField": "Field",
-        "orientation": "vertical",
-        "xTickLabelRotation": -45,
-        "xTickLabelSpacing": 0,
-        "showValue": "auto",
-        "stacking": "none",
-        "groupWidth": 0.7,
-        "barWidth": 0.97,
-        "fullHighlight": false,
-        "legend": { "showLegend": false, "displayMode": "list", "placement": "bottom" },
-        "tooltip": { "mode": "single", "sort": "none" }
+        "legend": { "showLegend": true, "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
       },
       "targets": [
         {
           "refId": "A",
           "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
-          "expr": "sum by (le) (increase(unique_search_proxy_agent_search_duration_seconds_bucket[$__range]))",
-          "format": "heatmap",
-          "instant": true,
-          "legendFormat": "{{le}}"
+          "expr": "sum by (path, status_code) (rate(python_http_requests_total[$__rate_interval]))",
+          "legendFormat": "{{path}} [{{status_code}}]"
         }
-      ],
-      "transformations": [
-        { "id": "reduce", "options": { "reducers": ["lastNotNull"], "mode": "seriesToRows" } }
+      ]
+    },
+    {
+      "id": 62,
+      "type": "timeseries",
+      "title": "HTTP latency p50 / p95 / p99 by path (s)",
+      "description": "Endpoint latency percentiles.",
+      "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 55 },
+      "fieldConfig": {
+        "defaults": { "unit": "s", "custom": { "fillOpacity": 0, "lineWidth": 1 } },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "showLegend": true, "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max", "lastNotNull"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
+          "expr": "histogram_quantile(0.50, sum by (le, path) (rate(python_http_request_duration_seconds_bucket[$__rate_interval])))",
+          "legendFormat": "p50 {{path}}"
+        },
+        {
+          "refId": "B",
+          "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
+          "expr": "histogram_quantile(0.95, sum by (le, path) (rate(python_http_request_duration_seconds_bucket[$__rate_interval])))",
+          "legendFormat": "p95 {{path}}"
+        },
+        {
+          "refId": "C",
+          "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
+          "expr": "histogram_quantile(0.99, sum by (le, path) (rate(python_http_request_duration_seconds_bucket[$__rate_interval])))",
+          "legendFormat": "p99 {{path}}"
+        }
+      ]
+    },
+    {
+      "id": 63,
+      "type": "timeseries",
+      "title": "Top-level API errors by code (err/s)",
+      "description": "Errors returned to clients across ALL endpoints (search, agent search, crawl), by normalized error code. Incremented by the global ProxyError handler — e.g. a crawl batch timeout appears here as UPSTREAM_TIMEOUT.",
+      "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 55 },
+      "fieldConfig": {
+        "defaults": { "unit": "reqps", "custom": { "fillOpacity": 10, "lineWidth": 1 } },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "showLegend": true, "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "%%PROMETHEUS_UID%%" },
+          "expr": "sum by (error_code) (rate(unique_search_proxy_proxy_errors_total[$__rate_interval]))",
+          "legendFormat": "{{error_code}}"
+        }
       ]
     }
   ]

--- a/connectors/unique_search_proxy/unique_search_proxy_client/tests/test_m3_basic_crawler.py
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/tests/test_m3_basic_crawler.py
@@ -190,8 +190,33 @@ def test_crawl_endpoint_returns_per_url_results(client: TestClient) -> None:
     failure = next(r for r in body["results"] if "blocked.example" in r["url"])
     assert failure["error"] is not None
     assert failure["error"]["code"] == ProxyErrorCode.UPSTREAM_ERROR.value
+    assert failure["error"]["statusCode"] == 403
     assert failure["contentType"] == "text/plain"
     assert failure["raw"] == "forbidden"
+
+
+@pytest.mark.ai
+def test_crawl_records_per_url_outcome_metrics(client: TestClient) -> None:
+    resp = client.post(
+        "/v1/crawl",
+        json={
+            "urls": ["https://example.com/a", "https://blocked.example/x"],
+            "crawler": CrawlerType.BASIC.value,
+            "contentTypes": {"html": True},
+        },
+    )
+    assert resp.status_code == 200
+
+    metrics = client.get("/metrics").text
+    assert (
+        'unique_search_proxy_crawl_url_outcomes_total{crawler="Basic",'
+        'error_code="",http_status="",outcome="success"}' in metrics
+    )
+    assert (
+        'unique_search_proxy_crawl_url_outcomes_total{crawler="Basic",'
+        f'error_code="{ProxyErrorCode.UPSTREAM_ERROR.value}",'
+        'http_status="403",outcome="error"}' in metrics
+    )
 
 
 @pytest.mark.ai

--- a/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/api/v1/crawl.py
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/api/v1/crawl.py
@@ -11,7 +11,11 @@ from unique_search_proxy_core.errors import (
     UpstreamTimeoutError,
     attach_request_context,
 )
-from unique_search_proxy_core.schema import CrawlResponse, ProxyErrorCode
+from unique_search_proxy_core.schema import (
+    CrawlResponse,
+    CrawlUrlResult,
+    ProxyErrorCode,
+)
 
 from unique_search_proxy_client.web.api.v1.openapi_examples import (
     CRAWL_OPENAPI_EXAMPLES,
@@ -28,6 +32,7 @@ from unique_search_proxy_client.web.core.url_safety.gate import (
 from unique_search_proxy_client.web.monitoring.metrics import (
     record_crawl_error,
     record_crawl_success,
+    record_crawl_url_outcomes,
 )
 
 router = APIRouter(tags=["crawl"])
@@ -40,6 +45,22 @@ def _crawl_request_context(exc: ProxyError, *, crawler_id: str) -> ProxyError:
         request="crawl",
         provider=crawler_id,
     )
+
+
+def _url_outcomes(results: list[CrawlUrlResult]) -> list[tuple[str, str, str]]:
+    """Derive ``(outcome, error_code, http_status)`` triples from merged results."""
+    outcomes: list[tuple[str, str, str]] = []
+    for result in results:
+        if result.error is None:
+            outcomes.append(("success", "", ""))
+            continue
+        http_status = (
+            str(result.error.status_code)
+            if result.error.status_code is not None
+            else ""
+        )
+        outcomes.append(("error", result.error.code, http_status))
+    return outcomes
 
 
 @router.post(
@@ -71,6 +92,15 @@ async def crawl(
                     len(body.urls),
                     duration,
                 )
+                merged_results = merge_crawl_results(
+                    body.urls,
+                    blocked_by_index=gate.blocked_by_index,
+                    crawler_results=[],
+                )
+                record_crawl_url_outcomes(
+                    crawler_id,
+                    _url_outcomes(merged_results),
+                )
                 _LOGGER.info(
                     "crawl success crawler=%s urls=%d blocked=%d results=0 duration=%.0fms",
                     crawler_id,
@@ -80,11 +110,7 @@ async def crawl(
                 )
                 return CrawlResponse(
                     crawler=crawler_id,
-                    results=merge_crawl_results(
-                        body.urls,
-                        blocked_by_index=gate.blocked_by_index,
-                        crawler_results=[],
-                    ),
+                    results=merged_results,
                 )
 
             crawl_body = body.model_copy(
@@ -121,6 +147,11 @@ async def crawl(
             crawler_id=crawler_id,
         ) from exc
     except ProxyError as exc:
+        record_crawl_error(
+            crawler_id,
+            exc.code.value if hasattr(exc.code, "value") else str(exc.code),
+            time.perf_counter() - started,
+        )
         _LOGGER.warning(
             "crawl failed crawler=%s code=%s duration=%.0fms",
             crawler_id,
@@ -148,6 +179,7 @@ async def crawl(
         blocked_by_index=gate.blocked_by_index,
         crawler_results=crawler_results,
     )
+    record_crawl_url_outcomes(crawler_id, _url_outcomes(merged_results))
     _LOGGER.info(
         "crawl success crawler=%s urls=%d blocked=%d results=%d duration=%.0fms",
         crawler_id,

--- a/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/api/v1/search.py
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/api/v1/search.py
@@ -93,6 +93,11 @@ async def search(
             engine_id=engine_id,
         ) from exc
     except ProxyError as exc:
+        record_search_error(
+            engine_id,
+            exc.code.value if hasattr(exc.code, "value") else str(exc.code),
+            time.perf_counter() - started,
+        )
         _LOGGER.warning(
             "search failed engine=%s code=%s duration=%.0fms",
             engine_id,

--- a/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/core/crawlers/basic/service.py
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/core/crawlers/basic/service.py
@@ -144,6 +144,7 @@ class BasicCrawlerService(BaseCrawler[BasicCrawlRequest]):
                     f"HTTP {response.status_code} while fetching URL",
                     content_type=content_type,
                     raw=raw_body,
+                    status_code=response.status_code,
                 )
 
             content = await self._maybe_process_content(

--- a/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/core/provider_response.py
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/core/provider_response.py
@@ -69,13 +69,14 @@ def crawl_upstream_error(
     raw: Any | None = None,
     content_type: str | None = "text/markdown",
     code: str = ProxyErrorCode.UPSTREAM_ERROR.value,
+    status_code: int | None = None,
 ) -> CrawlUrlResult:
     """Build a per-URL crawl failure with optional upstream response attached."""
     return CrawlUrlResult(
         url=url,
         content=None,
         content_type=content_type,
-        error=PerUrlError(code=code, message=message),
+        error=PerUrlError(code=code, message=message, status_code=status_code),
         raw=raw,
     )
 

--- a/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/error_handlers.py
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/error_handlers.py
@@ -37,16 +37,10 @@ def register_exception_handlers(app: FastAPI) -> None:
     @app.exception_handler(ProxyError)
     async def proxy_error_handler(_request: Request, exc: ProxyError) -> JSONResponse:
         from unique_search_proxy_client.web.monitoring.metrics import (
-            record_crawl_error,
             record_proxy_error,
-            record_search_error,
         )
 
         record_proxy_error(exc.code.value)
-        if exc.request == "search" and exc.provider is not None:
-            record_search_error(exc.provider, exc.code.value, 0.0)
-        if exc.request == "crawl" and exc.provider is not None:
-            record_crawl_error(exc.provider, exc.code.value, 0.0)
         _LOGGER.warning(
             "Proxy error [%s] request=%s provider=%s: %s",
             exc.code.value,

--- a/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/monitoring/metrics.py
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/monitoring/metrics.py
@@ -1,13 +1,35 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
+
 from unique_toolkit.monitoring import MetricNamespace
 
 m = MetricNamespace("unique_search_proxy")
+
+
+def _linear_buckets(ceiling: float, steps: int) -> tuple[float, ...]:
+    """Constant-step latency buckets (seconds) up to ``ceiling`` in ``steps``.
+
+    The range ``(0, ceiling]`` is split into ``steps`` equal buckets, yielding
+    ``ceiling/steps, 2*ceiling/steps, ..., ceiling`` inclusive. Observations above
+    the ceiling land in the implicit +Inf bucket prometheus_client appends;
+    histogram_quantile cannot resolve past the largest finite bucket, so each
+    ceiling exceeds the workload's typical timeout. Using the same ``steps`` count
+    keeps resolution comparable across workloads while the ceiling adapts to range.
+    """
+    step = ceiling / steps
+    return tuple(round(step * i, 3) for i in range(1, steps + 1))
+
+
+_SEARCH_LATENCY_BUCKETS = _linear_buckets(ceiling=5.0, steps=20)
+_CRAWL_LATENCY_BUCKETS = _linear_buckets(ceiling=60.0, steps=20)
+_AGENT_SEARCH_LATENCY_BUCKETS = _linear_buckets(ceiling=120.0, steps=20)
 
 search_duration_seconds = m.histogram(
     "search_duration_seconds",
     "Search request latency",
     ["engine"],
+    buckets=_SEARCH_LATENCY_BUCKETS,
 )
 search_total = m.counter(
     "search_total",
@@ -24,6 +46,7 @@ crawl_duration_seconds = m.histogram(
     "crawl_duration_seconds",
     "Crawl request latency",
     ["crawler"],
+    buckets=_CRAWL_LATENCY_BUCKETS,
 )
 crawl_total = m.counter(
     "crawl_total",
@@ -40,6 +63,11 @@ crawl_urls_total = m.counter(
     "URLs submitted to crawl",
     ["crawler"],
 )
+crawl_url_outcomes_total = m.counter(
+    "crawl_url_outcomes_total",
+    "Per-URL crawl outcomes",
+    ["crawler", "outcome", "error_code", "http_status"],
+)
 
 crawl_blocked_total = m.counter(
     "crawl_blocked_total",
@@ -51,6 +79,7 @@ agent_search_duration_seconds = m.histogram(
     "agent_search_duration_seconds",
     "Agent search request latency",
     ["engine"],
+    buckets=_AGENT_SEARCH_LATENCY_BUCKETS,
 )
 agent_search_total = m.counter(
     "agent_search_total",
@@ -103,6 +132,29 @@ def record_crawl_error(crawler: str, error_code: str, duration_seconds: float) -
         return
     crawl_errors_total.labels(crawler=crawler, error_code=error_code).inc()
     crawl_duration_seconds.labels(crawler=crawler).observe(duration_seconds)
+
+
+def record_crawl_url_outcomes(
+    crawler: str,
+    outcomes: Iterable[tuple[str, str, str]],
+) -> None:
+    """Record per-URL crawl outcomes.
+
+    Each item is an ``(outcome, error_code, http_status)`` triple where
+    ``outcome`` is ``"success"`` or ``"error"``, ``error_code`` is ``""`` on
+    success or the per-URL :class:`PerUrlError` code otherwise, and
+    ``http_status`` is the upstream HTTP status (e.g. ``"403"``) when the failure
+    was an HTTP error or ``""`` when no HTTP response was received.
+    """
+    if not _metrics_enabled():
+        return
+    for outcome, error_code, http_status in outcomes:
+        crawl_url_outcomes_total.labels(
+            crawler=crawler,
+            outcome=outcome,
+            error_code=error_code,
+            http_status=http_status,
+        ).inc()
 
 
 def record_crawl_blocked(reason_category: str, count: int = 1) -> None:

--- a/connectors/unique_search_proxy/unique_search_proxy_core/unique_search_proxy_core/schema.py
+++ b/connectors/unique_search_proxy/unique_search_proxy_core/unique_search_proxy_core/schema.py
@@ -142,6 +142,14 @@ class PerUrlError(BaseModel):
 
     code: str
     message: str
+    status_code: int | None = Field(
+        default=None,
+        description=(
+            "Upstream HTTP status code for this URL when the failure was an HTTP "
+            "error (e.g. 403, 404, 500 from the Basic crawler); null when no HTTP "
+            "response was received (timeouts, transport, processing, blocked targets)"
+        ),
+    )
 
 
 class CrawlUrlResult(BaseModel):

--- a/unique_toolkit/unique_toolkit/monitoring/registry.py
+++ b/unique_toolkit/unique_toolkit/monitoring/registry.py
@@ -5,6 +5,7 @@ import functools
 import os
 import time
 import warnings
+from collections.abc import Sequence
 from contextlib import contextmanager
 from typing import Any, Callable, Literal
 
@@ -66,9 +67,31 @@ class MetricNamespace:
     def __init__(self, prefix: str) -> None:
         self._prefix = prefix
 
-    def histogram(self, name: str, description: str, labels: list[str]) -> Histogram:
+    def histogram(
+        self,
+        name: str,
+        description: str,
+        labels: list[str],
+        buckets: Sequence[float] | None = None,
+    ) -> Histogram:
+        """Create a Histogram, optionally with custom bucket boundaries.
+
+        When ``buckets`` is omitted, prometheus_client's default buckets are used
+        (top finite bucket 10s). Provide explicit buckets for workloads whose
+        latency regularly exceeds 10s so ``histogram_quantile`` can resolve the
+        tail; observations above the largest bucket fall into the implicit +Inf
+        bucket. prometheus_client appends +Inf automatically.
+        """
+        if buckets is None:
+            return Histogram(
+                f"{self._prefix}_{name}", description, labels, registry=REGISTRY
+            )
         return Histogram(
-            f"{self._prefix}_{name}", description, labels, registry=REGISTRY
+            f"{self._prefix}_{name}",
+            description,
+            labels,
+            registry=REGISTRY,
+            buckets=tuple(buckets),
         )
 
     def counter(self, name: str, description: str, labels: list[str]) -> Counter:


### PR DESCRIPTION
Ref: UN-23313

## Summary
- Crawl errors were only recorded per batch, so individual URL failures and their upstream HTTP status were invisible. This adds per-URL outcome metrics (success/error + normalized error code + HTTP status) so partial batch failures and status-specific errors (403/404/500/...) are observable.
- Adds custom, constant-step latency histogram buckets so `histogram_quantile` resolves past the 10s prometheus default (crawl 60s, agent search 120s, search 30s).
- Rebuilds the deployed Grafana dashboard into a professional layout with an overview KPI row and per-URL error/HTTP-status breakdowns.

## Changes
**Metrics (`unique_search_proxy_client`)**
- New `crawl_url_outcomes_total` counter labelled `(crawler, outcome, error_code, http_status)` + `record_crawl_url_outcomes`.
- Crawl endpoint derives `(outcome, error_code, http_status)` triples from merged results and records them on both success paths; the `ProxyError` path now records `record_crawl_error` before re-raising.
- Constant-step latency buckets via a small `_linear_buckets(ceiling, steps)` helper.

**Core schema (`unique_search_proxy_core`)**
- `PerUrlError` gains an optional `status_code: int | None` (upstream HTTP status when the failure was an HTTP error; null otherwise). Threaded through `crawl_upstream_error` and populated in the Basic crawler's HTTP-error path.

**Toolkit (`unique_toolkit`)**
- `MetricNamespace.histogram` gains an optional `buckets` argument (backward-compatible; default buckets unchanged for all other callers).

**Dashboard (`deploy/helm-chart/files/grafana/dashboards/search-proxy.json`)**
- Aligned with the locally-tested layout: overview KPIs, per-URL outcomes, error-code pie, top upstream HTTP statuses, error-by-code/status table, and consistent rate -> errors -> latency ordering across crawl/search/agent-search. Datasource refs keep the `%%PROMETHEUS_UID%%` deploy token.

**Tests**
- Assert the `http_status` label on `crawl_url_outcomes_total` and `statusCode` in the per-URL error response.

## Test plan
- [x] `ruff check` + `ruff format --check` on both connector packages and the toolkit registry
- [x] `basedpyright` on `metrics.py` and `registry.py` (0 errors)
- [x] `pytest` — connector client suite (301 passed) + toolkit registry tests (15 passed)

## Risk / rollout
- Low risk. New metric label and optional schema field are additive; the toolkit histogram change is backward-compatible. New latency buckets change bucket boundaries for the three search-proxy histograms only — historical series with old buckets will coexist until scraped out.

Made with [Cursor](https://cursor.com)