### PR TITLE
fix(user-memory): prompt improvement

### DIFF
--- a/postprocessors/unique_follow_up_questions/unique_follow_up_questions/prompts/system_prompt.j2
+++ b/postprocessors/unique_follow_up_questions/unique_follow_up_questions/prompts/system_prompt.j2
@@ -21,5 +21,10 @@ Your task is to generate follow-up {{number_of_questions}} questions that are li
 You should avoid repeating questions that you have seen in the conversation history.
 You should take the examples as inspiration, but not copy them exactly or paraphrase them.
 
+Every follow-up question must be about the user's own topic or the subject matter of the conversation, never about the assistant or the platform itself. Never generate:
+- questions that ask the assistant to remember, save, update, or delete anything in the user's memory or profile
+- questions that merely accept or confirm something the assistant offered to do (for example "Yes, please update my profile")
+- questions about the assistant's configuration, settings, tools, or capabilities
+
 You should strictly follow the output schema provided below:
 {{output_schema}}

--- a/postprocessors/unique_user_memory/README.md
+++ b/postprocessors/unique_user_memory/README.md
@@ -10,6 +10,7 @@ The package provides:
 
 - `UserMemoryConfig` - Pydantic configuration for the consolidation model, profile token budget, and memory folder.
 - `load_user_memory(...)` - resolves the user's private memory folder, downloads `memory.md`, and enforces the configured token budget. The `language_model` argument is used to tokenize `memory.md` when capping it, so it must be the same effective model the postprocessor uses for consolidation (see Integration below). Returns a `UserMemoryState` with the profile text and scope id.
+- `profile_body(...)` - strips the YAML frontmatter and returns only the Markdown body. Use it whenever the profile is shown to a model; the frontmatter is bookkeeping for consolidation.
 - `UserMemoryMessageLogger` - emits chat Steps (MessageLogs) for load and update, including typed `UserMemory` detail entries the chat frontend renders as a badge that opens Settings → Context Memory. Frontends that do not know the entry type render nothing, so the entries are safe to emit in any deploy order.
 - `UserMemoryPostprocessor` - runs after the assistant response, consolidates the latest turn into the profile, and uploads the updated `memory.md`.
 
@@ -20,7 +21,7 @@ The memory file is intentionally small and structured. It is rewritten as a full
 1. The orchestrator enables memory when `space.allow_user_memory` is true.
 2. The orchestrator emits a **Loading context memory** Step, then `load_user_memory(...)` resolves the pre-provisioned root folder, ensures a private child folder for the current user, and downloads `/user-memory/<user_id>/memory.md` if it exists.
 3. When load returns a `UserMemoryState`, that Step is completed with a **Context memory** detail entry (`type: UserMemory`) that the chat frontend renders as a badge opening Settings → Context Memory. A successful `None` return (soft skip) completes the Step without the entry; a raised exception marks the Step failed.
-4. If memory was loaded, its text is passed into the agent context for the current turn.
+4. If memory was loaded, `profile_body(...)` of its text is passed into the agent context for the current turn — the prompt only gets the Markdown body, while the postprocessor keeps the full file because it needs the frontmatter to carry `turn_count` forward.
 5. `UserMemoryPostprocessor` runs after the assistant response.
 6. The package asks the configured language model to either return `NOOP` or a complete rewritten profile.
 7. If a rewrite runs, an **Updating your memory** Step is shown while consolidating (no settings entry yet).
@@ -99,7 +100,7 @@ Typical orchestration code loads memory before the agent loop and registers the 
 
 ```python
 from unique_toolkit.agentic.message_log_manager.service import MessageStepLogger
-from unique_user_memory.user_memory import load_user_memory
+from unique_user_memory.user_memory import load_user_memory, profile_body
 from unique_user_memory.user_memory_message_log import UserMemoryMessageLogger
 from unique_user_memory.user_memory_postprocessor import UserMemoryPostprocessor
 
@@ -143,7 +144,9 @@ finally:
 
 if load_succeeded and user_memory_state is not None:
     await memory_message_step_logger.log_loading_complete(with_settings_entry=True)
-    user_memory_text = user_memory_state.text
+    # The postprocessor keeps the full file (it needs the frontmatter to
+    # carry turn_count forward); the prompt only gets the Markdown body.
+    user_memory_text = profile_body(user_memory_state.text)
     postprocessor_manager.add_postprocessor(
         UserMemoryPostprocessor(
             config=user_memory_config,

--- a/postprocessors/unique_user_memory/unique_user_memory/tests/test_user_memory.py
+++ b/postprocessors/unique_user_memory/unique_user_memory/tests/test_user_memory.py
@@ -21,6 +21,7 @@ from unique_user_memory.user_memory import (
     enforce_token_cap,
     ensure_user_memory_folder,
     fit_user_memory,
+    profile_body,
     should_consolidate_memory,
     upload_user_memory,
 )
@@ -44,6 +45,37 @@ def test_memory_profile_keeps_follow_up_tasks_but_excludes_open_questions() -> N
     assert "## Follow-ups" in profile
     assert "concrete tasks the user intends to complete" in consolidation_prompt
     assert "Concrete future tasks the user intends to complete" in gate_prompt
+
+
+def test_profile_body_strips_frontmatter() -> None:
+    # The orchestrator renders this into the system prompt, where the
+    # bookkeeping fields are noise for the model.
+    content = (
+        "---\n"
+        "user_id: 233737684428787846\n"
+        "strategy: codex\n"
+        "schema_version: 1\n"
+        "last_updated: 2026-07-27T10:20:00+00:00\n"
+        "turn_count: 83\n"
+        "---\n\n"
+        "# User Memory\n\n## Identity\n- Andreas\n"
+    )
+
+    body = profile_body(content)
+
+    assert body == "# User Memory\n\n## Identity\n- Andreas"
+    for field in ("user_id:", "strategy:", "schema_version:", "turn_count:"):
+        assert field not in body
+
+
+def test_profile_body_leaves_frontmatterless_profile_untouched() -> None:
+    content = "# User Memory\n\n## Identity\n- Andreas"
+
+    assert profile_body(content) == content
+
+
+def test_profile_body_returns_empty_for_frontmatter_only_profile() -> None:
+    assert profile_body("---\nuser_id: 42\nturn_count: 0\n---\n") == ""
 
 
 def test_enforce_token_cap_truncates_long_content() -> None:

--- a/postprocessors/unique_user_memory/unique_user_memory/user_memory.py
+++ b/postprocessors/unique_user_memory/unique_user_memory/user_memory.py
@@ -63,7 +63,14 @@ _FRONTMATTER_RE = re.compile(r"^---\n.*?\n---\n", re.DOTALL)
 _TURN_COUNT_RE = re.compile(r"^turn_count:\s*(\d+)\s*$", re.MULTILINE)
 
 
-def _profile_body(content: str) -> str:
+def profile_body(content: str) -> str:
+    """Return the profile without its YAML frontmatter.
+
+    The frontmatter is bookkeeping for the consolidation pass (turn count,
+    schema version, timestamps); consumers that show the profile to a model --
+    consolidation prompts and the orchestrator system prompt -- only want the
+    Markdown body.
+    """
     return _FRONTMATTER_RE.sub("", content, count=1).strip()
 
 
@@ -195,7 +202,7 @@ async def condense_user_memory(
     condensed profile, or ``None`` when the call fails or the output does
     not look like a profile (the caller then falls back to a hard cut).
     """
-    body = _profile_body(content)
+    body = profile_body(content)
     current_tokens = count_tokens(content=body, language_model=language_model)
     target_tokens = max(1, int(max_tokens * _CONDENSE_TARGET_RATIO))
 
@@ -265,7 +272,7 @@ async def condense_user_memory(
         )
         return None
 
-    candidate = _profile_body(_strip_code_fences(raw))
+    candidate = profile_body(_strip_code_fences(raw))
     if not _is_well_formed_profile(candidate):
         logger.warning(
             "[user-memory] condense output did not look like a profile (%d chars)",
@@ -826,7 +833,7 @@ async def _rewrite_user_memory(
             ),
             LanguageModelUserMessage(
                 content=consolidation_user_prompt(
-                    existing_memory=_profile_body(safe_current),
+                    existing_memory=profile_body(safe_current),
                     user_message=_sanitize_for_xml_context(user_message or ""),
                     assistant_message=_sanitize_for_xml_context(
                         assistant_message or ""
@@ -883,7 +890,7 @@ async def _rewrite_user_memory(
         logger.info("[user-memory] consolidation NOOP - keeping existing memory")
         return safe_current
 
-    candidate_body = _profile_body(_strip_code_fences(raw))
+    candidate_body = profile_body(_strip_code_fences(raw))
     if not _is_well_formed_profile(candidate_body):
         logger.warning(
             "[user-memory] LLM output did not look like a profile (%d chars)",
@@ -891,7 +898,7 @@ async def _rewrite_user_memory(
         )
         return safe_current
 
-    if safe_current and candidate_body == _profile_body(safe_current):
+    if safe_current and candidate_body == profile_body(safe_current):
         logger.debug("[user-memory] memory body unchanged - skipping update")
         return safe_current
 

--- a/unique_orchestrator/unique_orchestrator/prompts/system_prompt.jinja2
+++ b/unique_orchestrator/unique_orchestrator/prompts/system_prompt.jinja2
@@ -30,7 +30,10 @@ Here is some metadata about the user, which may help you write better queries, a
 # What I know about you
 The following profile was distilled from past conversations with this user. Treat it as durable user context: adapt your tone, examples, and depth to it. If the user asks what you know or remember about them, you may share this memory back to them, including verbatim if they request it. Do not treat it as authoritative for facts about the world.
 
-You can read this memory while answering. Memory updates happen only in a postprocessing step after your final answer, so do not claim that you can directly edit the memory during the main response.
+The memory is maintained for you: an automatic postprocessing step re-reads every turn after your final answer and updates the profile on its own. You can read the memory while answering, but you cannot add to, edit, or delete it during your response, and nothing the user says changes whether the update runs. Therefore:
+- Never ask the user whether something should be remembered, saved, or added to their profile.
+- Never offer to update the memory, and never state that you have updated it, are updating it, or will update it.
+- When the user shares a new fact about themselves, or asks you to remember or forget something, acknowledge it in one short clause and continue with their actual request.
 
 {{ user_memory }}
 {%- endif %}

--- a/unique_orchestrator/unique_orchestrator/unique_ai_builder.py
+++ b/unique_orchestrator/unique_orchestrator/unique_ai_builder.py
@@ -69,7 +69,7 @@ from unique_toolkit.experimental.integrations.openai.streaming.event_routing imp
 )
 from unique_toolkit.language_model.infos import LanguageModelInfo, ModelCapabilities
 from unique_toolkit.protocols.support import ResponsesSupportCompleteWithReferences
-from unique_user_memory.user_memory import load_user_memory
+from unique_user_memory.user_memory import load_user_memory, profile_body
 from unique_user_memory.user_memory_message_log import UserMemoryMessageLogger
 from unique_user_memory.user_memory_postprocessor import UserMemoryPostprocessor
 
@@ -426,7 +426,9 @@ async def _build_common(
             await memory_message_step_logger.log_loading_complete(
                 with_settings_entry=True
             )
-            user_memory_text = user_memory_state.text
+            # The postprocessor keeps the full file (it needs the frontmatter to
+            # carry turn_count forward); the prompt only gets the Markdown body.
+            user_memory_text = profile_body(user_memory_state.text)
             postprocessor_manager.add_postprocessor(
                 UserMemoryPostprocessor(
                     config=user_memory_config,


### PR DESCRIPTION
Refs: https://unique-ch.atlassian.net/browse/UN-23550

## Summary
- The orchestrator kept asking users things like "Would you like me to save that to your profile?" — memory consolidation is an unconditional postprocessing step, so the question is meaningless and the agent cannot act on the answer. The system prompt now says the memory is maintained for the agent and forbids asking, offering, or claiming to update it.
- The raw memory file's YAML frontmatter (`user_id`, `strategy`, `schema_version`, `last_updated`, `turn_count`) was being rendered into the system prompt as noise. The prompt now receives only the Markdown body; the postprocessor still gets the full file because it needs `turn_count`.
- Follow-up question generation could suggest memory-related questions (e.g. "Yes, please update my profile"), which re-triggered the same behaviour. Its prompt now restricts questions to the user's own subject matter.
## Changes
- `unique_orchestrator/prompts/system_prompt.jinja2` — replaced the single "do not claim you can edit the memory" sentence with an explicit three-rule block covering asking, offering/claiming, and how to acknowledge new facts.
- `unique_orchestrator/unique_ai_builder.py` — pass `profile_body(user_memory_state.text)` into the prompt instead of the raw file.
- `postprocessors/unique_user_memory/user_memory.py` — promoted `_profile_body` to public `profile_body` (now used by the orchestrator) and documented it; all internal call sites updated.
- `postprocessors/unique_follow_up_questions/prompts/system_prompt.j2` — forbid follow-ups about memory/profile, confirmation-only questions, and assistant configuration.
- Tests for `profile_body`: strips frontmatter, leaves frontmatterless profiles untouched, returns empty for a frontmatter-only profile.
## Test plan
- [x] `pytest postprocessors/unique_user_memory`
- [x] Manual: converse with a user that has an existing memory profile, share a new personal fact, and confirm the answer acknowledges it in one clause without asking permission or claiming an update.
- [x] Manual: confirm the rendered system prompt no longer contains `user_id:` / `turn_count:`.
- [x] Manual: confirm generated follow-up questions are all about the conversation topic.
## Risk / rollout
- Prompt-only behavioural change plus one prompt-input change; no schema or storage changes, so rollback is a revert.
- This only fixes the **default** template shipped in code. Assistants whose `systemPromptTemplate` is already persisted in the DB need the companion data migration in `Unique-AG/monorepo` (`fix(chat): harden user memory section in stored system prompts`) — ship both together, otherwise existing assistants keep the old paragraph.
