### PR TITLE
fix(unique_sdk): UN-23307 redact request payload debug logs by default

### DIFF
--- a/unique_sdk/tests/test_request_logging.py
+++ b/unique_sdk/tests/test_request_logging.py
@@ -1,0 +1,120 @@
+"""Request/response debug logging must not emit payloads by default."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+
+from unique_sdk import _util
+
+
+@pytest.fixture
+def capture_unique_debug_logs(caplog: pytest.LogCaptureFixture):
+    caplog.set_level(logging.DEBUG, logger="unique")
+    return caplog
+
+
+def _request_payload() -> dict[str, Any]:
+    return {
+        "messages": [
+            {
+                "role": "user",
+                "content": "Draft a note for Dr. Client Name about portfolio PTY-0001",
+            }
+        ]
+    }
+
+
+def _request_headers() -> dict[str, str]:
+    return {
+        "Authorization": "Bearer secret-token",
+        "Content-Type": "application/json",
+        "x-user-id": "user-1",
+        "x-company-id": "company-1",
+    }
+
+
+def test_request_details_redacted_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+    capture_unique_debug_logs: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.delenv("INSECURE_UNIQUE_SDK_LOG_PAYLOADS", raising=False)
+
+    _util.log_request_details(
+        data=_request_payload(),
+        headers=_request_headers(),
+        api_version="2023-12-06",
+    )
+
+    assert len(capture_unique_debug_logs.records) == 1
+    message = capture_unique_debug_logs.records[0].getMessage()
+    assert "message='Request details'" in message
+    assert "data=<redacted>" in message
+    assert "headers=<redacted>" in message
+    assert "payload_bytes=" in message
+    assert "Dr. Client Name" not in message
+    assert "secret-token" not in message
+    assert "Bearer" not in message
+
+
+def test_response_body_redacted_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+    capture_unique_debug_logs: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.delenv("INSECURE_UNIQUE_SDK_LOG_PAYLOADS", raising=False)
+
+    _util.log_response_body(body=b'{"text":"client portfolio details"}')
+
+    assert len(capture_unique_debug_logs.records) == 1
+    message = capture_unique_debug_logs.records[0].getMessage()
+    assert "message='Unique response body'" in message
+    assert "body=<redacted>" in message
+    assert "payload_bytes=" in message
+    assert "client portfolio details" not in message
+
+
+def test_request_details_include_payload_when_insecure_flag_set(
+    monkeypatch: pytest.MonkeyPatch,
+    capture_unique_debug_logs: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setenv("INSECURE_UNIQUE_SDK_LOG_PAYLOADS", "true")
+
+    _util.log_request_details(
+        data=_request_payload(),
+        headers=_request_headers(),
+        api_version="2023-12-06",
+    )
+
+    assert len(capture_unique_debug_logs.records) == 1
+    message = capture_unique_debug_logs.records[0].getMessage()
+    assert "Dr. Client Name" in message
+    assert "x-company-id" in message
+    assert "secret-token" not in message
+    assert "Authorization" in message
+    assert "<redacted>" in message
+
+
+def test_authorization_never_logged_even_with_insecure_flag(
+    monkeypatch: pytest.MonkeyPatch,
+    capture_unique_debug_logs: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setenv("INSECURE_UNIQUE_SDK_LOG_PAYLOADS", "true")
+
+    _util.log_request_details(
+        data={"ok": True},
+        headers={"authorization": "Bearer another-secret"},
+        api_version="2023-12-06",
+    )
+
+    message = capture_unique_debug_logs.records[0].getMessage()
+    assert "another-secret" not in message
+    assert "Bearer" not in message
+
+
+def test_payload_byte_size_handles_bytes_and_str() -> None:
+    assert _util._payload_byte_size(None) == 0
+    assert _util._payload_byte_size(b"abc") == 3
+    assert _util._payload_byte_size("é") == 2
+    assert _util._payload_byte_size({"a": 1}) > 0

--- a/unique_sdk/tests/test_request_logging.py
+++ b/unique_sdk/tests/test_request_logging.py
@@ -125,7 +125,9 @@ def test_body_for_error_message_redacted_by_default(
 ) -> None:
     monkeypatch.delenv("INSECURE_UNIQUE_SDK_LOG_PAYLOADS", raising=False)
 
-    result = _util.body_for_error_message(b'{"text":"client portfolio details"}')
+    result = _util.redacted_body_for_error_message(
+        b'{"text":"client portfolio details"}'
+    )
 
     assert "client portfolio details" not in str(result)
     assert str(result) == "<redacted 35 bytes>"
@@ -137,7 +139,7 @@ def test_body_for_error_message_passthrough_when_insecure_flag_set(
     monkeypatch.setenv("INSECURE_UNIQUE_SDK_LOG_PAYLOADS", "true")
 
     body = b'{"text":"client portfolio details"}'
-    assert _util.body_for_error_message(body) is body
+    assert _util.redacted_body_for_error_message(body) is body
 
 
 def test_invalid_response_body_error_message_is_redacted(
@@ -166,8 +168,8 @@ def test_error_params_redacted_by_default(
 ) -> None:
     monkeypatch.delenv("INSECURE_UNIQUE_SDK_LOG_PAYLOADS", raising=False)
 
-    assert _util.error_params_for_log({"text": "Dr. Client Name"}) == "<redacted>"
-    assert _util.error_params_for_log(None) is None
+    assert _util.redacted_error_params({"text": "Dr. Client Name"}) == "<redacted>"
+    assert _util.redacted_error_params(None) is None
 
 
 def test_error_params_passthrough_when_insecure_flag_set(
@@ -176,4 +178,4 @@ def test_error_params_passthrough_when_insecure_flag_set(
     monkeypatch.setenv("INSECURE_UNIQUE_SDK_LOG_PAYLOADS", "true")
 
     params = {"text": "Dr. Client Name"}
-    assert _util.error_params_for_log(params) is params
+    assert _util.redacted_error_params(params) is params

--- a/unique_sdk/tests/test_request_logging.py
+++ b/unique_sdk/tests/test_request_logging.py
@@ -118,3 +118,62 @@ def test_payload_byte_size_handles_bytes_and_str() -> None:
     assert _util._payload_byte_size(b"abc") == 3
     assert _util._payload_byte_size("é") == 2
     assert _util._payload_byte_size({"a": 1}) > 0
+
+
+def test_body_for_error_message_redacted_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("INSECURE_UNIQUE_SDK_LOG_PAYLOADS", raising=False)
+
+    result = _util.body_for_error_message(b'{"text":"client portfolio details"}')
+
+    assert "client portfolio details" not in str(result)
+    assert str(result) == "<redacted 35 bytes>"
+
+
+def test_body_for_error_message_passthrough_when_insecure_flag_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("INSECURE_UNIQUE_SDK_LOG_PAYLOADS", "true")
+
+    body = b'{"text":"client portfolio details"}'
+    assert _util.body_for_error_message(body) is body
+
+
+def test_invalid_response_body_error_message_is_redacted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("INSECURE_UNIQUE_SDK_LOG_PAYLOADS", raising=False)
+
+    from unique_sdk._api_requestor import APIRequestor
+    from unique_sdk._error import APIError
+
+    requestor = APIRequestor(
+        key="sk-test", app_id="app-test", user_id="user-1", company_id="company-1"
+    )
+    # Latin-1 bytes that cannot decode as UTF-8 → interpret_response raises.
+    bad_body = 'note for Dr. Client Name: "caf\xe9"'.encode("latin-1")
+
+    with pytest.raises(APIError) as exc_info:
+        requestor.interpret_response(bad_body, 200, {})
+
+    assert "Client Name" not in str(exc_info.value)
+    assert "<redacted" in str(exc_info.value)
+
+
+def test_error_params_redacted_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("INSECURE_UNIQUE_SDK_LOG_PAYLOADS", raising=False)
+
+    assert _util.error_params_for_log({"text": "Dr. Client Name"}) == "<redacted>"
+    assert _util.error_params_for_log(None) is None
+
+
+def test_error_params_passthrough_when_insecure_flag_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("INSECURE_UNIQUE_SDK_LOG_PAYLOADS", "true")
+
+    params = {"text": "Dr. Client Name"}
+    assert _util.error_params_for_log(params) is params

--- a/unique_sdk/unique_sdk/_api_requestor.py
+++ b/unique_sdk/unique_sdk/_api_requestor.py
@@ -194,8 +194,7 @@ class APIRequestor(object):
         )
 
         _util.log_info("Request to Unique", method=method, path=abs_url)
-        _util.log_debug(
-            "Request details",
+        _util.log_request_details(
             data=post_data,
             headers=headers,
             api_version=self.api_version,
@@ -206,7 +205,7 @@ class APIRequestor(object):
         )
 
         _util.log_info("Unique response", path=abs_url, status=rcode)
-        _util.log_debug("Unique response body", body=rcontent)
+        _util.log_response_body(body=rcontent)
 
         if "Request-Id" in rheaders:
             request_id = rheaders["Request-Id"]
@@ -230,11 +229,11 @@ class APIRequestor(object):
         )
 
         _util.log_info("Async request to Unique", method=method, path=abs_url)
-        _util.log_debug(
-            "Async request details",
+        _util.log_request_details(
             data=post_data,
             headers=headers,
             api_version=self.api_version,
+            message="Async request details",
         )
 
         rcontent, rcode, rheaders = await self._client.request_async(
@@ -242,7 +241,7 @@ class APIRequestor(object):
         )
 
         _util.log_info("Unique response", path=abs_url, status=rcode)
-        _util.log_debug("Unique response body", body=rcontent)
+        _util.log_response_body(body=rcontent)
 
         if "Request-Id" in rheaders:
             request_id = rheaders["Request-Id"]

--- a/unique_sdk/unique_sdk/_api_requestor.py
+++ b/unique_sdk/unique_sdk/_api_requestor.py
@@ -361,13 +361,10 @@ class APIRequestor(object):
                 rheaders,
             )
         except Exception as e:
-            # The raw body must not go into the exception *message*: messages
-            # surface at ERROR via retry logs and tracebacks regardless of
-            # LOG_LEVEL (UN-23307). It stays available on http_body.
             raise _error.APIError(
                 "Invalid response body from API: %s "
                 "(HTTP response code was %d)"
-                % (_util.body_for_error_message(rbody), rcode),
+                % (_util.redacted_body_for_error_message(rbody), rcode),
                 cast(bytes, rbody),
                 rcode,
                 rheaders,
@@ -402,9 +399,7 @@ class APIRequestor(object):
             error_code=status,
             error_type=error_data.get("type"),
             error_message=error_data.get("message"),
-            # Validation errors echo submitted values in params — redacted
-            # unless the insecure opt-in is set (UN-23307).
-            error_params=_util.error_params_for_log(error_data.get("params")),
+            error_params=_util.redacted_error_params(error_data.get("params")),
         )
 
         error = cause.get("error", {}) if cause else {}

--- a/unique_sdk/unique_sdk/_api_requestor.py
+++ b/unique_sdk/unique_sdk/_api_requestor.py
@@ -361,9 +361,13 @@ class APIRequestor(object):
                 rheaders,
             )
         except Exception as e:
+            # The raw body must not go into the exception *message*: messages
+            # surface at ERROR via retry logs and tracebacks regardless of
+            # LOG_LEVEL (UN-23307). It stays available on http_body.
             raise _error.APIError(
                 "Invalid response body from API: %s "
-                "(HTTP response code was %d)" % (rbody, rcode),
+                "(HTTP response code was %d)"
+                % (_util.body_for_error_message(rbody), rcode),
                 cast(bytes, rbody),
                 rcode,
                 rheaders,
@@ -398,7 +402,9 @@ class APIRequestor(object):
             error_code=status,
             error_type=error_data.get("type"),
             error_message=error_data.get("message"),
-            error_params=error_data.get("params"),
+            # Validation errors echo submitted values in params — redacted
+            # unless the insecure opt-in is set (UN-23307).
+            error_params=_util.error_params_for_log(error_data.get("params")),
         )
 
         error = cause.get("error", {}) if cause else {}

--- a/unique_sdk/unique_sdk/_util.py
+++ b/unique_sdk/unique_sdk/_util.py
@@ -129,7 +129,7 @@ def log_response_body(*, body: Any) -> None:
     )
 
 
-def body_for_error_message(body: Any) -> Any:
+def redacted_body_for_error_message(body: Any) -> Any:
     """Body representation safe to embed in exception *messages*.
 
     Exception messages surface at ERROR (retry logs, tracebacks) regardless
@@ -142,7 +142,7 @@ def body_for_error_message(body: Any) -> Any:
     return f"<redacted {_payload_byte_size(body)} bytes>"
 
 
-def error_params_for_log(params: Any) -> Any:
+def redacted_error_params(params: Any) -> Any:
     """Error ``params`` for the INFO-level 'Unique error received' log.
 
     API validation errors commonly echo submitted values in ``params``, so

--- a/unique_sdk/unique_sdk/_util.py
+++ b/unique_sdk/unique_sdk/_util.py
@@ -9,6 +9,7 @@ import random
 import re
 import sys
 import time
+from collections.abc import Mapping
 from functools import wraps
 from typing import (
     Any,
@@ -58,7 +59,7 @@ def _payload_byte_size(value: Any) -> int:
     return len(str(value).encode("utf-8"))
 
 
-def _headers_for_log(headers: Any) -> Any:
+def _headers_for_log(headers: Mapping[str, str] | None) -> dict[str, str] | str | None:
     """Return headers for debug logs; Authorization is always redacted."""
     if not _insecure_log_payloads_enabled():
         return _REDACTED
@@ -97,7 +98,7 @@ def log_info(message, **params):
 def log_request_details(
     *,
     data: Any,
-    headers: Any,
+    headers: Mapping[str, str] | None,
     api_version: str | None,
     message: str = "Request details",
 ) -> None:

--- a/unique_sdk/unique_sdk/_util.py
+++ b/unique_sdk/unique_sdk/_util.py
@@ -33,6 +33,8 @@ UNIQUE_LOG = os.environ.get("UNIQUE_LOG")
 
 logger: logging.Logger = logging.getLogger("unique")
 
+_REDACTED = "<redacted>"
+
 
 def _console_log_level():
     if unique_sdk.log in ["debug", "info"]:
@@ -40,6 +42,42 @@ def _console_log_level():
     if UNIQUE_LOG in ["debug", "info"]:
         return UNIQUE_LOG
     return None
+
+
+def _insecure_log_payloads_enabled() -> bool:
+    return os.environ.get("INSECURE_UNIQUE_SDK_LOG_PAYLOADS") == "true"
+
+
+def _payload_byte_size(value: Any) -> int:
+    if value is None:
+        return 0
+    if isinstance(value, (bytes, bytearray)):
+        return len(value)
+    if isinstance(value, str):
+        return len(value.encode("utf-8"))
+    return len(str(value).encode("utf-8"))
+
+
+def _headers_for_log(headers: Any) -> Any:
+    """Return headers for debug logs; Authorization is always redacted."""
+    if not _insecure_log_payloads_enabled():
+        return _REDACTED
+    if headers is None:
+        return None
+    try:
+        sanitized = dict(headers)
+    except (TypeError, ValueError):
+        return _REDACTED
+    for key in list(sanitized):
+        if str(key).lower() == "authorization":
+            sanitized[key] = _REDACTED
+    return sanitized
+
+
+def _body_for_log(body: Any) -> Any:
+    if _insecure_log_payloads_enabled():
+        return body
+    return _REDACTED
 
 
 def log_debug(message, **params):
@@ -54,6 +92,41 @@ def log_info(message, **params):
     if _console_log_level() in ["debug", "info"]:
         print(msg, file=sys.stderr)
     logger.info(msg)
+
+
+def log_request_details(
+    *,
+    data: Any,
+    headers: Any,
+    api_version: str | None,
+    message: str = "Request details",
+) -> None:
+    if _insecure_log_payloads_enabled():
+        log_debug(
+            message,
+            data=data,
+            headers=_headers_for_log(headers),
+            api_version=api_version,
+        )
+        return
+    log_debug(
+        message,
+        data=_REDACTED,
+        headers=_REDACTED,
+        api_version=api_version,
+        payload_bytes=_payload_byte_size(data),
+    )
+
+
+def log_response_body(*, body: Any) -> None:
+    if _insecure_log_payloads_enabled():
+        log_debug("Unique response body", body=body)
+        return
+    log_debug(
+        "Unique response body",
+        body=_body_for_log(body),
+        payload_bytes=_payload_byte_size(body),
+    )
 
 
 def logfmt(props):

--- a/unique_sdk/unique_sdk/_util.py
+++ b/unique_sdk/unique_sdk/_util.py
@@ -129,6 +129,30 @@ def log_response_body(*, body: Any) -> None:
     )
 
 
+def body_for_error_message(body: Any) -> Any:
+    """Body representation safe to embed in exception *messages*.
+
+    Exception messages surface at ERROR (retry logs, tracebacks) regardless
+    of LOG_LEVEL, so the raw body must not be embedded unless the insecure
+    opt-in is set. The full body stays available programmatically on the
+    exception's ``http_body`` attribute.
+    """
+    if _insecure_log_payloads_enabled():
+        return body
+    return f"<redacted {_payload_byte_size(body)} bytes>"
+
+
+def error_params_for_log(params: Any) -> Any:
+    """Error ``params`` for the INFO-level 'Unique error received' log.
+
+    API validation errors commonly echo submitted values in ``params``, so
+    they are redacted unless the insecure opt-in is set.
+    """
+    if params is None or _insecure_log_payloads_enabled():
+        return params
+    return _REDACTED
+
+
 def logfmt(props):
     def fmt(key, val):
         # Handle case where val is a bytes or bytesarray


### PR DESCRIPTION
## Summary

Resolves [UN-23307](https://unique-ch.atlassian.net/browse/UN-23307)
References [UN-23303](https://unique-ch.atlassian.net/browse/UN-23303)

- Redact Unique SDK DEBUG `data=` / `headers=` / `body=` by default (safe metadata + payload size only)
- Redact raw response body from `APIError` exception messages (`<redacted N bytes>`) — exception messages surface at ERROR via retry logs and tracebacks regardless of LOG_LEVEL; the full body stays available programmatically on `http_body`
- Redact `error_params` in the INFO-level `Unique error received` log — API validation errors echo submitted values in params
- Opt-in only via undocumented `INSECURE_UNIQUE_SDK_LOG_PAYLOADS=true`
- Never log `Authorization`, even with the opt-in flag
- Unit tests cover default redaction, insecure opt-in, Authorization scrubbing, APIError message redaction, and error_params redaction (10 tests)

## Test plan

- [x] `uv run pytest unique_sdk/tests/test_request_logging.py` (10 passed)
- [ ] Confirm release-please picks up `fix(unique_sdk)` for the next unique-sdk publish
- [ ] Companion monorepo PR: [Unique-AG/monorepo#27227](https://github.com/Unique-AG/monorepo/pull/27227) (polyagent `LOG_LEVEL` default INFO + defense-in-depth filters); bump polyagent unique-sdk pin once this is published

Made with [Cursor](https://cursor.com)

[UN-23307]: https://unique-ch.atlassian.net/browse/UN-23307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[UN-23303]: https://unique-ch.atlassian.net/browse/UN-23303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ