### PR TITLE
perf(unique-toolkit): defer deepdiff import and drop numpy from history construction [UN-23464]

### DIFF
--- a/unique_toolkit/unique_toolkit/_common/config_checker/differ.py
+++ b/unique_toolkit/unique_toolkit/_common/config_checker/differ.py
@@ -5,7 +5,6 @@ import logging
 import re
 from typing import Any
 
-from deepdiff import DeepDiff
 from pydantic import BaseModel, Field
 
 from unique_toolkit._common.config_checker.models import DefaultChange
@@ -54,6 +53,10 @@ class ConfigDiffer:
         Returns:
             List of DefaultChange objects for any differences
         """
+        # deepdiff drags in pandas, which costs ~1.5s of import time in every
+        # service that only ever wants ``register_config`` from this package.
+        from deepdiff import DeepDiff
+
         from unique_toolkit._common.config_checker.exporter import ConfigExporter
 
         new_json = ConfigExporter._serialize_model(new_instance)

--- a/unique_toolkit/unique_toolkit/agentic/history_manager/history_construction_with_contents.py
+++ b/unique_toolkit/unique_toolkit/agentic/history_manager/history_construction_with_contents.py
@@ -5,14 +5,13 @@ import logging
 import mimetypes
 from datetime import datetime
 from enum import StrEnum
-from itertools import groupby
+from itertools import accumulate, groupby
 from typing import TYPE_CHECKING, Callable, Iterator
 
 if TYPE_CHECKING:
     from unique_toolkit.content.schemas import ContentChunk
     from unique_toolkit.language_model.builder import MessagesBuilder
 
-import numpy as np
 from pydantic import RootModel
 
 from unique_toolkit._common.token.token_counting import (
@@ -691,7 +690,7 @@ def limit_to_token_window(
         encode=encode,
     )
 
-    to_take: list[bool] = (np.cumsum(token_per_message_reversed) < token_limit).tolist()
+    to_take = [total < token_limit for total in accumulate(token_per_message_reversed)]
     to_take.reverse()
 
     return LanguageModelMessages(


### PR DESCRIPTION
## Summary
- Move the `deepdiff` import inside `ConfigDiffer.get_changed_defaults`: `deepdiff` drags in pandas, costing ~1.5 s of import time in every service that only wants `register_config` (measured on sandbox pod cold boot).
- Replace the single `np.cumsum` in `history_construction_with_contents.py` with `itertools.accumulate`, dropping numpy from the agentic history-manager import chain (~0.4 s).

Together these shave roughly 2 s off cold agent boot after idle (UN-23464). Complements the orchestrator-side fixes in Unique-AG/monorepo#27480.

## Test plan
- [x] `pytest tests/agentic/test_history_construction*` and token-reducer tests (77 passed)
- [x] `pytest -k "config_checker or differ"` (73 passed, 4 skipped)
- [x] Verified `deepdiff`, `pandas`, `numpy` no longer appear in `sys.modules` after importing both touched modules

Refs: UN-23464