### PR TITLE
feat(cli): agentic-table write commands (create-sheet, import, export) [UN-22200]

### DIFF
--- a/unique_sdk/docs/cli/agentic_table.md
+++ b/unique_sdk/docs/cli/agentic_table.md
@@ -195,7 +195,9 @@ Created:           2026-01-01 00:00
 
 Import questions and/or source files into a sheet. Adding **new questions** (file ids or texts) triggers the agent run; adding only sources does not. Ids/texts already on the sheet are skipped. The call is rejected while the sheet is already processing.
 
-With `--wait`, the command blocks until the triggered run finishes (or `--timeout` elapses) so you can chain an `export`. If only sources were added (no run started), that is reported as a note, not an error.
+With `--wait`, the command blocks until the triggered run finishes (or `--timeout` elapses) so you can chain an `export`.
+
+What happens when no run is observed depends on what you submitted. A sources-only import never starts one, so that is reported as a note and the command succeeds. If you submitted questions, a run was expected — not seeing one within 120s is treated as an error, because the pickup may simply be late and exiting 0 would let a `&&` chain export a sheet that is still being answered. Re-check the sheet state and retry the export rather than the import. Re-importing questions the sheet already has produces the same error: also a no-op, but not one the command can tell apart from a late pickup.
 
 **Synopsis:**
 

--- a/unique_sdk/docs/cli/agentic_table.md
+++ b/unique_sdk/docs/cli/agentic_table.md
@@ -197,14 +197,16 @@ Import questions and/or source files into a sheet. Adding **new questions** (fil
 
 With `--wait`, the command blocks until the triggered run finishes (or `--timeout` elapses) so you can chain an `export`.
 
-What happens when no run is observed depends on what you submitted. A sources-only import never starts one, so that is reported as a note and the command succeeds. If you submitted questions, a run was expected — not seeing one within 120s is treated as an error, because the pickup may simply be late and exiting 0 would let a `&&` chain export a sheet that is still being answered. Re-check the sheet state and retry the export rather than the import. Re-importing questions the sheet already has produces the same error: also a no-op, but not one the command can tell apart from a late pickup.
+A run leaves no durable record of itself, so the wait has to catch the sheet in `PROCESSING`. A very short run can pass through between two polls; polling is dense over the opening seconds to narrow that window, but it cannot close it — that needs a per-run signal the public API does not expose yet ([UN-23683](https://unique-ch.atlassian.net/browse/UN-23683)). Transient read failures during the wait are retried, since the import itself has already been accepted by then.
+
+What happens when no run is observed depends on what you submitted. A sources-only import never starts one, so that is reported as a note and the command succeeds. If you submitted questions, a run was expected — not seeing one within 120s is treated as an error, because the pickup may simply be late and exiting 0 would let a `&&` chain export a sheet that is still being answered. The outcome is then unknown rather than failed: poll `get-sheet` until the state settles on `IDLE` and the imported rows carry answers, and export only after that. Exporting straight away would report unanswered rows as the result. Re-importing is not the answer either — questions the sheet already has produce the same error: also a no-op, but not one the command can tell apart from a late pickup.
 
 **Synopsis:**
 
 ```
 agentic-table import <table_id> [--question-file-id <id>]... [--question-text <text>]...
                                 [--source-file-id <id>]... [--context <text>]
-                                [--wait] [--timeout <seconds>] [--json]
+                                [--wait] [--timeout <seconds>] [--start-timeout <seconds>] [--json]
 ```
 
 **Options:**
@@ -217,7 +219,8 @@ agentic-table import <table_id> [--question-file-id <id>]... [--question-text <t
 | `--context` | Free-text context for the run | |
 | `--wait` | Wait for the triggered run to finish | off |
 | `--timeout` | Max seconds to wait when `--wait` is set | 600 |
-| `--json` | Print raw JSON | off |
+| `--start-timeout` | Max seconds to wait for the run to be picked up, before treating it as never started. Counts against `--timeout`. Raise it when the worker queue is slow | 120 |
+| `--json` | Print raw JSON. `--wait` adds `runStarted` and `finalState` alongside `result` | off |
 
 **Example:**
 
@@ -251,7 +254,7 @@ agentic-table export <table_id> --type <TYPE>... [--wait] [--timeout <seconds>] 
 | `--type` | Artifact type: `FULL_REPORT`, `QUESTIONS`, or `AGENTIC_REPORT` (repeatable, required) | |
 | `--wait` | Wait for the requested artifacts to be ready, then list them | off |
 | `--timeout` | Max seconds to wait when `--wait` is set | 600 |
-| `--json` | Print raw JSON | off |
+| `--json` | Print raw JSON. `--wait` adds `artifacts` alongside `result` | off |
 
 **Example:**
 
@@ -272,13 +275,16 @@ FULL_REPORT  DONE   artifact_1   cont_export  2026-01-01 00:01
 
 ## Full-loop recipe
 
-Create a sheet, populate and run it, then export the answers. Because every step exits non-zero on failure — including a rejection the backend reports in the response body rather than as an HTTP error — the steps can be chained with `&&`:
+Create a sheet, populate and run it, then export the answers. Every step exits non-zero on failure — including a rejection the backend reports in the response body rather than as an HTTP error — so the steps can be chained with `&&`:
 
 ```bash
-SHEET=$(unique-cli agentic-table create-sheet asst_123 --name "Vendor DDQ" --json | jq -r .sheetId) && \
+SHEET_JSON=$(unique-cli agentic-table create-sheet asst_123 --name "Vendor DDQ" --json) && \
+SHEET=$(printf '%s' "$SHEET_JSON" | jq -r .sheetId) && \
 unique-cli agentic-table import "$SHEET" --question-file-id c_questions --source-file-id c_sources --wait && \
 unique-cli agentic-table export "$SHEET" --type FULL_REPORT --wait && \
 unique-cli agentic-table get-sheet "$SHEET" --cells
 ```
+
+Capture the JSON and parse it in two steps rather than piping `create-sheet` straight into `jq`. A shell assignment takes the exit status of the last command in the pipeline, so `SHEET=$(unique-cli ... | jq ...)` reports `jq`'s status and discards the CLI's. Errors go to stderr, so `jq` would read empty input, print nothing and succeed — leaving `$SHEET` empty and the `&&` chain running on against a sheet that was never created. Splitting the assignment puts the CLI's own exit status back in the chain. `set -o pipefail` also works if the recipe runs inside a script you control.
 
 Read the produced answers with `get-sheet --cells` / `get-cell` and download an export via the Content API using the `contentId` shown by `export` / `list-exports`.

--- a/unique_sdk/docs/cli/agentic_table.md
+++ b/unique_sdk/docs/cli/agentic_table.md
@@ -270,7 +270,7 @@ FULL_REPORT  DONE   artifact_1   cont_export  2026-01-01 00:01
 
 ## Full-loop recipe
 
-Create a sheet, populate and run it, then export the answers. Because each `--wait` step exits non-zero on failure, the steps can be chained with `&&`:
+Create a sheet, populate and run it, then export the answers. Because every step exits non-zero on failure — including a rejection the backend reports in the response body rather than as an HTTP error — the steps can be chained with `&&`:
 
 ```bash
 SHEET=$(unique-cli agentic-table create-sheet asst_123 --name "Vendor DDQ" --json | jq -r .sheetId) && \

--- a/unique_sdk/docs/cli/agentic_table.md
+++ b/unique_sdk/docs/cli/agentic_table.md
@@ -3,7 +3,7 @@
 !!! warning "Experimental"
     The CLI is experimental and its interface may change in future releases.
 
-Read Agentic Table (magic table) sheets, cells, and cell history through the public magic-table API. These are **Tier 0** reads: they never write and never require confirmation. Every call is scoped to the configured user/company; sheet-role access (Owner / Can manage / Can edit) is enforced on the server, and a denial is reported as `agentic-table: permission denied`.
+Work with Agentic Table (magic table) sheets through the public magic-table API. The **read** commands (`get-sheet`, `get-cell`, `cell-history`, `list-exports`) are **Tier 0**: they never write and never require confirmation. The **write** commands (`create-sheet`, `import`, `export`) drive the full loop — create a sheet, populate it, run the agent, and export the answers. Every call is scoped to the configured user/company; sheet-role access (Owner / Can manage / Can edit) is enforced on the server, and a denial is reported as `agentic-table: permission denied`.
 
 ## agentic-table get-sheet
 
@@ -147,3 +147,136 @@ TYPE         STATE        ID          CONTENT       UPDATED
 FULL_REPORT  DONE         artifact_1  cont_export   2026-01-01 00:01
 QUESTIONS    IN_PROGRESS  artifact_2  -             2026-01-01 00:00
 ```
+
+---
+
+## agentic-table create-sheet
+
+Create a new, empty sheet in a space. The printed `ID` is the `table_id` used by every other command.
+
+**Synopsis:**
+
+```
+agentic-table create-sheet <assistant_id> [--name <name>] [--due-at <iso8601>] [--json]
+```
+
+**Arguments:**
+
+| Argument | Description |
+|----------|-------------|
+| `assistant_id` | The space (assistant) the sheet is created in; you must have write access |
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--name` | Sheet name |
+| `--due-at` | Due date (ISO-8601, e.g. `2026-12-31T00:00:00Z`) |
+| `--json` | Print the raw sheet JSON |
+
+**Example:**
+
+```bash
+unique-cli agentic-table create-sheet asst_123 --name "Vendor DDQ"
+```
+
+```
+Sheet:             Vendor DDQ
+ID:                mt_abc123
+Due diligence ID:  dd_1
+State:             IDLE
+Created by:        user_abc
+Created:           2026-01-01 00:00
+```
+
+---
+
+## agentic-table import
+
+Import questions and/or source files into a sheet. Adding **new questions** (file ids or texts) triggers the agent run; adding only sources does not. Ids/texts already on the sheet are skipped. The call is rejected while the sheet is already processing.
+
+With `--wait`, the command blocks until the triggered run finishes (or `--timeout` elapses) so you can chain an `export`. If only sources were added (no run started), that is reported as a note, not an error.
+
+**Synopsis:**
+
+```
+agentic-table import <table_id> [--question-file-id <id>]... [--question-text <text>]...
+                                [--source-file-id <id>]... [--context <text>]
+                                [--wait] [--timeout <seconds>] [--json]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--question-file-id` | Content id of a questionnaire file (repeatable) | |
+| `--question-text` | A question to add directly (repeatable) | |
+| `--source-file-id` | Content id of a source/knowledge file (repeatable) | |
+| `--context` | Free-text context for the run | |
+| `--wait` | Wait for the triggered run to finish | off |
+| `--timeout` | Max seconds to wait when `--wait` is set | 600 |
+| `--json` | Print raw JSON | off |
+
+**Example:**
+
+```bash
+unique-cli agentic-table import mt_abc123 --question-file-id c_q --source-file-id c_src --wait
+```
+
+```
+Action:  import
+Result:  OK
+Detail:  accepted
+Run finished (state: IDLE).
+```
+
+---
+
+## agentic-table export
+
+Generate export artifacts (`FULL_REPORT`, `QUESTIONS`, `AGENTIC_REPORT`). Generation is asynchronous. With `--wait`, the command polls until each requested type is `DONE` and prints the artifact table with the `contentId` to download; an artifact entering `ERROR` fails fast.
+
+**Synopsis:**
+
+```
+agentic-table export <table_id> --type <TYPE>... [--wait] [--timeout <seconds>] [--json]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--type` | Artifact type: `FULL_REPORT`, `QUESTIONS`, or `AGENTIC_REPORT` (repeatable, required) | |
+| `--wait` | Wait for the requested artifacts to be ready, then list them | off |
+| `--timeout` | Max seconds to wait when `--wait` is set | 600 |
+| `--json` | Print raw JSON | off |
+
+**Example:**
+
+```bash
+unique-cli agentic-table export mt_abc123 --type FULL_REPORT --wait
+```
+
+```
+Action:  export
+Result:  OK
+1 export artifact(s):
+
+TYPE         STATE  ID           CONTENT      UPDATED
+FULL_REPORT  DONE   artifact_1   cont_export  2026-01-01 00:01
+```
+
+---
+
+## Full-loop recipe
+
+Create a sheet, populate and run it, then export the answers. Because each `--wait` step exits non-zero on failure, the steps can be chained with `&&`:
+
+```bash
+SHEET=$(unique-cli agentic-table create-sheet asst_123 --name "Vendor DDQ" --json | jq -r .sheetId) && \
+unique-cli agentic-table import "$SHEET" --question-file-id c_questions --source-file-id c_sources --wait && \
+unique-cli agentic-table export "$SHEET" --type FULL_REPORT --wait && \
+unique-cli agentic-table get-sheet "$SHEET" --cells
+```
+
+Read the produced answers with `get-sheet --cells` / `get-cell` and download an export via the Content API using the `contentId` shown by `export` / `list-exports`.

--- a/unique_sdk/tests/cli/test_agentic_table_write.py
+++ b/unique_sdk/tests/cli/test_agentic_table_write.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import time
 from unittest.mock import AsyncMock, patch
 
 from click.testing import CliRunner
@@ -14,11 +15,13 @@ from unique_sdk.api_resources._agentic_table import (
     MagicTableArtifactType,
 )
 from unique_sdk.cli.cli import main as cli_main
+from unique_sdk.cli.commands.agentic_table import is_error_output
 from unique_sdk.cli.commands.agentic_table_write import (
+    _FAST_POLL_WINDOW_SECONDS,
+    _poll_interval,
     cmd_create_sheet,
     cmd_export,
     cmd_import,
-    is_error_output,
 )
 from unique_sdk.cli.config import Config
 from unique_sdk.cli.state import ShellState
@@ -247,7 +250,7 @@ def test_cmd_import_wait_questions_but_no_run_is_error() -> None:
 
     assert is_error_output(out)
     assert "no run started" in out
-    assert "re-check the sheet state" in out
+    assert "before exporting" in out, "must steer away from exporting an unrun sheet"
 
 
 def test_cmd_import_wait_timeout_is_error() -> None:
@@ -510,3 +513,166 @@ def test_cli_write_error_exits_non_zero(mock_cmd: object) -> None:
 
     assert result.exit_code == 1
     assert result.output.strip() == "agentic-table: permission denied"
+
+
+# -- polling behaviour -----------------------------------------------------
+
+
+def test_poll_interval_is_dense_before_settling() -> None:
+    """A short run fits inside one settled interval, so the opening window is
+    sampled closely; otherwise a run that finished looks like one that never
+    started."""
+    now = time.monotonic()
+    assert _poll_interval(now, 5.0) == 1.0
+    assert _poll_interval(now - _FAST_POLL_WINDOW_SECONDS - 1, 5.0) == 5.0
+
+
+def test_poll_interval_never_exceeds_the_callers_interval() -> None:
+    assert _poll_interval(time.monotonic(), 0.25) == 0.25
+
+
+def test_wait_survives_a_transient_read_failure() -> None:
+    """The write already landed, so one failed poll must not report it as failed."""
+    states = [
+        UniqueError("bad gateway", http_status=502),
+        AgenticTableSheetState.PROCESSING,
+        AgenticTableSheetState.IDLE,
+    ]
+    with (
+        _patch("add_metadata", return_value=_OK),
+        _patch("get_sheet_state", side_effect=states),
+        _no_sleep(),
+    ):
+        out = cmd_import(
+            _state(), "mt_1", question_texts=["q?"], wait=True, timeout=60.0
+        )
+
+    assert not is_error_output(out)
+    assert "Run finished" in out
+
+
+def test_wait_does_not_retry_a_denial() -> None:
+    """A 403 is a decision rather than a blip: retrying only delays the report."""
+    with (
+        _patch(
+            "get_sheet_state", side_effect=UniqueError("nope", http_status=403)
+        ) as mock_state,
+        _patch("add_metadata", return_value=_OK),
+        _no_sleep(),
+    ):
+        out = cmd_import(
+            _state(), "mt_1", question_texts=["q?"], wait=True, timeout=60.0
+        )
+
+    assert out == "agentic-table: permission denied"
+    assert mock_state.await_count == 1
+
+
+def test_wait_gives_up_after_repeated_read_failures() -> None:
+    with (
+        _patch("add_metadata", return_value=_OK),
+        _patch("get_sheet_state", side_effect=UniqueError("down", http_status=502)),
+        _no_sleep(),
+    ):
+        out = cmd_import(
+            _state(), "mt_1", question_texts=["q?"], wait=True, timeout=60.0
+        )
+
+    assert is_error_output(out)
+
+
+def test_export_wait_accepts_a_new_artifact_with_no_timestamp() -> None:
+    """Freshness falls back to identity when ``updatedAt`` is absent.
+
+    Comparing two missing timestamps would exclude the artifact on every poll
+    and hang the wait on a generation that had in fact succeeded.
+    """
+    stale = _artifact("FULL_REPORT", "IN_PROGRESS")
+    fresh = {
+        "id": "art_new",
+        "artifactType": "FULL_REPORT",
+        "artifactState": "DONE",
+        "contentId": "cont_1",
+    }
+    with (
+        _patch("generate_artifact", return_value=_OK),
+        _patch("list_artifacts", side_effect=[[stale], [stale, fresh]]),
+        _no_sleep(),
+    ):
+        out = cmd_export(
+            _state(),
+            "mt_1",
+            artifact_types=[MagicTableArtifactType.FULL_REPORT],
+            wait=True,
+            timeout=60.0,
+        )
+
+    assert not is_error_output(out)
+    assert "cont_1" in out
+
+
+# -- --json shapes under --wait --------------------------------------------
+
+
+def test_cmd_import_wait_json_shape() -> None:
+    """Agents pipe this to jq, so the keys --wait adds are part of the contract."""
+    states = [
+        AgenticTableSheetState.IDLE,
+        AgenticTableSheetState.PROCESSING,
+        AgenticTableSheetState.IDLE,
+    ]
+    with (
+        _patch("add_metadata", return_value=_OK),
+        _patch("get_sheet_state", side_effect=states),
+        _no_sleep(),
+    ):
+        out = cmd_import(
+            _state(),
+            "mt_1",
+            question_texts=["q?"],
+            wait=True,
+            timeout=60.0,
+            output_json=True,
+        )
+
+    payload = json.loads(out)
+    assert payload["result"] == _OK
+    assert payload["runStarted"] is True
+    assert payload["finalState"] == "IDLE"
+
+
+def test_cmd_export_wait_json_shape() -> None:
+    stale = _artifact("FULL_REPORT", "DONE", updated_at="2026-01-01T00:00:00.000Z")
+    fresh = _artifact(
+        "FULL_REPORT",
+        "DONE",
+        content_id="cont_1",
+        updated_at="2026-01-02T00:00:00.000Z",
+    )
+    with (
+        _patch("generate_artifact", return_value=_OK),
+        _patch("list_artifacts", side_effect=[[stale], [stale, fresh]]),
+        _no_sleep(),
+    ):
+        out = cmd_export(
+            _state(),
+            "mt_1",
+            artifact_types=[MagicTableArtifactType.FULL_REPORT],
+            wait=True,
+            timeout=60.0,
+            output_json=True,
+        )
+
+    payload = json.loads(out)
+    assert payload["result"] == _OK
+    assert [a["contentId"] for a in payload["artifacts"]] == ["cont_1"]
+
+
+def test_missing_status_field_is_not_reported_as_a_rejection() -> None:
+    """An unintelligible body may mean the mutation landed; do not invite a retry."""
+    with _patch("add_metadata", return_value={}):
+        out = cmd_import(_state(), "mt_1", question_texts=["q?"])
+
+    assert is_error_output(out)
+    assert "outcome is unknown" in out
+    assert "rejected" not in out

--- a/unique_sdk/tests/cli/test_agentic_table_write.py
+++ b/unique_sdk/tests/cli/test_agentic_table_write.py
@@ -166,6 +166,32 @@ def test_cmd_import_maps_422_verbatim() -> None:
     assert is_error_output(out)
 
 
+def test_cmd_import_soft_failure_is_error() -> None:
+    """A 200 body with ``status: false`` must fail, not print FAILED and exit 0."""
+    with _patch(
+        "add_metadata", return_value={"status": False, "message": "sheet is locked"}
+    ):
+        out = cmd_import(_state(), "mt_1", question_texts=["q?"])
+
+    assert is_error_output(out)
+    assert "import rejected" in out
+    assert "sheet is locked" in out
+
+
+def test_cmd_import_soft_failure_skips_wait() -> None:
+    """A declined import must not fall through to polling for a run it never triggered."""
+    with (
+        _patch("add_metadata", return_value={"status": False}),
+        _patch("get_sheet_state") as mock_state,
+        _no_sleep(),
+    ):
+        out = cmd_import(_state(), "mt_1", question_texts=["q?"], wait=True)
+
+    assert is_error_output(out)
+    assert "no detail returned" in out
+    mock_state.assert_not_awaited()
+
+
 # -- import (--wait) -------------------------------------------------------
 
 
@@ -246,6 +272,31 @@ def test_cmd_export_maps_403() -> None:
         out = cmd_export(_state(), "mt_1", artifact_types=["FULL_REPORT"])
 
     assert out == "agentic-table: permission denied"
+
+
+def test_cmd_export_soft_failure_is_error() -> None:
+    with _patch(
+        "generate_artifact",
+        return_value={"status": False, "message": "nothing to export"},
+    ):
+        out = cmd_export(_state(), "mt_1", artifact_types=["FULL_REPORT"])
+
+    assert is_error_output(out)
+    assert "export rejected" in out
+    assert "nothing to export" in out
+
+
+def test_cmd_export_soft_failure_skips_wait() -> None:
+    """A declined generation must not poll for artifacts that were never queued."""
+    with (
+        _patch("generate_artifact", return_value={"status": False}),
+        _patch("list_artifacts") as mock_list,
+        _no_sleep(),
+    ):
+        out = cmd_export(_state(), "mt_1", artifact_types=["FULL_REPORT"], wait=True)
+
+    assert is_error_output(out)
+    mock_list.assert_not_awaited()
 
 
 # -- export (--wait) -------------------------------------------------------

--- a/unique_sdk/tests/cli/test_agentic_table_write.py
+++ b/unique_sdk/tests/cli/test_agentic_table_write.py
@@ -215,6 +215,7 @@ def test_cmd_import_wait_run_finishes() -> None:
 
 
 def test_cmd_import_wait_no_run_started() -> None:
+    """Sources alone never trigger a run, so nothing starting is the expected outcome."""
     with (
         _patch("add_metadata", return_value=_OK),
         _patch("get_sheet_state", return_value=AgenticTableSheetState.IDLE),
@@ -226,6 +227,26 @@ def test_cmd_import_wait_no_run_started() -> None:
 
     assert "No agent run started" in out
     assert not is_error_output(out)
+
+
+def test_cmd_import_wait_questions_but_no_run_is_error() -> None:
+    """A run was expected but never observed: indeterminate, so break the chain.
+
+    Exiting 0 here would let the documented ``&&`` recipe export a sheet whose
+    answers are still being generated.
+    """
+    with (
+        _patch("add_metadata", return_value=_OK),
+        _patch("get_sheet_state", return_value=AgenticTableSheetState.IDLE),
+        _no_sleep(),
+    ):
+        out = cmd_import(
+            _state(), "mt_1", question_texts=["q?"], wait=True, timeout=0.0
+        )
+
+    assert is_error_output(out)
+    assert "no run started" in out
+    assert "re-check the sheet state" in out
 
 
 def test_cmd_import_wait_timeout_is_error() -> None:

--- a/unique_sdk/tests/cli/test_agentic_table_write.py
+++ b/unique_sdk/tests/cli/test_agentic_table_write.py
@@ -1,0 +1,399 @@
+"""Tests for the unique-cli agentic-table write commands (full loop)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+from click.testing import CliRunner
+
+from unique_sdk._error import UniqueError
+from unique_sdk.api_resources._agentic_table import (
+    AgenticTableSheetState,
+    MagicTableArtifactState,
+    MagicTableArtifactType,
+)
+from unique_sdk.cli.cli import main as cli_main
+from unique_sdk.cli.commands.agentic_table_write import (
+    cmd_create_sheet,
+    cmd_export,
+    cmd_import,
+    is_error_output,
+)
+from unique_sdk.cli.config import Config
+from unique_sdk.cli.state import ShellState
+
+_CREATED = {
+    "sheetId": "mt_new",
+    "dueDiligenceId": "dd_1",
+    "name": "Vendor DDQ",
+    "state": "IDLE",
+    "createdBy": "u1",
+    "companyId": "c1",
+    "createdAt": "2026-01-01T00:00:00.000Z",
+}
+
+_OK = {"status": True, "message": "accepted"}
+
+
+def _config() -> Config:
+    return Config(
+        user_id="u1",
+        company_id="c1",
+        api_key="key",
+        app_id="app",
+        api_base="https://example.com",
+    )
+
+
+def _state() -> ShellState:
+    return ShellState(_config())
+
+
+def _patch(method: str, **kwargs: object) -> object:
+    return patch(
+        f"unique_sdk.cli.commands.agentic_table_write.AgenticTable.{method}",
+        new_callable=AsyncMock,
+        **kwargs,
+    )
+
+
+def _no_sleep() -> object:
+    return patch(
+        "unique_sdk.cli.commands.agentic_table_write.asyncio.sleep",
+        new_callable=AsyncMock,
+    )
+
+
+def _artifact(
+    artifact_type: str,
+    artifact_state: str,
+    *,
+    content_id: str | None = None,
+) -> dict[str, object]:
+    return {
+        "id": f"art_{artifact_type}",
+        "artifactType": artifact_type,
+        "artifactState": artifact_state,
+        "contentId": content_id,
+        "createdAt": "2026-01-01T00:00:00.000Z",
+        "updatedAt": "2026-01-01T00:01:00.000Z",
+    }
+
+
+# -- create-sheet ----------------------------------------------------------
+
+
+def test_cmd_create_sheet_human_readable() -> None:
+    with _patch("create_sheet", return_value=_CREATED) as mock_create:
+        out = cmd_create_sheet(
+            _state(), "asst_1", name="Vendor DDQ", due_at="2026-12-31"
+        )
+
+    assert "Sheet:" in out and "Vendor DDQ" in out
+    assert "ID:" in out and "mt_new" in out
+    assert "Due diligence ID:" in out and "dd_1" in out
+    kwargs = mock_create.await_args.kwargs
+    assert kwargs["user_id"] == "u1"
+    assert kwargs["company_id"] == "c1"
+    assert kwargs["assistantId"] == "asst_1"
+    assert kwargs["name"] == "Vendor DDQ"
+    assert kwargs["dueAt"] == "2026-12-31"
+
+
+def test_cmd_create_sheet_omits_unset_optionals() -> None:
+    with _patch("create_sheet", return_value=_CREATED) as mock_create:
+        cmd_create_sheet(_state(), "asst_1")
+
+    kwargs = mock_create.await_args.kwargs
+    assert "name" not in kwargs
+    assert "dueAt" not in kwargs
+
+
+def test_cmd_create_sheet_json() -> None:
+    with _patch("create_sheet", return_value=_CREATED):
+        out = cmd_create_sheet(_state(), "asst_1", output_json=True)
+
+    assert json.loads(out)["sheetId"] == "mt_new"
+
+
+def test_cmd_create_sheet_maps_403() -> None:
+    with _patch("create_sheet", side_effect=UniqueError("Forbidden", http_status=403)):
+        out = cmd_create_sheet(_state(), "asst_1")
+
+    assert out == "agentic-table: permission denied"
+    assert is_error_output(out)
+
+
+# -- import (no wait) ------------------------------------------------------
+
+
+def test_cmd_import_human_readable() -> None:
+    with _patch("add_metadata", return_value=_OK) as mock_add:
+        out = cmd_import(
+            _state(),
+            "mt_1",
+            question_file_ids=["c_q"],
+            source_file_ids=["c_src"],
+        )
+
+    assert "Action:" in out and "import" in out
+    assert "Result:" in out and "OK" in out
+    kwargs = mock_add.await_args.kwargs
+    assert kwargs["tableId"] == "mt_1"
+    assert kwargs["questionFileIds"] == ["c_q"]
+    assert kwargs["sourceFileIds"] == ["c_src"]
+    assert "questionTexts" not in kwargs
+    assert "context" not in kwargs
+
+
+def test_cmd_import_json() -> None:
+    with _patch("add_metadata", return_value=_OK):
+        out = cmd_import(_state(), "mt_1", question_texts=["q?"], output_json=True)
+
+    assert json.loads(out)["result"]["status"] is True
+
+
+def test_cmd_import_maps_422_verbatim() -> None:
+    with _patch(
+        "add_metadata",
+        side_effect=UniqueError("Sheet is processing", http_status=422),
+    ):
+        out = cmd_import(_state(), "mt_1", question_texts=["q?"])
+
+    assert out.startswith("agentic-table: ")
+    assert "processing" in out.lower()
+    assert is_error_output(out)
+
+
+# -- import (--wait) -------------------------------------------------------
+
+
+def test_cmd_import_wait_run_finishes() -> None:
+    states = [
+        AgenticTableSheetState.IDLE,  # not started yet
+        AgenticTableSheetState.PROCESSING,  # run started
+        AgenticTableSheetState.IDLE,  # run finished
+    ]
+    with (
+        _patch("add_metadata", return_value=_OK),
+        _patch("get_sheet_state", side_effect=states),
+        _no_sleep(),
+    ):
+        out = cmd_import(
+            _state(), "mt_1", question_texts=["q?"], wait=True, timeout=60.0
+        )
+
+    assert "Result:" in out and "OK" in out
+    assert "Run finished" in out and "IDLE" in out
+
+
+def test_cmd_import_wait_no_run_started() -> None:
+    with (
+        _patch("add_metadata", return_value=_OK),
+        _patch("get_sheet_state", return_value=AgenticTableSheetState.IDLE),
+        _no_sleep(),
+    ):
+        out = cmd_import(
+            _state(), "mt_1", source_file_ids=["c_src"], wait=True, timeout=0.0
+        )
+
+    assert "No agent run started" in out
+    assert not is_error_output(out)
+
+
+def test_cmd_import_wait_timeout_is_error() -> None:
+    with (
+        _patch("add_metadata", return_value=_OK),
+        _patch("get_sheet_state", return_value=AgenticTableSheetState.PROCESSING),
+        _no_sleep(),
+    ):
+        out = cmd_import(
+            _state(), "mt_1", question_texts=["q?"], wait=True, timeout=0.0
+        )
+
+    assert is_error_output(out)
+    assert "timed out" in out
+
+
+# -- export (no wait) ------------------------------------------------------
+
+
+def test_cmd_export_human_readable() -> None:
+    with _patch("generate_artifact", return_value=_OK) as mock_gen:
+        out = cmd_export(_state(), "mt_1", artifact_types=["FULL_REPORT"])
+
+    assert "Action:" in out and "export" in out
+    assert "Result:" in out and "OK" in out
+    kwargs = mock_gen.await_args.kwargs
+    assert kwargs["tableId"] == "mt_1"
+    assert kwargs["artifactTypes"] == [MagicTableArtifactType.FULL_REPORT]
+
+
+def test_cmd_export_json() -> None:
+    with _patch("generate_artifact", return_value=_OK):
+        out = cmd_export(
+            _state(), "mt_1", artifact_types=["FULL_REPORT"], output_json=True
+        )
+
+    assert json.loads(out)["result"]["status"] is True
+
+
+def test_cmd_export_maps_403() -> None:
+    with _patch(
+        "generate_artifact", side_effect=UniqueError("Forbidden", http_status=403)
+    ):
+        out = cmd_export(_state(), "mt_1", artifact_types=["FULL_REPORT"])
+
+    assert out == "agentic-table: permission denied"
+
+
+# -- export (--wait) -------------------------------------------------------
+
+
+def test_cmd_export_wait_done_lists_artifacts() -> None:
+    lists = [
+        [_artifact("FULL_REPORT", MagicTableArtifactState.IN_PROGRESS)],
+        [_artifact("FULL_REPORT", MagicTableArtifactState.DONE, content_id="cont_x")],
+    ]
+    with (
+        _patch("generate_artifact", return_value=_OK),
+        _patch("list_artifacts", side_effect=lists),
+        _no_sleep(),
+    ):
+        out = cmd_export(
+            _state(), "mt_1", artifact_types=["FULL_REPORT"], wait=True, timeout=60.0
+        )
+
+    assert "FULL_REPORT" in out and "DONE" in out
+    assert "cont_x" in out
+    assert not is_error_output(out)
+
+
+def test_cmd_export_wait_error_is_error() -> None:
+    lists = [
+        [_artifact("FULL_REPORT", MagicTableArtifactState.IN_PROGRESS)],
+        [_artifact("FULL_REPORT", MagicTableArtifactState.ERROR)],
+    ]
+    with (
+        _patch("generate_artifact", return_value=_OK),
+        _patch("list_artifacts", side_effect=lists),
+        _no_sleep(),
+    ):
+        out = cmd_export(
+            _state(), "mt_1", artifact_types=["FULL_REPORT"], wait=True, timeout=60.0
+        )
+
+    assert is_error_output(out)
+    assert "failed" in out and "FULL_REPORT" in out
+
+
+def test_cmd_export_wait_timeout_is_error() -> None:
+    with (
+        _patch("generate_artifact", return_value=_OK),
+        _patch("list_artifacts", return_value=[]),
+        _no_sleep(),
+    ):
+        out = cmd_export(
+            _state(), "mt_1", artifact_types=["FULL_REPORT"], wait=True, timeout=0.0
+        )
+
+    assert is_error_output(out)
+    assert "timed out" in out and "FULL_REPORT" in out
+
+
+# -- error detector + CLI wiring ------------------------------------------
+
+
+def test_error_output_detector() -> None:
+    assert is_error_output("agentic-table: permission denied")
+    assert not is_error_output("Action:  import")
+
+
+@patch("unique_sdk.cli.cli.cmd_create_sheet")
+def test_cli_create_sheet_wiring(mock_cmd: object) -> None:
+    mock_cmd.return_value = "ok"  # type: ignore[attr-defined]
+    runner = CliRunner()
+
+    result = runner.invoke(
+        cli_main,
+        ["agentic-table", "create-sheet", "asst_1", "--name", "DDQ"],
+        env={"UNIQUE_USER_ID": "u1", "UNIQUE_COMPANY_ID": "c1"},
+    )
+
+    assert result.exit_code == 0
+    kwargs = mock_cmd.call_args.kwargs  # type: ignore[attr-defined]
+    assert kwargs["name"] == "DDQ"
+    assert mock_cmd.call_args.args[1] == "asst_1"  # type: ignore[attr-defined]
+
+
+@patch("unique_sdk.cli.cli.cmd_import")
+def test_cli_import_wiring(mock_cmd: object) -> None:
+    mock_cmd.return_value = "ok"  # type: ignore[attr-defined]
+    runner = CliRunner()
+
+    result = runner.invoke(
+        cli_main,
+        [
+            "agentic-table",
+            "import",
+            "mt_1",
+            "--question-file-id",
+            "c_q",
+            "--source-file-id",
+            "c_src",
+            "--wait",
+        ],
+        env={"UNIQUE_USER_ID": "u1", "UNIQUE_COMPANY_ID": "c1"},
+    )
+
+    assert result.exit_code == 0
+    kwargs = mock_cmd.call_args.kwargs  # type: ignore[attr-defined]
+    assert kwargs["question_file_ids"] == ["c_q"]
+    assert kwargs["source_file_ids"] == ["c_src"]
+    assert kwargs["wait"] is True
+
+
+@patch("unique_sdk.cli.cli.cmd_export")
+def test_cli_export_wiring(mock_cmd: object) -> None:
+    mock_cmd.return_value = "ok"  # type: ignore[attr-defined]
+    runner = CliRunner()
+
+    result = runner.invoke(
+        cli_main,
+        ["agentic-table", "export", "mt_1", "--type", "FULL_REPORT", "--json"],
+        env={"UNIQUE_USER_ID": "u1", "UNIQUE_COMPANY_ID": "c1"},
+    )
+
+    assert result.exit_code == 0
+    kwargs = mock_cmd.call_args.kwargs  # type: ignore[attr-defined]
+    assert kwargs["artifact_types"] == ["FULL_REPORT"]
+    assert kwargs["output_json"] is True
+
+
+@patch("unique_sdk.cli.cli.cmd_export")
+def test_cli_export_rejects_invalid_type(mock_cmd: object) -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(
+        cli_main,
+        ["agentic-table", "export", "mt_1", "--type", "NOPE"],
+        env={"UNIQUE_USER_ID": "u1", "UNIQUE_COMPANY_ID": "c1"},
+    )
+
+    assert result.exit_code != 0
+
+
+@patch("unique_sdk.cli.cli.cmd_import")
+def test_cli_write_error_exits_non_zero(mock_cmd: object) -> None:
+    mock_cmd.return_value = "agentic-table: permission denied"  # type: ignore[attr-defined]
+    runner = CliRunner()
+
+    result = runner.invoke(
+        cli_main,
+        ["agentic-table", "import", "mt_1", "--question-text", "q?"],
+        env={"UNIQUE_USER_ID": "u1", "UNIQUE_COMPANY_ID": "c1"},
+    )
+
+    assert result.exit_code == 1
+    assert result.output.strip() == "agentic-table: permission denied"

--- a/unique_sdk/tests/cli/test_agentic_table_write.py
+++ b/unique_sdk/tests/cli/test_agentic_table_write.py
@@ -70,14 +70,15 @@ def _artifact(
     artifact_state: str,
     *,
     content_id: str | None = None,
+    updated_at: str = "2026-01-01T00:00:00.000Z",
 ) -> dict[str, object]:
     return {
-        "id": f"art_{artifact_type}",
+        "id": f"art_{artifact_type}_{updated_at}",
         "artifactType": artifact_type,
         "artifactState": artifact_state,
         "contentId": content_id,
-        "createdAt": "2026-01-01T00:00:00.000Z",
-        "updatedAt": "2026-01-01T00:01:00.000Z",
+        "createdAt": updated_at,
+        "updatedAt": updated_at,
     }
 
 
@@ -308,16 +309,21 @@ def test_cmd_export_soft_failure_is_error() -> None:
 
 
 def test_cmd_export_soft_failure_skips_wait() -> None:
-    """A declined generation must not poll for artifacts that were never queued."""
+    """A declined generation must not poll for artifacts that were never queued.
+
+    One call is expected regardless: the freshness baseline is taken before the
+    trigger. Anything beyond it would be polling for a generation that a
+    ``status: false`` body says never started.
+    """
     with (
         _patch("generate_artifact", return_value={"status": False}),
-        _patch("list_artifacts") as mock_list,
+        _patch("list_artifacts", return_value=[]) as mock_list,
         _no_sleep(),
     ):
         out = cmd_export(_state(), "mt_1", artifact_types=["FULL_REPORT"], wait=True)
 
     assert is_error_output(out)
-    mock_list.assert_not_awaited()
+    assert mock_list.await_count == 1
 
 
 # -- export (--wait) -------------------------------------------------------
@@ -325,6 +331,7 @@ def test_cmd_export_soft_failure_skips_wait() -> None:
 
 def test_cmd_export_wait_done_lists_artifacts() -> None:
     lists = [
+        [],  # pre-trigger snapshot
         [_artifact("FULL_REPORT", MagicTableArtifactState.IN_PROGRESS)],
         [_artifact("FULL_REPORT", MagicTableArtifactState.DONE, content_id="cont_x")],
     ]
@@ -342,8 +349,42 @@ def test_cmd_export_wait_done_lists_artifacts() -> None:
     assert not is_error_output(out)
 
 
+def test_cmd_export_wait_returns_report_finished_between_polls() -> None:
+    """The report can go DONE without its IN_PROGRESS phase ever being seen.
+
+    A sheet carries two records per type: the trigger's nameless marker, which
+    is never updated to DONE, and the report itself. On a small sheet the report
+    is written within one poll interval, so waiting to observe it IN_PROGRESS
+    would hang until timeout even though the export succeeded.
+    """
+    marker = _artifact("FULL_REPORT", MagicTableArtifactState.IN_PROGRESS)
+    stale = _artifact(
+        "FULL_REPORT", MagicTableArtifactState.DONE, content_id="cont_old"
+    )
+    fresh = _artifact(
+        "FULL_REPORT",
+        MagicTableArtifactState.DONE,
+        content_id="cont_new",
+        updated_at="2026-01-01T00:00:05.000Z",
+    )
+    lists = [[stale, marker], [stale, marker], [fresh, marker]]
+    with (
+        _patch("generate_artifact", return_value=_OK),
+        _patch("list_artifacts", side_effect=lists),
+        _no_sleep(),
+    ):
+        out = cmd_export(
+            _state(), "mt_1", artifact_types=["FULL_REPORT"], wait=True, timeout=60.0
+        )
+
+    assert not is_error_output(out)
+    assert "cont_new" in out
+    assert "cont_old" not in out
+
+
 def test_cmd_export_wait_error_is_error() -> None:
     lists = [
+        [],  # pre-trigger snapshot
         [_artifact("FULL_REPORT", MagicTableArtifactState.IN_PROGRESS)],
         [_artifact("FULL_REPORT", MagicTableArtifactState.ERROR)],
     ]

--- a/unique_sdk/tests/cli/test_agentic_table_write.py
+++ b/unique_sdk/tests/cli/test_agentic_table_write.py
@@ -6,6 +6,7 @@ import json
 import time
 from unittest.mock import AsyncMock, patch
 
+import pytest
 from click.testing import CliRunner
 
 from unique_sdk._error import UniqueError
@@ -311,6 +312,17 @@ def test_cmd_export_soft_failure_is_error() -> None:
     assert "nothing to export" in out
 
 
+def test_cmd_export_unknown_type_is_an_error_line_not_an_exception() -> None:
+    """``click.Choice`` guards the CLI path; a direct caller has to be told too."""
+    with _patch("generate_artifact") as mock_generate:
+        out = cmd_export(_state(), "mt_1", artifact_types=["FULL_REPORT", "SUMMARY"])
+
+    assert is_error_output(out)
+    assert "unknown artifact type: SUMMARY" in out
+    assert "FULL_REPORT" in out  # the valid one is listed as accepted, not rejected
+    mock_generate.assert_not_awaited()
+
+
 def test_cmd_export_soft_failure_skips_wait() -> None:
     """A declined generation must not poll for artifacts that were never queued.
 
@@ -498,6 +510,35 @@ def test_cli_export_rejects_invalid_type(mock_cmd: object) -> None:
     )
 
     assert result.exit_code != 0
+
+
+@pytest.mark.parametrize(
+    ("command", "option"),
+    [
+        ("import", "--timeout"),
+        ("import", "--start-timeout"),
+        ("export", "--timeout"),
+    ],
+)
+@patch("unique_sdk.cli.cli.cmd_import")
+@patch("unique_sdk.cli.cli.cmd_export")
+def test_cli_rejects_a_negative_wait_budget(
+    mock_export: object, mock_import: object, command: str, option: str
+) -> None:
+    """A negative budget is a typo, and expires instantly — say so up front."""
+    runner = CliRunner()
+    extra = ["--type", "FULL_REPORT"] if command == "export" else []
+
+    result = runner.invoke(
+        cli_main,
+        ["agentic-table", command, "mt_1", *extra, option, "-1", "--wait"],
+        env={"UNIQUE_USER_ID": "u1", "UNIQUE_COMPANY_ID": "c1"},
+    )
+
+    assert result.exit_code != 0
+    assert option in result.output
+    mock_import.assert_not_called()  # type: ignore[attr-defined]
+    mock_export.assert_not_called()  # type: ignore[attr-defined]
 
 
 @patch("unique_sdk.cli.cli.cmd_import")

--- a/unique_sdk/tests/cli/test_skills.py
+++ b/unique_sdk/tests/cli/test_skills.py
@@ -56,10 +56,12 @@ def test_search_skill_does_not_reference_uploaded_search() -> None:
     assert "searching uploaded documents" not in text
 
 
-def test_agentic_table_skill_exists_and_documents_read_commands() -> None:
-    """The agentic-table skill is ungated (Tier 0 reads, server-side access
-    enforcement), so it ships in every workspace. It must name itself and
-    document each read command the CLI exposes."""
+def test_agentic_table_skill_documents_every_command() -> None:
+    """The agentic-table skill is ungated and carries the full command range,
+    reads and writes alike. Awareness gating was rejected because a user's
+    access varies per space and per sheet, so a per-space skill flag cannot
+    express what the agent may do; server-side authorization is the control.
+    The skill must therefore name itself and document every command."""
     text = _read_skill("unique-cli-agentic-table")
     assert "name: unique-cli-agentic-table" in text
     for command in (
@@ -67,16 +69,21 @@ def test_agentic_table_skill_exists_and_documents_read_commands() -> None:
         "agentic-table get-cell",
         "agentic-table cell-history",
         "agentic-table list-exports",
+        "agentic-table create-sheet",
+        "agentic-table import",
+        "agentic-table export",
     ):
         assert command in text, f"skill does not document `{command}`"
 
 
-def test_agentic_table_skill_is_read_only() -> None:
-    """Guard against write commands leaking into the ungated read skill: writes
-    have side-effects/authz needs and must live in a separate gated skill."""
+def test_agentic_table_skill_teaches_permission_handling() -> None:
+    """Because the skill advertises commands the caller may not be entitled to
+    use on a given sheet, it has to teach what to do about that: access varies
+    per sheet, a denial is an expected outcome rather than a failure to work
+    around, and probing other ids is not an acceptable response."""
     text = _read_skill("unique-cli-agentic-table").lower()
-    assert "read-only" in text
-    for write_command in ("set-cell", "set_cell", "update-cell", "delete"):
-        assert write_command not in text, (
-            f"ungated read skill must not document write command `{write_command}`"
-        )
+    assert "permission denied" in text
+    assert "per sheet" in text, "skill must state that access varies per sheet"
+    assert "probing" in text or "probe" in text, (
+        "skill must forbid probing other sheet ids after a denial"
+    )

--- a/unique_sdk/tests/cli/test_skills.py
+++ b/unique_sdk/tests/cli/test_skills.py
@@ -18,9 +18,13 @@ wheel, and a regression here is invisible to ordinary import/CLI tests.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
+import click
+
 import unique_sdk.cli
+from unique_sdk.cli.cli import main
 
 _SKILLS_DIR = Path(unique_sdk.cli.__file__).parent / "skills"
 
@@ -74,6 +78,24 @@ def test_agentic_table_skill_documents_every_command() -> None:
         "agentic-table export",
     ):
         assert command in text, f"skill does not document `{command}`"
+
+
+def test_agentic_table_skill_documents_nothing_that_is_not_a_command() -> None:
+    """The upper bound on an ungated skill.
+
+    Awareness gating was rejected, so nothing stops a command being described
+    here — but a name the CLI does not implement is worse than an absent one:
+    the agent will spend a turn on it and get a usage error. This also catches a
+    command that is renamed or dropped without the skill following.
+    """
+    shell = "\n".join(
+        re.findall(r"```bash\n(.*?)```", _read_skill("unique-cli-agentic-table"), re.S)
+    )
+    documented = set(re.findall(r"unique-cli agentic-table ([a-z][a-z-]*)", shell))
+    group = main.commands["agentic-table"]
+    assert isinstance(group, click.Group)
+    unknown = documented - set(group.commands)
+    assert not unknown, f"skill documents commands the CLI does not have: {unknown}"
 
 
 def test_agentic_table_skill_teaches_permission_handling() -> None:

--- a/unique_sdk/unique_sdk/cli/cli.py
+++ b/unique_sdk/unique_sdk/cli/cli.py
@@ -23,9 +23,6 @@ from unique_sdk.cli.commands.agentic_table_write import (
     cmd_export,
     cmd_import,
 )
-from unique_sdk.cli.commands.agentic_table_write import (
-    is_error_output as _is_agentic_table_write_error_output,
-)
 from unique_sdk.cli.commands.browser import (
     cmd_browser_action,
     cmd_browser_control,
@@ -2531,7 +2528,7 @@ def agentic_table_create_sheet(
             due_at=due_at,
             output_json=output_json,
         ),
-        is_error=_is_agentic_table_write_error_output,
+        is_error=_is_agentic_table_error_output,
     )
 
 
@@ -2574,6 +2571,17 @@ def agentic_table_create_sheet(
     help="Max seconds to wait when --wait is set.",
 )
 @click.option(
+    "--start-timeout",
+    "start_timeout",
+    type=float,
+    default=120.0,
+    show_default=True,
+    help=(
+        "Max seconds to wait for the run to be picked up before treating it as "
+        "never started. Raise it when the worker queue is slow."
+    ),
+)
+@click.option(
     "--json", "output_json", is_flag=True, default=False, help="Print raw JSON."
 )
 @click.pass_context
@@ -2586,6 +2594,7 @@ def agentic_table_import(
     context: str | None,
     wait: bool,
     timeout: float,
+    start_timeout: float,
     output_json: bool,
 ) -> None:
     """Import questions and sources into a sheet.
@@ -2610,9 +2619,10 @@ def agentic_table_import(
             context=context,
             wait=wait,
             timeout=timeout,
+            start_timeout=start_timeout,
             output_json=output_json,
         ),
-        is_error=_is_agentic_table_write_error_output,
+        is_error=_is_agentic_table_error_output,
     )
 
 
@@ -2673,5 +2683,5 @@ def agentic_table_export(
             timeout=timeout,
             output_json=output_json,
         ),
-        is_error=_is_agentic_table_write_error_output,
+        is_error=_is_agentic_table_error_output,
     )

--- a/unique_sdk/unique_sdk/cli/cli.py
+++ b/unique_sdk/unique_sdk/cli/cli.py
@@ -18,6 +18,14 @@ from unique_sdk.cli.commands.agentic_table import (
 from unique_sdk.cli.commands.agentic_table import (
     is_error_output as _is_agentic_table_error_output,
 )
+from unique_sdk.cli.commands.agentic_table_write import (
+    cmd_create_sheet,
+    cmd_export,
+    cmd_import,
+)
+from unique_sdk.cli.commands.agentic_table_write import (
+    is_error_output as _is_agentic_table_write_error_output,
+)
 from unique_sdk.cli.commands.browser import (
     cmd_browser_action,
     cmd_browser_control,
@@ -2285,28 +2293,35 @@ def web_search_crawl_cmd(
 
 
 _AGENTIC_TABLE_HELP = """\
-Read Agentic Table (magic table) sheets, cells, and cell history.
+Work with Agentic Table (magic table) sheets over the public magic-table API.
 
 \b
-These are Tier 0 reads over the public magic-table API: no confirmation,
-no writes. Every call is scoped to the current user/company; sheet-role
-access (Owner / Can manage / Can edit) is enforced server-side and a denial
-is reported as `agentic-table: permission denied`.
+Reads (get-sheet / get-cell / cell-history / list-exports) are Tier 0: no
+confirmation, no side effects. Writes (create-sheet / import / export) build
+and run a sheet — the full loop of create, populate, run, and export. Every
+call is scoped to the current user/company; sheet-role access (Owner / Can
+manage / Can edit) is enforced server-side and a denial is reported as
+`agentic-table: permission denied`.
 
 \b
-Subcommands:
+Read subcommands:
   get-sheet      Show a sheet summary (state, row count, metadata, cells)
   get-cell       Show a single cell by row/column order
   cell-history   Show a single cell's log/edit history
   list-exports   List a sheet's export artifacts (reports, question exports)
 
 \b
+Write subcommands:
+  create-sheet   Create a new sheet in a space
+  import         Import questions/sources (adding questions triggers the run)
+  export         Generate export artifacts (report / question export)
+
+\b
 Examples:
-  unique-cli agentic-table get-sheet mt_abc123
   unique-cli agentic-table get-sheet mt_abc123 --cells --metadata
-  unique-cli agentic-table get-cell mt_abc123 --row 1 --col 2
-  unique-cli agentic-table cell-history mt_abc123 --row 1 --col 2 --json
-  unique-cli agentic-table list-exports mt_abc123
+  unique-cli agentic-table create-sheet asst_123 --name "Vendor DDQ"
+  unique-cli agentic-table import mt_abc123 --question-file-id c_q --source-file-id c_src --wait
+  unique-cli agentic-table export mt_abc123 --type FULL_REPORT --wait
 """
 
 
@@ -2475,4 +2490,188 @@ def agentic_table_list_exports(
             output_json=output_json,
         ),
         is_error=_is_agentic_table_error_output,
+    )
+
+
+@agentic_table.command(name="create-sheet")
+@click.argument("assistant_id")
+@click.option("--name", "name", default=None, help="Sheet name.")
+@click.option(
+    "--due-at",
+    "due_at",
+    default=None,
+    help="Due date (ISO-8601, e.g. 2026-12-31T00:00:00Z).",
+)
+@click.option(
+    "--json", "output_json", is_flag=True, default=False, help="Print raw JSON."
+)
+@click.pass_context
+def agentic_table_create_sheet(
+    ctx: click.Context,
+    assistant_id: str,
+    name: str | None,
+    due_at: str | None,
+    output_json: bool,
+) -> None:
+    """Create a new sheet in a space.
+
+    \b
+    ASSISTANT_ID is the space the sheet is created in; you must have write
+    access to it. The printed ID is the table id for import/export/reads.
+
+    \b
+    Examples:
+      unique-cli agentic-table create-sheet asst_123 --name "Vendor DDQ"
+    """
+    emit(
+        cmd_create_sheet(
+            LazyState.get(ctx),
+            assistant_id,
+            name=name,
+            due_at=due_at,
+            output_json=output_json,
+        ),
+        is_error=_is_agentic_table_write_error_output,
+    )
+
+
+@agentic_table.command(name="import")
+@click.argument("table_id")
+@click.option(
+    "--question-file-id",
+    "question_file_ids",
+    multiple=True,
+    help="Content id of a questionnaire file (repeatable).",
+)
+@click.option(
+    "--question-text",
+    "question_texts",
+    multiple=True,
+    help="A question to add directly (repeatable).",
+)
+@click.option(
+    "--source-file-id",
+    "source_file_ids",
+    multiple=True,
+    help="Content id of a source/knowledge file (repeatable).",
+)
+@click.option(
+    "--context", "context", default=None, help="Free-text context for the run."
+)
+@click.option(
+    "--wait",
+    "wait",
+    is_flag=True,
+    default=False,
+    help="Wait for the triggered run to finish before returning.",
+)
+@click.option(
+    "--timeout",
+    "timeout",
+    type=float,
+    default=600.0,
+    show_default=True,
+    help="Max seconds to wait when --wait is set.",
+)
+@click.option(
+    "--json", "output_json", is_flag=True, default=False, help="Print raw JSON."
+)
+@click.pass_context
+def agentic_table_import(
+    ctx: click.Context,
+    table_id: str,
+    question_file_ids: tuple[str, ...],
+    question_texts: tuple[str, ...],
+    source_file_ids: tuple[str, ...],
+    context: str | None,
+    wait: bool,
+    timeout: float,
+    output_json: bool,
+) -> None:
+    """Import questions and sources into a sheet.
+
+    \b
+    Adding new questions triggers the agent run; adding only sources does not.
+    Ids/texts already on the sheet are skipped. With --wait, blocks until the
+    run finishes so you can chain an export.
+
+    \b
+    Examples:
+      unique-cli agentic-table import mt_abc123 --question-file-id c_q --source-file-id c_src
+      unique-cli agentic-table import mt_abc123 --question-text "What is the fee?" --wait
+    """
+    emit(
+        cmd_import(
+            LazyState.get(ctx),
+            table_id,
+            question_file_ids=list(question_file_ids),
+            question_texts=list(question_texts),
+            source_file_ids=list(source_file_ids),
+            context=context,
+            wait=wait,
+            timeout=timeout,
+            output_json=output_json,
+        ),
+        is_error=_is_agentic_table_write_error_output,
+    )
+
+
+@agentic_table.command(name="export")
+@click.argument("table_id")
+@click.option(
+    "--type",
+    "artifact_types",
+    multiple=True,
+    required=True,
+    type=click.Choice(["FULL_REPORT", "QUESTIONS", "AGENTIC_REPORT"]),
+    help="Artifact type to generate (repeatable).",
+)
+@click.option(
+    "--wait",
+    "wait",
+    is_flag=True,
+    default=False,
+    help="Wait for the requested artifacts to be ready, then list them.",
+)
+@click.option(
+    "--timeout",
+    "timeout",
+    type=float,
+    default=600.0,
+    show_default=True,
+    help="Max seconds to wait when --wait is set.",
+)
+@click.option(
+    "--json", "output_json", is_flag=True, default=False, help="Print raw JSON."
+)
+@click.pass_context
+def agentic_table_export(
+    ctx: click.Context,
+    table_id: str,
+    artifact_types: tuple[str, ...],
+    wait: bool,
+    timeout: float,
+    output_json: bool,
+) -> None:
+    """Generate export artifacts for a sheet.
+
+    \b
+    Generation is asynchronous. With --wait, blocks until each requested type
+    is DONE and prints the artifact table with the content id to download.
+
+    \b
+    Examples:
+      unique-cli agentic-table export mt_abc123 --type FULL_REPORT
+      unique-cli agentic-table export mt_abc123 --type FULL_REPORT --type QUESTIONS --wait
+    """
+    emit(
+        cmd_export(
+            LazyState.get(ctx),
+            table_id,
+            artifact_types=list(artifact_types),
+            wait=wait,
+            timeout=timeout,
+            output_json=output_json,
+        ),
+        is_error=_is_agentic_table_write_error_output,
     )

--- a/unique_sdk/unique_sdk/cli/cli.py
+++ b/unique_sdk/unique_sdk/cli/cli.py
@@ -2565,7 +2565,7 @@ def agentic_table_create_sheet(
 @click.option(
     "--timeout",
     "timeout",
-    type=float,
+    type=click.FloatRange(min=0),
     default=600.0,
     show_default=True,
     help="Max seconds to wait when --wait is set.",
@@ -2573,7 +2573,7 @@ def agentic_table_create_sheet(
 @click.option(
     "--start-timeout",
     "start_timeout",
-    type=float,
+    type=click.FloatRange(min=0),
     default=120.0,
     show_default=True,
     help=(
@@ -2646,7 +2646,7 @@ def agentic_table_import(
 @click.option(
     "--timeout",
     "timeout",
-    type=float,
+    type=click.FloatRange(min=0),
     default=600.0,
     show_default=True,
     help="Max seconds to wait when --wait is set.",

--- a/unique_sdk/unique_sdk/cli/commands/agentic_table_write.py
+++ b/unique_sdk/unique_sdk/cli/commands/agentic_table_write.py
@@ -18,8 +18,11 @@ run/artifact polling mirrors ``AgenticTableService.wait_for_run`` /
 accepting a terminal state, so a state left over from an earlier run is not
 mistaken for the freshly triggered one.
 
-These commands always exist in the binary; whether an agent is told about them
-is controlled separately by the gated write skill (see UN-22200 / PR C).
+The skill documents these alongside the read commands rather than gating them
+behind a separate write skill: access varies per sheet, not per space, so a
+skill-level toggle cannot express it. Authorization is enforced server-side on
+every call, and the skill teaches the agent to check its access first and to
+treat a denial as information rather than as a failure to work around.
 """
 
 from __future__ import annotations
@@ -47,11 +50,10 @@ from unique_sdk.cli.state import ShellState
 AGENTIC_TABLE_ERROR_PREFIX = "agentic-table:"
 
 # Poll cadence and default budgets for the opt-in ``--wait`` flows. The run
-# start window is short: if a run has not begun by then the trigger almost
-# certainly added no new questions (import is delta-based), which is reported
-# rather than waited out for the full timeout.
+# start window matches ``AgenticTableService.wait_for_run`` so the CLI and the
+# toolkit agree on how long a pickup may take before it is treated as absent.
 _POLL_INTERVAL_SECONDS = 5.0
-_RUN_START_TIMEOUT_SECONDS = 30.0
+_RUN_START_TIMEOUT_SECONDS = 120.0
 _DEFAULT_WAIT_TIMEOUT_SECONDS = 600.0
 
 
@@ -143,9 +145,17 @@ def cmd_import(
     it; either way the command fails rather than falling through to the wait.
 
     With ``wait``, polls the sheet state until the triggered run finishes (or
-    ``timeout`` elapses) so the caller can chain an export. If no run starts
-    within the start window (e.g. only sources were added), that is reported as
-    a note rather than an error.
+    ``timeout`` elapses) so the caller can chain an export.
+
+    Whether an unobserved run is benign depends on what was submitted, so the
+    two cases are kept apart rather than both reported as a note. A
+    sources-only import never triggers a run, so nothing starting is the
+    expected outcome and the command succeeds. When questions were submitted a
+    run was expected, and not seeing one is indeterminate — the pickup may
+    simply be late — so the command fails rather than letting a ``&&`` chain
+    export a sheet that is still being answered. A re-import of questions the
+    sheet already has lands here too: also a no-op, but not one this command
+    can distinguish from a late pickup.
     """
     params: AgenticTable.AddMetaData = {"tableId": table_id}
     if question_file_ids:
@@ -177,6 +187,14 @@ def cmd_import(
             return (
                 f"{AGENTIC_TABLE_ERROR_PREFIX} timed out after {timeout:g}s waiting "
                 f"for the run to finish (sheet {table_id} still PROCESSING)"
+            )
+        if not started and (question_file_ids or question_texts):
+            window = min(_RUN_START_TIMEOUT_SECONDS, timeout)
+            return (
+                f"{AGENTIC_TABLE_ERROR_PREFIX} imported questions into sheet "
+                f"{table_id} but no run started within {window:g}s (state: "
+                f"{final_state}); it may still be picked up, so re-check the "
+                f"sheet state before exporting"
             )
         if output_json:
             return json.dumps(

--- a/unique_sdk/unique_sdk/cli/commands/agentic_table_write.py
+++ b/unique_sdk/unique_sdk/cli/commands/agentic_table_write.py
@@ -306,6 +306,17 @@ def cmd_export(
     download; an artifact entering ``ERROR`` fails fast. Without ``wait``,
     returns once generation is accepted.
     """
+    # `click.Choice` already rejects an unknown type on the command line, but
+    # this function is importable and the enum would raise a bare ValueError
+    # past that guard — an exception where every other failure here is an
+    # `agentic-table:` line the caller can test with `is_error_output`.
+    allowed = {t.value for t in MagicTableArtifactType}
+    unknown = [t for t in artifact_types if t not in allowed]
+    if unknown:
+        return (
+            f"{AGENTIC_TABLE_ERROR_PREFIX} unknown artifact type: "
+            f"{', '.join(unknown)} (expected: {', '.join(sorted(allowed))})"
+        )
     wanted = [MagicTableArtifactType(t) for t in artifact_types]
 
     async def _run() -> str:

--- a/unique_sdk/unique_sdk/cli/commands/agentic_table_write.py
+++ b/unique_sdk/unique_sdk/cli/commands/agentic_table_write.py
@@ -11,18 +11,23 @@ already reads with the Tier 0 commands in ``agentic_table.py``. Writes are the
 first callers of the lifecycle mutations, so the write-path error mapping
 (permission denied, sheet-processing, locked-row) lands here.
 
-Each mutation is fire-and-forget by default; ``--wait`` opts into polling the
-sheet/artifact state to completion so a caller can chain the next step. The
-run/artifact polling mirrors ``AgenticTableService.wait_for_run`` /
-``wait_for_artifacts``: it waits for the work to be observed *starting* before
-accepting a terminal state, so a state left over from an earlier run is not
-mistaken for the freshly triggered one.
+Each mutation is fire-and-forget by default; ``--wait`` opts into polling to
+completion so a caller can chain the next step. Both waits have to tell the
+result of *this* trigger apart from state left over from an earlier one, and
+they do it differently because the evidence differs:
+
+- Artifacts are durable records, so ``_wait_for_artifacts`` compares against a
+  snapshot taken before the trigger and accepts only what is new.
+- A run leaves no durable record, so ``_wait_for_run`` has to catch the sheet in
+  ``PROCESSING`` — which a short run can pass through between two polls. Dense
+  early polling narrows that window; only a per-run signal from the backend
+  would close it (UN-23683).
 
 The skill documents these alongside the read commands rather than gating them
 behind a separate write skill: access varies per sheet, not per space, so a
 skill-level toggle cannot express it. Authorization is enforced server-side on
-every call, and the skill teaches the agent to check its access first and to
-treat a denial as information rather than as a failure to work around.
+every call, and the skill teaches the agent to attempt the operation and treat
+a denial as information rather than as a failure to work around.
 """
 
 from __future__ import annotations
@@ -30,6 +35,8 @@ from __future__ import annotations
 import asyncio
 import json
 import time
+from collections.abc import Awaitable, Callable
+from typing import NamedTuple, TypeVar
 
 from unique_sdk._error import UniqueError
 from unique_sdk.api_resources._agentic_table import (
@@ -40,14 +47,18 @@ from unique_sdk.api_resources._agentic_table import (
     MagicTableArtifactState,
     MagicTableArtifactType,
 )
+
+# Reads and writes are one CLI group under one error prefix, so they share the
+# prefix and the `is_error_output` predicate that goes with it, both of which
+# live with the reads. Other command modules own a prefix each and define their
+# own predicate; here a second copy would just be the same string twice.
+from unique_sdk.cli.commands.agentic_table import AGENTIC_TABLE_ERROR_PREFIX
 from unique_sdk.cli.formatting import (
     format_agentic_table_action_result,
     format_agentic_table_artifacts,
     format_agentic_table_created_sheet,
 )
 from unique_sdk.cli.state import ShellState
-
-AGENTIC_TABLE_ERROR_PREFIX = "agentic-table:"
 
 # Poll cadence and default budgets for the opt-in ``--wait`` flows. The run
 # start window matches ``AgenticTableService.wait_for_run`` so the CLI and the
@@ -56,10 +67,51 @@ _POLL_INTERVAL_SECONDS = 5.0
 _RUN_START_TIMEOUT_SECONDS = 120.0
 _DEFAULT_WAIT_TIMEOUT_SECONDS = 600.0
 
+# Sheet state is the only evidence that a run happened at all, and it is
+# transient: a small sheet can be picked up and finished well inside one
+# ``_POLL_INTERVAL_SECONDS``, leaving a completed run indistinguishable from one
+# that never started. Sample densely over the window where a short run lives.
+_FAST_POLL_INTERVAL_SECONDS = 1.0
+_FAST_POLL_WINDOW_SECONDS = 20.0
 
-def is_error_output(output: str) -> bool:
-    """Return ``True`` when *output* is an error message from an ``agentic-table`` write command."""
-    return output.startswith(AGENTIC_TABLE_ERROR_PREFIX)
+# A poll is an idempotent read issued *after* the mutation has landed, so a
+# blip on one request must not be reported as the write having failed.
+_POLL_READ_ATTEMPTS = 3
+_POLL_READ_BACKOFF_SECONDS = 1.0
+
+_T = TypeVar("_T")
+
+
+def _poll_interval(started_at: float, interval: float) -> float:
+    """Poll densely at first, then settle to *interval*.
+
+    A run is only visible while it is in flight, and a small sheet can be picked
+    up and finished well inside one 5s interval — which looks identical to a run
+    that never started. Sampling the opening seconds closely shrinks that blind
+    spot without holding a ten-minute wait at a high request rate.
+    """
+    if time.monotonic() - started_at < _FAST_POLL_WINDOW_SECONDS:
+        return min(_FAST_POLL_INTERVAL_SECONDS, interval)
+    return interval
+
+
+async def _poll_read(read: Callable[[], Awaitable[_T]]) -> _T:
+    """Run one polling read, absorbing a transient failure.
+
+    Polls happen after the mutation has already been accepted, so letting a
+    single failed request end the wait would report a write that landed as an
+    error. A 4xx is not retried: it is a decision rather than a blip, and it
+    will read the same way on the next attempt.
+    """
+    for attempt in range(_POLL_READ_ATTEMPTS):
+        try:
+            return await read()
+        except UniqueError as exc:
+            client_error = exc.http_status is not None and 400 <= exc.http_status < 500
+            if client_error or attempt == _POLL_READ_ATTEMPTS - 1:
+                raise
+            await asyncio.sleep(_POLL_READ_BACKOFF_SECONDS)
+    raise AssertionError("unreachable: the loop either returns or raises")
 
 
 def _error(exc: UniqueError) -> str:
@@ -84,7 +136,17 @@ def _rejected(result: MagicTableActionResult, *, action: str) -> str:
     would exit 0 and let an agent's ``&&`` chain continue — exporting stale
     answers after an import that never landed. ``AgenticTableService`` raises in
     the same situation.
+
+    A body with no ``status`` field at all is a different case and says so: the
+    request was not declined, it was unintelligible, and the mutation may well
+    have been applied. Collapsing that into "rejected" would invite a retry.
     """
+    if "status" not in result:
+        return (
+            f"{AGENTIC_TABLE_ERROR_PREFIX} {action} returned a response with no status "
+            "field, so the outcome is unknown — it may have been applied. Check the "
+            "sheet before retrying."
+        )
     message = result.get("message") or "no detail returned"
     return f"{AGENTIC_TABLE_ERROR_PREFIX} {action} rejected: {message}"
 
@@ -134,6 +196,7 @@ def cmd_import(
     context: str | None = None,
     wait: bool = False,
     timeout: float = _DEFAULT_WAIT_TIMEOUT_SECONDS,
+    start_timeout: float = _RUN_START_TIMEOUT_SECONDS,
     output_json: bool = False,
 ) -> str:
     """Import questions/sources into a sheet (``POST /magic-table/{id}/metadata``).
@@ -156,6 +219,10 @@ def cmd_import(
     export a sheet that is still being answered. A re-import of questions the
     sheet already has lands here too: also a no-op, but not one this command
     can distinguish from a late pickup.
+
+    ``start_timeout`` bounds how long a pickup may take before it is treated as
+    absent; raise it when the worker queue is known to be slow, since a run that
+    has not been picked up yet is not the same thing as a run that will not be.
     """
     params: AgenticTable.AddMetaData = {"tableId": table_id}
     if question_file_ids:
@@ -181,7 +248,7 @@ def cmd_import(
             return format_agentic_table_action_result(result, action="import")
 
         started, final_state, timed_out = await _wait_for_run(
-            state, table_id, timeout=timeout
+            state, table_id, timeout=timeout, start_timeout=start_timeout
         )
         if started and timed_out:
             return (
@@ -189,12 +256,14 @@ def cmd_import(
                 f"for the run to finish (sheet {table_id} still PROCESSING)"
             )
         if not started and (question_file_ids or question_texts):
-            window = min(_RUN_START_TIMEOUT_SECONDS, timeout)
+            window = min(start_timeout, timeout)
             return (
                 f"{AGENTIC_TABLE_ERROR_PREFIX} imported questions into sheet "
                 f"{table_id} but no run started within {window:g}s (state: "
-                f"{final_state}); it may still be picked up, so re-check the "
-                f"sheet state before exporting"
+                f"{final_state}); the questions are on the sheet and may still be "
+                f"picked up, or may already have been answered. Poll get-sheet until "
+                f"the state settles and the rows have answers before exporting — an "
+                f"export now would report unanswered rows"
             )
         if output_json:
             return json.dumps(
@@ -241,7 +310,9 @@ def cmd_export(
 
     async def _run() -> str:
         since = (
-            await _latest_artifact_timestamps(state, table_id, wanted) if wait else {}
+            await _artifact_baseline(state, table_id, wanted)
+            if wait
+            else _ArtifactBaseline(ids=frozenset(), latest={})
         )
         result = await AgenticTable.generate_artifact(
             user_id=state.config.user_id,
@@ -300,6 +371,12 @@ async def _wait_for_run(
     the sheet to enter ``PROCESSING`` (bounded by the shorter of ``start_timeout``
     and ``timeout``), then wait for it to leave ``PROCESSING``.
 
+    The first phase is inherently lossy: ``PROCESSING`` is transient, so a run
+    that finishes between two polls is indistinguishable from one that never
+    began. Polling densely at the start (see ``_poll_interval``) narrows the gap
+    but does not close it; closing it needs a durable per-run or per-row signal
+    from the backend, which the public API does not expose yet (UN-23683).
+
     Returns ``(started, final_state, timed_out)``:
     - ``(False, last_state, False)`` — no run began within the start window.
     - ``(True, terminal_state, False)`` — the run started and finished.
@@ -307,54 +384,104 @@ async def _wait_for_run(
     """
 
     async def _state() -> AgenticTableSheetState:
-        return await AgenticTable.get_sheet_state(
-            user_id=state.config.user_id,
-            company_id=state.config.company_id,
-            tableId=table_id,
+        return await _poll_read(
+            lambda: AgenticTable.get_sheet_state(
+                user_id=state.config.user_id,
+                company_id=state.config.company_id,
+                tableId=table_id,
+            )
         )
 
-    overall_deadline = time.monotonic() + timeout
-    start_deadline = time.monotonic() + min(start_timeout, timeout)
+    began_at = time.monotonic()
+    overall_deadline = began_at + timeout
+    start_deadline = began_at + min(start_timeout, timeout)
     current = await _state()
     while current != AgenticTableSheetState.PROCESSING:
         if time.monotonic() >= start_deadline:
             return False, current, False
-        await asyncio.sleep(interval)
+        await asyncio.sleep(_poll_interval(began_at, interval))
         current = await _state()
 
     while current == AgenticTableSheetState.PROCESSING:
         if time.monotonic() >= overall_deadline:
             return True, current, True
-        await asyncio.sleep(interval)
+        await asyncio.sleep(_poll_interval(began_at, interval))
         current = await _state()
     return True, current, False
 
 
-async def _latest_artifact_timestamps(
+async def _list_artifacts(state: ShellState, table_id: str) -> list[MagicTableArtifact]:
+    return await _poll_read(
+        lambda: AgenticTable.list_artifacts(
+            user_id=state.config.user_id,
+            company_id=state.config.company_id,
+            tableId=table_id,
+        )
+    )
+
+
+class _ArtifactBaseline(NamedTuple):
+    """What the sheet's artifacts looked like before a generation was triggered.
+
+    ``ids`` are the records that already existed; ``latest`` is the newest
+    ``updatedAt`` per requested type. Two signals rather than one because either
+    can be absent: ``updatedAt`` is optional in the payload, and a record can be
+    refreshed in place rather than replaced.
+    """
+
+    ids: frozenset[str]
+    latest: dict[MagicTableArtifactType, str]
+
+
+async def _artifact_baseline(
     state: ShellState,
     table_id: str,
     wanted_types: list[MagicTableArtifactType],
-) -> dict[MagicTableArtifactType, str]:
-    """Newest ``updatedAt`` per requested type, for use as a freshness baseline.
+) -> _ArtifactBaseline:
+    """Snapshot the artifacts of interest before triggering a generation.
 
-    Taken before triggering a generation so the wait can tell the resulting
-    artifact apart from one left over from an earlier run.
+    Taken up front so the wait can tell the resulting artifact apart from one
+    left over from an earlier run.
     """
     wanted = set(wanted_types)
-    artifacts = await AgenticTable.list_artifacts(
-        user_id=state.config.user_id,
-        company_id=state.config.company_id,
-        tableId=table_id,
-    )
+    artifacts = await _list_artifacts(state, table_id)
+    ids: set[str] = set()
     latest: dict[MagicTableArtifactType, str] = {}
     for artifact in artifacts:
         artifact_type = artifact.get("artifactType")
         if artifact_type is None or artifact_type not in wanted:
             continue
+        artifact_id = artifact.get("id")
+        if artifact_id is not None:
+            ids.add(artifact_id)
         updated_at = artifact.get("updatedAt") or ""
         if updated_at > latest.get(artifact_type, ""):
             latest[artifact_type] = updated_at
-    return latest
+    return _ArtifactBaseline(ids=frozenset(ids), latest=latest)
+
+
+def _is_fresh(artifact: MagicTableArtifact, baseline: _ArtifactBaseline) -> bool:
+    """Whether *artifact* came out of the generation that was just triggered.
+
+    Identity first: a record that did not exist before the trigger is new, which
+    is how a finished report normally arrives — the backend stores it under its
+    filename, as a separate row from the nameless ``IN_PROGRESS`` marker.
+
+    ``updatedAt`` is the fallback, for a record refreshed in place. It has to be
+    the fallback rather than the primary signal because it is optional in the
+    payload: comparing two absent values would exclude the artifact on every
+    poll and hang the wait on a generation that had in fact succeeded. The
+    comparison is textual, which holds while the backend emits ISO-8601 in UTC
+    at a fixed precision; if that ever changes, identity still carries the case.
+    """
+    artifact_id = artifact.get("id")
+    if artifact_id is not None and artifact_id not in baseline.ids:
+        return True
+    artifact_type = artifact.get("artifactType")
+    if artifact_type is None:
+        return False
+    updated_at = artifact.get("updatedAt") or ""
+    return bool(updated_at) and updated_at > baseline.latest.get(artifact_type, "")
 
 
 async def _wait_for_artifacts(
@@ -362,15 +489,15 @@ async def _wait_for_artifacts(
     table_id: str,
     wanted_types: list[MagicTableArtifactType],
     *,
-    since: dict[MagicTableArtifactType, str],
+    since: _ArtifactBaseline,
     timeout: float,
     interval: float = _POLL_INTERVAL_SECONDS,
 ) -> tuple[str, list[MagicTableArtifact], list[str]]:
     """Poll ``list_artifacts`` until the requested types are freshly ``DONE``.
 
-    ``since`` is the pre-trigger output of ``_latest_artifact_timestamps``; an
-    artifact counts only once its ``updatedAt`` has moved past that baseline, so
-    a report left over from an earlier generation is never mistaken for this one.
+    ``since`` is the pre-trigger snapshot from ``_artifact_baseline``; an
+    artifact counts only once ``_is_fresh`` recognises it, so a report left over
+    from an earlier generation is never mistaken for this one.
 
     Freshness rather than an observed ``IN_PROGRESS`` phase is the signal
     deliberately. A sheet holds more than one artifact of a type — the trigger
@@ -386,20 +513,17 @@ async def _wait_for_artifacts(
     - ``"timeout"`` — ``missing`` lists the type values not yet DONE.
     """
     wanted = set(wanted_types)
-    deadline = time.monotonic() + timeout
+    began_at = time.monotonic()
+    deadline = began_at + timeout
     while True:
-        artifacts = await AgenticTable.list_artifacts(
-            user_id=state.config.user_id,
-            company_id=state.config.company_id,
-            tableId=table_id,
-        )
+        artifacts = await _list_artifacts(state, table_id)
         done: dict[MagicTableArtifactType, MagicTableArtifact] = {}
         failed: list[MagicTableArtifact] = []
         for artifact in artifacts:
             artifact_type = artifact.get("artifactType")
             if artifact_type is None or artifact_type not in wanted:
                 continue
-            if (artifact.get("updatedAt") or "") <= since.get(artifact_type, ""):
+            if not _is_fresh(artifact, since):
                 continue
             artifact_state = artifact.get("artifactState")
             if artifact_state == MagicTableArtifactState.DONE:
@@ -413,4 +537,4 @@ async def _wait_for_artifacts(
         if time.monotonic() >= deadline:
             missing = sorted(str(t) for t in wanted - set(done.keys()))
             return "timeout", [], missing
-        await asyncio.sleep(interval)
+        await asyncio.sleep(_poll_interval(began_at, interval))

--- a/unique_sdk/unique_sdk/cli/commands/agentic_table_write.py
+++ b/unique_sdk/unique_sdk/cli/commands/agentic_table_write.py
@@ -240,6 +240,9 @@ def cmd_export(
     wanted = [MagicTableArtifactType(t) for t in artifact_types]
 
     async def _run() -> str:
+        since = (
+            await _latest_artifact_timestamps(state, table_id, wanted) if wait else {}
+        )
         result = await AgenticTable.generate_artifact(
             user_id=state.config.user_id,
             company_id=state.config.company_id,
@@ -254,7 +257,7 @@ def cmd_export(
             return format_agentic_table_action_result(result, action="export")
 
         status, artifacts, missing = await _wait_for_artifacts(
-            state, table_id, wanted, timeout=timeout
+            state, table_id, wanted, since=since, timeout=timeout
         )
         if status == "error":
             failed = ", ".join(sorted(str(a.get("artifactType")) for a in artifacts))
@@ -327,20 +330,55 @@ async def _wait_for_run(
     return True, current, False
 
 
+async def _latest_artifact_timestamps(
+    state: ShellState,
+    table_id: str,
+    wanted_types: list[MagicTableArtifactType],
+) -> dict[MagicTableArtifactType, str]:
+    """Newest ``updatedAt`` per requested type, for use as a freshness baseline.
+
+    Taken before triggering a generation so the wait can tell the resulting
+    artifact apart from one left over from an earlier run.
+    """
+    wanted = set(wanted_types)
+    artifacts = await AgenticTable.list_artifacts(
+        user_id=state.config.user_id,
+        company_id=state.config.company_id,
+        tableId=table_id,
+    )
+    latest: dict[MagicTableArtifactType, str] = {}
+    for artifact in artifacts:
+        artifact_type = artifact.get("artifactType")
+        if artifact_type is None or artifact_type not in wanted:
+            continue
+        updated_at = artifact.get("updatedAt") or ""
+        if updated_at > latest.get(artifact_type, ""):
+            latest[artifact_type] = updated_at
+    return latest
+
+
 async def _wait_for_artifacts(
     state: ShellState,
     table_id: str,
     wanted_types: list[MagicTableArtifactType],
     *,
+    since: dict[MagicTableArtifactType, str],
     timeout: float,
     interval: float = _POLL_INTERVAL_SECONDS,
 ) -> tuple[str, list[MagicTableArtifact], list[str]]:
-    """Poll ``list_artifacts`` until the requested types are ``DONE``.
+    """Poll ``list_artifacts`` until the requested types are freshly ``DONE``.
 
-    Mirrors ``AgenticTableService.wait_for_artifacts``: a terminal state is
-    accepted for a type only after ``IN_PROGRESS`` has been observed for it, so
-    an artifact left over from an earlier generation is not mistaken for the
-    newly triggered one.
+    ``since`` is the pre-trigger output of ``_latest_artifact_timestamps``; an
+    artifact counts only once its ``updatedAt`` has moved past that baseline, so
+    a report left over from an earlier generation is never mistaken for this one.
+
+    Freshness rather than an observed ``IN_PROGRESS`` phase is the signal
+    deliberately. A sheet holds more than one artifact of a type — the trigger
+    records its ``IN_PROGRESS`` marker under no name and the finished report is
+    stored under its filename, so they are separate records and the marker is
+    never updated to ``DONE``. Waiting to see the report itself turn
+    ``IN_PROGRESS`` would also lose any generation that finishes inside one poll
+    interval, which is the common case on a small sheet.
 
     Returns ``(status, artifacts, missing)`` where ``status`` is:
     - ``"done"`` — ``artifacts`` are the DONE records (one per requested type).
@@ -348,7 +386,6 @@ async def _wait_for_artifacts(
     - ``"timeout"`` — ``missing`` lists the type values not yet DONE.
     """
     wanted = set(wanted_types)
-    started: set[MagicTableArtifactType] = set()
     deadline = time.monotonic() + timeout
     while True:
         artifacts = await AgenticTable.list_artifacts(
@@ -356,30 +393,21 @@ async def _wait_for_artifacts(
             company_id=state.config.company_id,
             tableId=table_id,
         )
-        current: dict[MagicTableArtifactType, MagicTableArtifact] = {}
+        done: dict[MagicTableArtifactType, MagicTableArtifact] = {}
+        failed: list[MagicTableArtifact] = []
         for artifact in artifacts:
             artifact_type = artifact.get("artifactType")
-            if artifact_type is not None and artifact_type in wanted:
-                current[artifact_type] = artifact
-        started.update(
-            artifact_type
-            for artifact_type, artifact in current.items()
-            if artifact.get("artifactState") == MagicTableArtifactState.IN_PROGRESS
-        )
-        failed = [
-            artifact
-            for artifact_type, artifact in current.items()
-            if artifact_type in started
-            and artifact.get("artifactState") == MagicTableArtifactState.ERROR
-        ]
+            if artifact_type is None or artifact_type not in wanted:
+                continue
+            if (artifact.get("updatedAt") or "") <= since.get(artifact_type, ""):
+                continue
+            artifact_state = artifact.get("artifactState")
+            if artifact_state == MagicTableArtifactState.DONE:
+                done[artifact_type] = artifact
+            elif artifact_state == MagicTableArtifactState.ERROR:
+                failed.append(artifact)
         if failed:
             return "error", failed, []
-        done = {
-            artifact_type: artifact
-            for artifact_type, artifact in current.items()
-            if artifact_type in started
-            and artifact.get("artifactState") == MagicTableArtifactState.DONE
-        }
         if wanted <= set(done.keys()):
             return "done", [done[t] for t in wanted_types], []
         if time.monotonic() >= deadline:

--- a/unique_sdk/unique_sdk/cli/commands/agentic_table_write.py
+++ b/unique_sdk/unique_sdk/cli/commands/agentic_table_write.py
@@ -32,6 +32,7 @@ from unique_sdk._error import UniqueError
 from unique_sdk.api_resources._agentic_table import (
     AgenticTable,
     AgenticTableSheetState,
+    MagicTableActionResult,
     MagicTableArtifact,
     MagicTableArtifactState,
     MagicTableArtifactType,
@@ -73,6 +74,19 @@ def _error(exc: UniqueError) -> str:
     return f"{AGENTIC_TABLE_ERROR_PREFIX} {exc}"
 
 
+def _rejected(result: MagicTableActionResult, *, action: str) -> str:
+    """Render a soft backend rejection as a CLI error line.
+
+    The lifecycle mutations report rejection in a 200 body (``status: false``)
+    rather than an HTTP error, so it has to be mapped explicitly or the command
+    would exit 0 and let an agent's ``&&`` chain continue — exporting stale
+    answers after an import that never landed. ``AgenticTableService`` raises in
+    the same situation.
+    """
+    message = result.get("message") or "no detail returned"
+    return f"{AGENTIC_TABLE_ERROR_PREFIX} {action} rejected: {message}"
+
+
 def cmd_create_sheet(
     state: ShellState,
     assistant_id: str,
@@ -87,7 +101,7 @@ def cmd_create_sheet(
     write access to it. The returned ``sheetId`` is the ``table_id`` for every
     subsequent command.
     """
-    params: dict[str, str] = {"assistantId": assistant_id}
+    params: AgenticTable.CreateSheet = {"assistantId": assistant_id}
     if name is not None:
         params["name"] = name
     if due_at is not None:
@@ -97,7 +111,7 @@ def cmd_create_sheet(
             AgenticTable.create_sheet(
                 user_id=state.config.user_id,
                 company_id=state.config.company_id,
-                **params,  # type: ignore[arg-type]
+                **params,
             )
         )
     except UniqueError as exc:
@@ -125,14 +139,15 @@ def cmd_import(
     Delta semantics: ids/texts already on the sheet are skipped, and the agent
     run is triggered only when *new* questions are added (sources alone do not
     trigger a run). The call is rejected with 422 while the sheet is already
-    ``PROCESSING``.
+    ``PROCESSING``, and with a ``status: false`` body when the backend declines
+    it; either way the command fails rather than falling through to the wait.
 
     With ``wait``, polls the sheet state until the triggered run finishes (or
     ``timeout`` elapses) so the caller can chain an export. If no run starts
     within the start window (e.g. only sources were added), that is reported as
     a note rather than an error.
     """
-    params: dict[str, object] = {"tableId": table_id}
+    params: AgenticTable.AddMetaData = {"tableId": table_id}
     if question_file_ids:
         params["questionFileIds"] = question_file_ids
     if question_texts:
@@ -146,8 +161,10 @@ def cmd_import(
         result = await AgenticTable.add_metadata(
             user_id=state.config.user_id,
             company_id=state.config.company_id,
-            **params,  # type: ignore[arg-type]
+            **params,
         )
+        if not result.get("status"):
+            return _rejected(result, action="import")
         if output_json and not wait:
             return json.dumps({"result": result}, indent=2, default=str)
         if not wait:
@@ -195,10 +212,12 @@ def cmd_export(
 ) -> str:
     """Generate export artifacts for a sheet (``POST .../generate-artifact``).
 
-    Generation is asynchronous. With ``wait``, polls ``list_artifacts`` until
-    every requested type reaches ``DONE`` (or ``timeout``), then prints the
-    artifact table with the ``contentId`` to download; an artifact entering
-    ``ERROR`` fails fast. Without ``wait``, returns once generation is accepted.
+    Generation is asynchronous, so a ``status: false`` body means the trigger
+    itself was declined and the command fails without polling. With ``wait``,
+    polls ``list_artifacts`` until every requested type reaches ``DONE`` (or
+    ``timeout``), then prints the artifact table with the ``contentId`` to
+    download; an artifact entering ``ERROR`` fails fast. Without ``wait``,
+    returns once generation is accepted.
     """
     wanted = [MagicTableArtifactType(t) for t in artifact_types]
 
@@ -209,6 +228,8 @@ def cmd_export(
             tableId=table_id,
             artifactTypes=wanted,
         )
+        if not result.get("status"):
+            return _rejected(result, action="export")
         if output_json and not wait:
             return json.dumps({"result": result}, indent=2, default=str)
         if not wait:
@@ -317,9 +338,11 @@ async def _wait_for_artifacts(
             company_id=state.config.company_id,
             tableId=table_id,
         )
-        current = {
-            a["artifactType"]: a for a in artifacts if a.get("artifactType") in wanted
-        }
+        current: dict[MagicTableArtifactType, MagicTableArtifact] = {}
+        for artifact in artifacts:
+            artifact_type = artifact.get("artifactType")
+            if artifact_type is not None and artifact_type in wanted:
+                current[artifact_type] = artifact
         started.update(
             artifact_type
             for artifact_type, artifact in current.items()

--- a/unique_sdk/unique_sdk/cli/commands/agentic_table_write.py
+++ b/unique_sdk/unique_sdk/cli/commands/agentic_table_write.py
@@ -1,0 +1,347 @@
+"""Agentic Table (magic table) write commands for the Unique CLI.
+
+The full-loop write slice over the public magic-table API (``2023-12-06``):
+
+- ``create-sheet`` — create an empty sheet in a space.
+- ``import`` — add questions/sources; adding new questions triggers the agent run.
+- ``export`` — generate export artifacts (report / question export) and list them.
+
+Together these let an agent build a sheet, run it, and collect the answers it
+already reads with the Tier 0 commands in ``agentic_table.py``. Writes are the
+first callers of the lifecycle mutations, so the write-path error mapping
+(permission denied, sheet-processing, locked-row) lands here.
+
+Each mutation is fire-and-forget by default; ``--wait`` opts into polling the
+sheet/artifact state to completion so a caller can chain the next step. The
+run/artifact polling mirrors ``AgenticTableService.wait_for_run`` /
+``wait_for_artifacts``: it waits for the work to be observed *starting* before
+accepting a terminal state, so a state left over from an earlier run is not
+mistaken for the freshly triggered one.
+
+These commands always exist in the binary; whether an agent is told about them
+is controlled separately by the gated write skill (see UN-22200 / PR C).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+
+from unique_sdk._error import UniqueError
+from unique_sdk.api_resources._agentic_table import (
+    AgenticTable,
+    AgenticTableSheetState,
+    MagicTableArtifact,
+    MagicTableArtifactState,
+    MagicTableArtifactType,
+)
+from unique_sdk.cli.formatting import (
+    format_agentic_table_action_result,
+    format_agentic_table_artifacts,
+    format_agentic_table_created_sheet,
+)
+from unique_sdk.cli.state import ShellState
+
+AGENTIC_TABLE_ERROR_PREFIX = "agentic-table:"
+
+# Poll cadence and default budgets for the opt-in ``--wait`` flows. The run
+# start window is short: if a run has not begun by then the trigger almost
+# certainly added no new questions (import is delta-based), which is reported
+# rather than waited out for the full timeout.
+_POLL_INTERVAL_SECONDS = 5.0
+_RUN_START_TIMEOUT_SECONDS = 30.0
+_DEFAULT_WAIT_TIMEOUT_SECONDS = 600.0
+
+
+def is_error_output(output: str) -> bool:
+    """Return ``True`` when *output* is an error message from an ``agentic-table`` write command."""
+    return output.startswith(AGENTIC_TABLE_ERROR_PREFIX)
+
+
+def _error(exc: UniqueError) -> str:
+    """Render an SDK error as a CLI error line.
+
+    A 403 (the platform's sheet-access guard) collapses to a stable
+    ``permission denied`` so agent ``&&`` chains stop cleanly and no backend
+    detail leaks. Other errors — including 422 while the sheet is ``PROCESSING``
+    and locked-row rejections — pass through verbatim, since the backend message
+    is already actionable.
+    """
+    if exc.http_status == 403:
+        return f"{AGENTIC_TABLE_ERROR_PREFIX} permission denied"
+    return f"{AGENTIC_TABLE_ERROR_PREFIX} {exc}"
+
+
+def cmd_create_sheet(
+    state: ShellState,
+    assistant_id: str,
+    *,
+    name: str | None = None,
+    due_at: str | None = None,
+    output_json: bool = False,
+) -> str:
+    """Create a new sheet in a space (``POST /magic-table``).
+
+    ``assistant_id`` is the space the sheet is created in; the caller must have
+    write access to it. The returned ``sheetId`` is the ``table_id`` for every
+    subsequent command.
+    """
+    params: dict[str, str] = {"assistantId": assistant_id}
+    if name is not None:
+        params["name"] = name
+    if due_at is not None:
+        params["dueAt"] = due_at
+    try:
+        sheet = asyncio.run(
+            AgenticTable.create_sheet(
+                user_id=state.config.user_id,
+                company_id=state.config.company_id,
+                **params,  # type: ignore[arg-type]
+            )
+        )
+    except UniqueError as exc:
+        return _error(exc)
+
+    if output_json:
+        return json.dumps(sheet, indent=2, default=str)
+    return format_agentic_table_created_sheet(sheet)
+
+
+def cmd_import(
+    state: ShellState,
+    table_id: str,
+    *,
+    question_file_ids: list[str] | None = None,
+    question_texts: list[str] | None = None,
+    source_file_ids: list[str] | None = None,
+    context: str | None = None,
+    wait: bool = False,
+    timeout: float = _DEFAULT_WAIT_TIMEOUT_SECONDS,
+    output_json: bool = False,
+) -> str:
+    """Import questions/sources into a sheet (``POST /magic-table/{id}/metadata``).
+
+    Delta semantics: ids/texts already on the sheet are skipped, and the agent
+    run is triggered only when *new* questions are added (sources alone do not
+    trigger a run). The call is rejected with 422 while the sheet is already
+    ``PROCESSING``.
+
+    With ``wait``, polls the sheet state until the triggered run finishes (or
+    ``timeout`` elapses) so the caller can chain an export. If no run starts
+    within the start window (e.g. only sources were added), that is reported as
+    a note rather than an error.
+    """
+    params: dict[str, object] = {"tableId": table_id}
+    if question_file_ids:
+        params["questionFileIds"] = question_file_ids
+    if question_texts:
+        params["questionTexts"] = question_texts
+    if source_file_ids:
+        params["sourceFileIds"] = source_file_ids
+    if context is not None:
+        params["context"] = context
+
+    async def _run() -> str:
+        result = await AgenticTable.add_metadata(
+            user_id=state.config.user_id,
+            company_id=state.config.company_id,
+            **params,  # type: ignore[arg-type]
+        )
+        if output_json and not wait:
+            return json.dumps({"result": result}, indent=2, default=str)
+        if not wait:
+            return format_agentic_table_action_result(result, action="import")
+
+        started, final_state, timed_out = await _wait_for_run(
+            state, table_id, timeout=timeout
+        )
+        if started and timed_out:
+            return (
+                f"{AGENTIC_TABLE_ERROR_PREFIX} timed out after {timeout:g}s waiting "
+                f"for the run to finish (sheet {table_id} still PROCESSING)"
+            )
+        if output_json:
+            return json.dumps(
+                {
+                    "result": result,
+                    "runStarted": started,
+                    "finalState": str(final_state) if final_state else None,
+                },
+                indent=2,
+                default=str,
+            )
+        note = (
+            f"Run finished (state: {final_state})."
+            if started
+            else "No agent run started (import adds a run only for new questions)."
+        )
+        return f"{format_agentic_table_action_result(result, action='import')}\n{note}"
+
+    try:
+        return asyncio.run(_run())
+    except UniqueError as exc:
+        return _error(exc)
+
+
+def cmd_export(
+    state: ShellState,
+    table_id: str,
+    *,
+    artifact_types: list[str],
+    wait: bool = False,
+    timeout: float = _DEFAULT_WAIT_TIMEOUT_SECONDS,
+    output_json: bool = False,
+) -> str:
+    """Generate export artifacts for a sheet (``POST .../generate-artifact``).
+
+    Generation is asynchronous. With ``wait``, polls ``list_artifacts`` until
+    every requested type reaches ``DONE`` (or ``timeout``), then prints the
+    artifact table with the ``contentId`` to download; an artifact entering
+    ``ERROR`` fails fast. Without ``wait``, returns once generation is accepted.
+    """
+    wanted = [MagicTableArtifactType(t) for t in artifact_types]
+
+    async def _run() -> str:
+        result = await AgenticTable.generate_artifact(
+            user_id=state.config.user_id,
+            company_id=state.config.company_id,
+            tableId=table_id,
+            artifactTypes=wanted,
+        )
+        if output_json and not wait:
+            return json.dumps({"result": result}, indent=2, default=str)
+        if not wait:
+            return format_agentic_table_action_result(result, action="export")
+
+        status, artifacts, missing = await _wait_for_artifacts(
+            state, table_id, wanted, timeout=timeout
+        )
+        if status == "error":
+            failed = ", ".join(sorted(str(a.get("artifactType")) for a in artifacts))
+            return (
+                f"{AGENTIC_TABLE_ERROR_PREFIX} artifact generation failed for "
+                f"{failed} on sheet {table_id}"
+            )
+        if status == "timeout":
+            pending = ", ".join(missing)
+            return (
+                f"{AGENTIC_TABLE_ERROR_PREFIX} timed out after {timeout:g}s waiting "
+                f"for exports ({pending}) on sheet {table_id}"
+            )
+        if output_json:
+            return json.dumps(
+                {"result": result, "artifacts": artifacts}, indent=2, default=str
+            )
+        return (
+            f"{format_agentic_table_action_result(result, action='export')}\n"
+            f"{format_agentic_table_artifacts(artifacts)}"
+        )
+
+    try:
+        return asyncio.run(_run())
+    except UniqueError as exc:
+        return _error(exc)
+
+
+async def _wait_for_run(
+    state: ShellState,
+    table_id: str,
+    *,
+    timeout: float,
+    start_timeout: float = _RUN_START_TIMEOUT_SECONDS,
+    interval: float = _POLL_INTERVAL_SECONDS,
+) -> tuple[bool, AgenticTableSheetState | None, bool]:
+    """Poll the sheet state through a triggered run.
+
+    Two-phase, mirroring ``AgenticTableService.wait_for_run``: first wait for
+    the sheet to enter ``PROCESSING`` (bounded by the shorter of ``start_timeout``
+    and ``timeout``), then wait for it to leave ``PROCESSING``.
+
+    Returns ``(started, final_state, timed_out)``:
+    - ``(False, last_state, False)`` — no run began within the start window.
+    - ``(True, terminal_state, False)`` — the run started and finished.
+    - ``(True, PROCESSING, True)`` — the run started but did not finish in time.
+    """
+
+    async def _state() -> AgenticTableSheetState:
+        return await AgenticTable.get_sheet_state(
+            user_id=state.config.user_id,
+            company_id=state.config.company_id,
+            tableId=table_id,
+        )
+
+    overall_deadline = time.monotonic() + timeout
+    start_deadline = time.monotonic() + min(start_timeout, timeout)
+    current = await _state()
+    while current != AgenticTableSheetState.PROCESSING:
+        if time.monotonic() >= start_deadline:
+            return False, current, False
+        await asyncio.sleep(interval)
+        current = await _state()
+
+    while current == AgenticTableSheetState.PROCESSING:
+        if time.monotonic() >= overall_deadline:
+            return True, current, True
+        await asyncio.sleep(interval)
+        current = await _state()
+    return True, current, False
+
+
+async def _wait_for_artifacts(
+    state: ShellState,
+    table_id: str,
+    wanted_types: list[MagicTableArtifactType],
+    *,
+    timeout: float,
+    interval: float = _POLL_INTERVAL_SECONDS,
+) -> tuple[str, list[MagicTableArtifact], list[str]]:
+    """Poll ``list_artifacts`` until the requested types are ``DONE``.
+
+    Mirrors ``AgenticTableService.wait_for_artifacts``: a terminal state is
+    accepted for a type only after ``IN_PROGRESS`` has been observed for it, so
+    an artifact left over from an earlier generation is not mistaken for the
+    newly triggered one.
+
+    Returns ``(status, artifacts, missing)`` where ``status`` is:
+    - ``"done"`` — ``artifacts`` are the DONE records (one per requested type).
+    - ``"error"`` — ``artifacts`` are the failed records.
+    - ``"timeout"`` — ``missing`` lists the type values not yet DONE.
+    """
+    wanted = set(wanted_types)
+    started: set[MagicTableArtifactType] = set()
+    deadline = time.monotonic() + timeout
+    while True:
+        artifacts = await AgenticTable.list_artifacts(
+            user_id=state.config.user_id,
+            company_id=state.config.company_id,
+            tableId=table_id,
+        )
+        current = {
+            a["artifactType"]: a for a in artifacts if a.get("artifactType") in wanted
+        }
+        started.update(
+            artifact_type
+            for artifact_type, artifact in current.items()
+            if artifact.get("artifactState") == MagicTableArtifactState.IN_PROGRESS
+        )
+        failed = [
+            artifact
+            for artifact_type, artifact in current.items()
+            if artifact_type in started
+            and artifact.get("artifactState") == MagicTableArtifactState.ERROR
+        ]
+        if failed:
+            return "error", failed, []
+        done = {
+            artifact_type: artifact
+            for artifact_type, artifact in current.items()
+            if artifact_type in started
+            and artifact.get("artifactState") == MagicTableArtifactState.DONE
+        }
+        if wanted <= set(done.keys()):
+            return "done", [done[t] for t in wanted_types], []
+        if time.monotonic() >= deadline:
+            missing = sorted(str(t) for t in wanted - set(done.keys()))
+            return "timeout", [], missing
+        await asyncio.sleep(interval)

--- a/unique_sdk/unique_sdk/cli/formatting.py
+++ b/unique_sdk/unique_sdk/cli/formatting.py
@@ -14,6 +14,8 @@ if TYPE_CHECKING:
     from unique_sdk.api_resources._agentic_table import (
         AgenticTableCell,
         AgenticTableSheet,
+        CreatedAgenticTableSheet,
+        MagicTableActionResult,
         MagicTableArtifact,
     )
     from unique_sdk.api_resources._mcp import MCP
@@ -468,3 +470,48 @@ def format_agentic_table_artifacts(artifacts: list[MagicTableArtifact]) -> str:
     lines = [f"{len(artifacts)} export artifact(s):\n"]
     lines.extend(_pad_columns(rows))
     return "\n".join(lines)
+
+
+def format_agentic_table_created_sheet(sheet: CreatedAgenticTableSheet) -> str:
+    """Format the result of creating a sheet (``POST /magic-table``).
+
+    ``ID`` is the ``sheetId`` to pass as ``table_id`` to every subsequent
+    command; ``chatId`` / ``dueAt`` are only shown when the backend returned
+    them.
+    """
+    rows = [
+        ["Sheet:", sheet.get("name", "?")],
+        ["ID:", sheet.get("sheetId", "?")],
+        ["Due diligence ID:", sheet.get("dueDiligenceId", "?")],
+        ["State:", str(sheet.get("state", "?"))],
+        ["Created by:", sheet.get("createdBy", "?")],
+        ["Created:", _format_date(sheet.get("createdAt"))],
+    ]
+    chat_id = sheet.get("chatId")
+    if chat_id:
+        rows.append(["Chat:", chat_id])
+    due_at = sheet.get("dueAt")
+    if due_at:
+        rows.append(["Due at:", _format_date(due_at)])
+    return "\n".join(_pad_columns(rows))
+
+
+def format_agentic_table_action_result(
+    result: MagicTableActionResult,
+    *,
+    action: str,
+) -> str:
+    """Format a lifecycle mutation's ``{status, message?}`` response.
+
+    Shared by ``import`` and ``export`` (before the optional ``--wait``): shows
+    the action, whether the backend accepted it, and any message it returned.
+    """
+    status = "OK" if result.get("status") else "FAILED"
+    rows = [
+        ["Action:", action],
+        ["Result:", status],
+    ]
+    message = result.get("message")
+    if message:
+        rows.append(["Detail:", str(message)])
+    return "\n".join(_pad_columns(rows))

--- a/unique_sdk/unique_sdk/cli/skills/unique-cli-agentic-table/SKILL.md
+++ b/unique_sdk/unique_sdk/cli/skills/unique-cli-agentic-table/SKILL.md
@@ -132,8 +132,14 @@ run; adding only sources does not.** Ids and texts already on the sheet are
 skipped. The call is rejected while the sheet is already processing.
 
 `--wait` blocks until the triggered run finishes (default timeout 600s) so you
-can chain an export. If only sources were added and no run started, that is
-reported as a note rather than an error.
+can chain an export.
+
+If you imported **only sources**, no run starts and the command succeeds with a
+note. If you imported **questions** and no run starts within 120s, the command
+fails: the run may just have been picked up late, and treating that as success
+would export a sheet that is still being answered. On that error, re-check the
+sheet state and retry the *export* — do not re-import, which will not start a
+second run for questions the sheet already has.
 
 ```bash
 unique-cli agentic-table import mt_abc123 --question-file-id c_q --source-file-id c_src --wait

--- a/unique_sdk/unique_sdk/cli/skills/unique-cli-agentic-table/SKILL.md
+++ b/unique_sdk/unique_sdk/cli/skills/unique-cli-agentic-table/SKILL.md
@@ -1,27 +1,52 @@
 ---
 name: unique-cli-agentic-table
 description: >-
-  Read Agentic Table (magic table / due-diligence) sheets through the
-  unique-cli agentic-table command. Use when the user or task involves
-  inspecting an Agentic Table: a sheet's state and metadata, a specific
-  cell's value or lock state, a cell's edit/answer history, or the sheet's
-  generated export artifacts (reports, question exports). These are
-  read-only (Tier 0) commands — they never modify the sheet and never
-  require confirmation. Access to each sheet is enforced by the platform;
-  a denial is reported as `agentic-table: permission denied`.
+  Read and drive Agentic Table (magic table / due-diligence) sheets through the
+  unique-cli agentic-table command. Use when the user or task involves an
+  Agentic Table: inspecting a sheet's state, a cell's value or lock state, a
+  cell's edit history or its export artifacts; or running the full loop —
+  creating a sheet, importing a questionnaire and sources, waiting for the
+  agent to answer, and exporting the result. Access is enforced per sheet by
+  the platform and varies from sheet to sheet; a denial is reported as
+  `agentic-table: permission denied`.
 ---
 
-# Unique CLI -- Agentic Table (read)
+# Unique CLI -- Agentic Table
 
-Inspect Agentic Table (a.k.a. magic table) sheets over the public magic-table
+Work with Agentic Table (a.k.a. magic table) sheets over the public magic-table
 API. Every command is scoped to the current user/company automatically; you
-never pass credentials. Sheet-role access (Owner / Can manage / Can edit) is
-enforced **server-side** — if you are not entitled to a sheet the command exits
-with `agentic-table: permission denied` rather than returning data.
+never pass credentials.
 
-All commands here are **reads only**. There are no write commands in this skill.
+Commands fall into two groups:
 
-## Commands
+- **Read (Tier 0)** — `get-sheet`, `get-cell`, `cell-history`, `list-exports`.
+  Never modify anything, never need confirmation.
+- **Write** — `create-sheet`, `import`, `export`. These create a sheet, add
+  questions and sources, start the agent run, and produce export artifacts.
+
+## Permissions
+
+Access is enforced **server-side, per sheet**. This is the part most likely to
+trip you up, because it is not uniform: the same user can own one sheet, hold
+edit access on a second, and read-only access on a third. Do not assume that
+succeeding on one sheet means you can do the same thing on another.
+
+There is no command yet that reports your access level on a sheet, so:
+
+1. Start with a read (`get-sheet`) before attempting a write on a sheet you
+   have not touched in this session. It costs one call and tells you whether
+   the sheet is reachable at all.
+2. Treat `agentic-table: permission denied` as **information, not failure**.
+   It means the current user lacks the level that operation needs. Report it
+   and ask the user how to proceed.
+3. Never retry a denial with different ids to discover what you can reach.
+   That is access probing, and it will not find anything you are entitled to.
+
+Some rows are protected. A row whose review status is locked or final rejects
+edits from everyone, including you — that is deliberate, and it usually means
+a person has already approved that answer. Do not try to route around it.
+
+## Read commands
 
 ### Sheet summary
 
@@ -79,22 +104,89 @@ report) with their state. The content id needed to download a file is only
 present once an artifact reaches the `DONE` state. Add `--json` for the raw
 list.
 
+## Write commands
+
+### Create a sheet
+
 ```bash
-unique-cli agentic-table list-exports mt_abc123
+unique-cli agentic-table create-sheet <assistant_id> [--name <name>] [--due-at <iso8601>]
 ```
+
+Creates an empty sheet in a space. The printed `ID` is the `table_id` every
+other command takes. Requires write access to the space.
+
+```bash
+unique-cli agentic-table create-sheet asst_123 --name "Vendor DDQ"
+```
+
+### Import questions and sources
+
+```bash
+unique-cli agentic-table import <table_id> [--question-file-id <id>]... [--question-text <text>]...
+                                           [--source-file-id <id>]... [--context <text>]
+                                           [--wait] [--timeout <seconds>]
+```
+
+Adds questions and/or source files. **Adding new questions starts the agent
+run; adding only sources does not.** Ids and texts already on the sheet are
+skipped. The call is rejected while the sheet is already processing.
+
+`--wait` blocks until the triggered run finishes (default timeout 600s) so you
+can chain an export. If only sources were added and no run started, that is
+reported as a note rather than an error.
+
+```bash
+unique-cli agentic-table import mt_abc123 --question-file-id c_q --source-file-id c_src --wait
+```
+
+### Export answers
+
+```bash
+unique-cli agentic-table export <table_id> --type <TYPE>... [--wait] [--timeout <seconds>]
+```
+
+Generates `FULL_REPORT`, `QUESTIONS` or `AGENTIC_REPORT` artifacts. Generation
+is asynchronous; `--wait` polls until each requested type is `DONE` and prints
+the `contentId` to download. An artifact entering `ERROR` fails fast.
+
+```bash
+unique-cli agentic-table export mt_abc123 --type FULL_REPORT --wait
+```
+
+## Full loop
+
+Create a sheet, populate and run it, then read the answers. Every step exits
+non-zero on failure — including a rejection the backend reports in the response
+body rather than as an HTTP error — so the steps chain safely with `&&`:
+
+```bash
+SHEET=$(unique-cli agentic-table create-sheet asst_123 --name "Vendor DDQ" --json | jq -r .sheetId) && \
+unique-cli agentic-table import "$SHEET" --question-file-id c_questions --source-file-id c_sources --wait && \
+unique-cli agentic-table export "$SHEET" --type FULL_REPORT --wait && \
+unique-cli agentic-table get-sheet "$SHEET" --cells
+```
+
+To fill in an existing questionnaire from a sheet someone else has already
+answered, skip the create and import steps: read the answers with
+`get-sheet --cells` or `get-cell`, and use `cell-history` if you need to know
+whether an answer came from a person or the assistant.
 
 ## Rules
 
-1. Treat these as read-only diagnostics. To answer a question about a sheet,
-   fetch exactly what you need (`get-cell` for one value, `get-sheet --cells`
-   for an overview) rather than dumping the whole sheet unless asked.
-2. `--row` and `--col` are **0-based** orders. Row 0 is the header row.
-3. A `agentic-table: permission denied` line means the current user cannot
-   access that sheet. Do not retry with different ids to probe access — report
-   the denial and stop.
-4. Use `--json` when you need to parse fields programmatically (e.g. to read a
+1. `--row` and `--col` are **0-based** orders. Row 0 is the header row.
+2. Fetch what you need, not everything. `get-cell` for one value,
+   `get-sheet --cells` for an overview — don't dump a whole sheet unless asked.
+3. Use `--wait` when a later step depends on the result, and only then. Without
+   it, `import` and `export` return as soon as the request is accepted, and the
+   answers or artifacts will not be ready yet.
+4. Never re-run `import` with the same questions to "retry" — ids and texts
+   already on the sheet are skipped, and a run that is already in flight will
+   reject the call.
+5. Tell the user what you changed. A sheet is shared, and someone else may be
+   working in it.
+6. Use `--json` when you need to parse fields programmatically (e.g. reading a
    `contentId` before downloading an export); use the default formatted output
-   when summarising for the user.
+   when summarising for a person.
 
 ## Prerequisites
 

--- a/unique_sdk/unique_sdk/cli/skills/unique-cli-agentic-table/SKILL.md
+++ b/unique_sdk/unique_sdk/cli/skills/unique-cli-agentic-table/SKILL.md
@@ -21,8 +21,11 @@ Commands fall into two groups:
 
 - **Read (Tier 0)** — `get-sheet`, `get-cell`, `cell-history`, `list-exports`.
   Never modify anything, never need confirmation.
-- **Write** — `create-sheet`, `import`, `export`. These create a sheet, add
-  questions and sources, start the agent run, and produce export artifacts.
+- **Write (Tier 1)** — `create-sheet`, `import`, `export`. These create a sheet,
+  add questions and sources, start the agent run, and produce export artifacts.
+  They add to a sheet rather than overwriting existing answers, so they do not
+  prompt for confirmation — but they do change a shared artifact, so say what
+  you did afterwards. Nothing here deletes or replaces a human's answer.
 
 ## Permissions
 
@@ -31,11 +34,14 @@ trip you up, because it is not uniform: the same user can own one sheet, hold
 edit access on a second, and read-only access on a third. Do not assume that
 succeeding on one sheet means you can do the same thing on another.
 
-There is no command yet that reports your access level on a sheet, so:
+There is no command yet that reports your access level on a sheet. Until there
+is, you cannot establish up front what you are allowed to do — a successful
+`get-sheet` proves the sheet exists and you can read it, and nothing more. So:
 
-1. Start with a read (`get-sheet`) before attempting a write on a sheet you
-   have not touched in this session. It costs one call and tells you whether
-   the sheet is reachable at all.
+1. Attempt the operation and handle the outcome. Do not treat a read as a
+   permission check for a write; it is not one. A read first is still worth it
+   when you need the sheet's shape or row numbers anyway, or to fail early on
+   an id that does not resolve.
 2. Treat `agentic-table: permission denied` as **information, not failure**.
    It means the current user lacks the level that operation needs. Report it
    and ask the user how to proceed.
@@ -137,9 +143,14 @@ can chain an export.
 If you imported **only sources**, no run starts and the command succeeds with a
 note. If you imported **questions** and no run starts within 120s, the command
 fails: the run may just have been picked up late, and treating that as success
-would export a sheet that is still being answered. On that error, re-check the
-sheet state and retry the *export* — do not re-import, which will not start a
-second run for questions the sheet already has.
+would export a sheet that is still being answered.
+
+That error means the outcome is unknown, not that the import failed. Do **not**
+export yet — an export now would report unanswered rows as if they were the
+result. Poll `get-sheet` until the state settles on `IDLE` and the rows you
+imported have answers, and only then export. Do not re-import either: the
+questions are already on the sheet, so a second import starts no run and
+returns the same error.
 
 ```bash
 unique-cli agentic-table import mt_abc123 --question-file-id c_q --source-file-id c_src --wait
@@ -163,14 +174,21 @@ unique-cli agentic-table export mt_abc123 --type FULL_REPORT --wait
 
 Create a sheet, populate and run it, then read the answers. Every step exits
 non-zero on failure — including a rejection the backend reports in the response
-body rather than as an HTTP error — so the steps chain safely with `&&`:
+body rather than as an HTTP error — so the steps chain with `&&`:
 
 ```bash
-SHEET=$(unique-cli agentic-table create-sheet asst_123 --name "Vendor DDQ" --json | jq -r .sheetId) && \
+SHEET_JSON=$(unique-cli agentic-table create-sheet asst_123 --name "Vendor DDQ" --json) && \
+SHEET=$(printf '%s' "$SHEET_JSON" | jq -r .sheetId) && \
 unique-cli agentic-table import "$SHEET" --question-file-id c_questions --source-file-id c_sources --wait && \
 unique-cli agentic-table export "$SHEET" --type FULL_REPORT --wait && \
 unique-cli agentic-table get-sheet "$SHEET" --cells
 ```
+
+Capture the JSON first and parse it in a second step, as above. Do **not** pipe
+`create-sheet` directly into `jq`: an assignment takes the exit status of the
+last command in the pipeline, so the CLI's failure is discarded, and because
+errors go to stderr `jq` reads empty input and succeeds — leaving `$SHEET`
+empty and the rest of the chain running against a sheet that does not exist.
 
 To fill in an existing questionnaire from a sheet someone else has already
 answered, skip the create and import steps: read the answers with


### PR DESCRIPTION
## Summary
- Adds the full-loop Agentic Table **write** commands to `unique-cli`, stacked on the merged read foundation (#2101): `create-sheet`, `import` (questions/sources — adding new questions triggers the agent run), and `export` (generate artifacts).
- Fire-and-forget by default with opt-in `--wait/--timeout`. `import --wait` polls the sheet in two phases: wait for it to enter `PROCESSING`, then to leave it. `export --wait` snapshots each artifact type's `updatedAt` before triggering and accepts a `DONE` artifact that has moved past that baseline, so a report left over from an earlier generation is never mistaken for this one.
- Write-path error mapping (403 → `agentic-table: permission denied`; 422 while PROCESSING and locked-row messages pass through verbatim), new formatters, and CLI docs with a copy-paste full-loop recipe.

All three operations are already SDK-backed in `_agentic_table.py` (merged in #2052), so this is pure CLI-layer work.

Refs: UN-22200

## Gating decision — resolved

The skill ships **ungated**: a single `unique-cli-agentic-table` skill covering read and write commands. An earlier revision of this PR deferred a separate gated `unique-cli-agentic-table-write` skill plus a monorepo gate, pending a team decision. That decision was taken on 29 July and the gated approach (Option A in the one-pager) was **rejected** — the same user holds different permissions on different sheets, so a per-space awareness flag is the wrong granularity: gate it on and the agent is taught commands it will be refused on half the sheets it touches; gate it off and it loses capability it legitimately has elsewhere.

What ships instead: the skill teaches the full command range plus how to establish what it may do on a given sheet before acting, and treats `403` as a routine outcome rather than an error to retry. The backend per-sheet `ResourceAccess` ladder is the control. Two tests hold that shape — `test_agentic_table_skill_documents_every_command` and `test_agentic_table_skill_teaches_permission_handling`.

Record: https://unique-ch.atlassian.net/wiki/spaces/~7120209aadbec57bad48518bd0d490cadf0245/pages/2535555116

The same decision makes REST/GraphQL authz parity and the bulk-upsert lock hole blocking prerequisites before the *editing* commands (cell, row and column — UN-22201) are enabled. Those do not affect this PR: `POST /magic-table`, `POST /:tableId/metadata` and `POST /:tableId/generate-artifact` all carry `@EnforceAuthz` and audit logging, and generate-artifact additionally requires `@RequireMagicTableAccess(ANSWER)`.

## Note on the export poller

`export --wait` originally waited to observe the report turn `IN_PROGRESS` and then `DONE`. That could never happen, so it timed out on every invocation despite the export itself succeeding in about a second. Two reasons: the backend writes its trigger marker under no name and the finished report under its filename, so they are separate records and the marker is never resolved (raised as **UN-23674**); and the report's own transition falls inside one five-second poll on any small sheet. Keying the wait on `updatedAt` freshness removes the dependency on catching a transient state. Local testing caught this — the unit tests passed throughout.

## Not in this PR (deferred)
- Per-row answer/rerun: the backend endpoint (UN-23496) has landed, and the CLI command is stacked in #2173.

## Test plan
- [x] `ruff check` + `ruff format` clean (repo-pinned ruff)
- [x] `pytest tests/cli` green — write tests cover 403/422 mapping, `--wait` finish / no-run-started / timeout, export done/error/timeout, soft `status: false` rejections that must not start polling, the stale-vs-fresh artifact case, and CLI wiring; full `tests/cli` 970 passed
- [x] Verified end to end against a local stack (node-chat plus the `python-agentic-table` worker, so real agent runs): `create-sheet` → `import --wait` → `export --wait` → `get-sheet --cells`, and the chained `&&` recipe exits 0. Error paths (nonexistent sheet, locked row, rejected trigger) exit non-zero and skip polling.
- [ ] Manual on QA

Made with [Cursor](https://cursor.com)
