### PR TITLE
fix(cli): choose cite --read-method by modality read, not page location [UN-23250]

### DIFF
--- a/unique_sdk/unique_sdk/cli/skills/unique-cli-file-management/SKILL.md
+++ b/unique_sdk/unique_sdk/cli/skills/unique-cli-file-management/SKILL.md
@@ -235,24 +235,29 @@ If you obtained the content some other way (you `download`ed the raw bytes and p
 CSV, `.txt`, HTML, images) have no pages — always omit `--pages`** and cite the
 whole file.
 
-**Choosing `--read-method`** (declare the *representation* of the source you actually read):
+**Choosing `--read-method`** (declare the *representation* you actually read the
+cited value from). Pick it by the **modality you read** — NOT by how you *located*
+the page. Locating a page with `unique-cli read` does **not** force `indexed`: if you
+then rendered that page and read a chart/figure with vision, the method is `vision`.
 
 - `text` → you used **extracted text** (`pdftotext`, PyMuPDF / `fitz` `page.get_text()`, MarkItDown, or any text extraction).
-- `vision` → you read a **rendered image** of the page/slide (e.g. `get_pixmap()`) with your vision capability.
-- `indexed` → you relied on **`unique-cli read`** output (the platform's indexed chunks).
+- `vision` → you read a **rendered image** of the page/slide (e.g. `get_pixmap()`) with your vision capability — including when you located the page via `unique-cli read` but then rendered it to read a chart, figure, table, or scanned page.
+- `indexed` → you used the **text returned by `unique-cli read`** (the platform's indexed chunks) as your answer source.
 
 | Value | When to use |
 |-------|-------------|
-| `text` | You read the page/document as extracted text and used that text. |
-| `vision` | You rendered the page to an image and read it with your vision capability. |
-| `indexed` | You read the content via `unique-cli read` (indexed chunks). |
+| `text` | You extracted the page/document text yourself and used that text. |
+| `vision` | You read a rendered image of the page with your vision capability — even if you located the page via `unique-cli read`. |
+| `indexed` | You used the text returned by `unique-cli read` (indexed chunks) as your source. |
 
-**Verify page numbers before citing — unless you already have them from `unique-cli read`.**
-If you cited straight from `unique-cli read` output (`--read-method indexed`), its
-`[p.N]` / `[p.N-M]` markers are already physical positions — skip the checks below
-and cite them directly. Otherwise — you read the raw bytes yourself
-(`--read-method text`/`vision`) — pick the row matching the file you read and
-verify the cited content really is where you claim before calling `cite`:
+**Verify page numbers before citing — unless you located them via `unique-cli read`.**
+This is about the *page number* only, and is **independent of `--read-method`**. If you
+located the page with `unique-cli read`, its `[p.N]` / `[p.N-M]` markers are already
+physical positions — trust them and skip the checks below, even if you then rendered the
+page and read it with vision (in that case still cite `--read-method vision`). Only when
+you obtained the page some other way — you `download`ed the raw bytes and parsed them
+yourself, or `read` returned no `[p.N]` markers — pick the row matching the file you read
+and verify the cited content really is where you claim before calling `cite`:
 
 - **PDF** — `pdfinfo file.pdf | grep Pages` for the total physical page count, then
   for **each** page run `pdftotext -f N -l N file.pdf -` and confirm the content is
@@ -265,11 +270,13 @@ verify the cited content really is where you claim before calling `cite`:
 - **Non-paginated (XLSX/CSV/TXT/HTML/images)** — there are no pages. Do **NOT**
   pass `--pages`; cite the whole file and verify the content exists in it.
 
-Then determine `--read-method`: report the representation you actually read. In a
-fallback chain (e.g. text extraction returned nothing → render + read visually),
-report `text` if you used extracted text or `vision` if you read a rendered image.
-Only after verifying, call `unique-cli cite` with the verified page numbers (if any)
-and `--read-method`.
+Then determine `--read-method` by the **modality you actually read** — independent of
+how you located the page. In a fallback chain (e.g. text extraction returned nothing →
+render + read visually), report `text` if you used extracted text or `vision` if you read
+a rendered image. If you located the page via `unique-cli read` but read the cited value
+off a rendered image (a chart, figure, table, or scanned page), report `vision`, not
+`indexed`. Only after confirming the page numbers, call `unique-cli cite` with the
+verified page numbers (if any) and `--read-method`.
 
 - **One method per `cite` call.** If different pages were read with different methods, issue separate `cite` calls — one per method.
 - Numbers are **per-turn only**; do not reuse from prior turns.


### PR DESCRIPTION
## Summary

Fixes a self-contradiction in the `unique-cli-file-management` skill that could make the agent misdeclare `--read-method` for citations — grounding faithfulness checks on the wrong representation of a page.

The skill conflated two **orthogonal** axes:

1. **How a page was located** — via `unique-cli read` (trust the `[p.N]` physical positions, skip page-number verification) vs. parsing raw bytes yourself (verify pages).
2. **Which modality was actually read** — indexed chunk text / extracted text / rendered image → sets `--read-method`.

The old wording:
- Defined `indexed` as *"you relied on `unique-cli read` output"* (i.e. by how the page was obtained), and
- Drew a hard dichotomy (L250–255): cite from `unique-cli read` ⇒ `indexed` and skip checks, **otherwise** you read raw bytes ⇒ `text`/`vision` and verify.

That dichotomy has **no slot for the common hybrid**: locate a page via `unique-cli read`, then render it and read a **chart/figure/table** with vision. Following the guidance literally, the agent cites the visually-read figure as `indexed`, so the hallucination/faithfulness check reconstructs the page's **text** chunks as ground truth (`ground_truth_reconstruction.fetch_indexed_chunks`) — which lack the drawn values — and the cited claim is judged unsupported.

## What changed

`unique_sdk/unique_sdk/cli/skills/unique-cli-file-management/SKILL.md`:

- `--read-method` is now defined by the **modality actually read**, explicitly *independent of how the page was located*.
- `indexed` = *"you used the text returned by `unique-cli read` as your answer source"* (not merely located the page via it).
- Page-number verification is decoupled from `--read-method`: locating via `unique-cli read` only buys trust in the `[p.N]` positions; it does **not** force `indexed`.
- Added the hybrid carve-out: a figure read off a rendered image is `vision` **even when the page was located via `unique-cli read`**.

## Why this is doc-only and safe

- `--read-method` never enters the reference chip. In the monorepo runner, a cited file page becomes a `ContentReference` keyed on `contentId + page` (`_reference_for_file_source`); `read_method` only selects ground-truth reconstruction for the faithfulness judge (`text` → PyMuPDF text, `vision` → rendered PNG, `indexed` → platform chunks). So referencing/linking is identical regardless of method — this change only fixes which representation the faithfulness check grounds on.
- No code or test changes; `tests/cli/test_skills.py` asserts skill front-matter/commands, not this wording.

## Context

- Aligns the vendored skill with the already-correct guidance in `swappable_intelligence/agent_md.py`.
- Follow-up to the Bugbot review ("Conflicting citation read-method guidance") on Unique-AG/monorepo#27022.
- Introduced by #1895 (`feat(dci): cite read-method taxonomy`).

Ticket: UN-23250

## Test plan

- [ ] Rendered skill reads coherently; `indexed`/`text`/`vision` defined by modality.
- [ ] After a `unique-sdk` release + monorepo dependency bump, spot-check that a figure question located via `unique-cli read` is cited with `--read-method vision` and passes the faithfulness check.

Made with [Cursor](https://cursor.com)