### PR TITLE
feat(search-proxy): place dashboard under connectors [UN-23444]

### DIFF
--- a/connectors/unique_search_proxy/unique_search_proxy_client/deploy/helm-chart/values.schema.json
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/deploy/helm-chart/values.schema.json
@@ -1384,6 +1384,14 @@
                 false
               ]
             },
+            "folder": {
+              "type": "string",
+              "description": "Grafana folder for provisioned dashboards (ConfigMap annotation grafana_folder). Defaults to apps.",
+              "examples": [
+                "apps",
+                "connectors"
+              ]
+            },
             "replacements": {
               "type": "object",
               "description": "Map of placeholder to resolved datasource UID. Dashboard JSON files should use %%PLACEHOLDER%% markers (e.g. %%PROMETHEUS_UID%%) instead of hardcoded UIDs. Each entry replaces a marker with the actual UID before the ConfigMap is rendered. The dedicated chart sets defaults; customer overlays override per tenant.",

--- a/connectors/unique_search_proxy/unique_search_proxy_client/deploy/helm-chart/values.yaml
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/deploy/helm-chart/values.yaml
@@ -215,6 +215,7 @@ pdb:
 grafana:
   dashboards:
     enabled: true
+    folder: connectors
     replacements:
       '%%PROMETHEUS_UID%%': prometheus
 


### PR DESCRIPTION
## Summary

- configure the Search Proxy dashboard to use Grafana's `connectors` folder
- extend the chart schema with the shared `grafana.dashboards.folder` field
- group Search Proxy with the existing Confluence and SharePoint connector dashboards instead of the generic `apps` folder

## Changes

- `deploy/helm-chart/values.yaml`: set `grafana.dashboards.folder: connectors`
- `deploy/helm-chart/values.schema.json`: accept and document the folder setting

## Test plan

- [x] `git diff --check`
- [ ] bump the base chart dependency after https://github.com/Unique-AG/monorepo/pull/27330 is merged and the new base version is published
- [ ] render the updated chart and verify the dashboard ConfigMap contains `grafana_folder: connectors`

## Risk / rollout

This PR is intentionally a draft. The currently referenced base chart still hardcodes `apps`, so this configuration is ignored until the dependency is bumped to a version containing monorepo PR #27330. Existing dashboards are unaffected because the base capability retains `apps` as its default.

Refs: UN-23444

Made with [Cursor](https://cursor.com)