### PR TITLE
fix: user memory message logs

### DIFF
--- a/postprocessors/unique_user_memory/README.md
+++ b/postprocessors/unique_user_memory/README.md
@@ -10,7 +10,7 @@ The package provides:
 
 - `UserMemoryConfig` - Pydantic configuration for the consolidation model, profile token budget, and memory folder.
 - `load_user_memory(...)` - resolves the user's private memory folder, downloads `memory.md`, and enforces the configured token budget. The `language_model` argument is used to tokenize `memory.md` when capping it, so it must be the same effective model the postprocessor uses for consolidation (see Integration below). Returns a `UserMemoryState` with the profile text and scope id.
-- `UserMemoryMessageLogger` - emits chat Steps (MessageLogs) for load and update, including clickable pills that open Settings → Context Memory via `unique://settings/context-memory`.
+- `UserMemoryMessageLogger` - emits chat Steps (MessageLogs) for load and update, including typed `UserMemory` detail entries the chat frontend renders as a badge that opens Settings → Context Memory. Frontends that do not know the entry type render nothing, so the entries are safe to emit in any deploy order.
 - `UserMemoryPostprocessor` - runs after the assistant response, consolidates the latest turn into the profile, and uploads the updated `memory.md`.
 
 The memory file is intentionally small and structured. It is rewritten as a full Markdown profile rather than appended to as an event log.
@@ -19,12 +19,12 @@ The memory file is intentionally small and structured. It is rewritten as a full
 
 1. The orchestrator enables memory when `space.allow_user_memory` is true.
 2. The orchestrator emits a **Loading context memory** Step, then `load_user_memory(...)` resolves the pre-provisioned root folder, ensures a private child folder for the current user, and downloads `/user-memory/<user_id>/memory.md` if it exists.
-3. When load returns a `UserMemoryState`, that Step is completed with a **Context memory** pill (`unique://settings/context-memory`) that opens Settings → Context Memory. A successful `None` return (soft skip) completes the Step without a pill; a raised exception marks the Step failed.
+3. When load returns a `UserMemoryState`, that Step is completed with a **Context memory** detail entry (`type: UserMemory`) that the chat frontend renders as a badge opening Settings → Context Memory. A successful `None` return (soft skip) completes the Step without the entry; a raised exception marks the Step failed.
 4. If memory was loaded, its text is passed into the agent context for the current turn.
 5. `UserMemoryPostprocessor` runs after the assistant response.
 6. The package asks the configured language model to either return `NOOP` or a complete rewritten profile.
-7. If a rewrite runs, an **Updating your memory** Step is shown while consolidating (no pill yet).
-8. If the profile changed and `memory.md` uploads successfully (ingestion skipped, content hidden from chat), that Step is completed with a **Review your context memory** pill (same settings link). On NOOP or failed upload the Step completes without a pill.
+7. If a rewrite runs, an **Updating your memory** Step is shown while consolidating (no settings entry yet).
+8. If the profile changed and `memory.md` uploads successfully (ingestion skipped, content hidden from chat), that Step is completed with a **Review your context memory** detail entry (same settings badge). On NOOP or failed upload the Step completes without the entry.
 
 ## Storage Model
 
@@ -142,7 +142,7 @@ finally:
         await memory_message_logger.log_loading_failed()
 
 if load_succeeded and user_memory_state is not None:
-    await memory_message_logger.log_loading_complete(with_pill=True)
+    await memory_message_logger.log_loading_complete(with_settings_entry=True)
     user_memory_text = user_memory_state.text
     postprocessor_manager.add_postprocessor(
         UserMemoryPostprocessor(
@@ -156,7 +156,7 @@ if load_succeeded and user_memory_state is not None:
         )
     )
 elif load_succeeded:
-    await memory_message_logger.log_loading_complete(with_pill=False)
+    await memory_message_logger.log_loading_complete(with_settings_entry=False)
 ```
 
 Note that `UserMemoryPostprocessor` re-derives the effective model internally from `use_orchestrator_language_model`, so passing `memory_language_model` (rather than the raw orchestrator model) keeps its behavior identical while ensuring `load_user_memory` caps with the matching tokenizer.

--- a/postprocessors/unique_user_memory/README.md
+++ b/postprocessors/unique_user_memory/README.md
@@ -114,11 +114,11 @@ memory_language_model = (
 )
 
 message_step_logger = MessageStepLogger(chat_service)
-memory_message_logger = UserMemoryMessageLogger(
+memory_message_step_logger = UserMemoryMessageLogger(
     message_step_logger,
     logger=logger,
 )
-await memory_message_logger.log_loading_start()
+await memory_message_step_logger.log_loading_start()
 user_memory_state = None
 load_succeeded = False
 try:
@@ -139,10 +139,10 @@ finally:
     # Always close the RUNNING step — otherwise the chat Steps UI stays stuck
     # on "Loading context memory" for that turn when load raises.
     if not load_succeeded:
-        await memory_message_logger.log_loading_failed()
+        await memory_message_step_logger.log_loading_failed()
 
 if load_succeeded and user_memory_state is not None:
-    await memory_message_logger.log_loading_complete(with_settings_entry=True)
+    await memory_message_step_logger.log_loading_complete(with_settings_entry=True)
     user_memory_text = user_memory_state.text
     postprocessor_manager.add_postprocessor(
         UserMemoryPostprocessor(
@@ -151,12 +151,11 @@ if load_succeeded and user_memory_state is not None:
             event=event,
             state=user_memory_state,
             logger=logger,
-            chat_service=chat_service,
-            message_logger=memory_message_logger,
+            message_step_logger=memory_message_step_logger,
         )
     )
 elif load_succeeded:
-    await memory_message_logger.log_loading_complete(with_settings_entry=False)
+    await memory_message_step_logger.log_loading_complete(with_settings_entry=False)
 ```
 
 Note that `UserMemoryPostprocessor` re-derives the effective model internally from `use_orchestrator_language_model`, so passing `memory_language_model` (rather than the raw orchestrator model) keeps its behavior identical while ensuring `load_user_memory` caps with the matching tokenizer.

--- a/postprocessors/unique_user_memory/README.md
+++ b/postprocessors/unique_user_memory/README.md
@@ -19,8 +19,8 @@ The memory file is intentionally small and structured. It is rewritten as a full
 
 1. The orchestrator enables memory when `space.allow_user_memory` is true.
 2. The orchestrator emits a **Loading context memory** Step, then `load_user_memory(...)` resolves the pre-provisioned root folder, ensures a private child folder for the current user, and downloads `/user-memory/<user_id>/memory.md` if it exists.
-3. When load succeeds, that Step is completed with a **Context memory** pill (`unique://settings/context-memory`) that opens Settings → Context Memory.
-4. The loaded memory text is passed into the agent context for the current turn.
+3. When load returns a `UserMemoryState`, that Step is completed with a **Context memory** pill (`unique://settings/context-memory`) that opens Settings → Context Memory. A successful `None` return (soft skip) completes the Step without a pill; a raised exception marks the Step failed.
+4. If memory was loaded, its text is passed into the agent context for the current turn.
 5. `UserMemoryPostprocessor` runs after the assistant response.
 6. The package asks the configured language model to either return `NOOP` or a complete rewritten profile.
 7. If a rewrite runs, an **Updating your memory** Step is shown while consolidating (no pill yet).

--- a/postprocessors/unique_user_memory/README.md
+++ b/postprocessors/unique_user_memory/README.md
@@ -23,8 +23,8 @@ The memory file is intentionally small and structured. It is rewritten as a full
 4. The loaded memory text is passed into the agent context for the current turn.
 5. `UserMemoryPostprocessor` runs after the assistant response.
 6. The package asks the configured language model to either return `NOOP` or a complete rewritten profile.
-7. If a rewrite runs, an **Updating your memory** Step is shown with a **Review your context memory** pill (same settings link).
-8. If the profile changed, `memory.md` is uploaded back to the user's folder with ingestion skipped and the content hidden from chat.
+7. If a rewrite runs, an **Updating your memory** Step is shown while consolidating (no pill yet).
+8. If the profile changed and `memory.md` uploads successfully (ingestion skipped, content hidden from chat), that Step is completed with a **Review your context memory** pill (same settings link). On NOOP or failed upload the Step completes without a pill.
 
 ## Storage Model
 
@@ -119,14 +119,29 @@ memory_message_logger = UserMemoryMessageLogger(
     logger=logger,
 )
 await memory_message_logger.log_loading_start()
-user_memory_state = await load_user_memory(
-    event=event,
-    config=user_memory_config,
-    language_model=memory_language_model,
-    logger=logger,
-)
+user_memory_state = None
+load_succeeded = False
+try:
+    user_memory_state = await load_user_memory(
+        event=event,
+        config=user_memory_config,
+        language_model=memory_language_model,
+        logger=logger,
+    )
+    load_succeeded = True
+except Exception as exc:
+    logger.warning(
+        "[user-memory] load raised - running without memory: [%s] %s",
+        type(exc).__name__,
+        exc,
+    )
+finally:
+    # Always close the RUNNING step — otherwise the chat Steps UI stays stuck
+    # on "Loading context memory" for that turn when load raises.
+    if not load_succeeded:
+        await memory_message_logger.log_loading_failed()
 
-if user_memory_state is not None:
+if load_succeeded and user_memory_state is not None:
     await memory_message_logger.log_loading_complete(with_pill=True)
     user_memory_text = user_memory_state.text
     postprocessor_manager.add_postprocessor(
@@ -140,7 +155,7 @@ if user_memory_state is not None:
             message_logger=memory_message_logger,
         )
     )
-else:
+elif load_succeeded:
     await memory_message_logger.log_loading_complete(with_pill=False)
 ```
 

--- a/postprocessors/unique_user_memory/README.md
+++ b/postprocessors/unique_user_memory/README.md
@@ -10,7 +10,7 @@ The package provides:
 
 - `UserMemoryConfig` - Pydantic configuration for the consolidation model, profile token budget, and memory folder.
 - `load_user_memory(...)` - resolves the user's private memory folder, downloads `memory.md`, and enforces the configured token budget. The `language_model` argument is used to tokenize `memory.md` when capping it, so it must be the same effective model the postprocessor uses for consolidation (see Integration below). Returns a `UserMemoryState` that includes the profile text and, when present, the `memory.md` content id.
-- `UserMemoryMessageLogger` - emits chat Steps (MessageLogs) for load and update, including clickable pills that link to `memory.md` via `unique://content/<id>`.
+- `UserMemoryMessageLogger` - emits chat Steps (MessageLogs) for load and update, including clickable pills that open Settings → Context Memory via `unique://settings/context-memory`.
 - `UserMemoryPostprocessor` - runs after the assistant response, consolidates the latest turn into the profile, and uploads the updated `memory.md`.
 
 The memory file is intentionally small and structured. It is rewritten as a full Markdown profile rather than appended to as an event log.
@@ -19,11 +19,11 @@ The memory file is intentionally small and structured. It is rewritten as a full
 
 1. The orchestrator enables memory when `space.allow_user_memory` is true.
 2. The orchestrator emits a **Loading context memory** Step, then `load_user_memory(...)` resolves the pre-provisioned root folder, ensures a private child folder for the current user, and downloads `/user-memory/<user_id>/memory.md` if it exists.
-3. When `memory.md` exists, that Step is completed with a **Context memory** pill linking to that file.
+3. When load succeeds, that Step is completed with a **Context memory** pill (`unique://settings/context-memory`) that opens Settings → Context Memory.
 4. The loaded memory text is passed into the agent context for the current turn.
 5. `UserMemoryPostprocessor` runs after the assistant response.
 6. The package asks the configured language model to either return `NOOP` or a complete rewritten profile.
-7. If a rewrite runs, an **Updating your memory** Step is shown (with a **Review your context memory** pill when a content id is known).
+7. If a rewrite runs, an **Updating your memory** Step is shown with a **Review your context memory** pill (same settings link).
 8. If the profile changed, `memory.md` is uploaded back to the user's folder with ingestion skipped and the content hidden from chat.
 
 ## Storage Model
@@ -127,9 +127,7 @@ user_memory_state = await load_user_memory(
 )
 
 if user_memory_state is not None:
-    await memory_message_logger.log_loading_complete(
-        content_id=user_memory_state.content_id,
-    )
+    await memory_message_logger.log_loading_complete(with_pill=True)
     user_memory_text = user_memory_state.text
     postprocessor_manager.add_postprocessor(
         UserMemoryPostprocessor(
@@ -143,7 +141,7 @@ if user_memory_state is not None:
         )
     )
 else:
-    await memory_message_logger.log_loading_complete(content_id=None)
+    await memory_message_logger.log_loading_complete(with_pill=False)
 ```
 
 Note that `UserMemoryPostprocessor` re-derives the effective model internally from `use_orchestrator_language_model`, so passing `memory_language_model` (rather than the raw orchestrator model) keeps its behavior identical while ensuring `load_user_memory` caps with the matching tokenizer.

--- a/postprocessors/unique_user_memory/README.md
+++ b/postprocessors/unique_user_memory/README.md
@@ -9,7 +9,7 @@ Persistent per-user memory for Unique AI agents.
 The package provides:
 
 - `UserMemoryConfig` - Pydantic configuration for the consolidation model, profile token budget, and memory folder.
-- `load_user_memory(...)` - resolves the user's private memory folder, downloads `memory.md`, and enforces the configured token budget. The `language_model` argument is used to tokenize `memory.md` when capping it, so it must be the same effective model the postprocessor uses for consolidation (see Integration below). Returns a `UserMemoryState` that includes the profile text and, when present, the `memory.md` content id.
+- `load_user_memory(...)` - resolves the user's private memory folder, downloads `memory.md`, and enforces the configured token budget. The `language_model` argument is used to tokenize `memory.md` when capping it, so it must be the same effective model the postprocessor uses for consolidation (see Integration below). Returns a `UserMemoryState` with the profile text and scope id.
 - `UserMemoryMessageLogger` - emits chat Steps (MessageLogs) for load and update, including clickable pills that open Settings → Context Memory via `unique://settings/context-memory`.
 - `UserMemoryPostprocessor` - runs after the assistant response, consolidates the latest turn into the profile, and uploads the updated `memory.md`.
 

--- a/postprocessors/unique_user_memory/README.md
+++ b/postprocessors/unique_user_memory/README.md
@@ -9,7 +9,8 @@ Persistent per-user memory for Unique AI agents.
 The package provides:
 
 - `UserMemoryConfig` - Pydantic configuration for the consolidation model, profile token budget, and memory folder.
-- `load_user_memory(...)` - resolves the user's private memory folder, downloads `memory.md`, and enforces the configured token budget. The `language_model` argument is used to tokenize `memory.md` when capping it, so it must be the same effective model the postprocessor uses for consolidation (see Integration below).
+- `load_user_memory(...)` - resolves the user's private memory folder, downloads `memory.md`, and enforces the configured token budget. The `language_model` argument is used to tokenize `memory.md` when capping it, so it must be the same effective model the postprocessor uses for consolidation (see Integration below). Returns a `UserMemoryState` that includes the profile text and, when present, the `memory.md` content id.
+- `UserMemoryMessageLogger` - emits chat Steps (MessageLogs) for load and update, including clickable pills that link to `memory.md` via `unique://content/<id>`.
 - `UserMemoryPostprocessor` - runs after the assistant response, consolidates the latest turn into the profile, and uploads the updated `memory.md`.
 
 The memory file is intentionally small and structured. It is rewritten as a full Markdown profile rather than appended to as an event log.
@@ -17,11 +18,13 @@ The memory file is intentionally small and structured. It is rewritten as a full
 ## Lifecycle
 
 1. The orchestrator enables memory when `space.allow_user_memory` is true.
-2. `load_user_memory(...)` resolves the pre-provisioned root folder, ensures a private child folder for the current user, and downloads `/user-memory/<user_id>/memory.md` if it exists.
-3. The loaded memory text is passed into the agent context for the current turn.
-4. `UserMemoryPostprocessor` runs after the assistant response.
-5. The package asks the configured language model to either return `NOOP` or a complete rewritten profile.
-6. If the profile changed, `memory.md` is uploaded back to the user's folder with ingestion skipped and the content hidden from chat.
+2. The orchestrator emits a **Loading context memory** Step, then `load_user_memory(...)` resolves the pre-provisioned root folder, ensures a private child folder for the current user, and downloads `/user-memory/<user_id>/memory.md` if it exists.
+3. When `memory.md` exists, that Step is completed with a **Context memory** pill linking to that file.
+4. The loaded memory text is passed into the agent context for the current turn.
+5. `UserMemoryPostprocessor` runs after the assistant response.
+6. The package asks the configured language model to either return `NOOP` or a complete rewritten profile.
+7. If a rewrite runs, an **Updating your memory** Step is shown (with a **Review your context memory** pill when a content id is known).
+8. If the profile changed, `memory.md` is uploaded back to the user's folder with ingestion skipped and the content hidden from chat.
 
 ## Storage Model
 
@@ -95,7 +98,9 @@ Typical orchestration code loads memory before the agent loop and registers the 
 `load_user_memory` and `UserMemoryPostprocessor` must be given the **same** effective language model: the postprocessor consolidates memory with either the orchestrator model or the configured one depending on `use_orchestrator_language_model`, and load-time token capping must use that same model so the loaded baseline is tokenized the way consolidation expects. Resolve the effective model once and pass it to both:
 
 ```python
+from unique_toolkit.agentic.message_log_manager.service import MessageStepLogger
 from unique_user_memory.user_memory import load_user_memory
+from unique_user_memory.user_memory_message_log import UserMemoryMessageLogger
 from unique_user_memory.user_memory_postprocessor import UserMemoryPostprocessor
 
 user_memory_config = config.agent.services.user_memory_config
@@ -108,6 +113,12 @@ memory_language_model = (
     else user_memory_config.language_model
 )
 
+message_step_logger = MessageStepLogger(chat_service)
+memory_message_logger = UserMemoryMessageLogger(
+    message_step_logger,
+    logger=logger,
+)
+await memory_message_logger.log_loading_start()
 user_memory_state = await load_user_memory(
     event=event,
     config=user_memory_config,
@@ -116,6 +127,9 @@ user_memory_state = await load_user_memory(
 )
 
 if user_memory_state is not None:
+    await memory_message_logger.log_loading_complete(
+        content_id=user_memory_state.content_id,
+    )
     user_memory_text = user_memory_state.text
     postprocessor_manager.add_postprocessor(
         UserMemoryPostprocessor(
@@ -124,8 +138,12 @@ if user_memory_state is not None:
             event=event,
             state=user_memory_state,
             logger=logger,
+            chat_service=chat_service,
+            message_logger=memory_message_logger,
         )
     )
+else:
+    await memory_message_logger.log_loading_complete(content_id=None)
 ```
 
 Note that `UserMemoryPostprocessor` re-derives the effective model internally from `use_orchestrator_language_model`, so passing `memory_language_model` (rather than the raw orchestrator model) keeps its behavior identical while ensuring `load_user_memory` caps with the matching tokenizer.

--- a/postprocessors/unique_user_memory/unique_user_memory/config.py
+++ b/postprocessors/unique_user_memory/unique_user_memory/config.py
@@ -42,14 +42,6 @@ class UserMemoryConfig(BaseModel):
             "runs."
         ),
     )
-    updating_notice_enabled: bool = Field(
-        default=True,
-        description=(
-            "When true, a transient 'updating context memory' notice is appended to the "
-            "assistant message while the memory rewrite runs, and removed "
-            "again once it completes."
-        ),
-    )
     root_folder: Annotated[str, RJSFMetaTag.SpecialWidget.hidden()] = Field(
         default="user-memory",
         min_length=1,

--- a/postprocessors/unique_user_memory/unique_user_memory/tests/test_user_memory.py
+++ b/postprocessors/unique_user_memory/unique_user_memory/tests/test_user_memory.py
@@ -680,15 +680,13 @@ async def test_consolidate_user_memory_invokes_update_end_when_start_cancelled(
 
 
 @pytest.mark.asyncio
-async def test_user_memory_message_logger_load_emits_pill_when_content_id_present() -> (
-    None
-):
+async def test_user_memory_message_logger_load_emits_settings_pill() -> None:
     step_logger = MagicMock()
     step_logger.create_or_update_message_log_async = AsyncMock(return_value=MagicMock())
     message_logger = UserMemoryMessageLogger(step_logger)
 
     await message_logger.log_loading_start()
-    await message_logger.log_loading_complete(content_id="content_1")
+    await message_logger.log_loading_complete(with_pill=True)
 
     assert step_logger.create_or_update_message_log_async.await_count == 2
     start_kwargs = step_logger.create_or_update_message_log_async.await_args_list[
@@ -701,16 +699,17 @@ async def test_user_memory_message_logger_load_emits_pill_when_content_id_presen
     ].kwargs
     assert complete_kwargs["status"] == MessageLogStatus.COMPLETED
     assert complete_kwargs["references"][0].name == "Context memory"
-    assert complete_kwargs["references"][0].url == "unique://content/content_1"
+    assert complete_kwargs["references"][0].source == "context-memory"
+    assert complete_kwargs["references"][0].url == "unique://settings/context-memory"
 
 
 @pytest.mark.asyncio
-async def test_user_memory_message_logger_load_skips_pill_without_content_id() -> None:
+async def test_user_memory_message_logger_load_skips_pill_when_disabled() -> None:
     step_logger = MagicMock()
     step_logger.create_or_update_message_log_async = AsyncMock(return_value=MagicMock())
     message_logger = UserMemoryMessageLogger(step_logger)
 
-    await message_logger.log_loading_complete(content_id=None)
+    await message_logger.log_loading_complete(with_pill=False)
 
     complete_kwargs = step_logger.create_or_update_message_log_async.await_args.kwargs
     assert complete_kwargs["references"] == []
@@ -722,8 +721,8 @@ async def test_user_memory_message_logger_update_attaches_review_pill() -> None:
     step_logger.create_or_update_message_log_async = AsyncMock(return_value=MagicMock())
     message_logger = UserMemoryMessageLogger(step_logger)
 
-    await message_logger.log_updating_start(content_id="content_1")
-    await message_logger.log_updating_complete(content_id="content_1")
+    await message_logger.log_updating_start()
+    await message_logger.log_updating_complete()
 
     assert step_logger.create_or_update_message_log_async.await_count == 2
     start_kwargs = step_logger.create_or_update_message_log_async.await_args_list[
@@ -731,7 +730,8 @@ async def test_user_memory_message_logger_update_attaches_review_pill() -> None:
     ].kwargs
     assert start_kwargs["header"] == "Updating your memory"
     assert start_kwargs["references"][0].name == "Review your context memory"
-    assert start_kwargs["references"][0].url == "unique://content/content_1"
+    assert start_kwargs["references"][0].source == "context-memory"
+    assert start_kwargs["references"][0].url == "unique://settings/context-memory"
 
 
 @pytest.mark.asyncio
@@ -751,7 +751,7 @@ async def test_user_memory_postprocessor_emits_updating_message_logs(
     )
     monkeypatch.setattr(
         "unique_user_memory.user_memory_postprocessor.upload_user_memory",
-        AsyncMock(return_value="content_uploaded"),
+        AsyncMock(return_value=True),
     )
     chat_service = MagicMock()
     chat_service.modify_assistant_message_async = AsyncMock()
@@ -771,7 +771,6 @@ async def test_user_memory_postprocessor_emits_updating_message_logs(
         state=UserMemoryState(
             scope_id="scope_1",
             text=empty_profile("user_1"),
-            content_id="content_1",
         ),
         logger=MagicMock(),
         chat_service=chat_service,
@@ -781,13 +780,8 @@ async def test_user_memory_postprocessor_emits_updating_message_logs(
     await postprocessor.run(loop_response)
 
     chat_service.modify_assistant_message_async.assert_not_awaited()
-    message_logger.log_updating_start.assert_awaited_once_with(content_id="content_1")
-    # complete is called from consolidate finally and again after upload with new id
-    assert message_logger.log_updating_complete.await_count == 2
-    assert (
-        message_logger.log_updating_complete.await_args_list[-1].kwargs["content_id"]
-        == "content_uploaded"
-    )
+    message_logger.log_updating_start.assert_awaited_once_with()
+    message_logger.log_updating_complete.assert_awaited_once_with()
 
 
 @pytest.mark.asyncio
@@ -807,7 +801,7 @@ async def test_user_memory_postprocessor_does_not_mutate_assistant_message_text(
     )
     monkeypatch.setattr(
         "unique_user_memory.user_memory_postprocessor.upload_user_memory",
-        AsyncMock(return_value="content_uploaded"),
+        AsyncMock(return_value=True),
     )
     chat_service = MagicMock()
     chat_service.modify_assistant_message_async = AsyncMock()
@@ -845,7 +839,7 @@ async def test_download_user_memory_returns_empty_when_file_missing(
         search_contents,
     )
 
-    text, content_id = await download_user_memory(
+    text = await download_user_memory(
         scope_id="scope_1",
         user_id="user_1",
         company_id="company_1",
@@ -853,7 +847,6 @@ async def test_download_user_memory_returns_empty_when_file_missing(
     )
 
     assert text == ""
-    assert content_id is None
     search_contents.assert_awaited_once_with(
         user_id="user_1",
         company_id="company_1",
@@ -880,7 +873,7 @@ async def test_download_user_memory_downloads_existing_file_to_memory(
         download_content,
     )
 
-    text, content_id = await download_user_memory(
+    text = await download_user_memory(
         scope_id="scope_1",
         user_id="user_1",
         company_id="company_1",
@@ -888,7 +881,6 @@ async def test_download_user_memory_downloads_existing_file_to_memory(
     )
 
     assert text == "# User Memory\n\n## Identity\n- Test"
-    assert content_id == "content_1"
     search_contents.assert_awaited_once_with(
         user_id="user_1",
         company_id="company_1",
@@ -1090,7 +1082,7 @@ async def test_upload_user_memory_writes_hidden_skip_ingestion_file(
         logger=MagicMock(),
     )
 
-    assert result == "content_uploaded"
+    assert result is True
     upload_content.assert_awaited_once()
     assert upload_content.call_args.kwargs["content"] == (
         b"# User Memory\n\n## Identity\n- Test"
@@ -1110,7 +1102,7 @@ async def test_user_memory_postprocessor_logs_success_when_upload_succeeds(
 ) -> None:
     updated_memory = "# User Memory\n\n## Identity\n- Updated"
     consolidate = AsyncMock(return_value=updated_memory)
-    upload = AsyncMock(return_value="content_uploaded")
+    upload = AsyncMock(return_value=True)
     monkeypatch.setattr(
         "unique_user_memory.user_memory_postprocessor.consolidate_user_memory",
         consolidate,
@@ -1266,7 +1258,7 @@ async def test_user_memory_postprocessor_does_not_log_success_when_upload_fails(
     )
     monkeypatch.setattr(
         "unique_user_memory.user_memory_postprocessor.upload_user_memory",
-        AsyncMock(return_value=None),
+        AsyncMock(return_value=False),
     )
     event = MagicMock()
     event.user_id = "user_1"

--- a/postprocessors/unique_user_memory/unique_user_memory/tests/test_user_memory.py
+++ b/postprocessors/unique_user_memory/unique_user_memory/tests/test_user_memory.py
@@ -716,22 +716,33 @@ async def test_user_memory_message_logger_load_skips_pill_when_disabled() -> Non
 
 
 @pytest.mark.asyncio
-async def test_user_memory_message_logger_update_attaches_review_pill() -> None:
+async def test_user_memory_message_logger_update_attaches_review_pill_only_when_requested() -> (
+    None
+):
     step_logger = MagicMock()
     step_logger.create_or_update_message_log_async = AsyncMock(return_value=MagicMock())
     message_logger = UserMemoryMessageLogger(step_logger)
 
     await message_logger.log_updating_start()
-    await message_logger.log_updating_complete()
+    await message_logger.log_updating_complete(with_pill=False)
+    await message_logger.log_updating_complete(with_pill=True)
 
-    assert step_logger.create_or_update_message_log_async.await_count == 2
+    assert step_logger.create_or_update_message_log_async.await_count == 3
     start_kwargs = step_logger.create_or_update_message_log_async.await_args_list[
         0
     ].kwargs
     assert start_kwargs["header"] == "Updating your memory"
-    assert start_kwargs["references"][0].name == "Review your context memory"
-    assert start_kwargs["references"][0].source == "context-memory"
-    assert start_kwargs["references"][0].url == "unique://settings/context-memory"
+    assert start_kwargs["references"] == []
+    complete_without_pill = step_logger.create_or_update_message_log_async.await_args_list[
+        1
+    ].kwargs
+    assert complete_without_pill["references"] == []
+    complete_with_pill = step_logger.create_or_update_message_log_async.await_args_list[
+        2
+    ].kwargs
+    assert complete_with_pill["references"][0].name == "Review your context memory"
+    assert complete_with_pill["references"][0].source == "context-memory"
+    assert complete_with_pill["references"][0].url == "unique://settings/context-memory"
 
 
 @pytest.mark.asyncio
@@ -781,7 +792,9 @@ async def test_user_memory_postprocessor_emits_updating_message_logs(
 
     chat_service.modify_assistant_message_async.assert_not_awaited()
     message_logger.log_updating_start.assert_awaited_once_with()
-    message_logger.log_updating_complete.assert_awaited_once_with()
+    assert [
+        call.kwargs for call in message_logger.log_updating_complete.await_args_list
+    ] == [{"with_pill": False}, {"with_pill": True}]
 
 
 @pytest.mark.asyncio

--- a/postprocessors/unique_user_memory/unique_user_memory/tests/test_user_memory.py
+++ b/postprocessors/unique_user_memory/unique_user_memory/tests/test_user_memory.py
@@ -680,7 +680,9 @@ async def test_consolidate_user_memory_invokes_update_end_when_start_cancelled(
 
 
 @pytest.mark.asyncio
-async def test_user_memory_message_logger_load_emits_settings_detail_entry() -> None:
+async def test_user_memory_message_step_logger_load_emits_settings_detail_entry() -> (
+    None
+):
     step_logger = MagicMock()
     step_logger.create_or_update_message_log_async = AsyncMock(return_value=MagicMock())
     message_logger = UserMemoryMessageLogger(step_logger)
@@ -706,7 +708,7 @@ async def test_user_memory_message_logger_load_emits_settings_detail_entry() -> 
 
 
 @pytest.mark.asyncio
-async def test_user_memory_message_logger_load_skips_entry_when_disabled() -> None:
+async def test_user_memory_message_step_logger_load_skips_entry_when_disabled() -> None:
     step_logger = MagicMock()
     step_logger.create_or_update_message_log_async = AsyncMock(return_value=MagicMock())
     message_logger = UserMemoryMessageLogger(step_logger)
@@ -719,7 +721,9 @@ async def test_user_memory_message_logger_load_skips_entry_when_disabled() -> No
 
 
 @pytest.mark.asyncio
-async def test_user_memory_message_logger_load_failed_marks_failed_status() -> None:
+async def test_user_memory_message_step_logger_load_failed_marks_failed_status() -> (
+    None
+):
     """
     Purpose: log_loading_failed updates the loading Step to FAILED with no
     settings entry.
@@ -744,7 +748,7 @@ async def test_user_memory_message_logger_load_failed_marks_failed_status() -> N
 
 
 @pytest.mark.asyncio
-async def test_user_memory_message_logger_update_attaches_review_entry_only_when_requested() -> (
+async def test_user_memory_message_step_logger_update_attaches_review_entry_only_when_requested() -> (
     None
 ):
     step_logger = MagicMock()
@@ -793,11 +797,9 @@ async def test_user_memory_postprocessor_emits_updating_message_logs(
         "unique_user_memory.user_memory_postprocessor.upload_user_memory",
         AsyncMock(return_value=True),
     )
-    chat_service = MagicMock()
-    chat_service.modify_assistant_message_async = AsyncMock()
-    message_logger = MagicMock()
-    message_logger.log_updating_start = AsyncMock()
-    message_logger.log_updating_complete = AsyncMock()
+    message_step_logger = MagicMock()
+    message_step_logger.log_updating_start = AsyncMock()
+    message_step_logger.log_updating_complete = AsyncMock()
     event = MagicMock()
     event.user_id = "user_1"
     event.company_id = "company_1"
@@ -813,62 +815,16 @@ async def test_user_memory_postprocessor_emits_updating_message_logs(
             text=empty_profile("user_1"),
         ),
         logger=MagicMock(),
-        chat_service=chat_service,
-        message_logger=message_logger,
+        message_step_logger=message_step_logger,
     )
 
     await postprocessor.run(loop_response)
 
-    chat_service.modify_assistant_message_async.assert_not_awaited()
-    message_logger.log_updating_start.assert_awaited_once_with()
+    message_step_logger.log_updating_start.assert_awaited_once_with()
     assert [
-        call.kwargs for call in message_logger.log_updating_complete.await_args_list
+        call.kwargs
+        for call in message_step_logger.log_updating_complete.await_args_list
     ] == [{"with_settings_entry": False}, {"with_settings_entry": True}]
-
-
-@pytest.mark.asyncio
-async def test_user_memory_postprocessor_does_not_mutate_assistant_message_text(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    updated_memory = "# User Memory\n\n## Identity\n- Updated"
-
-    async def fake_consolidate(*, on_update_start, on_update_end, **kwargs) -> str:  # type: ignore[no-untyped-def]
-        await on_update_start()
-        await on_update_end()
-        return updated_memory
-
-    monkeypatch.setattr(
-        "unique_user_memory.user_memory_postprocessor.consolidate_user_memory",
-        fake_consolidate,
-    )
-    monkeypatch.setattr(
-        "unique_user_memory.user_memory_postprocessor.upload_user_memory",
-        AsyncMock(return_value=True),
-    )
-    chat_service = MagicMock()
-    chat_service.modify_assistant_message_async = AsyncMock()
-    event = MagicMock()
-    event.user_id = "user_1"
-    event.company_id = "company_1"
-    event.payload.user_message.text = "remember this"
-    loop_response = MagicMock()
-    loop_response.message.text = "answer"
-    postprocessor = UserMemoryPostprocessor(
-        config=UserMemoryConfig(),
-        language_model=_TEST_LANGUAGE_MODEL,
-        event=event,
-        state=UserMemoryState(scope_id="scope_1", text=empty_profile("user_1")),
-        logger=MagicMock(),
-        chat_service=chat_service,
-        message_logger=MagicMock(
-            log_updating_start=AsyncMock(),
-            log_updating_complete=AsyncMock(),
-        ),
-    )
-
-    await postprocessor.run(loop_response)
-
-    chat_service.modify_assistant_message_async.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -1160,8 +1116,7 @@ async def test_user_memory_postprocessor_logs_success_when_upload_succeeds(
     loop_response = MagicMock()
     loop_response.message.text = "noted"
     logger = MagicMock()
-    chat_service = MagicMock()
-    message_logger = MagicMock(
+    message_step_logger = MagicMock(
         log_updating_start=AsyncMock(),
         log_updating_complete=AsyncMock(),
     )
@@ -1171,8 +1126,7 @@ async def test_user_memory_postprocessor_logs_success_when_upload_succeeds(
         event=event,
         state=UserMemoryState(scope_id="scope_1", text=empty_profile("user_1")),
         logger=logger,
-        chat_service=chat_service,
-        message_logger=message_logger,
+        message_step_logger=message_step_logger,
     )
 
     updated = await postprocessor.run(loop_response)
@@ -1185,7 +1139,7 @@ async def test_user_memory_postprocessor_logs_success_when_upload_succeeds(
         company_id="company_1",
         logger=logger,
     )
-    message_logger.log_updating_complete.assert_awaited_once_with(
+    message_step_logger.log_updating_complete.assert_awaited_once_with(
         with_settings_entry=True
     )
     logger.info.assert_any_call(
@@ -1244,7 +1198,10 @@ async def test_user_memory_postprocessor_run_resets_invocation_stats(
         event=event,
         state=state,
         logger=MagicMock(),
-        chat_service=MagicMock(),
+        message_step_logger=MagicMock(
+            log_updating_start=AsyncMock(),
+            log_updating_complete=AsyncMock(),
+        ),
     )
 
     await postprocessor.run(loop_response)
@@ -1284,7 +1241,7 @@ def test_user_memory_postprocessor_take_pending_invocation_stats_drains_once() -
         event=event,
         state=state,
         logger=MagicMock(),
-        chat_service=MagicMock(),
+        message_step_logger=MagicMock(),
     )
 
     taken = postprocessor.take_pending_invocation_stats()
@@ -1313,15 +1270,13 @@ async def test_user_memory_postprocessor_does_not_log_success_when_upload_fails(
     loop_response = MagicMock()
     loop_response.message.text = "noted"
     logger = MagicMock()
-    chat_service = MagicMock()
     postprocessor = UserMemoryPostprocessor(
         config=UserMemoryConfig(),
         language_model=_TEST_LANGUAGE_MODEL,
         event=event,
         state=UserMemoryState(scope_id="scope_1", text=empty_profile("user_1")),
         logger=logger,
-        chat_service=chat_service,
-        message_logger=MagicMock(
+        message_step_logger=MagicMock(
             log_updating_start=AsyncMock(),
             log_updating_complete=AsyncMock(),
         ),

--- a/postprocessors/unique_user_memory/unique_user_memory/tests/test_user_memory.py
+++ b/postprocessors/unique_user_memory/unique_user_memory/tests/test_user_memory.py
@@ -2,6 +2,7 @@ import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from unique_toolkit.chat.schemas import MessageLogStatus
 from unique_toolkit.language_model.default_language_model import (
     DEFAULT_LANGUAGE_MODEL,
 )
@@ -20,10 +21,10 @@ from unique_user_memory.user_memory import (
     enforce_token_cap,
     ensure_user_memory_folder,
     fit_user_memory,
-    noop_update_callback,
     should_consolidate_memory,
     upload_user_memory,
 )
+from unique_user_memory.user_memory_message_log import UserMemoryMessageLogger
 from unique_user_memory.user_memory_postprocessor import UserMemoryPostprocessor
 from unique_user_memory.user_memory_prompts import (
     consolidation_system_prompt,
@@ -679,11 +680,65 @@ async def test_consolidate_user_memory_invokes_update_end_when_start_cancelled(
 
 
 @pytest.mark.asyncio
-async def test_user_memory_postprocessor_shows_and_removes_updating_notice(
+async def test_user_memory_message_logger_load_emits_pill_when_content_id_present() -> (
+    None
+):
+    step_logger = MagicMock()
+    step_logger.create_or_update_message_log_async = AsyncMock(return_value=MagicMock())
+    message_logger = UserMemoryMessageLogger(step_logger)
+
+    await message_logger.log_loading_start()
+    await message_logger.log_loading_complete(content_id="content_1")
+
+    assert step_logger.create_or_update_message_log_async.await_count == 2
+    start_kwargs = step_logger.create_or_update_message_log_async.await_args_list[
+        0
+    ].kwargs
+    assert start_kwargs["header"] == "Loading context memory"
+    assert start_kwargs["references"] == []
+    complete_kwargs = step_logger.create_or_update_message_log_async.await_args_list[
+        1
+    ].kwargs
+    assert complete_kwargs["status"] == MessageLogStatus.COMPLETED
+    assert complete_kwargs["references"][0].name == "Context memory"
+    assert complete_kwargs["references"][0].url == "unique://content/content_1"
+
+
+@pytest.mark.asyncio
+async def test_user_memory_message_logger_load_skips_pill_without_content_id() -> None:
+    step_logger = MagicMock()
+    step_logger.create_or_update_message_log_async = AsyncMock(return_value=MagicMock())
+    message_logger = UserMemoryMessageLogger(step_logger)
+
+    await message_logger.log_loading_complete(content_id=None)
+
+    complete_kwargs = step_logger.create_or_update_message_log_async.await_args.kwargs
+    assert complete_kwargs["references"] == []
+
+
+@pytest.mark.asyncio
+async def test_user_memory_message_logger_update_attaches_review_pill() -> None:
+    step_logger = MagicMock()
+    step_logger.create_or_update_message_log_async = AsyncMock(return_value=MagicMock())
+    message_logger = UserMemoryMessageLogger(step_logger)
+
+    await message_logger.log_updating_start(content_id="content_1")
+    await message_logger.log_updating_complete(content_id="content_1")
+
+    assert step_logger.create_or_update_message_log_async.await_count == 2
+    start_kwargs = step_logger.create_or_update_message_log_async.await_args_list[
+        0
+    ].kwargs
+    assert start_kwargs["header"] == "Updating your memory"
+    assert start_kwargs["references"][0].name == "Review your context memory"
+    assert start_kwargs["references"][0].url == "unique://content/content_1"
+
+
+@pytest.mark.asyncio
+async def test_user_memory_postprocessor_emits_updating_message_logs(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     updated_memory = "# User Memory\n\n## Identity\n- Updated"
-    original_text = "Here is your answer."
 
     async def fake_consolidate(*, on_update_start, on_update_end, **kwargs) -> str:  # type: ignore[no-untyped-def]
         await on_update_start()
@@ -696,50 +751,54 @@ async def test_user_memory_postprocessor_shows_and_removes_updating_notice(
     )
     monkeypatch.setattr(
         "unique_user_memory.user_memory_postprocessor.upload_user_memory",
-        AsyncMock(return_value=True),
+        AsyncMock(return_value="content_uploaded"),
     )
     chat_service = MagicMock()
     chat_service.modify_assistant_message_async = AsyncMock()
-    monkeypatch.setattr(
-        "unique_user_memory.user_memory_postprocessor.ChatService",
-        MagicMock(return_value=chat_service),
-    )
+    message_logger = MagicMock()
+    message_logger.log_updating_start = AsyncMock()
+    message_logger.log_updating_complete = AsyncMock()
     event = MagicMock()
     event.user_id = "user_1"
     event.company_id = "company_1"
     event.payload.user_message.text = "remember this"
     loop_response = MagicMock()
-    loop_response.message.text = original_text
-    loop_response.message.id = "msg_1"
-    loop_response.message.references = []
+    loop_response.message.text = "Here is your answer."
     postprocessor = UserMemoryPostprocessor(
         config=UserMemoryConfig(),
         language_model=_TEST_LANGUAGE_MODEL,
         event=event,
-        state=UserMemoryState(scope_id="scope_1", text=empty_profile("user_1")),
+        state=UserMemoryState(
+            scope_id="scope_1",
+            text=empty_profile("user_1"),
+            content_id="content_1",
+        ),
         logger=MagicMock(),
         chat_service=chat_service,
+        message_logger=message_logger,
     )
 
     await postprocessor.run(loop_response)
 
-    calls = chat_service.modify_assistant_message_async.await_args_list
-    assert len(calls) == 2
-    assert calls[0].kwargs["content"].startswith(original_text)
-    assert calls[0].kwargs["content"] != original_text
-    assert calls[0].kwargs["message_id"] == "msg_1"
-    assert calls[1].kwargs["content"] == original_text
+    chat_service.modify_assistant_message_async.assert_not_awaited()
+    message_logger.log_updating_start.assert_awaited_once_with(content_id="content_1")
+    # complete is called from consolidate finally and again after upload with new id
+    assert message_logger.log_updating_complete.await_count == 2
+    assert (
+        message_logger.log_updating_complete.await_args_list[-1].kwargs["content_id"]
+        == "content_uploaded"
+    )
 
 
 @pytest.mark.asyncio
-async def test_user_memory_postprocessor_skips_notice_when_disabled(
+async def test_user_memory_postprocessor_does_not_mutate_assistant_message_text(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     updated_memory = "# User Memory\n\n## Identity\n- Updated"
 
     async def fake_consolidate(*, on_update_start, on_update_end, **kwargs) -> str:  # type: ignore[no-untyped-def]
-        assert on_update_start is noop_update_callback
-        assert on_update_end is noop_update_callback
+        await on_update_start()
+        await on_update_end()
         return updated_memory
 
     monkeypatch.setattr(
@@ -748,29 +807,27 @@ async def test_user_memory_postprocessor_skips_notice_when_disabled(
     )
     monkeypatch.setattr(
         "unique_user_memory.user_memory_postprocessor.upload_user_memory",
-        AsyncMock(return_value=True),
+        AsyncMock(return_value="content_uploaded"),
     )
     chat_service = MagicMock()
     chat_service.modify_assistant_message_async = AsyncMock()
-    monkeypatch.setattr(
-        "unique_user_memory.user_memory_postprocessor.ChatService",
-        MagicMock(return_value=chat_service),
-    )
     event = MagicMock()
     event.user_id = "user_1"
     event.company_id = "company_1"
     event.payload.user_message.text = "remember this"
     loop_response = MagicMock()
     loop_response.message.text = "answer"
-    loop_response.message.id = "msg_1"
-    loop_response.message.references = []
     postprocessor = UserMemoryPostprocessor(
-        config=UserMemoryConfig(updating_notice_enabled=False),
+        config=UserMemoryConfig(),
         language_model=_TEST_LANGUAGE_MODEL,
         event=event,
         state=UserMemoryState(scope_id="scope_1", text=empty_profile("user_1")),
         logger=MagicMock(),
         chat_service=chat_service,
+        message_logger=MagicMock(
+            log_updating_start=AsyncMock(),
+            log_updating_complete=AsyncMock(),
+        ),
     )
 
     await postprocessor.run(loop_response)
@@ -788,14 +845,15 @@ async def test_download_user_memory_returns_empty_when_file_missing(
         search_contents,
     )
 
-    result = await download_user_memory(
+    text, content_id = await download_user_memory(
         scope_id="scope_1",
         user_id="user_1",
         company_id="company_1",
         logger=MagicMock(),
     )
 
-    assert result == ""
+    assert text == ""
+    assert content_id is None
     search_contents.assert_awaited_once_with(
         user_id="user_1",
         company_id="company_1",
@@ -822,14 +880,15 @@ async def test_download_user_memory_downloads_existing_file_to_memory(
         download_content,
     )
 
-    result = await download_user_memory(
+    text, content_id = await download_user_memory(
         scope_id="scope_1",
         user_id="user_1",
         company_id="company_1",
         logger=MagicMock(),
     )
 
-    assert result == "# User Memory\n\n## Identity\n- Test"
+    assert text == "# User Memory\n\n## Identity\n- Test"
+    assert content_id == "content_1"
     search_contents.assert_awaited_once_with(
         user_id="user_1",
         company_id="company_1",
@@ -1015,7 +1074,9 @@ async def test_ensure_user_memory_folder_returns_none_when_access_grant_fails_af
 async def test_upload_user_memory_writes_hidden_skip_ingestion_file(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    upload_content = AsyncMock()
+    uploaded = MagicMock()
+    uploaded.id = "content_uploaded"
+    upload_content = AsyncMock(return_value=uploaded)
     monkeypatch.setattr(
         "unique_user_memory.user_memory.upload_content_from_bytes_async",
         upload_content,
@@ -1029,7 +1090,7 @@ async def test_upload_user_memory_writes_hidden_skip_ingestion_file(
         logger=MagicMock(),
     )
 
-    assert result is True
+    assert result == "content_uploaded"
     upload_content.assert_awaited_once()
     assert upload_content.call_args.kwargs["content"] == (
         b"# User Memory\n\n## Identity\n- Test"
@@ -1049,7 +1110,7 @@ async def test_user_memory_postprocessor_logs_success_when_upload_succeeds(
 ) -> None:
     updated_memory = "# User Memory\n\n## Identity\n- Updated"
     consolidate = AsyncMock(return_value=updated_memory)
-    upload = AsyncMock(return_value=True)
+    upload = AsyncMock(return_value="content_uploaded")
     monkeypatch.setattr(
         "unique_user_memory.user_memory_postprocessor.consolidate_user_memory",
         consolidate,
@@ -1073,6 +1134,10 @@ async def test_user_memory_postprocessor_logs_success_when_upload_succeeds(
         state=UserMemoryState(scope_id="scope_1", text=empty_profile("user_1")),
         logger=logger,
         chat_service=chat_service,
+        message_logger=MagicMock(
+            log_updating_start=AsyncMock(),
+            log_updating_complete=AsyncMock(),
+        ),
     )
 
     updated = await postprocessor.run(loop_response)
@@ -1201,7 +1266,7 @@ async def test_user_memory_postprocessor_does_not_log_success_when_upload_fails(
     )
     monkeypatch.setattr(
         "unique_user_memory.user_memory_postprocessor.upload_user_memory",
-        AsyncMock(return_value=False),
+        AsyncMock(return_value=None),
     )
     event = MagicMock()
     event.user_id = "user_1"
@@ -1218,6 +1283,10 @@ async def test_user_memory_postprocessor_does_not_log_success_when_upload_fails(
         state=UserMemoryState(scope_id="scope_1", text=empty_profile("user_1")),
         logger=logger,
         chat_service=chat_service,
+        message_logger=MagicMock(
+            log_updating_start=AsyncMock(),
+            log_updating_complete=AsyncMock(),
+        ),
     )
 
     updated = await postprocessor.run(loop_response)

--- a/postprocessors/unique_user_memory/unique_user_memory/tests/test_user_memory.py
+++ b/postprocessors/unique_user_memory/unique_user_memory/tests/test_user_memory.py
@@ -716,6 +716,29 @@ async def test_user_memory_message_logger_load_skips_pill_when_disabled() -> Non
 
 
 @pytest.mark.asyncio
+async def test_user_memory_message_logger_load_failed_marks_failed_status() -> None:
+    """
+    Purpose: log_loading_failed updates the loading Step to FAILED with no pill.
+    Why this matters: Callers must close a RUNNING loading Step when load
+    raises so the chat UI does not stay stuck.
+    Setup summary: Start then fail the loading step; assert FAILED status.
+    """
+    step_logger = MagicMock()
+    step_logger.create_or_update_message_log_async = AsyncMock(return_value=MagicMock())
+    message_logger = UserMemoryMessageLogger(step_logger)
+
+    await message_logger.log_loading_start()
+    await message_logger.log_loading_failed()
+
+    failed_kwargs = step_logger.create_or_update_message_log_async.await_args_list[
+        -1
+    ].kwargs
+    assert failed_kwargs["header"] == "Loading context memory"
+    assert failed_kwargs["status"] == MessageLogStatus.FAILED
+    assert failed_kwargs["references"] == []
+
+
+@pytest.mark.asyncio
 async def test_user_memory_message_logger_update_attaches_review_pill_only_when_requested() -> (
     None
 ):
@@ -733,9 +756,9 @@ async def test_user_memory_message_logger_update_attaches_review_pill_only_when_
     ].kwargs
     assert start_kwargs["header"] == "Updating your memory"
     assert start_kwargs["references"] == []
-    complete_without_pill = step_logger.create_or_update_message_log_async.await_args_list[
-        1
-    ].kwargs
+    complete_without_pill = (
+        step_logger.create_or_update_message_log_async.await_args_list[1].kwargs
+    )
     assert complete_without_pill["references"] == []
     complete_with_pill = step_logger.create_or_update_message_log_async.await_args_list[
         2
@@ -1132,6 +1155,10 @@ async def test_user_memory_postprocessor_logs_success_when_upload_succeeds(
     loop_response.message.text = "noted"
     logger = MagicMock()
     chat_service = MagicMock()
+    message_logger = MagicMock(
+        log_updating_start=AsyncMock(),
+        log_updating_complete=AsyncMock(),
+    )
     postprocessor = UserMemoryPostprocessor(
         config=UserMemoryConfig(),
         language_model=_TEST_LANGUAGE_MODEL,
@@ -1139,10 +1166,7 @@ async def test_user_memory_postprocessor_logs_success_when_upload_succeeds(
         state=UserMemoryState(scope_id="scope_1", text=empty_profile("user_1")),
         logger=logger,
         chat_service=chat_service,
-        message_logger=MagicMock(
-            log_updating_start=AsyncMock(),
-            log_updating_complete=AsyncMock(),
-        ),
+        message_logger=message_logger,
     )
 
     updated = await postprocessor.run(loop_response)
@@ -1155,6 +1179,7 @@ async def test_user_memory_postprocessor_logs_success_when_upload_succeeds(
         company_id="company_1",
         logger=logger,
     )
+    message_logger.log_updating_complete.assert_awaited_once_with(with_pill=True)
     logger.info.assert_any_call(
         "[user-memory] memory updated and uploaded successfully"
     )

--- a/postprocessors/unique_user_memory/unique_user_memory/tests/test_user_memory.py
+++ b/postprocessors/unique_user_memory/unique_user_memory/tests/test_user_memory.py
@@ -680,45 +680,49 @@ async def test_consolidate_user_memory_invokes_update_end_when_start_cancelled(
 
 
 @pytest.mark.asyncio
-async def test_user_memory_message_logger_load_emits_settings_pill() -> None:
+async def test_user_memory_message_logger_load_emits_settings_detail_entry() -> None:
     step_logger = MagicMock()
     step_logger.create_or_update_message_log_async = AsyncMock(return_value=MagicMock())
     message_logger = UserMemoryMessageLogger(step_logger)
 
     await message_logger.log_loading_start()
-    await message_logger.log_loading_complete(with_pill=True)
+    await message_logger.log_loading_complete(with_settings_entry=True)
 
     assert step_logger.create_or_update_message_log_async.await_count == 2
     start_kwargs = step_logger.create_or_update_message_log_async.await_args_list[
         0
     ].kwargs
     assert start_kwargs["header"] == "Loading context memory"
+    assert start_kwargs["details"] is None
     assert start_kwargs["references"] == []
     complete_kwargs = step_logger.create_or_update_message_log_async.await_args_list[
         1
     ].kwargs
     assert complete_kwargs["status"] == MessageLogStatus.COMPLETED
-    assert complete_kwargs["references"][0].name == "Context memory"
-    assert complete_kwargs["references"][0].source == "context-memory"
-    assert complete_kwargs["references"][0].url == "unique://settings/context-memory"
+    assert complete_kwargs["references"] == []
+    entry = complete_kwargs["details"].data[0]
+    assert entry.type == "UserMemory"
+    assert entry.text == "Context memory"
 
 
 @pytest.mark.asyncio
-async def test_user_memory_message_logger_load_skips_pill_when_disabled() -> None:
+async def test_user_memory_message_logger_load_skips_entry_when_disabled() -> None:
     step_logger = MagicMock()
     step_logger.create_or_update_message_log_async = AsyncMock(return_value=MagicMock())
     message_logger = UserMemoryMessageLogger(step_logger)
 
-    await message_logger.log_loading_complete(with_pill=False)
+    await message_logger.log_loading_complete(with_settings_entry=False)
 
     complete_kwargs = step_logger.create_or_update_message_log_async.await_args.kwargs
+    assert complete_kwargs["details"] is None
     assert complete_kwargs["references"] == []
 
 
 @pytest.mark.asyncio
 async def test_user_memory_message_logger_load_failed_marks_failed_status() -> None:
     """
-    Purpose: log_loading_failed updates the loading Step to FAILED with no pill.
+    Purpose: log_loading_failed updates the loading Step to FAILED with no
+    settings entry.
     Why this matters: Callers must close a RUNNING loading Step when load
     raises so the chat UI does not stay stuck.
     Setup summary: Start then fail the loading step; assert FAILED status.
@@ -735,11 +739,12 @@ async def test_user_memory_message_logger_load_failed_marks_failed_status() -> N
     ].kwargs
     assert failed_kwargs["header"] == "Loading context memory"
     assert failed_kwargs["status"] == MessageLogStatus.FAILED
+    assert failed_kwargs["details"] is None
     assert failed_kwargs["references"] == []
 
 
 @pytest.mark.asyncio
-async def test_user_memory_message_logger_update_attaches_review_pill_only_when_requested() -> (
+async def test_user_memory_message_logger_update_attaches_review_entry_only_when_requested() -> (
     None
 ):
     step_logger = MagicMock()
@@ -747,25 +752,26 @@ async def test_user_memory_message_logger_update_attaches_review_pill_only_when_
     message_logger = UserMemoryMessageLogger(step_logger)
 
     await message_logger.log_updating_start()
-    await message_logger.log_updating_complete(with_pill=False)
-    await message_logger.log_updating_complete(with_pill=True)
+    await message_logger.log_updating_complete(with_settings_entry=False)
+    await message_logger.log_updating_complete(with_settings_entry=True)
 
     assert step_logger.create_or_update_message_log_async.await_count == 3
     start_kwargs = step_logger.create_or_update_message_log_async.await_args_list[
         0
     ].kwargs
     assert start_kwargs["header"] == "Updating your memory"
-    assert start_kwargs["references"] == []
-    complete_without_pill = (
+    assert start_kwargs["details"] is None
+    complete_without_entry = (
         step_logger.create_or_update_message_log_async.await_args_list[1].kwargs
     )
-    assert complete_without_pill["references"] == []
-    complete_with_pill = step_logger.create_or_update_message_log_async.await_args_list[
-        2
-    ].kwargs
-    assert complete_with_pill["references"][0].name == "Review your context memory"
-    assert complete_with_pill["references"][0].source == "context-memory"
-    assert complete_with_pill["references"][0].url == "unique://settings/context-memory"
+    assert complete_without_entry["details"] is None
+    complete_with_entry = (
+        step_logger.create_or_update_message_log_async.await_args_list[2].kwargs
+    )
+    assert complete_with_entry["references"] == []
+    entry = complete_with_entry["details"].data[0]
+    assert entry.type == "UserMemory"
+    assert entry.text == "Review your context memory"
 
 
 @pytest.mark.asyncio
@@ -817,7 +823,7 @@ async def test_user_memory_postprocessor_emits_updating_message_logs(
     message_logger.log_updating_start.assert_awaited_once_with()
     assert [
         call.kwargs for call in message_logger.log_updating_complete.await_args_list
-    ] == [{"with_pill": False}, {"with_pill": True}]
+    ] == [{"with_settings_entry": False}, {"with_settings_entry": True}]
 
 
 @pytest.mark.asyncio
@@ -1179,7 +1185,9 @@ async def test_user_memory_postprocessor_logs_success_when_upload_succeeds(
         company_id="company_1",
         logger=logger,
     )
-    message_logger.log_updating_complete.assert_awaited_once_with(with_pill=True)
+    message_logger.log_updating_complete.assert_awaited_once_with(
+        with_settings_entry=True
+    )
     logger.info.assert_any_call(
         "[user-memory] memory updated and uploaded successfully"
     )

--- a/postprocessors/unique_user_memory/unique_user_memory/user_memory.py
+++ b/postprocessors/unique_user_memory/unique_user_memory/user_memory.py
@@ -100,7 +100,6 @@ def _restore_frontmatter(original: str, body: str) -> str:
 class UserMemoryState:
     scope_id: str
     text: str
-    content_id: str | None = None
     load_invocation_stats: tuple[LanguageModelInvocationStats, ...] = ()
 
 
@@ -372,7 +371,7 @@ async def load_user_memory(
         logger.info("[user-memory] folder ensure failed - running without memory")
         return None
 
-    text, content_id = await download_user_memory(
+    text = await download_user_memory(
         scope_id=scope_id,
         user_id=user_id,
         company_id=company_id,
@@ -390,7 +389,6 @@ async def load_user_memory(
             invocation_stats=invocation_stats,
             invocation_source="user_memory_load_condense",
         ),
-        content_id=content_id,
         load_invocation_stats=tuple(invocation_stats),
     )
 
@@ -529,7 +527,7 @@ async def download_user_memory(
     user_id: str,
     company_id: str,
     logger: Logger,
-) -> tuple[str, str | None]:
+) -> str:
     try:
         contents = await search_contents_async(
             user_id=user_id,
@@ -544,7 +542,7 @@ async def download_user_memory(
             type(exc).__name__,
             exc,
         )
-        return "", None
+        return ""
 
     memory_content = next(
         (content for content in contents if (content.key or "") == MEMORY_FILENAME),
@@ -556,7 +554,7 @@ async def download_user_memory(
             MEMORY_FILENAME,
             scope_id,
         )
-        return "", None
+        return ""
 
     try:
         content_bytes = await download_content_to_bytes_async(
@@ -572,7 +570,7 @@ async def download_user_memory(
             len(content_bytes),
             scope_id,
         )
-        return text, memory_content.id
+        return text
     except Exception as exc:
         logger.warning(
             "[user-memory] failed to download %s from scope %s: [%s] %s",
@@ -581,7 +579,7 @@ async def download_user_memory(
             type(exc).__name__,
             exc,
         )
-        return "", memory_content.id
+        return ""
 
 
 async def upload_user_memory(
@@ -591,16 +589,16 @@ async def upload_user_memory(
     user_id: str,
     company_id: str,
     logger: Logger,
-) -> str | None:
+) -> bool:
     if not content.strip():
         logger.warning(
             "[user-memory] refusing to upload empty memory file to scope %s",
             scope_id,
         )
-        return None
+        return False
 
     try:
-        uploaded = await upload_content_from_bytes_async(
+        await upload_content_from_bytes_async(
             user_id=user_id,
             company_id=company_id,
             content=content.encode("utf-8"),
@@ -618,7 +616,7 @@ async def upload_user_memory(
             len(content.encode("utf-8")),
             scope_id,
         )
-        return uploaded.id
+        return True
     except Exception as exc:
         logger.error(
             "[user-memory] upload failed for scope %s: [%s] %s",
@@ -627,7 +625,7 @@ async def upload_user_memory(
             exc,
             exc_info=True,
         )
-        return None
+        return False
 
 
 async def should_consolidate_memory(

--- a/postprocessors/unique_user_memory/unique_user_memory/user_memory.py
+++ b/postprocessors/unique_user_memory/unique_user_memory/user_memory.py
@@ -100,6 +100,7 @@ def _restore_frontmatter(original: str, body: str) -> str:
 class UserMemoryState:
     scope_id: str
     text: str
+    content_id: str | None = None
     load_invocation_stats: tuple[LanguageModelInvocationStats, ...] = ()
 
 
@@ -371,7 +372,7 @@ async def load_user_memory(
         logger.info("[user-memory] folder ensure failed - running without memory")
         return None
 
-    text = await download_user_memory(
+    text, content_id = await download_user_memory(
         scope_id=scope_id,
         user_id=user_id,
         company_id=company_id,
@@ -389,6 +390,7 @@ async def load_user_memory(
             invocation_stats=invocation_stats,
             invocation_source="user_memory_load_condense",
         ),
+        content_id=content_id,
         load_invocation_stats=tuple(invocation_stats),
     )
 
@@ -527,7 +529,7 @@ async def download_user_memory(
     user_id: str,
     company_id: str,
     logger: Logger,
-) -> str:
+) -> tuple[str, str | None]:
     try:
         contents = await search_contents_async(
             user_id=user_id,
@@ -542,7 +544,7 @@ async def download_user_memory(
             type(exc).__name__,
             exc,
         )
-        return ""
+        return "", None
 
     memory_content = next(
         (content for content in contents if (content.key or "") == MEMORY_FILENAME),
@@ -554,7 +556,7 @@ async def download_user_memory(
             MEMORY_FILENAME,
             scope_id,
         )
-        return ""
+        return "", None
 
     try:
         content_bytes = await download_content_to_bytes_async(
@@ -570,7 +572,7 @@ async def download_user_memory(
             len(content_bytes),
             scope_id,
         )
-        return text
+        return text, memory_content.id
     except Exception as exc:
         logger.warning(
             "[user-memory] failed to download %s from scope %s: [%s] %s",
@@ -579,7 +581,7 @@ async def download_user_memory(
             type(exc).__name__,
             exc,
         )
-        return ""
+        return "", memory_content.id
 
 
 async def upload_user_memory(
@@ -589,16 +591,16 @@ async def upload_user_memory(
     user_id: str,
     company_id: str,
     logger: Logger,
-) -> bool:
+) -> str | None:
     if not content.strip():
         logger.warning(
             "[user-memory] refusing to upload empty memory file to scope %s",
             scope_id,
         )
-        return False
+        return None
 
     try:
-        await upload_content_from_bytes_async(
+        uploaded = await upload_content_from_bytes_async(
             user_id=user_id,
             company_id=company_id,
             content=content.encode("utf-8"),
@@ -616,7 +618,7 @@ async def upload_user_memory(
             len(content.encode("utf-8")),
             scope_id,
         )
-        return True
+        return uploaded.id
     except Exception as exc:
         logger.error(
             "[user-memory] upload failed for scope %s: [%s] %s",
@@ -625,7 +627,7 @@ async def upload_user_memory(
             exc,
             exc_info=True,
         )
-        return False
+        return None
 
 
 async def should_consolidate_memory(

--- a/postprocessors/unique_user_memory/unique_user_memory/user_memory_message_log.py
+++ b/postprocessors/unique_user_memory/unique_user_memory/user_memory_message_log.py
@@ -1,30 +1,33 @@
 """MessageLog Steps for user-memory load and update."""
 
 from logging import Logger, getLogger
+from typing import Literal
 
 from unique_toolkit.agentic.message_log_manager.service import MessageStepLogger
-from unique_toolkit.chat.schemas import MessageLog, MessageLogStatus
-from unique_toolkit.content.schemas import ContentReference
+from unique_toolkit.chat.schemas import (
+    MessageLog,
+    MessageLogDetails,
+    MessageLogEvent,
+    MessageLogStatus,
+)
 
 _LOGGER = getLogger(__name__)
 
 _LOADING_HEADER = "Loading context memory"
 _UPDATING_HEADER = "Updating your memory"
-_CONTEXT_MEMORY_PILL = "Context memory"
-_REVIEW_MEMORY_PILL = "Review your context memory"
+_CONTEXT_MEMORY_ENTRY_TEXT = "Context memory"
+_REVIEW_MEMORY_ENTRY_TEXT = "Review your context memory"
 
-# Opens the chat Settings → Context Memory tab (handled by the frontend).
-SETTINGS_CONTEXT_MEMORY_URL = "unique://settings/context-memory"
-CONTEXT_MEMORY_REFERENCE_SOURCE = "context-memory"
+# Typed MessageLog detail entry recognised by the chat frontend, which renders
+# it as a badge that opens Settings → Context Memory. Frontends that don't know
+# the type parse it as "Unknown" and render nothing, so emitting it is always
+# safe regardless of deploy order.
+USER_MEMORY_EVENT_TYPE: Literal["UserMemory"] = "UserMemory"
 
 
-def _memory_settings_reference(*, name: str) -> ContentReference:
-    return ContentReference(
-        name=name,
-        sequence_number=0,
-        source=CONTEXT_MEMORY_REFERENCE_SOURCE,
-        source_id=CONTEXT_MEMORY_REFERENCE_SOURCE,
-        url=SETTINGS_CONTEXT_MEMORY_URL,
+def _memory_settings_details(*, text: str) -> MessageLogDetails:
+    return MessageLogDetails(
+        data=[MessageLogEvent(type=USER_MEMORY_EVENT_TYPE, text=text)]
     )
 
 
@@ -47,22 +50,24 @@ class UserMemoryMessageLogger:
             active_attr="_loading_log",
             header=_LOADING_HEADER,
             status=MessageLogStatus.RUNNING,
-            references=[],
+            details=None,
             action="start loading step",
         )
 
-    async def log_loading_complete(self, *, with_pill: bool = True) -> None:
-        # Attach the pill on the loading step itself (same pattern as update).
-        # A separate MessageLog with empty text is dropped / invisible in the
-        # chat Steps UI, so the link must ride on this COMPLETED entry.
-        references = (
-            [_memory_settings_reference(name=_CONTEXT_MEMORY_PILL)] if with_pill else []
+    async def log_loading_complete(self, *, with_settings_entry: bool = True) -> None:
+        # Attach the settings entry on the loading step itself (same pattern
+        # as update) — a separate MessageLog with empty text is dropped /
+        # invisible in the chat Steps UI.
+        details = (
+            _memory_settings_details(text=_CONTEXT_MEMORY_ENTRY_TEXT)
+            if with_settings_entry
+            else None
         )
         await self._safe_create_or_update(
             active_attr="_loading_log",
             header=_LOADING_HEADER,
             status=MessageLogStatus.COMPLETED,
-            references=references,
+            details=details,
             action="complete loading step",
         )
 
@@ -73,7 +78,7 @@ class UserMemoryMessageLogger:
             active_attr="_loading_log",
             header=_LOADING_HEADER,
             status=MessageLogStatus.FAILED,
-            references=[],
+            details=None,
             action="fail loading step",
         )
 
@@ -82,22 +87,24 @@ class UserMemoryMessageLogger:
             active_attr="_updating_log",
             header=_UPDATING_HEADER,
             status=MessageLogStatus.RUNNING,
-            references=[],
+            details=None,
             action="start updating step",
         )
 
-    async def log_updating_complete(self, *, with_pill: bool = False) -> None:
-        # Review pill only after memory was actually written (caller sets
-        # with_pill=True post-upload). While consolidating / on failed upload
-        # the step completes without a pill.
-        references = (
-            [_memory_settings_reference(name=_REVIEW_MEMORY_PILL)] if with_pill else []
+    async def log_updating_complete(self, *, with_settings_entry: bool = False) -> None:
+        # Review entry only after memory was actually written (caller sets
+        # with_settings_entry=True post-upload). While consolidating / on
+        # failed upload the step completes without it.
+        details = (
+            _memory_settings_details(text=_REVIEW_MEMORY_ENTRY_TEXT)
+            if with_settings_entry
+            else None
         )
         await self._safe_create_or_update(
             active_attr="_updating_log",
             header=_UPDATING_HEADER,
             status=MessageLogStatus.COMPLETED,
-            references=references,
+            details=details,
             action="complete updating step",
         )
 
@@ -107,7 +114,7 @@ class UserMemoryMessageLogger:
         active_attr: str,
         header: str,
         status: MessageLogStatus,
-        references: list[ContentReference],
+        details: MessageLogDetails | None,
         action: str,
     ) -> None:
         try:
@@ -117,7 +124,8 @@ class UserMemoryMessageLogger:
                     active_message_log=active,
                     header=header,
                     status=status,
-                    references=references,
+                    details=details,
+                    references=[],
                 )
             )
             if updated is not None:

--- a/postprocessors/unique_user_memory/unique_user_memory/user_memory_message_log.py
+++ b/postprocessors/unique_user_memory/unique_user_memory/user_memory_message_log.py
@@ -1,0 +1,122 @@
+"""MessageLog Steps for user-memory load and update."""
+
+from logging import Logger, getLogger
+
+from unique_toolkit.agentic.message_log_manager.service import MessageStepLogger
+from unique_toolkit.chat.schemas import MessageLog, MessageLogStatus
+from unique_toolkit.content.schemas import ContentReference
+
+_LOGGER = getLogger(__name__)
+
+_LOADING_HEADER = "Loading context memory"
+_UPDATING_HEADER = "Updating your memory"
+_CONTEXT_MEMORY_PILL = "Context memory"
+_REVIEW_MEMORY_PILL = "Review your context memory"
+
+
+def _memory_reference(*, name: str, content_id: str) -> ContentReference:
+    return ContentReference(
+        name=name,
+        sequence_number=0,
+        source="internal",
+        source_id=content_id,
+        url=f"unique://content/{content_id}",
+    )
+
+
+class UserMemoryMessageLogger:
+    """Emits Steps for loading and updating the user's context memory file."""
+
+    def __init__(
+        self,
+        message_step_logger: MessageStepLogger,
+        *,
+        logger: Logger | None = None,
+    ) -> None:
+        self._message_step_logger = message_step_logger
+        self._logger = logger or _LOGGER
+        self._loading_log: MessageLog | None = None
+        self._updating_log: MessageLog | None = None
+
+    async def log_loading_start(self) -> None:
+        await self._safe_create_or_update(
+            active_attr="_loading_log",
+            header=_LOADING_HEADER,
+            status=MessageLogStatus.RUNNING,
+            references=[],
+            action="start loading step",
+        )
+
+    async def log_loading_complete(self, *, content_id: str | None) -> None:
+        # Attach the pill on the loading step itself (same pattern as update).
+        # A separate MessageLog with empty text is dropped / invisible in the
+        # chat Steps UI, so the link must ride on this COMPLETED entry.
+        references = (
+            [_memory_reference(name=_CONTEXT_MEMORY_PILL, content_id=content_id)]
+            if content_id
+            else []
+        )
+        await self._safe_create_or_update(
+            active_attr="_loading_log",
+            header=_LOADING_HEADER,
+            status=MessageLogStatus.COMPLETED,
+            references=references,
+            action="complete loading step",
+        )
+
+    async def log_updating_start(self, *, content_id: str | None) -> None:
+        references = (
+            [_memory_reference(name=_REVIEW_MEMORY_PILL, content_id=content_id)]
+            if content_id
+            else []
+        )
+        await self._safe_create_or_update(
+            active_attr="_updating_log",
+            header=_UPDATING_HEADER,
+            status=MessageLogStatus.RUNNING,
+            references=references,
+            action="start updating step",
+        )
+
+    async def log_updating_complete(self, *, content_id: str | None) -> None:
+        references = (
+            [_memory_reference(name=_REVIEW_MEMORY_PILL, content_id=content_id)]
+            if content_id
+            else []
+        )
+        await self._safe_create_or_update(
+            active_attr="_updating_log",
+            header=_UPDATING_HEADER,
+            status=MessageLogStatus.COMPLETED,
+            references=references,
+            action="complete updating step",
+        )
+
+    async def _safe_create_or_update(
+        self,
+        *,
+        active_attr: str,
+        header: str,
+        status: MessageLogStatus,
+        references: list[ContentReference],
+        action: str,
+    ) -> None:
+        try:
+            active = getattr(self, active_attr)
+            updated = (
+                await self._message_step_logger.create_or_update_message_log_async(
+                    active_message_log=active,
+                    header=header,
+                    status=status,
+                    references=references,
+                )
+            )
+            if updated is not None:
+                setattr(self, active_attr, updated)
+        except Exception as exc:
+            self._logger.warning(
+                "[user-memory] failed to %s: [%s] %s",
+                action,
+                type(exc).__name__,
+                exc,
+            )

--- a/postprocessors/unique_user_memory/unique_user_memory/user_memory_message_log.py
+++ b/postprocessors/unique_user_memory/unique_user_memory/user_memory_message_log.py
@@ -71,16 +71,22 @@ class UserMemoryMessageLogger:
             active_attr="_updating_log",
             header=_UPDATING_HEADER,
             status=MessageLogStatus.RUNNING,
-            references=[_memory_settings_reference(name=_REVIEW_MEMORY_PILL)],
+            references=[],
             action="start updating step",
         )
 
-    async def log_updating_complete(self) -> None:
+    async def log_updating_complete(self, *, with_pill: bool = False) -> None:
+        # Review pill only after memory was actually written (caller sets
+        # with_pill=True post-upload). While consolidating / on failed upload
+        # the step completes without a pill.
+        references = (
+            [_memory_settings_reference(name=_REVIEW_MEMORY_PILL)] if with_pill else []
+        )
         await self._safe_create_or_update(
             active_attr="_updating_log",
             header=_UPDATING_HEADER,
             status=MessageLogStatus.COMPLETED,
-            references=[_memory_settings_reference(name=_REVIEW_MEMORY_PILL)],
+            references=references,
             action="complete updating step",
         )
 

--- a/postprocessors/unique_user_memory/unique_user_memory/user_memory_message_log.py
+++ b/postprocessors/unique_user_memory/unique_user_memory/user_memory_message_log.py
@@ -13,14 +13,18 @@ _UPDATING_HEADER = "Updating your memory"
 _CONTEXT_MEMORY_PILL = "Context memory"
 _REVIEW_MEMORY_PILL = "Review your context memory"
 
+# Opens the chat Settings → Context Memory tab (handled by the frontend).
+SETTINGS_CONTEXT_MEMORY_URL = "unique://settings/context-memory"
+CONTEXT_MEMORY_REFERENCE_SOURCE = "context-memory"
 
-def _memory_reference(*, name: str, content_id: str) -> ContentReference:
+
+def _memory_settings_reference(*, name: str) -> ContentReference:
     return ContentReference(
         name=name,
         sequence_number=0,
-        source="internal",
-        source_id=content_id,
-        url=f"unique://content/{content_id}",
+        source=CONTEXT_MEMORY_REFERENCE_SOURCE,
+        source_id=CONTEXT_MEMORY_REFERENCE_SOURCE,
+        url=SETTINGS_CONTEXT_MEMORY_URL,
     )
 
 
@@ -47,14 +51,12 @@ class UserMemoryMessageLogger:
             action="start loading step",
         )
 
-    async def log_loading_complete(self, *, content_id: str | None) -> None:
+    async def log_loading_complete(self, *, with_pill: bool = True) -> None:
         # Attach the pill on the loading step itself (same pattern as update).
         # A separate MessageLog with empty text is dropped / invisible in the
         # chat Steps UI, so the link must ride on this COMPLETED entry.
         references = (
-            [_memory_reference(name=_CONTEXT_MEMORY_PILL, content_id=content_id)]
-            if content_id
-            else []
+            [_memory_settings_reference(name=_CONTEXT_MEMORY_PILL)] if with_pill else []
         )
         await self._safe_create_or_update(
             active_attr="_loading_log",
@@ -64,31 +66,21 @@ class UserMemoryMessageLogger:
             action="complete loading step",
         )
 
-    async def log_updating_start(self, *, content_id: str | None) -> None:
-        references = (
-            [_memory_reference(name=_REVIEW_MEMORY_PILL, content_id=content_id)]
-            if content_id
-            else []
-        )
+    async def log_updating_start(self) -> None:
         await self._safe_create_or_update(
             active_attr="_updating_log",
             header=_UPDATING_HEADER,
             status=MessageLogStatus.RUNNING,
-            references=references,
+            references=[_memory_settings_reference(name=_REVIEW_MEMORY_PILL)],
             action="start updating step",
         )
 
-    async def log_updating_complete(self, *, content_id: str | None) -> None:
-        references = (
-            [_memory_reference(name=_REVIEW_MEMORY_PILL, content_id=content_id)]
-            if content_id
-            else []
-        )
+    async def log_updating_complete(self) -> None:
         await self._safe_create_or_update(
             active_attr="_updating_log",
             header=_UPDATING_HEADER,
             status=MessageLogStatus.COMPLETED,
-            references=references,
+            references=[_memory_settings_reference(name=_REVIEW_MEMORY_PILL)],
             action="complete updating step",
         )
 

--- a/postprocessors/unique_user_memory/unique_user_memory/user_memory_message_log.py
+++ b/postprocessors/unique_user_memory/unique_user_memory/user_memory_message_log.py
@@ -66,6 +66,17 @@ class UserMemoryMessageLogger:
             action="complete loading step",
         )
 
+    async def log_loading_failed(self) -> None:
+        # Always close the RUNNING step when load raises; otherwise the chat
+        # Steps UI leaves "Loading context memory" stuck for that turn.
+        await self._safe_create_or_update(
+            active_attr="_loading_log",
+            header=_LOADING_HEADER,
+            status=MessageLogStatus.FAILED,
+            references=[],
+            action="fail loading step",
+        )
+
     async def log_updating_start(self) -> None:
         await self._safe_create_or_update(
             active_attr="_updating_log",

--- a/postprocessors/unique_user_memory/unique_user_memory/user_memory_postprocessor.py
+++ b/postprocessors/unique_user_memory/unique_user_memory/user_memory_postprocessor.py
@@ -100,7 +100,8 @@ class UserMemoryPostprocessor(Postprocessor):
             await self._message_logger.log_updating_start()
 
         async def _on_update_end() -> None:
-            await self._message_logger.log_updating_complete()
+            # Complete without the review pill; attach it only after upload.
+            await self._message_logger.log_updating_complete(with_pill=False)
 
         on_update_start: Callable[[], Awaitable[None]] = _on_update_start
         on_update_end: Callable[[], Awaitable[None]] = _on_update_end
@@ -134,6 +135,7 @@ class UserMemoryPostprocessor(Postprocessor):
             self._logger.warning("[user-memory] memory update was not uploaded")
             return False
 
+        await self._message_logger.log_updating_complete(with_pill=True)
         self._logger.info("[user-memory] memory updated and uploaded successfully")
         return True
 

--- a/postprocessors/unique_user_memory/unique_user_memory/user_memory_postprocessor.py
+++ b/postprocessors/unique_user_memory/unique_user_memory/user_memory_postprocessor.py
@@ -99,8 +99,8 @@ class UserMemoryPostprocessor(Postprocessor):
             await self._message_logger.log_updating_start()
 
         async def _on_update_end() -> None:
-            # Complete without the review pill; attach it only after upload.
-            await self._message_logger.log_updating_complete(with_pill=False)
+            # Complete without the review entry; attach it only after upload.
+            await self._message_logger.log_updating_complete(with_settings_entry=False)
 
         on_update_start: Callable[[], Awaitable[None]] = _on_update_start
         on_update_end: Callable[[], Awaitable[None]] = _on_update_end
@@ -134,7 +134,7 @@ class UserMemoryPostprocessor(Postprocessor):
             self._logger.warning("[user-memory] memory update was not uploaded")
             return False
 
-        await self._message_logger.log_updating_complete(with_pill=True)
+        await self._message_logger.log_updating_complete(with_settings_entry=True)
         self._logger.info("[user-memory] memory updated and uploaded successfully")
         return True
 

--- a/postprocessors/unique_user_memory/unique_user_memory/user_memory_postprocessor.py
+++ b/postprocessors/unique_user_memory/unique_user_memory/user_memory_postprocessor.py
@@ -1,10 +1,10 @@
 from collections.abc import Awaitable, Callable
 from logging import Logger
 
+from unique_toolkit.agentic.message_log_manager.service import MessageStepLogger
 from unique_toolkit.agentic.postprocessor.postprocessor_manager import Postprocessor
 from unique_toolkit.app.schemas import ChatEvent
 from unique_toolkit.chat.service import ChatService
-from unique_toolkit.content.schemas import ContentReference
 from unique_toolkit.language_model.default_language_model import (
     DEFAULT_LANGUAGE_MODEL,
 )
@@ -16,13 +16,9 @@ from unique_user_memory.config import UserMemoryConfig
 from unique_user_memory.user_memory import (
     UserMemoryState,
     consolidate_user_memory,
-    noop_update_callback,
     upload_user_memory,
 )
-
-# Transient marker appended to the assistant message while the (slow) memory
-# rewrite runs; removed again once consolidation finishes.
-_UPDATING_NOTICE = "\n\n---\n\n🧠 _Updating context memory…_"
+from unique_user_memory.user_memory_message_log import UserMemoryMessageLogger
 
 
 class UserMemoryPostprocessor(Postprocessor):
@@ -37,6 +33,8 @@ class UserMemoryPostprocessor(Postprocessor):
         state: UserMemoryState,
         logger: Logger,
         chat_service: ChatService,
+        message_step_logger: MessageStepLogger | None = None,
+        message_logger: UserMemoryMessageLogger | None = None,
     ) -> None:
         super().__init__(name="UserMemoryPostprocessor")
         self._config = config
@@ -52,6 +50,18 @@ class UserMemoryPostprocessor(Postprocessor):
         self._chat_service: ChatService = chat_service
         self._pending_load_invocation_stats = list(state.load_invocation_stats)
         self._invocation_stats: list[LanguageModelInvocationStats] = []
+        if message_logger is not None:
+            self._message_logger = message_logger
+        elif message_step_logger is not None:
+            self._message_logger = UserMemoryMessageLogger(
+                message_step_logger,
+                logger=logger,
+            )
+        else:
+            self._message_logger = UserMemoryMessageLogger(
+                MessageStepLogger(chat_service),
+                logger=logger,
+            )
 
     @property
     def invocation_stats(self) -> list[LanguageModelInvocationStats]:
@@ -86,31 +96,16 @@ class UserMemoryPostprocessor(Postprocessor):
         if not user_id or not company_id:
             return False
 
-        on_update_start: Callable[[], Awaitable[None]] = noop_update_callback
-        on_update_end: Callable[[], Awaitable[None]] = noop_update_callback
-        if self._config.updating_notice_enabled:
-            original_text = loop_response.message.text or ""
-            message_id = loop_response.message.id
-            references = loop_response.message.references
+        content_id = self._state.content_id
 
-            async def _on_update_start() -> None:
-                await self._set_message_content(
-                    content=original_text + _UPDATING_NOTICE,
-                    message_id=message_id,
-                    references=references,
-                    action="show updating notice",
-                )
+        async def _on_update_start() -> None:
+            await self._message_logger.log_updating_start(content_id=content_id)
 
-            async def _on_update_end() -> None:
-                await self._set_message_content(
-                    content=original_text,
-                    message_id=message_id,
-                    references=references,
-                    action="remove updating notice",
-                )
+        async def _on_update_end() -> None:
+            await self._message_logger.log_updating_complete(content_id=content_id)
 
-            on_update_start = _on_update_start
-            on_update_end = _on_update_end
+        on_update_start: Callable[[], Awaitable[None]] = _on_update_start
+        on_update_end: Callable[[], Awaitable[None]] = _on_update_end
 
         self._new_memory = await consolidate_user_memory(
             current_memory=self._state.text,
@@ -130,41 +125,23 @@ class UserMemoryPostprocessor(Postprocessor):
             self._logger.debug("[user-memory] consolidation NOOP - skipping upload")
             return False
 
-        uploaded = await upload_user_memory(
+        uploaded_content_id = await upload_user_memory(
             scope_id=self._state.scope_id,
             content=self._new_memory,
             user_id=user_id,
             company_id=company_id,
             logger=self._logger,
         )
-        if not uploaded:
+        if not uploaded_content_id:
             self._logger.warning("[user-memory] memory update was not uploaded")
             return False
 
+        # Prefer the freshly uploaded id so the review pill works on first write.
+        await self._message_logger.log_updating_complete(
+            content_id=uploaded_content_id or content_id
+        )
         self._logger.info("[user-memory] memory updated and uploaded successfully")
         return True
-
-    async def _set_message_content(
-        self,
-        *,
-        content: str,
-        message_id: str | None,
-        references: list[ContentReference] | None,
-        action: str,
-    ) -> None:
-        try:
-            await self._chat_service.modify_assistant_message_async(
-                content=content,
-                message_id=message_id,
-                references=references,
-            )
-        except Exception as exc:
-            self._logger.warning(
-                "[user-memory] failed to %s: [%s] %s",
-                action,
-                type(exc).__name__,
-                exc,
-            )
 
     def apply_postprocessing_to_response(
         self, loop_response: LanguageModelStreamResponse

--- a/postprocessors/unique_user_memory/unique_user_memory/user_memory_postprocessor.py
+++ b/postprocessors/unique_user_memory/unique_user_memory/user_memory_postprocessor.py
@@ -96,13 +96,11 @@ class UserMemoryPostprocessor(Postprocessor):
         if not user_id or not company_id:
             return False
 
-        content_id = self._state.content_id
-
         async def _on_update_start() -> None:
-            await self._message_logger.log_updating_start(content_id=content_id)
+            await self._message_logger.log_updating_start()
 
         async def _on_update_end() -> None:
-            await self._message_logger.log_updating_complete(content_id=content_id)
+            await self._message_logger.log_updating_complete()
 
         on_update_start: Callable[[], Awaitable[None]] = _on_update_start
         on_update_end: Callable[[], Awaitable[None]] = _on_update_end
@@ -125,21 +123,17 @@ class UserMemoryPostprocessor(Postprocessor):
             self._logger.debug("[user-memory] consolidation NOOP - skipping upload")
             return False
 
-        uploaded_content_id = await upload_user_memory(
+        uploaded = await upload_user_memory(
             scope_id=self._state.scope_id,
             content=self._new_memory,
             user_id=user_id,
             company_id=company_id,
             logger=self._logger,
         )
-        if not uploaded_content_id:
+        if not uploaded:
             self._logger.warning("[user-memory] memory update was not uploaded")
             return False
 
-        # Prefer the freshly uploaded id so the review pill works on first write.
-        await self._message_logger.log_updating_complete(
-            content_id=uploaded_content_id or content_id
-        )
         self._logger.info("[user-memory] memory updated and uploaded successfully")
         return True
 

--- a/postprocessors/unique_user_memory/unique_user_memory/user_memory_postprocessor.py
+++ b/postprocessors/unique_user_memory/unique_user_memory/user_memory_postprocessor.py
@@ -1,10 +1,8 @@
 from collections.abc import Awaitable, Callable
 from logging import Logger
 
-from unique_toolkit.agentic.message_log_manager.service import MessageStepLogger
 from unique_toolkit.agentic.postprocessor.postprocessor_manager import Postprocessor
 from unique_toolkit.app.schemas import ChatEvent
-from unique_toolkit.chat.service import ChatService
 from unique_toolkit.language_model.default_language_model import (
     DEFAULT_LANGUAGE_MODEL,
 )
@@ -32,9 +30,7 @@ class UserMemoryPostprocessor(Postprocessor):
         event: ChatEvent,
         state: UserMemoryState,
         logger: Logger,
-        chat_service: ChatService,
-        message_step_logger: MessageStepLogger | None = None,
-        message_logger: UserMemoryMessageLogger | None = None,
+        message_step_logger: UserMemoryMessageLogger,
     ) -> None:
         super().__init__(name="UserMemoryPostprocessor")
         self._config = config
@@ -49,18 +45,7 @@ class UserMemoryPostprocessor(Postprocessor):
         self._new_memory: str | None = None
         self._pending_load_invocation_stats = list(state.load_invocation_stats)
         self._invocation_stats: list[LanguageModelInvocationStats] = []
-        if message_logger is not None:
-            self._message_logger = message_logger
-        elif message_step_logger is not None:
-            self._message_logger = UserMemoryMessageLogger(
-                message_step_logger,
-                logger=logger,
-            )
-        else:
-            self._message_logger = UserMemoryMessageLogger(
-                MessageStepLogger(chat_service),
-                logger=logger,
-            )
+        self._message_step_logger = message_step_logger
 
     @property
     def invocation_stats(self) -> list[LanguageModelInvocationStats]:
@@ -96,11 +81,13 @@ class UserMemoryPostprocessor(Postprocessor):
             return False
 
         async def _on_update_start() -> None:
-            await self._message_logger.log_updating_start()
+            await self._message_step_logger.log_updating_start()
 
         async def _on_update_end() -> None:
             # Complete without the review entry; attach it only after upload.
-            await self._message_logger.log_updating_complete(with_settings_entry=False)
+            await self._message_step_logger.log_updating_complete(
+                with_settings_entry=False
+            )
 
         on_update_start: Callable[[], Awaitable[None]] = _on_update_start
         on_update_end: Callable[[], Awaitable[None]] = _on_update_end
@@ -134,7 +121,7 @@ class UserMemoryPostprocessor(Postprocessor):
             self._logger.warning("[user-memory] memory update was not uploaded")
             return False
 
-        await self._message_logger.log_updating_complete(with_settings_entry=True)
+        await self._message_step_logger.log_updating_complete(with_settings_entry=True)
         self._logger.info("[user-memory] memory updated and uploaded successfully")
         return True
 

--- a/postprocessors/unique_user_memory/unique_user_memory/user_memory_postprocessor.py
+++ b/postprocessors/unique_user_memory/unique_user_memory/user_memory_postprocessor.py
@@ -47,7 +47,6 @@ class UserMemoryPostprocessor(Postprocessor):
         self._state = state
         self._logger = logger
         self._new_memory: str | None = None
-        self._chat_service: ChatService = chat_service
         self._pending_load_invocation_stats = list(state.load_invocation_stats)
         self._invocation_stats: list[LanguageModelInvocationStats] = []
         if message_logger is not None:

--- a/unique_orchestrator/tests/test_unique_ai_builder_uploaded_search.py
+++ b/unique_orchestrator/tests/test_unique_ai_builder_uploaded_search.py
@@ -25,6 +25,8 @@ from unique_orchestrator.unique_ai_builder import (
     _configure_uploaded_search_tool,
 )
 
+_DEFAULT_MEMORY_STATE = object()
+
 
 def _make_common_components(uploaded_documents):
     tool_manager_config = ToolManagerConfig(tools=[])
@@ -63,7 +65,7 @@ def _make_event(tool_choices):
 def _patch_build_common_user_memory(
     monkeypatch: pytest.MonkeyPatch,
     *,
-    memory_state: UserMemoryState | None = None,
+    memory_state: UserMemoryState | None | object = _DEFAULT_MEMORY_STATE,
 ) -> tuple[MagicMock, AsyncMock, MagicMock]:
     event = _make_event(tool_choices=[])
     event.payload.additional_parameters = None
@@ -119,7 +121,7 @@ def _patch_build_common_user_memory(
         "unique_orchestrator.unique_ai_builder.UserMemoryMessageLogger",
         MagicMock(return_value=memory_message_logger),
     )
-    if memory_state is None:
+    if memory_state is _DEFAULT_MEMORY_STATE:
         memory_state = UserMemoryState(
             scope_id="scope_1",
             text="remembered",
@@ -193,6 +195,14 @@ async def test_build_common_registers_user_memory_when_space_allow_user_memory(
 async def test_build_common_load_steps_skip_pill_when_memory_load_fails(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """
+    Purpose: When load_user_memory returns None, complete the loading Step
+    without the context-memory pill.
+    Why this matters: A soft-failed / missing memory load should not surface a
+    Settings pill as if memory were available.
+    Setup summary: Patch load to return None; assert complete(with_pill=False)
+    and that failed is not used.
+    """
     event, load_user_memory, memory_message_logger = _patch_build_common_user_memory(
         monkeypatch,
         memory_state=None,

--- a/unique_orchestrator/tests/test_unique_ai_builder_uploaded_search.py
+++ b/unique_orchestrator/tests/test_unique_ai_builder_uploaded_search.py
@@ -122,7 +122,6 @@ def _patch_build_common_user_memory(
         memory_state = UserMemoryState(
             scope_id="scope_1",
             text="remembered",
-            content_id="content_1",
         )
     load_user_memory = AsyncMock(return_value=memory_state)
     monkeypatch.setattr(
@@ -178,9 +177,7 @@ async def test_build_common_registers_user_memory_when_space_allow_user_memory(
 
     load_user_memory.assert_awaited_once()
     memory_message_logger.log_loading_start.assert_awaited_once()
-    memory_message_logger.log_loading_complete.assert_awaited_once_with(
-        content_id="content_1"
-    )
+    memory_message_logger.log_loading_complete.assert_awaited_once_with(with_pill=True)
     assert common_components.user_memory_text == "remembered"
     postprocessor_names = [
         postprocessor.name
@@ -192,12 +189,12 @@ async def test_build_common_registers_user_memory_when_space_allow_user_memory(
 
 
 @pytest.mark.asyncio
-async def test_build_common_load_steps_skip_pill_when_memory_file_missing(
+async def test_build_common_load_steps_skip_pill_when_memory_load_fails(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     event, load_user_memory, memory_message_logger = _patch_build_common_user_memory(
         monkeypatch,
-        memory_state=UserMemoryState(scope_id="scope_1", text="", content_id=None),
+        memory_state=None,
     )
 
     config = UniqueAIConfig(space={"allowUserMemory": True})
@@ -209,7 +206,7 @@ async def test_build_common_load_steps_skip_pill_when_memory_file_missing(
 
     load_user_memory.assert_awaited_once()
     memory_message_logger.log_loading_start.assert_awaited_once()
-    memory_message_logger.log_loading_complete.assert_awaited_once_with(content_id=None)
+    memory_message_logger.log_loading_complete.assert_awaited_once_with(with_pill=False)
 
 
 class TestSerializeUploadedFileForHistory:

--- a/unique_orchestrator/tests/test_unique_ai_builder_uploaded_search.py
+++ b/unique_orchestrator/tests/test_unique_ai_builder_uploaded_search.py
@@ -62,7 +62,9 @@ def _make_event(tool_choices):
 
 def _patch_build_common_user_memory(
     monkeypatch: pytest.MonkeyPatch,
-) -> tuple[MagicMock, AsyncMock]:
+    *,
+    memory_state: UserMemoryState | None = None,
+) -> tuple[MagicMock, AsyncMock, MagicMock]:
     event = _make_event(tool_choices=[])
     event.payload.additional_parameters = None
     event.payload.mcp_servers = []
@@ -109,21 +111,35 @@ def _patch_build_common_user_memory(
         "unique_orchestrator.unique_ai_builder.MessageStepLogger",
         MagicMock(return_value=MagicMock()),
     )
-    memory_state = UserMemoryState(scope_id="scope_1", text="remembered")
+    memory_message_logger = MagicMock()
+    memory_message_logger.log_loading_start = AsyncMock()
+    memory_message_logger.log_loading_complete = AsyncMock()
+    monkeypatch.setattr(
+        "unique_orchestrator.unique_ai_builder.UserMemoryMessageLogger",
+        MagicMock(return_value=memory_message_logger),
+    )
+    if memory_state is None:
+        memory_state = UserMemoryState(
+            scope_id="scope_1",
+            text="remembered",
+            content_id="content_1",
+        )
     load_user_memory = AsyncMock(return_value=memory_state)
     monkeypatch.setattr(
         "unique_orchestrator.unique_ai_builder.load_user_memory",
         load_user_memory,
     )
 
-    return event, load_user_memory
+    return event, load_user_memory, memory_message_logger
 
 
 @pytest.mark.asyncio
 async def test_build_common_skips_user_memory_when_space_disallows_user_memory(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    event, load_user_memory = _patch_build_common_user_memory(monkeypatch)
+    event, load_user_memory, memory_message_logger = _patch_build_common_user_memory(
+        monkeypatch
+    )
 
     config = UniqueAIConfig()
 
@@ -134,6 +150,7 @@ async def test_build_common_skips_user_memory_when_space_disallows_user_memory(
     )
 
     load_user_memory.assert_not_awaited()
+    memory_message_logger.log_loading_start.assert_not_awaited()
     assert common_components.user_memory_text == ""
     postprocessor_names = [
         postprocessor.name
@@ -148,7 +165,9 @@ async def test_build_common_skips_user_memory_when_space_disallows_user_memory(
 async def test_build_common_registers_user_memory_when_space_allow_user_memory(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    event, load_user_memory = _patch_build_common_user_memory(monkeypatch)
+    event, load_user_memory, memory_message_logger = _patch_build_common_user_memory(
+        monkeypatch
+    )
 
     config = UniqueAIConfig(space={"allowUserMemory": True})
     common_components = await _build_common(
@@ -158,6 +177,10 @@ async def test_build_common_registers_user_memory_when_space_allow_user_memory(
     )
 
     load_user_memory.assert_awaited_once()
+    memory_message_logger.log_loading_start.assert_awaited_once()
+    memory_message_logger.log_loading_complete.assert_awaited_once_with(
+        content_id="content_1"
+    )
     assert common_components.user_memory_text == "remembered"
     postprocessor_names = [
         postprocessor.name
@@ -166,6 +189,27 @@ async def test_build_common_registers_user_memory_when_space_allow_user_memory(
         )
     ]
     assert "UserMemoryPostprocessor" in postprocessor_names
+
+
+@pytest.mark.asyncio
+async def test_build_common_load_steps_skip_pill_when_memory_file_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    event, load_user_memory, memory_message_logger = _patch_build_common_user_memory(
+        monkeypatch,
+        memory_state=UserMemoryState(scope_id="scope_1", text="", content_id=None),
+    )
+
+    config = UniqueAIConfig(space={"allowUserMemory": True})
+    await _build_common(
+        event=event,
+        logger=MagicMock(),
+        config=config,
+    )
+
+    load_user_memory.assert_awaited_once()
+    memory_message_logger.log_loading_start.assert_awaited_once()
+    memory_message_logger.log_loading_complete.assert_awaited_once_with(content_id=None)
 
 
 class TestSerializeUploadedFileForHistory:

--- a/unique_orchestrator/tests/test_unique_ai_builder_uploaded_search.py
+++ b/unique_orchestrator/tests/test_unique_ai_builder_uploaded_search.py
@@ -113,13 +113,13 @@ def _patch_build_common_user_memory(
         "unique_orchestrator.unique_ai_builder.MessageStepLogger",
         MagicMock(return_value=MagicMock()),
     )
-    memory_message_logger = MagicMock()
-    memory_message_logger.log_loading_start = AsyncMock()
-    memory_message_logger.log_loading_complete = AsyncMock()
-    memory_message_logger.log_loading_failed = AsyncMock()
+    memory_message_step_logger = MagicMock()
+    memory_message_step_logger.log_loading_start = AsyncMock()
+    memory_message_step_logger.log_loading_complete = AsyncMock()
+    memory_message_step_logger.log_loading_failed = AsyncMock()
     monkeypatch.setattr(
         "unique_orchestrator.unique_ai_builder.UserMemoryMessageLogger",
-        MagicMock(return_value=memory_message_logger),
+        MagicMock(return_value=memory_message_step_logger),
     )
     if memory_state is _DEFAULT_MEMORY_STATE:
         memory_state = UserMemoryState(
@@ -132,14 +132,14 @@ def _patch_build_common_user_memory(
         load_user_memory,
     )
 
-    return event, load_user_memory, memory_message_logger
+    return event, load_user_memory, memory_message_step_logger
 
 
 @pytest.mark.asyncio
 async def test_build_common_skips_user_memory_when_space_disallows_user_memory(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    event, load_user_memory, memory_message_logger = _patch_build_common_user_memory(
+    event, load_user_memory, memory_message_step_logger = _patch_build_common_user_memory(
         monkeypatch
     )
 
@@ -152,7 +152,7 @@ async def test_build_common_skips_user_memory_when_space_disallows_user_memory(
     )
 
     load_user_memory.assert_not_awaited()
-    memory_message_logger.log_loading_start.assert_not_awaited()
+    memory_message_step_logger.log_loading_start.assert_not_awaited()
     assert common_components.user_memory_text == ""
     postprocessor_names = [
         postprocessor.name
@@ -167,7 +167,7 @@ async def test_build_common_skips_user_memory_when_space_disallows_user_memory(
 async def test_build_common_registers_user_memory_when_space_allow_user_memory(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    event, load_user_memory, memory_message_logger = _patch_build_common_user_memory(
+    event, load_user_memory, memory_message_step_logger = _patch_build_common_user_memory(
         monkeypatch
     )
 
@@ -179,8 +179,8 @@ async def test_build_common_registers_user_memory_when_space_allow_user_memory(
     )
 
     load_user_memory.assert_awaited_once()
-    memory_message_logger.log_loading_start.assert_awaited_once()
-    memory_message_logger.log_loading_complete.assert_awaited_once_with(
+    memory_message_step_logger.log_loading_start.assert_awaited_once()
+    memory_message_step_logger.log_loading_complete.assert_awaited_once_with(
         with_settings_entry=True
     )
     assert common_components.user_memory_text == "remembered"
@@ -205,7 +205,7 @@ async def test_build_common_load_steps_skip_settings_entry_when_memory_load_fail
     Setup summary: Patch load to return None; assert complete(with_settings_entry=False)
     and that failed is not used.
     """
-    event, load_user_memory, memory_message_logger = _patch_build_common_user_memory(
+    event, load_user_memory, memory_message_step_logger = _patch_build_common_user_memory(
         monkeypatch,
         memory_state=None,
     )
@@ -218,11 +218,11 @@ async def test_build_common_load_steps_skip_settings_entry_when_memory_load_fail
     )
 
     load_user_memory.assert_awaited_once()
-    memory_message_logger.log_loading_start.assert_awaited_once()
-    memory_message_logger.log_loading_complete.assert_awaited_once_with(
+    memory_message_step_logger.log_loading_start.assert_awaited_once()
+    memory_message_step_logger.log_loading_complete.assert_awaited_once_with(
         with_settings_entry=False
     )
-    memory_message_logger.log_loading_failed.assert_not_awaited()
+    memory_message_step_logger.log_loading_failed.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -237,7 +237,7 @@ async def test_build_common_closes_loading_step_when_memory_load_raises(
     Setup summary: Patch load to raise; assert failed is awaited, complete is
     not, and UserMemoryPostprocessor is not registered.
     """
-    event, load_user_memory, memory_message_logger = _patch_build_common_user_memory(
+    event, load_user_memory, memory_message_step_logger = _patch_build_common_user_memory(
         monkeypatch
     )
     load_user_memory.side_effect = RuntimeError("memory store unavailable")
@@ -251,9 +251,9 @@ async def test_build_common_closes_loading_step_when_memory_load_raises(
     )
 
     load_user_memory.assert_awaited_once()
-    memory_message_logger.log_loading_start.assert_awaited_once()
-    memory_message_logger.log_loading_failed.assert_awaited_once()
-    memory_message_logger.log_loading_complete.assert_not_awaited()
+    memory_message_step_logger.log_loading_start.assert_awaited_once()
+    memory_message_step_logger.log_loading_failed.assert_awaited_once()
+    memory_message_step_logger.log_loading_complete.assert_not_awaited()
     assert common_components.user_memory_text == ""
     postprocessor_names = [
         postprocessor.name

--- a/unique_orchestrator/tests/test_unique_ai_builder_uploaded_search.py
+++ b/unique_orchestrator/tests/test_unique_ai_builder_uploaded_search.py
@@ -180,7 +180,9 @@ async def test_build_common_registers_user_memory_when_space_allow_user_memory(
 
     load_user_memory.assert_awaited_once()
     memory_message_logger.log_loading_start.assert_awaited_once()
-    memory_message_logger.log_loading_complete.assert_awaited_once_with(with_pill=True)
+    memory_message_logger.log_loading_complete.assert_awaited_once_with(
+        with_settings_entry=True
+    )
     assert common_components.user_memory_text == "remembered"
     postprocessor_names = [
         postprocessor.name
@@ -192,15 +194,15 @@ async def test_build_common_registers_user_memory_when_space_allow_user_memory(
 
 
 @pytest.mark.asyncio
-async def test_build_common_load_steps_skip_pill_when_memory_load_fails(
+async def test_build_common_load_steps_skip_settings_entry_when_memory_load_fails(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """
     Purpose: When load_user_memory returns None, complete the loading Step
-    without the context-memory pill.
+    without the context-memory settings entry.
     Why this matters: A soft-failed / missing memory load should not surface a
-    Settings pill as if memory were available.
-    Setup summary: Patch load to return None; assert complete(with_pill=False)
+    Settings entry as if memory were available.
+    Setup summary: Patch load to return None; assert complete(with_settings_entry=False)
     and that failed is not used.
     """
     event, load_user_memory, memory_message_logger = _patch_build_common_user_memory(
@@ -217,7 +219,9 @@ async def test_build_common_load_steps_skip_pill_when_memory_load_fails(
 
     load_user_memory.assert_awaited_once()
     memory_message_logger.log_loading_start.assert_awaited_once()
-    memory_message_logger.log_loading_complete.assert_awaited_once_with(with_pill=False)
+    memory_message_logger.log_loading_complete.assert_awaited_once_with(
+        with_settings_entry=False
+    )
     memory_message_logger.log_loading_failed.assert_not_awaited()
 
 

--- a/unique_orchestrator/tests/test_unique_ai_builder_uploaded_search.py
+++ b/unique_orchestrator/tests/test_unique_ai_builder_uploaded_search.py
@@ -139,8 +139,8 @@ def _patch_build_common_user_memory(
 async def test_build_common_skips_user_memory_when_space_disallows_user_memory(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    event, load_user_memory, memory_message_step_logger = _patch_build_common_user_memory(
-        monkeypatch
+    event, load_user_memory, memory_message_step_logger = (
+        _patch_build_common_user_memory(monkeypatch)
     )
 
     config = UniqueAIConfig()
@@ -167,8 +167,8 @@ async def test_build_common_skips_user_memory_when_space_disallows_user_memory(
 async def test_build_common_registers_user_memory_when_space_allow_user_memory(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    event, load_user_memory, memory_message_step_logger = _patch_build_common_user_memory(
-        monkeypatch
+    event, load_user_memory, memory_message_step_logger = (
+        _patch_build_common_user_memory(monkeypatch)
     )
 
     config = UniqueAIConfig(space={"allowUserMemory": True})
@@ -205,9 +205,11 @@ async def test_build_common_load_steps_skip_settings_entry_when_memory_load_fail
     Setup summary: Patch load to return None; assert complete(with_settings_entry=False)
     and that failed is not used.
     """
-    event, load_user_memory, memory_message_step_logger = _patch_build_common_user_memory(
-        monkeypatch,
-        memory_state=None,
+    event, load_user_memory, memory_message_step_logger = (
+        _patch_build_common_user_memory(
+            monkeypatch,
+            memory_state=None,
+        )
     )
 
     config = UniqueAIConfig(space={"allowUserMemory": True})
@@ -237,8 +239,8 @@ async def test_build_common_closes_loading_step_when_memory_load_raises(
     Setup summary: Patch load to raise; assert failed is awaited, complete is
     not, and UserMemoryPostprocessor is not registered.
     """
-    event, load_user_memory, memory_message_step_logger = _patch_build_common_user_memory(
-        monkeypatch
+    event, load_user_memory, memory_message_step_logger = (
+        _patch_build_common_user_memory(monkeypatch)
     )
     load_user_memory.side_effect = RuntimeError("memory store unavailable")
     logger = MagicMock()

--- a/unique_orchestrator/tests/test_unique_ai_builder_uploaded_search.py
+++ b/unique_orchestrator/tests/test_unique_ai_builder_uploaded_search.py
@@ -114,6 +114,7 @@ def _patch_build_common_user_memory(
     memory_message_logger = MagicMock()
     memory_message_logger.log_loading_start = AsyncMock()
     memory_message_logger.log_loading_complete = AsyncMock()
+    memory_message_logger.log_loading_failed = AsyncMock()
     monkeypatch.setattr(
         "unique_orchestrator.unique_ai_builder.UserMemoryMessageLogger",
         MagicMock(return_value=memory_message_logger),
@@ -207,6 +208,51 @@ async def test_build_common_load_steps_skip_pill_when_memory_load_fails(
     load_user_memory.assert_awaited_once()
     memory_message_logger.log_loading_start.assert_awaited_once()
     memory_message_logger.log_loading_complete.assert_awaited_once_with(with_pill=False)
+    memory_message_logger.log_loading_failed.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_build_common_closes_loading_step_when_memory_load_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Purpose: When load_user_memory raises after log_loading_start, the loading
+    Step is marked FAILED and the turn continues without memory.
+    Why this matters: Otherwise the chat Steps UI leaves "Loading context
+    memory" stuck in RUNNING for that turn.
+    Setup summary: Patch load to raise; assert failed is awaited, complete is
+    not, and UserMemoryPostprocessor is not registered.
+    """
+    event, load_user_memory, memory_message_logger = _patch_build_common_user_memory(
+        monkeypatch
+    )
+    load_user_memory.side_effect = RuntimeError("memory store unavailable")
+    logger = MagicMock()
+
+    config = UniqueAIConfig(space={"allowUserMemory": True})
+    common_components = await _build_common(
+        event=event,
+        logger=logger,
+        config=config,
+    )
+
+    load_user_memory.assert_awaited_once()
+    memory_message_logger.log_loading_start.assert_awaited_once()
+    memory_message_logger.log_loading_failed.assert_awaited_once()
+    memory_message_logger.log_loading_complete.assert_not_awaited()
+    assert common_components.user_memory_text == ""
+    postprocessor_names = [
+        postprocessor.name
+        for postprocessor in common_components.postprocessor_manager.get_postprocessors(
+            "ignored"
+        )
+    ]
+    assert "UserMemoryPostprocessor" not in postprocessor_names
+    logger.warning.assert_any_call(
+        "[user-memory] load raised - running without memory: [%s] %s",
+        "RuntimeError",
+        load_user_memory.side_effect,
+    )
 
 
 class TestSerializeUploadedFileForHistory:

--- a/unique_orchestrator/unique_orchestrator/unique_ai_builder.py
+++ b/unique_orchestrator/unique_orchestrator/unique_ai_builder.py
@@ -423,7 +423,7 @@ async def _build_common(
                 await memory_message_logger.log_loading_failed()
 
         if load_succeeded and user_memory_state is not None:
-            await memory_message_logger.log_loading_complete(with_pill=True)
+            await memory_message_logger.log_loading_complete(with_settings_entry=True)
             user_memory_text = user_memory_state.text
             postprocessor_manager.add_postprocessor(
                 UserMemoryPostprocessor(
@@ -437,7 +437,7 @@ async def _build_common(
                 )
             )
         elif load_succeeded:
-            await memory_message_logger.log_loading_complete(with_pill=False)
+            await memory_message_logger.log_loading_complete(with_settings_entry=False)
 
     return _CommonComponents(
         chat_service=chat_service,

--- a/unique_orchestrator/unique_orchestrator/unique_ai_builder.py
+++ b/unique_orchestrator/unique_orchestrator/unique_ai_builder.py
@@ -400,13 +400,29 @@ async def _build_common(
             logger=logger,
         )
         await memory_message_logger.log_loading_start()
-        user_memory_state = await load_user_memory(
-            event=event,
-            config=user_memory_config,
-            language_model=memory_language_model,
-            logger=logger,
-        )
-        if user_memory_state is not None:
+        user_memory_state = None
+        load_succeeded = False
+        try:
+            user_memory_state = await load_user_memory(
+                event=event,
+                config=user_memory_config,
+                language_model=memory_language_model,
+                logger=logger,
+            )
+            load_succeeded = True
+        except Exception as exc:
+            # Soft-fail like a None return: keep the turn running without
+            # memory, but always close the RUNNING loading Step first.
+            logger.warning(
+                "[user-memory] load raised - running without memory: [%s] %s",
+                type(exc).__name__,
+                exc,
+            )
+        finally:
+            if not load_succeeded:
+                await memory_message_logger.log_loading_failed()
+
+        if load_succeeded and user_memory_state is not None:
             await memory_message_logger.log_loading_complete(with_pill=True)
             user_memory_text = user_memory_state.text
             postprocessor_manager.add_postprocessor(
@@ -420,7 +436,7 @@ async def _build_common(
                     message_logger=memory_message_logger,
                 )
             )
-        else:
+        elif load_succeeded:
             await memory_message_logger.log_loading_complete(with_pill=False)
 
     return _CommonComponents(

--- a/unique_orchestrator/unique_orchestrator/unique_ai_builder.py
+++ b/unique_orchestrator/unique_orchestrator/unique_ai_builder.py
@@ -70,6 +70,7 @@ from unique_toolkit.experimental.integrations.openai.streaming.event_routing imp
 from unique_toolkit.language_model.infos import LanguageModelInfo, ModelCapabilities
 from unique_toolkit.protocols.support import ResponsesSupportCompleteWithReferences
 from unique_user_memory.user_memory import load_user_memory
+from unique_user_memory.user_memory_message_log import UserMemoryMessageLogger
 from unique_user_memory.user_memory_postprocessor import UserMemoryPostprocessor
 
 from unique_orchestrator._builders import (
@@ -298,6 +299,7 @@ async def _build_common(
     config: UniqueAIConfig,
 ) -> _CommonComponents:
     chat_service = ChatService(event)
+    message_step_logger = MessageStepLogger(chat_service)
 
     llm_service = LanguageModelService.from_event(event)
 
@@ -393,6 +395,11 @@ async def _build_common(
             if user_memory_config.use_orchestrator_language_model
             else user_memory_config.language_model
         )
+        memory_message_logger = UserMemoryMessageLogger(
+            message_step_logger,
+            logger=logger,
+        )
+        await memory_message_logger.log_loading_start()
         user_memory_state = await load_user_memory(
             event=event,
             config=user_memory_config,
@@ -400,6 +407,9 @@ async def _build_common(
             logger=logger,
         )
         if user_memory_state is not None:
+            await memory_message_logger.log_loading_complete(
+                content_id=user_memory_state.content_id,
+            )
             user_memory_text = user_memory_state.text
             postprocessor_manager.add_postprocessor(
                 UserMemoryPostprocessor(
@@ -409,8 +419,11 @@ async def _build_common(
                     state=user_memory_state,
                     logger=logger,
                     chat_service=chat_service,
+                    message_logger=memory_message_logger,
                 )
             )
+        else:
+            await memory_message_logger.log_loading_complete(content_id=None)
 
     return _CommonComponents(
         chat_service=chat_service,
@@ -429,7 +442,7 @@ async def _build_common(
         user_memory_text=user_memory_text,
         postprocessor_manager=postprocessor_manager,
         response_watcher=response_watcher,
-        message_step_logger=MessageStepLogger(chat_service),
+        message_step_logger=message_step_logger,
     )
 
 

--- a/unique_orchestrator/unique_orchestrator/unique_ai_builder.py
+++ b/unique_orchestrator/unique_orchestrator/unique_ai_builder.py
@@ -395,11 +395,11 @@ async def _build_common(
             if user_memory_config.use_orchestrator_language_model
             else user_memory_config.language_model
         )
-        memory_message_logger = UserMemoryMessageLogger(
+        memory_message_step_logger = UserMemoryMessageLogger(
             message_step_logger,
             logger=logger,
         )
-        await memory_message_logger.log_loading_start()
+        await memory_message_step_logger.log_loading_start()
         user_memory_state = None
         load_succeeded = False
         try:
@@ -420,10 +420,12 @@ async def _build_common(
             )
         finally:
             if not load_succeeded:
-                await memory_message_logger.log_loading_failed()
+                await memory_message_step_logger.log_loading_failed()
 
         if load_succeeded and user_memory_state is not None:
-            await memory_message_logger.log_loading_complete(with_settings_entry=True)
+            await memory_message_step_logger.log_loading_complete(
+                with_settings_entry=True
+            )
             user_memory_text = user_memory_state.text
             postprocessor_manager.add_postprocessor(
                 UserMemoryPostprocessor(
@@ -432,12 +434,13 @@ async def _build_common(
                     event=event,
                     state=user_memory_state,
                     logger=logger,
-                    chat_service=chat_service,
-                    message_logger=memory_message_logger,
+                    message_step_logger=memory_message_step_logger,
                 )
             )
         elif load_succeeded:
-            await memory_message_logger.log_loading_complete(with_settings_entry=False)
+            await memory_message_step_logger.log_loading_complete(
+                with_settings_entry=False
+            )
 
     return _CommonComponents(
         chat_service=chat_service,

--- a/unique_orchestrator/unique_orchestrator/unique_ai_builder.py
+++ b/unique_orchestrator/unique_orchestrator/unique_ai_builder.py
@@ -407,9 +407,7 @@ async def _build_common(
             logger=logger,
         )
         if user_memory_state is not None:
-            await memory_message_logger.log_loading_complete(
-                content_id=user_memory_state.content_id,
-            )
+            await memory_message_logger.log_loading_complete(with_pill=True)
             user_memory_text = user_memory_state.text
             postprocessor_manager.add_postprocessor(
                 UserMemoryPostprocessor(
@@ -423,7 +421,7 @@ async def _build_common(
                 )
             )
         else:
-            await memory_message_logger.log_loading_complete(content_id=None)
+            await memory_message_logger.log_loading_complete(with_pill=False)
 
     return _CommonComponents(
         chat_service=chat_service,

--- a/unique_toolkit/unique_toolkit/chat/schemas.py
+++ b/unique_toolkit/unique_toolkit/chat/schemas.py
@@ -217,7 +217,13 @@ class MessageLogUncitedReferences(BaseModel):
 class MessageLogEvent(BaseModel):
     model_config = model_config
     type: Literal[
-        "WebSearch", "InternalSearch", "Elicitation", "Thinking", "ToolCall", "Todo"
+        "WebSearch",
+        "InternalSearch",
+        "Elicitation",
+        "Thinking",
+        "ToolCall",
+        "Todo",
+        "UserMemory",
     ]
     text: str
     step_type: str | None = None


### PR DESCRIPTION
## Summary

- Context memory now reports itself through proper chat Steps ("Loading context memory" / "Updating your memory") instead of appending and then stripping a transient `🧠 _Updating context memory…_` marker inside the assistant's answer text.
- Both Steps can carry a typed `UserMemory` detail entry that the chat frontend renders as a badge linking to Settings → Context Memory, so users can see that memory was loaded and review what was written.
- A `load_user_memory` failure no longer leaves the Steps UI stuck on a RUNNING step: the turn soft-fails without memory and the step is closed as FAILED.

## Changes

**`postprocessors/unique_user_memory/`**
- New `user_memory_message_log.py` with `UserMemoryMessageLogger`: `log_loading_start` / `log_loading_complete` / `log_loading_failed` and `log_updating_start` / `log_updating_complete`. Every step write goes through a guarded helper that logs a warning on failure, so a MessageLog problem can never break the turn.
- `user_memory_postprocessor.py`: dropped `_UPDATING_NOTICE` and `_set_message_content`; the assistant message text is no longer mutated. Takes a `message_logger` (or a `message_step_logger`, otherwise builds one from `chat_service`). The "Review your context memory" entry is attached only after `memory.md` uploads successfully — a NOOP consolidation or a failed upload completes the step without it.
- `config.py`: removed `updating_notice_enabled`; there is no longer an in-message notice to toggle.
- README: documented `UserMemoryMessageLogger`, the updated lifecycle, and the new integration snippet.

**`unique_orchestrator/`**
- `_build_common` creates one `MessageStepLogger` per turn and reuses it for both the memory logger and `_CommonComponents`.
- `load_user_memory` is wrapped in `try/except`: a raised exception is treated like a `None` return (warn, continue without memory), and `finally` marks the loading step FAILED so it always closes.
- On success the loading step completes with the settings entry only when memory was actually loaded; the same logger instance is handed to `UserMemoryPostprocessor`.

**`unique_toolkit/`**
- Added `"UserMemory"` to the `MessageLogEvent.type` literal.

## Test plan

- [x] `cd postprocessors/unique_user_memory && poe test` — covers the new logger (entry text, `COMPLETED`/`FAILED` statuses, entry suppression) and asserts the postprocessor no longer calls `modify_assistant_message_async`.
- [x] `cd unique_orchestrator && poe test` — covers the three load paths in `_build_common`: state returned, `None` returned, and load raising.
- [x] `poe typecheck` / `poe lint` in both packages.
- [x] Manual: in a space with `allowUserMemory: true`, send a message that changes memory and confirm the Steps panel shows "Loading context memory" completing with a badge, then "Updating your memory" completing with a "Review your context memory" badge that opens Settings → Context Memory. Confirm the answer text itself is untouched.

## Risk / rollout

- Frontend rendering of the badge lands in the companion monorepo change (`parseUserMemoryEntry`). Unknown detail-entry types parse as "Unknown" and render nothing, so emitting `UserMemory` is safe in either deploy order.
- `updating_notice_enabled` is gone from `UserMemoryConfig`. Pydantic ignores extra keys here, so existing space configs that still set `updatingNoticeEnabled` keep parsing — the key simply becomes a no-op and drops out of the generated config schema.
- Rollback is limited to this PR; no data or storage-format changes (`memory.md` layout is unchanged).

Refs: https://unique-ch.atlassian.net/browse/UN-23418


https://github.com/user-attachments/assets/f66ae1a9-a1b2-4d4c-a609-59169c0c5309


