### PR TITLE
feat(sdk): thread chatId through web-search CLI/SDK to activate node-chat Web Search toggle guard

### DIFF
--- a/unique_sdk/tests/cli/test_web_search.py
+++ b/unique_sdk/tests/cli/test_web_search.py
@@ -510,6 +510,22 @@ class TestCmdWebSearch:
         assert "web-search:" in out
         assert "upstream boom" in out
 
+    @patch("unique_sdk.WebSearch.search")
+    def test_cmd_web_search_with_chat_id_sends_chat_id(
+        self, mock_search: MagicMock
+    ) -> None:
+        mock_search.return_value = _FakeResource(_make_search_payload(results=[]))
+        cmd_web_search(_state(), "x", chat_id="chat_123")
+        assert mock_search.call_args[1]["chatId"] == "chat_123"
+
+    @patch("unique_sdk.WebSearch.search")
+    def test_cmd_web_search_without_chat_id_omits_chat_id(
+        self, mock_search: MagicMock
+    ) -> None:
+        mock_search.return_value = _FakeResource(_make_search_payload(results=[]))
+        cmd_web_search(_state(), "x")
+        assert "chatId" not in mock_search.call_args[1]
+
 
 class TestCmdWebCrawl:
     @patch("unique_sdk.WebCrawl.crawl")
@@ -573,6 +589,22 @@ class TestCmdWebCrawl:
         out = cmd_web_crawl(_state(), ["u"])
         assert "web-crawl:" in out
         assert "nope" in out
+
+    @patch("unique_sdk.WebCrawl.crawl")
+    def test_cmd_web_crawl_with_chat_id_sends_chat_id(
+        self, mock_crawl: MagicMock
+    ) -> None:
+        mock_crawl.return_value = _FakeResource(_make_crawl_payload(results=[]))
+        cmd_web_crawl(_state(), ["https://a"], chat_id="chat_123")
+        assert mock_crawl.call_args[1]["chatId"] == "chat_123"
+
+    @patch("unique_sdk.WebCrawl.crawl")
+    def test_cmd_web_crawl_without_chat_id_omits_chat_id(
+        self, mock_crawl: MagicMock
+    ) -> None:
+        mock_crawl.return_value = _FakeResource(_make_crawl_payload(results=[]))
+        cmd_web_crawl(_state(), ["https://a"])
+        assert "chatId" not in mock_crawl.call_args[1]
 
 
 class TestApiResourceContract:
@@ -1124,3 +1156,76 @@ class TestClickIntegration:
         )
         assert result.exit_code == 0
         assert mock_cmd.call_args[1]["config_path"] == str(cfg)
+
+
+class TestClickIntegrationChatId:
+    """--chat-id / $UNIQUE_CHAT_ID resolution for web-search search/crawl."""
+
+    def _bootstrap_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("UNIQUE_USER_ID", "u1")
+        monkeypatch.setenv("UNIQUE_COMPANY_ID", "c1")
+        monkeypatch.setenv("UNIQUE_API_KEY", "ukey_test")
+        monkeypatch.setenv("UNIQUE_APP_ID", "app_test")
+        monkeypatch.delenv(ENV_CONFIG_PATH, raising=False)
+
+    @patch("unique_sdk.cli.cli.cmd_web_search")
+    def test_search_reads_chat_id_from_env(
+        self, mock_cmd: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._bootstrap_env(monkeypatch)
+        monkeypatch.setenv("UNIQUE_CHAT_ID", "chat_from_env")
+        mock_cmd.return_value = "ok"
+        runner = CliRunner()
+        result = runner.invoke(cli_main, ["web-search", "search", "x"])
+        assert result.exit_code == 0
+        assert mock_cmd.call_args[1]["chat_id"] == "chat_from_env"
+
+    @patch("unique_sdk.cli.cli.cmd_web_search")
+    def test_search_chat_id_defaults_to_none_without_env(
+        self, mock_cmd: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._bootstrap_env(monkeypatch)
+        monkeypatch.delenv("UNIQUE_CHAT_ID", raising=False)
+        mock_cmd.return_value = "ok"
+        runner = CliRunner()
+        result = runner.invoke(cli_main, ["web-search", "search", "x"])
+        assert result.exit_code == 0
+        assert mock_cmd.call_args[1]["chat_id"] is None
+
+    @patch("unique_sdk.cli.cli.cmd_web_search")
+    def test_search_explicit_flag_overrides_env(
+        self, mock_cmd: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._bootstrap_env(monkeypatch)
+        monkeypatch.setenv("UNIQUE_CHAT_ID", "chat_from_env")
+        mock_cmd.return_value = "ok"
+        runner = CliRunner()
+        result = runner.invoke(
+            cli_main, ["web-search", "search", "x", "--chat-id", "chat_explicit"]
+        )
+        assert result.exit_code == 0
+        assert mock_cmd.call_args[1]["chat_id"] == "chat_explicit"
+
+    @patch("unique_sdk.cli.cli.cmd_web_crawl")
+    def test_crawl_reads_chat_id_from_env(
+        self, mock_cmd: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._bootstrap_env(monkeypatch)
+        monkeypatch.setenv("UNIQUE_CHAT_ID", "chat_from_env")
+        mock_cmd.return_value = "ok"
+        runner = CliRunner()
+        result = runner.invoke(cli_main, ["web-search", "crawl", "https://a"])
+        assert result.exit_code == 0
+        assert mock_cmd.call_args[1]["chat_id"] == "chat_from_env"
+
+    @patch("unique_sdk.cli.cli.cmd_web_crawl")
+    def test_crawl_chat_id_defaults_to_none_without_env(
+        self, mock_cmd: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._bootstrap_env(monkeypatch)
+        monkeypatch.delenv("UNIQUE_CHAT_ID", raising=False)
+        mock_cmd.return_value = "ok"
+        runner = CliRunner()
+        result = runner.invoke(cli_main, ["web-search", "crawl", "https://a"])
+        assert result.exit_code == 0
+        assert mock_cmd.call_args[1]["chat_id"] is None

--- a/unique_sdk/unique_sdk/api_resources/_web_search.py
+++ b/unique_sdk/unique_sdk/api_resources/_web_search.py
@@ -58,6 +58,10 @@ class WebSearch(APIResource["WebSearch"]):
         searchEngineConfig: NotRequired[dict[str, Any] | None]
         # Used only when includeContent=True and the engine needs scraping.
         crawlerConfig: NotRequired[dict[str, Any] | None]
+        # Optional: when set, the space's Web Search toggle is enforced
+        # server-side for this call. Omit for callers not acting on
+        # behalf of a specific chat (unchanged legacy behavior).
+        chatId: NotRequired[str | None]
 
     # Response envelope.
     engine: str
@@ -130,6 +134,10 @@ class WebCrawl(APIResource["WebCrawl"]):
         urls: list[str]
         parallel: NotRequired[int | None]
         crawlerConfig: NotRequired[dict[str, Any] | None]
+        # Optional: when set, the space's Web Search toggle is enforced
+        # server-side for this call. Omit for callers not acting on
+        # behalf of a specific chat (unchanged legacy behavior).
+        chatId: NotRequired[str | None]
 
     # Response envelope.
     crawler: str

--- a/unique_sdk/unique_sdk/cli/cli.py
+++ b/unique_sdk/unique_sdk/cli/cli.py
@@ -2135,6 +2135,18 @@ Examples:
     is_flag=True,
     help="Output results as JSON (suitable for piping into web-search crawl --stdin).",
 )
+@click.option(
+    "--chat-id",
+    "chat_id",
+    default=None,
+    envvar="UNIQUE_CHAT_ID",
+    help=(
+        "Chat id this call is made on behalf of. Defaults to $UNIQUE_CHAT_ID "
+        "(auto-set in Conduct sandboxes). When set, the space's Web Search "
+        "toggle is enforced server-side and the call is rejected if Web "
+        "Search is disabled for that space."
+    ),
+)
 @click.pass_context
 def web_search_search_cmd(
     ctx: click.Context,
@@ -2145,6 +2157,7 @@ def web_search_search_cmd(
     crawler_config_raw: str | None,
     config_path: str | None,
     output_json: bool,
+    chat_id: str | None,
 ) -> None:
     """Search the web via the Unique public API."""
     resolved_config = _resolve_web_search_config_path(ctx, config_path)
@@ -2157,6 +2170,7 @@ def web_search_search_cmd(
         crawler_config_raw=crawler_config_raw,
         output_json=output_json,
         config_path=resolved_config,
+        chat_id=chat_id,
     )
     _emit_web_search(ctx, output)
 
@@ -2212,6 +2226,18 @@ Examples:
     is_flag=True,
     help="Output results as JSON.",
 )
+@click.option(
+    "--chat-id",
+    "chat_id",
+    default=None,
+    envvar="UNIQUE_CHAT_ID",
+    help=(
+        "Chat id this call is made on behalf of. Defaults to $UNIQUE_CHAT_ID "
+        "(auto-set in Conduct sandboxes). When set, the space's Web Search "
+        "toggle is enforced server-side and the call is rejected if Web "
+        "Search is disabled for that space."
+    ),
+)
 @click.pass_context
 def web_search_crawl_cmd(
     ctx: click.Context,
@@ -2221,6 +2247,7 @@ def web_search_crawl_cmd(
     crawler_config_raw: str | None,
     config_path: str | None,
     output_json: bool,
+    chat_id: str | None,
 ) -> None:
     """Crawl URLs via the Unique public API."""
     url_list: list[str] = list(urls)
@@ -2238,5 +2265,6 @@ def web_search_crawl_cmd(
         crawler_config_raw=crawler_config_raw,
         output_json=output_json,
         config_path=resolved_config,
+        chat_id=chat_id,
     )
     _emit_web_search(ctx, output)

--- a/unique_sdk/unique_sdk/cli/commands/web_search.py
+++ b/unique_sdk/unique_sdk/cli/commands/web_search.py
@@ -317,6 +317,7 @@ def cmd_web_search(
     crawler_config_raw: str | None = None,
     output_json: bool = False,
     config_path: str | None = None,
+    chat_id: str | None = None,
 ) -> str:
     """Run a web search via the public API.
 
@@ -341,6 +342,8 @@ def cmd_web_search(
             then ``~/.unique-websearch.json``.
         output_json: When ``True``, return a JSON envelope instead of a
             human-friendly table.
+        chat_id: Optional chat id this call is made on behalf of. When
+            set, the space's Web Search toggle is enforced server-side.
     """
     file_overrides = _load_file_overrides(config_path)
     if isinstance(file_overrides, str):
@@ -368,6 +371,8 @@ def cmd_web_search(
         params["searchEngineConfig"] = engine_override
     if crawler_override is not None:
         params["crawlerConfig"] = crawler_override
+    if chat_id:
+        params["chatId"] = chat_id
 
     try:
         resource = unique_sdk.WebSearch.search(
@@ -394,6 +399,7 @@ def cmd_web_crawl(
     crawler_config_raw: str | None = None,
     output_json: bool = False,
     config_path: str | None = None,
+    chat_id: str | None = None,
 ) -> str:
     """Crawl a list of URLs via the public API.
 
@@ -410,6 +416,8 @@ def cmd_web_crawl(
             :func:`cmd_web_search` for resolution rules.
         output_json: When ``True``, return a JSON envelope instead of a
             human-friendly table.
+        chat_id: Optional chat id this call is made on behalf of. When
+            set, the space's Web Search toggle is enforced server-side.
     """
     if not urls:
         return f"{WEB_CRAWL_ERROR_PREFIX} no URLs provided. Pass URLs as arguments or use --stdin."
@@ -432,6 +440,8 @@ def cmd_web_crawl(
     params: dict[str, Any] = {"urls": list(urls), "parallel": parallel}
     if crawler_override is not None:
         params["crawlerConfig"] = crawler_override
+    if chat_id:
+        params["chatId"] = chat_id
 
     try:
         resource = unique_sdk.WebCrawl.crawl(


### PR DESCRIPTION
## Summary

Backport to `release/2026.30`:

- #2135 (`583c75b`) — Add optional `chatId` to `unique_sdk.WebSearch.search` / `unique_sdk.WebCrawl.crawl` and thread it through `unique-cli web-search search`/`crawl` (defaulting to `$UNIQUE_CHAT_ID`, already exported in every Conduct sandbox process), so the monorepo's `SpaceToolToggleGuard` on `POST /public/web-search-api/{search,crawl}` can actually enforce the space's Web Search toggle for CLI/Conduct sandbox traffic. Additive/optional `chatId` only — no behavior change for callers that omit it.

Refs: UN-23341, UN-23342

## Notes for reviewers

- Hotfix backport only; no new changes relative to the merged PR above (clean cherry-pick, no conflicts).
- **Companion node-chat change already backported separately, not in this PR:** `Unique-AG/monorepo#27199` (`SpaceToolToggleGuard` on the public API) lives in the `monorepo` repo and cannot be cherry-picked from this `ai` repo. Both PRs must land on `release/2026.30` for the guard to actually enforce anything for CLI/Conduct traffic on this release line.

## Test plan

- [x] `cd unique_sdk && uv run pytest tests/cli tests/api_resources -q` → 908 passed, 39 skipped (pre-existing, unrelated)
- [x] `cd unique_sdk && uv run poe lint` → all checks passed
- [x] `cd unique_sdk && uv run poe typecheck` → 0 errors, 0 warnings, 0 notes
- [ ] CI green on `release/2026.30` before merge

Made with [Cursor](https://cursor.com)