### PR TITLE
fix(unique_sdk): keep crawl-error payloads out of the web-refs manifest [UN-23356]

### DIFF
--- a/unique_sdk/tests/cli/test_web_search.py
+++ b/unique_sdk/tests/cli/test_web_search.py
@@ -329,6 +329,33 @@ class TestCitationManifest:
         assert entry["error"] == "HTTP 403 while fetching URL"
         assert entry["snippet"] == "Total revenue decreased 12% YoY to $22.5B"
 
+    def test_error_content_with_redirected_url_is_kept_out_of_manifest(
+        self, tmp_path: Path
+    ) -> None:
+        """The URL inside the error payload can differ from the result URL
+        (redirects, trailing-slash/query normalization) — detection must not
+        depend on an exact URL match."""
+        manifest = tmp_path / ".unique" / "web-refs.jsonl"
+        payload = _make_search_payload(
+            results=[
+                {
+                    "url": "https://example.com/report.pdf",
+                    "title": "R",
+                    "snippet": "s",
+                    "content": (
+                        "URL: https://example.com/report.pdf?utm=x\n\n"
+                        "Error: HTTP 403 while fetching URL"
+                    ),
+                }
+            ]
+        )
+
+        _annotate_web_results_for_citations(payload, refs_log_path=manifest)
+
+        entry = json.loads(manifest.read_text(encoding="utf-8").splitlines()[0])
+        assert entry["content"] is None
+        assert entry["error"] == "HTTP 403 while fetching URL"
+
     def test_bare_error_content_is_kept_out_of_manifest(self, tmp_path: Path) -> None:
         """Tavily/Jina-style failures are a bare ``"Error: <message>"``."""
         manifest = tmp_path / ".unique" / "web-refs.jsonl"

--- a/unique_sdk/tests/cli/test_web_search.py
+++ b/unique_sdk/tests/cli/test_web_search.py
@@ -302,6 +302,97 @@ class TestCitationManifest:
             }
         ]
 
+    def test_fetch_error_content_is_kept_out_of_manifest(self, tmp_path: Path) -> None:
+        """UN-23356: in-band crawl failures (``"URL: <url>\\n\\nError: ..."``)
+        must not be manifested as ``content`` — the platform grounds the
+        hallucination judge on it. The message moves to ``error`` and the
+        snippet stays the citable ground truth."""
+        url = "https://example.com/TSLA-Q2-2025-Update.pdf"
+        payload = _make_search_payload(
+            results=[
+                {
+                    "url": url,
+                    "title": "Q2 2025 Update",
+                    "snippet": "Total revenue decreased 12% YoY to $22.5B",
+                    "content": f"URL: {url}\n\nError: HTTP 403 while fetching URL",
+                }
+            ]
+        )
+        manifest = tmp_path / ".unique" / "web-refs.jsonl"
+
+        annotated = _annotate_web_results_for_citations(payload, refs_log_path=manifest)
+
+        # The on-screen result keeps the error text so the agent can react.
+        assert "HTTP 403" in annotated["results"][0]["content"]
+        entry = json.loads(manifest.read_text(encoding="utf-8").splitlines()[0])
+        assert entry["content"] is None
+        assert entry["error"] == "HTTP 403 while fetching URL"
+        assert entry["snippet"] == "Total revenue decreased 12% YoY to $22.5B"
+
+    def test_bare_error_content_is_kept_out_of_manifest(self, tmp_path: Path) -> None:
+        """Tavily/Jina-style failures are a bare ``"Error: <message>"``."""
+        manifest = tmp_path / ".unique" / "web-refs.jsonl"
+        payload = _make_crawl_payload(
+            results=[
+                {
+                    "url": "https://example.com/a",
+                    "content": "Error: URL not found in response",
+                    "error": None,
+                }
+            ]
+        )
+
+        _annotate_web_results_for_citations(payload, refs_log_path=manifest)
+
+        entry = json.loads(manifest.read_text(encoding="utf-8").splitlines()[0])
+        assert entry["content"] is None
+        assert entry["error"] == "URL not found in response"
+
+    def test_explicit_error_field_wins_over_extracted_message(
+        self, tmp_path: Path
+    ) -> None:
+        """When the backend already reports a structured ``error``, keep it."""
+        url = "https://example.com/a"
+        manifest = tmp_path / ".unique" / "web-refs.jsonl"
+        payload = _make_crawl_payload(
+            results=[
+                {
+                    "url": url,
+                    "content": f"URL: {url}\n\nError: HTTP 403 while fetching URL",
+                    "error": "structured upstream error",
+                }
+            ]
+        )
+
+        _annotate_web_results_for_citations(payload, refs_log_path=manifest)
+
+        entry = json.loads(manifest.read_text(encoding="utf-8").splitlines()[0])
+        assert entry["content"] is None
+        assert entry["error"] == "structured upstream error"
+
+    def test_content_mentioning_error_mid_text_is_manifested(
+        self, tmp_path: Path
+    ) -> None:
+        """Real page text that merely mentions an error is normal content."""
+        body = "The service returned an Error: HTTP 403 for some users."
+        manifest = tmp_path / ".unique" / "web-refs.jsonl"
+        payload = _make_search_payload(
+            results=[
+                {
+                    "url": "https://example.com/a",
+                    "title": "A",
+                    "snippet": "s",
+                    "content": body,
+                }
+            ]
+        )
+
+        _annotate_web_results_for_citations(payload, refs_log_path=manifest)
+
+        entry = json.loads(manifest.read_text(encoding="utf-8").splitlines()[0])
+        assert entry["content"] == body
+        assert entry["error"] is None
+
     def test_reuses_source_number_for_crawled_url(self, tmp_path: Path) -> None:
         manifest = tmp_path / ".unique" / "web-refs.jsonl"
         _annotate_web_results_for_citations(

--- a/unique_sdk/unique_sdk/cli/commands/web_search.py
+++ b/unique_sdk/unique_sdk/cli/commands/web_search.py
@@ -67,6 +67,25 @@ def _next_source_number(entries: list[dict[str, Any]]) -> int:
     return max(source_numbers, default=0) + 1
 
 
+def _fetch_error_message(content: Any, url: str) -> str | None:
+    """Extract the failure message when ``content`` is a crawl-error payload.
+
+    The web-search backend reports per-URL fetch failures in-band: proxy
+    crawlers return ``"URL: <url>\\n\\nError: <message>"``, Tavily/Jina a
+    bare ``"Error: <message>"``. Returns the message for error payloads and
+    ``None`` for real page content.
+    """
+    if not isinstance(content, str):
+        return None
+    stripped = content.strip()
+    url_prefix = f"URL: {url}"
+    if stripped.startswith(url_prefix):
+        stripped = stripped[len(url_prefix) :].lstrip()
+    if stripped.startswith("Error:"):
+        return stripped[len("Error:") :].strip() or "unknown crawl error"
+    return None
+
+
 def _annotate_web_results_for_citations(
     payload: dict[str, Any],
     *,
@@ -78,6 +97,14 @@ def _annotate_web_results_for_citations(
     ``sourceNumber`` across consecutive ``search`` / ``crawl`` calls in
     the same turn, so the crawled-content row carries the same citation
     marker the search-snippet row already advertised.
+
+    Crawl-error payloads (``_fetch_error_message``) are kept out of the
+    manifest's ``content`` field and recorded under ``error`` instead: the
+    platform grounds the hallucination judge on manifest ``content``, so an
+    in-band fetch error stored as content turns a correctly cited,
+    snippet-verifiable source into a false "high hallucination" verdict
+    (UN-23356). The on-screen result still shows the error text so the
+    agent can react to the failed fetch.
     """
     refs_log_path = refs_log_path or (Path.cwd() / _WEB_REFS_LOG_RELATIVE_PATH)
     with _locked_turn_refs_manifest(
@@ -109,13 +136,19 @@ def _annotate_web_results_for_citations(
 
             result["sourceNumber"] = source_number
             result["citation"] = f"websource{source_number}"
+            content = result.get("content")
+            error = result.get("error")
+            fetch_error = _fetch_error_message(content, url)
+            if fetch_error is not None:
+                content = None
+                error = error or fetch_error
             manifest_entry = {
                 "sourceNumber": source_number,
                 "url": url,
                 "title": result.get("title"),
                 "snippet": result.get("snippet"),
-                "content": result.get("content"),
-                "error": result.get("error"),
+                "content": content,
+                "error": error,
             }
             _append_turn_refs_manifest_entry(refs_log_path, manifest_entry)
             annotated_results.append(result)

--- a/unique_sdk/unique_sdk/cli/commands/web_search.py
+++ b/unique_sdk/unique_sdk/cli/commands/web_search.py
@@ -67,20 +67,24 @@ def _next_source_number(entries: list[dict[str, Any]]) -> int:
     return max(source_numbers, default=0) + 1
 
 
-def _fetch_error_message(content: Any, url: str) -> str | None:
+def _fetch_error_message(content: Any) -> str | None:
     """Extract the failure message when ``content`` is a crawl-error payload.
 
     The web-search backend reports per-URL fetch failures in-band: proxy
     crawlers return ``"URL: <url>\\n\\nError: <message>"``, Tavily/Jina a
     bare ``"Error: <message>"``. Returns the message for error payloads and
     ``None`` for real page content.
+
+    Any leading ``URL: …`` line is skipped without matching it against the
+    result's own URL — redirects or normalization can make the reported URL
+    differ from the requested one.
     """
     if not isinstance(content, str):
         return None
     stripped = content.strip()
-    url_prefix = f"URL: {url}"
-    if stripped.startswith(url_prefix):
-        stripped = stripped[len(url_prefix) :].lstrip()
+    first_line, _, rest = stripped.partition("\n")
+    if first_line.startswith("URL:"):
+        stripped = rest.lstrip()
     if stripped.startswith("Error:"):
         return stripped[len("Error:") :].strip() or "unknown crawl error"
     return None
@@ -138,7 +142,7 @@ def _annotate_web_results_for_citations(
             result["citation"] = f"websource{source_number}"
             content = result.get("content")
             error = result.get("error")
-            fetch_error = _fetch_error_message(content, url)
+            fetch_error = _fetch_error_message(content)
             if fetch_error is not None:
                 content = None
                 error = error or fetch_error


### PR DESCRIPTION
## Summary

CLI-side half of the fix for [UN-23356](https://unique-ch.atlassian.net/browse/UN-23356) (unreliable Web Search citations / false high-hallucination verdicts in Conduct).

The web-search backend reports per-URL fetch failures **in-band** (`"URL: <url>\n\nError: HTTP 403 while fetching URL"` from the proxy crawlers, bare `"Error: <message>"` from Tavily/Jina). `unique-cli web-search` manifested that text verbatim as the result's `content` in `.unique/web-refs.jsonl` — and the platform grounds the hallucination judge on manifest `content`, preferring it over the snippet. Citing a fetch-blocked source (tesla.com 403s all crawlers) therefore produced a false *high hallucination* verdict even when the search snippet verified the claim.

## Changes

`_annotate_web_results_for_citations` now detects crawl-error payloads: the manifest entry gets `content: null` and the message recorded under `error` (an explicit structured `error` from the backend wins over the extracted message). The on-screen result is unchanged — the agent still sees the error text and can react to the failed fetch.

Companion PR (server-side root cause + runner defense): Unique-AG/monorepo#27264.

## Testing

- `uv run pytest tests/cli/test_web_search.py` → 102 passed (4 new manifest-hygiene tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[UN-23356]: https://unique-ch.atlassian.net/browse/UN-23356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ