### PR TITLE
improvement(monitoring): configurable HTTP latency buckets

### DIFF
--- a/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/monitoring/metrics.py
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/monitoring/metrics.py
@@ -21,9 +21,28 @@ def _linear_buckets(ceiling: float, steps: int) -> tuple[float, ...]:
     return tuple(round(step * i, 3) for i in range(1, steps + 1))
 
 
+def _exponential_buckets(start: float, ceiling: float, count: int) -> tuple[float, ...]:
+    """Geometric-progression latency buckets (seconds) from ``start`` to ``ceiling``.
+
+    Yields ``count`` upper bounds ``start, start*factor, ..., ceiling`` where the
+    factor is derived so the last bucket lands exactly on ``ceiling``. Relative
+    resolution is constant across the range, which suits latencies spanning several
+    orders of magnitude: fine sub-second buckets at the low end without spending
+    dozens of buckets to reach the ceiling. Like ``_linear_buckets``, observations
+    above ``ceiling`` land in the implicit +Inf bucket and histogram_quantile
+    cannot resolve past the largest finite bucket.
+    """
+    factor = (ceiling / start) ** (1 / (count - 1))
+    return tuple(round(start * factor**i, 3) for i in range(count))
+
+
 _SEARCH_LATENCY_BUCKETS = _linear_buckets(ceiling=5.0, steps=20)
 _CRAWL_LATENCY_BUCKETS = _linear_buckets(ceiling=60.0, steps=20)
 _AGENT_SEARCH_LATENCY_BUCKETS = _linear_buckets(ceiling=120.0, steps=20)
+
+# One histogram covers every endpoint, from sub-second /v1/search to /v1/agent-search
+# runs approaching 120s — exponential buckets keep resolution useful at both ends.
+HTTP_LATENCY_BUCKETS = _exponential_buckets(start=0.05, ceiling=120.0, count=20)
 
 search_duration_seconds = m.histogram(
     "search_duration_seconds",

--- a/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/monitoring/setup.py
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/unique_search_proxy_client/web/monitoring/setup.py
@@ -6,6 +6,7 @@ from fastapi import FastAPI
 from fastapi.responses import PlainTextResponse
 
 import unique_search_proxy_client.web.settings.monitoring as monitoring_settings
+from unique_search_proxy_client.web.monitoring.metrics import HTTP_LATENCY_BUCKETS
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -36,7 +37,11 @@ def setup_prometheus(app: FastAPI) -> bool:
         )
         return False
 
-    app.add_middleware(MetricsMiddleware, excluded_paths=set(_METRICS_EXCLUDED_PATHS))
+    app.add_middleware(
+        MetricsMiddleware,
+        excluded_paths=set(_METRICS_EXCLUDED_PATHS),
+        duration_buckets=HTTP_LATENCY_BUCKETS,
+    )
 
     @app.get("/metrics", include_in_schema=False)
     async def metrics_endpoint() -> PlainTextResponse:

--- a/unique_toolkit/tests/monitoring/test_middleware.py
+++ b/unique_toolkit/tests/monitoring/test_middleware.py
@@ -269,15 +269,60 @@ def test_middleware__emits_python_prefixed_metric_names() -> None:
     Purpose: Verify MetricsMiddleware emits metrics with the python_ prefix.
     Why this matters: Grafana dashboards are built on python_http_* names; the old
     unprefixed names must not appear so cross-service naming is consistent.
-    Setup summary: Inspect the module-level metric objects for their fully-qualified name.
+    Setup summary: Construct a middleware (the duration histogram is created lazily),
+    then inspect the metric objects for their fully-qualified name.
     """
-    assert (
-        middleware_module._http_request_duration_seconds._name
-        == "python_http_request_duration_seconds"
-    )
+    middleware = MetricsMiddleware(_simple_app)
+
+    assert middleware._duration._name == "python_http_request_duration_seconds"
     # prometheus_client strips the _total suffix from Counter._name (it appends it at render time)
     assert middleware_module._http_requests_total._name == "python_http_requests"
     assert (
         middleware_module._http_requests_in_progress._name
         == "python_http_requests_in_progress"
     )
+
+
+# ---------------------------------------------------------------------------
+# Duration histogram buckets
+# ---------------------------------------------------------------------------
+
+
+def _finite_bounds(histogram) -> tuple[float, ...]:
+    return tuple(b for b in histogram._upper_bounds if b != float("inf"))
+
+
+@pytest.mark.ai
+def test_middleware__applies_custom_duration_buckets__on_first_construction() -> None:
+    """
+    Purpose: Verify duration_buckets sets the latency histogram buckets when the
+    histogram is created (first middleware construction in the process).
+    Why this matters: prometheus defaults top out at a 10s finite bucket, pinning
+    histogram_quantile p95/p99 at 10s for services with slower endpoints.
+    Setup summary: Reset the lazy singleton, construct with a 120s ceiling, assert
+    the finite upper bounds match; restore prior state afterwards.
+    """
+    from unique_toolkit.monitoring.registry import REGISTRY
+
+    buckets = (0.5, 1.0, 5.0, 30.0, 120.0)
+    previous = middleware_module._http_request_duration_seconds
+    if previous is not None:
+        REGISTRY.unregister(previous)
+    middleware_module._http_request_duration_seconds = None
+
+    try:
+        middleware = MetricsMiddleware(_simple_app, duration_buckets=buckets)
+
+        assert _finite_bounds(middleware._duration) == buckets
+
+        # The histogram is a per-process singleton: later constructions reuse it,
+        # so their duration_buckets are ignored.
+        second = MetricsMiddleware(_simple_app, duration_buckets=(1.0, 2.0))
+        assert second._duration is middleware._duration
+    finally:
+        created = middleware_module._http_request_duration_seconds
+        if created is not None:
+            REGISTRY.unregister(created)
+        middleware_module._http_request_duration_seconds = previous
+        if previous is not None:
+            REGISTRY.register(previous)

--- a/unique_toolkit/unique_toolkit/monitoring/middleware.py
+++ b/unique_toolkit/unique_toolkit/monitoring/middleware.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import time
+from collections.abc import Sequence
 
 from prometheus_client import (  # pyright: ignore[reportMissingImports]
     Counter,
@@ -16,12 +17,6 @@ _http_requests_total = Counter(
     ["method", "path", "status_code"],
     registry=REGISTRY,
 )
-_http_request_duration_seconds = Histogram(
-    "python_http_request_duration_seconds",
-    "HTTP request duration",
-    ["method", "path"],
-    registry=REGISTRY,
-)
 _http_requests_in_progress = Gauge(
     "python_http_requests_in_progress",
     "In-flight HTTP requests",
@@ -29,6 +24,35 @@ _http_requests_in_progress = Gauge(
     registry=REGISTRY,
     multiprocess_mode="livesum",
 )
+
+# Created lazily on first MetricsMiddleware construction so services can choose the
+# bucket layout. Prometheus allows a metric name to be registered only once per
+# registry, so the buckets passed to the first middleware win for the process.
+_http_request_duration_seconds: Histogram | None = None
+
+
+def _get_or_create_duration_histogram(
+    buckets: Sequence[float] | None,
+) -> Histogram:
+    global _http_request_duration_seconds
+    if _http_request_duration_seconds is None:
+        if buckets is None:
+            _http_request_duration_seconds = Histogram(
+                "python_http_request_duration_seconds",
+                "HTTP request duration",
+                ["method", "path"],
+                registry=REGISTRY,
+            )
+        else:
+            _http_request_duration_seconds = Histogram(
+                "python_http_request_duration_seconds",
+                "HTTP request duration",
+                ["method", "path"],
+                registry=REGISTRY,
+                buckets=tuple(buckets),
+            )
+    return _http_request_duration_seconds
+
 
 _DEFAULT_EXCLUDED_PATHS = frozenset({"/health", "/metrics", "/"})
 
@@ -51,13 +75,29 @@ class MetricsMiddleware:
 
         # Quart
         app.asgi_app = MetricsMiddleware(app.asgi_app)
+
+    ``duration_buckets`` overrides the latency histogram buckets (seconds). Without
+    it, prometheus_client's defaults apply and their top finite bucket is 10s —
+    histogram_quantile cannot resolve past the largest finite bucket, so services
+    with slower endpoints should pass buckets covering their full latency range::
+
+        app.add_middleware(MetricsMiddleware, duration_buckets=(1, 5, 30, 60, 120))
+
+    The histogram is registered once per process; the buckets of the first
+    constructed middleware apply.
     """
 
-    def __init__(self, app, excluded_paths: set[str] | None = None):
+    def __init__(
+        self,
+        app,
+        excluded_paths: set[str] | None = None,
+        duration_buckets: Sequence[float] | None = None,
+    ):
         self.app = app
         self._excluded_paths = (
             excluded_paths if excluded_paths is not None else _DEFAULT_EXCLUDED_PATHS
         )
+        self._duration = _get_or_create_duration_histogram(duration_buckets)
 
     async def __call__(self, scope, receive, send):
         # Pass through non-HTTP (WebSocket, lifespan)
@@ -87,9 +127,7 @@ class MetricsMiddleware:
         finally:
             duration = time.perf_counter() - start
             _http_requests_in_progress.labels(method=method).dec()
-            _http_request_duration_seconds.labels(method=method, path=path).observe(
-                duration
-            )
+            self._duration.labels(method=method, path=path).observe(duration)
             _http_requests_total.labels(
                 method=method, path=path, status_code=status_code
             ).inc()


### PR DESCRIPTION
## Summary
- The search-proxy Grafana dashboard showed HTTP p95/p99 latency capped at 10s: `prometheus_client`'s default histogram buckets end at a 10s finite bucket, and `histogram_quantile` cannot resolve past the largest finite bucket.
- `MetricsMiddleware` in `unique_toolkit` now accepts an optional `duration_buckets` parameter so each service can size the `python_http_request_duration_seconds` buckets to its own latency profile.
- The search proxy passes exponential buckets from 50ms to 120s, covering everything from sub-second `/v1/search` calls to `/v1/agent-search` runs approaching the 120s timeout.

## Changes
- `unique_toolkit/monitoring/middleware.py` — the duration histogram is now created lazily on first `MetricsMiddleware` construction (per-process singleton, since a metric name can only be registered once per registry); `duration_buckets` overrides the bucket layout, defaults unchanged when omitted.
- `unique_search_proxy_client/web/monitoring/metrics.py` — new `_exponential_buckets(start, ceiling, count)` helper (geometric progression, factor derived so the last bucket lands exactly on the ceiling) and `HTTP_LATENCY_BUCKETS = _exponential_buckets(start=0.05, ceiling=120.0, count=20)`.
- `unique_search_proxy_client/web/monitoring/setup.py` — passes `HTTP_LATENCY_BUCKETS` to `MetricsMiddleware`.
- `unique_toolkit/tests/monitoring/test_middleware.py` — covers custom buckets on first construction and the singleton reuse behavior.

## Test plan
- [x] `uv run pytest unique_toolkit/tests/monitoring/test_middleware.py` — 11 passed
- [x] `uv run pytest tests/test_monitoring.py` (search-proxy) — 4 passed
- [x] Sanity-checked generated buckets: 20 strictly increasing bounds, 0.05 → 120.0
- [x] `ruff check` / `ruff format` clean

## Risk / rollout
- Behavior for all other `unique_toolkit` consumers is unchanged: without `duration_buckets` the histogram uses prometheus defaults exactly as before, only its creation moved from import time to first middleware construction.
- Changing bucket boundaries on the proxy resets `_bucket` series; Grafana quantiles are computed from `rate()` so panels recover within one scrape/rate window after deploy.

Made with [Cursor](https://cursor.com)