### PR TITLE
feat(sdk): harden elicit ask for supervised waits

### DIFF
--- a/unique_sdk/docs/cli/elicitation.md
+++ b/unique_sdk/docs/cli/elicitation.md
@@ -52,7 +52,7 @@ elicit ask <message> [options]
 | `--schema` | | single required `answer` string | JSON Schema for the form body. |
 | `--chat-id` | `-c` | none | Attach the elicitation to a chat. |
 | `--message-id` | `-m` | none | Attach to a specific message. |
-| `--expires-in` | | none | Seconds before the platform auto-expires the request. |
+| `--expires-in` | | `--timeout`'s value | Seconds before the platform auto-expires the request, decoupled from `--timeout`. See "Decoupling expiry from the local wait" below. |
 | `--timeout` | | `7200` | Max seconds to block locally while polling. |
 | `--poll-interval` | | `2.0` | Seconds between polls. |
 | `--metadata` | | none | `key=value` metadata (repeatable). |
@@ -134,6 +134,57 @@ Updated:    2026-04-16 14:22
 ```
 
 Agents parse the JSON after `Response:` to get the structured answer.
+
+### Decoupling expiry from the local wait
+
+By default `ask` has a single knob: `--timeout` is both how long this process
+blocks polling *and* when the elicitation expires on the platform (it sends
+`--timeout`'s value as the server-side `expiresIn`). That coupling exists so
+the backend's short default expiry never leaves a record `PENDING` after the
+CLI has already stopped waiting.
+
+Pass `--expires-in` to decouple the two:
+
+```bash
+# Elicitation stays live on the platform for 2 hours even though this
+# process only waits 5 minutes before returning a "still PENDING" result.
+unique-cli elicit ask "Approve this change?" --expires-in 7200 --timeout 300
+```
+
+Use this when the caller's own wait budget is shorter than how long a human
+should realistically have to answer -- e.g. a harness with its own
+foreground-wait timeout. Without `--expires-in`, the request would expire
+under the user at the low `--timeout` value before they ever see it; with
+it, the request outlives the process and a later `elicit wait <id>` call (or
+another `ask`-style re-poll) can still pick up the answer. Omitting
+`--expires-in` reproduces exactly today's coupled behavior.
+
+### Elicitation-created stderr line
+
+Immediately after `ask` creates the elicitation -- before it starts polling
+-- it writes one line to **stderr** (never stdout):
+
+```
+UNIQUE_ELICITATION_CREATED id=<id> expires_at=<iso8601>
+```
+
+This is a stable, greppable, machine-readable line intended for callers
+(harnesses, wrapper scripts) that want the elicitation id the instant it
+exists, instead of polling `elicit pending` to discover it. It does not
+change `ask`'s stdout output in any way.
+
+### Transient-failure retries
+
+While polling, `ask` (via the same `cmd_elicit_wait` logic used by the
+standalone `elicit wait` command) retries transient failures -- connection
+errors, timeouts, and 5xx responses -- with bounded exponential backoff,
+instead of ending the wait on the first dropped connection. Each retry is
+logged to stderr with the attempt number and backoff delay. 4xx errors are
+not retried (they cannot succeed on retry). Retries are always bounded by
+the overall `--timeout` (or, for the standalone `elicit wait` command, the
+`--timeout` passed to it) -- a persistent failure still gives up once that
+budget is exhausted, returning the same `elicit: <error>` output as before
+this retry logic existed.
 
 !!! tip "Scripting"
     Extract the response with `awk` + `jq`:
@@ -264,6 +315,8 @@ unique-cli elicit wait elicit_9a7b --timeout 120
 ```
 
 On timeout, the CLI prints `elicit: still PENDING after Ns waiting for <id> (last status: PENDING) — this is NOT a stopping condition`, followed by an explicit `elicit wait` invocation to run again and the last observed snapshot. The elicitation remains live on the platform -- call `elicit wait` again to resume; a non-terminal timeout is never itself a reason to stop.
+
+Transient failures while polling (connection errors, timeouts, 5xx) are retried with bounded exponential backoff, logged to stderr, and bounded by the overall `--timeout` -- see "Transient-failure retries" under `elicit ask` above for details (the retry logic is shared between `ask` and `wait`).
 
 ---
 

--- a/unique_sdk/tests/cli/test_elicitation.py
+++ b/unique_sdk/tests/cli/test_elicitation.py
@@ -447,6 +447,86 @@ class TestElicitWait:
         mock.side_effect = unique_sdk.APIError("fail")
         assert "elicit:" in cmd_elicit_wait(_state(), "x", timeout=1)
 
+    @patch("unique_sdk.cli.commands.elicitation.time.sleep")
+    @patch("unique_sdk.Elicitation.get_elicitation")
+    def test_transient_error_then_success_retries_and_returns_terminal(
+        self,
+        mock_get: MagicMock,
+        mock_sleep: MagicMock,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """A 502 mid-poll must be retried, not treated as a stopping
+        condition -- this is the core bug fix in PR4 (UN-23310).
+        """
+        transient = unique_sdk.APIError("bad gateway", http_status=502)
+        mock_get.side_effect = [
+            transient,
+            _elicitation(status="RESPONDED", response_content={"answer": "ok"}),
+        ]
+        result = cmd_elicit_wait(_state(), "elicit_abc", timeout=30)
+        assert "RESPONDED" in result
+        assert mock_sleep.call_count == 1
+        captured = capsys.readouterr()
+        assert "transient error on attempt 1" in captured.err
+
+    @patch("unique_sdk.cli.commands.elicitation.time.sleep")
+    @patch("unique_sdk.cli.commands.elicitation.time.monotonic")
+    @patch("unique_sdk.Elicitation.get_elicitation")
+    def test_persistent_transient_error_gives_up_within_timeout(
+        self,
+        mock_get: MagicMock,
+        mock_monotonic: MagicMock,
+        mock_sleep: MagicMock,
+    ) -> None:
+        """A persistent 502 must give up once --timeout is exhausted, with
+        the same ``elicit: <error>`` contract as an unresolved wait always
+        had -- not hang forever, and not silently return a fake terminal
+        status.
+        """
+        mock_get.side_effect = unique_sdk.APIError("bad gateway", http_status=502)
+        # First call establishes the deadline (0.0 + 10 == 10.0). Every
+        # subsequent monotonic() call happens inside the retry helper's
+        # except branch; once it reports we're past the deadline, the
+        # helper re-raises instead of sleeping again.
+        mock_monotonic.side_effect = [0.0, 5.0, 11.0]
+        result = cmd_elicit_wait(_state(), "elicit_abc", timeout=10)
+        assert "elicit:" in result
+        assert "bad gateway" in result
+
+    @patch("unique_sdk.cli.commands.elicitation.time.sleep")
+    @patch("unique_sdk.Elicitation.get_elicitation")
+    def test_4xx_error_is_not_retried(
+        self,
+        mock_get: MagicMock,
+        mock_sleep: MagicMock,
+    ) -> None:
+        """A 4xx cannot succeed on retry -- retrying it would just burn the
+        wait budget on a request that is doomed regardless.
+        """
+        mock_get.side_effect = unique_sdk.APIError("bad request", http_status=400)
+        result = cmd_elicit_wait(_state(), "elicit_abc", timeout=30)
+        assert "elicit:" in result
+        assert "bad request" in result
+        assert mock_sleep.call_count == 0
+
+    @patch("unique_sdk.cli.commands.elicitation.time.sleep")
+    @patch("unique_sdk.Elicitation.get_elicitation")
+    def test_connection_error_is_retried(
+        self,
+        mock_get: MagicMock,
+        mock_sleep: MagicMock,
+    ) -> None:
+        """Connection-level failures (timeouts, resets) are transient too,
+        not just HTTP 5xx responses.
+        """
+        mock_get.side_effect = [
+            unique_sdk.APIConnectionError("connection reset"),
+            _elicitation(status="ACCEPTED", response_content={"answer": "ok"}),
+        ]
+        result = cmd_elicit_wait(_state(), "elicit_abc", timeout=30)
+        assert "ACCEPTED" in result
+        assert mock_sleep.call_count == 1
+
 
 class TestElicitAsk:
     @patch("unique_sdk.Elicitation.get_elicitation")
@@ -500,13 +580,80 @@ class TestElicitAsk:
     def test_expiry_always_matches_wait_timeout(
         self, mock_create: MagicMock, mock_get: MagicMock
     ) -> None:
-        """`ask` has a single knob: the record expires exactly when we stop waiting."""
+        """Characterization test (write first, before any PR4 edit): without
+        --expires-in, `ask` has a single knob and the record expires exactly
+        when we stop waiting. The request payload sent to the platform must
+        be byte-identical to what it was before --expires-in existed.
+        """
         mock_create.return_value = _elicitation()
         mock_get.return_value = _elicitation(
             status="RESPONDED", response_content={"answer": "hi"}
         )
         cmd_elicit_ask(_state(), message="What?", timeout=10)
         assert mock_create.call_args[1]["expiresInSeconds"] == 10
+        assert mock_create.call_args[1] == {
+            "user_id": "u1",
+            "company_id": "c1",
+            "mode": "FORM",
+            "message": "What?",
+            "toolName": "agent_question",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "answer": {
+                        "type": "string",
+                        "description": "Free-text answer to the question.",
+                    },
+                },
+                "required": ["answer"],
+            },
+            "expiresInSeconds": 10,
+        }
+
+    @patch("unique_sdk.Elicitation.get_elicitation")
+    @patch("unique_sdk.Elicitation.create_elicitation")
+    def test_expires_in_decouples_expiry_from_timeout(
+        self, mock_create: MagicMock, mock_get: MagicMock
+    ) -> None:
+        """`--expires-in` sends its own value to the server; `--timeout`
+        continues to govern only the local wait budget.
+        """
+        mock_create.return_value = _elicitation()
+        mock_get.return_value = _elicitation(
+            status="RESPONDED", response_content={"answer": "hi"}
+        )
+        cmd_elicit_ask(_state(), message="What?", timeout=300, expires_in_seconds=7200)
+        assert mock_create.call_args[1]["expiresInSeconds"] == 7200
+
+    @patch("unique_sdk.Elicitation.get_elicitation")
+    @patch("unique_sdk.Elicitation.create_elicitation")
+    def test_stderr_line_emitted_once_stdout_unchanged(
+        self,
+        mock_create: MagicMock,
+        mock_get: MagicMock,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """The UNIQUE_ELICITATION_CREATED contract line is stderr-only and
+        does not alter stdout's format -- the harness/skills parse stdout,
+        so any drift there is a regression, not a feature.
+        """
+        mock_create.return_value = _elicitation(eid="elicit_xyz")
+        mock_get.return_value = _elicitation(
+            eid="elicit_xyz",
+            status="RESPONDED",
+            response_content={"answer": "hi"},
+        )
+        expected_stdout = cmd_elicit_ask(_state(), message="What?")
+        # cmd_elicit_ask returns its would-be stdout as a plain string (the
+        # CLI layer is responsible for echoing it) -- capture stderr only.
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        stderr_lines = [ln for ln in captured.err.splitlines() if ln.strip()]
+        assert len(stderr_lines) == 1
+        assert stderr_lines[0].startswith(
+            "UNIQUE_ELICITATION_CREATED id=elicit_xyz expires_at="
+        )
+        assert "RESPONDED" in expected_stdout
 
 
 # --- Visibility workaround (UN-19815) -----------------------------------
@@ -1175,10 +1322,28 @@ class TestShellElicit:
         out = _capture(_shell(), 'elicit ask "x" --poll-interval abc')
         assert "Invalid --poll-interval" in out
 
-    def test_ask_rejects_expires_in_option(self) -> None:
-        """`ask` exposes only --timeout; --expires-in lives on `create`."""
-        out = _capture(_shell(), 'elicit ask "x" --expires-in 60')
-        assert "No such option" in out
+    @patch("unique_sdk.cli.shell.cmd_elicit_ask")
+    def test_ask_accepts_expires_in_option(self, mock: MagicMock) -> None:
+        """PR4 (UN-23310): `ask` now accepts --expires-in to decouple the
+        server-side expiry from --timeout (the local wait budget).
+        """
+        mock.return_value = "ASKED"
+        out = _capture(_shell(), 'elicit ask "x" --expires-in 7200 --timeout 300')
+        assert "ASKED" in out
+        kw = mock.call_args[1]
+        assert kw["expires_in_seconds"] == 7200
+        assert kw["timeout"] == 300
+
+    @patch("unique_sdk.cli.shell.cmd_elicit_ask")
+    def test_ask_without_expires_in_defaults_to_none(self, mock: MagicMock) -> None:
+        """Characterization: omitting --expires-in must forward ``None`` so
+        ``cmd_elicit_ask`` falls back to coupling expiry with --timeout,
+        exactly as it did before --expires-in existed.
+        """
+        mock.return_value = "ASKED"
+        out = _capture(_shell(), 'elicit ask "x" --timeout 30')
+        assert "ASKED" in out
+        assert mock.call_args[1]["expires_in_seconds"] is None
 
     def test_ask_invalid_metadata(self) -> None:
         out = _capture(_shell(), 'elicit ask "x" --metadata badformat')

--- a/unique_sdk/unique_sdk/cli/cli.py
+++ b/unique_sdk/unique_sdk/cli/cli.py
@@ -1154,9 +1154,24 @@ def elicit() -> None:
     default=DEFAULT_WAIT_TIMEOUT_SECONDS,
     show_default=True,
     help=(
-        "Max seconds to block waiting for the user's response. This also "
-        "sets when the elicitation expires, so the request expires exactly "
-        "when we stop waiting and the chat UI can offer a way to continue."
+        "Max seconds to block waiting for the user's response. Without "
+        "--expires-in, this also sets when the elicitation expires, so the "
+        "request expires exactly when we stop waiting and the chat UI can "
+        "offer a way to continue."
+    ),
+)
+@click.option(
+    "--expires-in",
+    "expires_in_seconds",
+    type=int,
+    default=None,
+    help=(
+        "Seconds before the platform expires the request, decoupled from "
+        "--timeout (the local wait budget). Use this when this process's "
+        "wait budget is shorter than how long a human should realistically "
+        "get to answer (e.g. a harness with its own foreground timeout) -- "
+        "otherwise the request expires under the user before they can "
+        "answer. Defaults to --timeout, exactly matching prior behavior."
     ),
 )
 @click.option(
@@ -1217,6 +1232,7 @@ def elicit_ask(
     chat_id: str | None,
     message_id: str | None,
     timeout: int,
+    expires_in_seconds: int | None,
     poll_interval: float,
     metadata: tuple[str, ...],
     visible: bool = True,
@@ -1229,7 +1245,9 @@ def elicit_ask(
     \b
     Creates a FORM elicitation in the Unique UI with the given MESSAGE
     and blocks until the user responds, the elicitation is declined /
-    cancelled / expired, or --timeout is reached.
+    cancelled / expired, or --timeout is reached. Immediately after
+    creation, before polling starts, a single line is written to stderr:
+    "UNIQUE_ELICITATION_CREATED id=<id> expires_at=<iso8601>".
 
     \b
     Examples:
@@ -1237,6 +1255,8 @@ def elicit_ask(
       unique-cli elicit ask "Confirm deletion of /Archive" --timeout 60
       unique-cli elicit ask "Pick a region" \\
         --schema '{"type":"object","properties":{"region":{"type":"string","enum":["EU","US","APAC"]}},"required":["region"]}'
+      unique-cli elicit ask "Long-running approval" \\
+        --expires-in 7200 --timeout 300
     """
     parsed_metadata: list[tuple[str, str]] = []
     for kv in metadata:
@@ -1253,6 +1273,7 @@ def elicit_ask(
         "chat_id": chat_id,
         "message_id": _resolve_cli_message_id(ctx, message_id),
         "timeout": timeout,
+        "expires_in_seconds": expires_in_seconds,
         "poll_interval": poll_interval,
         "metadata": parsed_metadata or None,
         "visible": visible,

--- a/unique_sdk/unique_sdk/cli/commands/elicitation.py
+++ b/unique_sdk/unique_sdk/cli/commands/elicitation.py
@@ -13,8 +13,9 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 import time
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, Literal, cast
 
 import unique_sdk
@@ -36,6 +37,23 @@ TERMINAL_STATUSES = {
     "EXPIRED",
     "COMPLETED",
 }
+
+# --- Transient-failure retry (UN-23310) ---------------------------------
+#
+# ``cmd_elicit_wait`` used to return on the very first ``APIError`` /
+# ``APIConnectionError`` raised mid-poll, treating a transient 502 the same
+# as a genuine terminal condition. Now that a single ``elicit ask`` call is
+# expected to carry the whole wait unsupervised, that one dropped connection
+# would otherwise cost the entire turn. These constants bound the retry
+# loop's backoff; the overall ``--timeout`` remains the hard outer bound.
+TRANSIENT_RETRY_BASE_SECONDS = 1.0
+TRANSIENT_RETRY_MAX_BACKOFF_SECONDS = 30.0
+
+# Prefix for the machine-readable line ``cmd_elicit_ask`` writes to stderr
+# immediately after creating the elicitation, before it starts polling. Kept
+# as a module constant so producer (here) and any future consumer/tests stay
+# in lockstep on the exact contract string.
+ELICITATION_CREATED_STDERR_PREFIX = "UNIQUE_ELICITATION_CREATED"
 
 # --- Visibility workaround for UN-19815 ---------------------------------
 #
@@ -632,6 +650,74 @@ def cmd_elicit_respond(
         return f"elicit: {exc}"
 
 
+def _is_transient_api_failure(exc: BaseException) -> bool:
+    """Return ``True`` if *exc* is worth retrying.
+
+    Transient: connection-level failures (timeouts, resets --
+    ``APIConnectionError``) and ``APIError``s with no HTTP status or a 5xx
+    status. Not transient: 4xx client errors, which cannot succeed on
+    retry -- retrying those would just burn the wait budget on a request
+    that is doomed regardless.
+
+    Note ``InvalidRequestError`` / ``AuthenticationError`` / ``PermissionError``
+    are not ``APIError`` subclasses and are not matched here; they propagate
+    unchanged, exactly as they did before this retry logic existed.
+    """
+    if isinstance(exc, unique_sdk.APIConnectionError):
+        return True
+    if isinstance(exc, unique_sdk.APIError):
+        status = getattr(exc, "http_status", None)
+        return status is None or status >= 500
+    return False
+
+
+def _get_elicitation_with_retry(
+    state: ShellState,
+    elicitation_id: str,
+    *,
+    deadline: float,
+) -> dict[str, Any]:
+    """Fetch an elicitation, retrying transient failures with backoff.
+
+    Retries are bounded by *deadline* (a ``time.monotonic()`` timestamp) --
+    once it passes, the last exception is re-raised so the caller's overall
+    ``--timeout`` is always the hard outer bound, never exceeded by retries.
+    Non-transient failures (see :func:`_is_transient_api_failure`) are
+    re-raised immediately without retrying. Each retry is logged to stderr
+    with the attempt number and backoff so a string of dropped connections
+    is diagnosable instead of silently eating the wait budget.
+    """
+    backoff = TRANSIENT_RETRY_BASE_SECONDS
+    attempt = 0
+    while True:
+        try:
+            return dict(
+                unique_sdk.Elicitation.get_elicitation(
+                    user_id=state.config.user_id,
+                    company_id=state.config.company_id,
+                    elicitation_id=elicitation_id,
+                )
+            )
+        except (unique_sdk.APIError, unique_sdk.APIConnectionError) as exc:
+            if not _is_transient_api_failure(exc):
+                raise
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise
+            attempt += 1
+            sleep_for = max(
+                0.0, min(backoff, TRANSIENT_RETRY_MAX_BACKOFF_SECONDS, remaining)
+            )
+            print(
+                f"elicit: transient error on attempt {attempt} fetching "
+                f"{elicitation_id} ({exc}); retrying in {sleep_for:.1f}s",
+                file=sys.stderr,
+            )
+            if sleep_for > 0:
+                time.sleep(sleep_for)
+            backoff = min(backoff * 2, TRANSIENT_RETRY_MAX_BACKOFF_SECONDS)
+
+
 def cmd_elicit_wait(
     state: ShellState,
     elicitation_id: str,
@@ -658,12 +744,10 @@ def cmd_elicit_wait(
     try:
         deadline = time.monotonic() + max(1, timeout)
         while True:
-            elicitation = unique_sdk.Elicitation.get_elicitation(
-                user_id=state.config.user_id,
-                company_id=state.config.company_id,
-                elicitation_id=elicitation_id,
+            elicitation = _get_elicitation_with_retry(
+                state, elicitation_id, deadline=deadline
             )
-            last = dict(elicitation)
+            last = elicitation
             status = str(elicitation.get("status", "")).upper()
             if status in TERMINAL_STATUSES:
                 terminal_status = status
@@ -675,12 +759,8 @@ def cmd_elicit_wait(
                 # same instant; this fetch forces the backend's lazy expiry to
                 # run so we report a clean EXPIRED — and publish it to the chat
                 # subscription — instead of a stale PENDING.
-                final = dict(
-                    unique_sdk.Elicitation.get_elicitation(
-                        user_id=state.config.user_id,
-                        company_id=state.config.company_id,
-                        elicitation_id=elicitation_id,
-                    )
+                final = _get_elicitation_with_retry(
+                    state, elicitation_id, deadline=deadline
                 )
                 last = final
                 final_status = str(final.get("status", "")).upper()
@@ -703,7 +783,7 @@ def cmd_elicit_wait(
                     f"{format_elicitation(last)}"
                 )
             time.sleep(poll_interval)
-    except unique_sdk.APIError as exc:
+    except (unique_sdk.APIError, unique_sdk.APIConnectionError) as exc:
         return f"elicit: {exc}"
     finally:
         # If the poll loop exited before we ever received a response
@@ -720,7 +800,7 @@ def cmd_elicit_wait(
                         elicitation_id=elicitation_id,
                     )
                 )
-            except unique_sdk.APIError:
+            except (unique_sdk.APIError, unique_sdk.APIConnectionError):
                 last = None
         ctx = _extract_visibility_context(last)
         if ctx is not None:
@@ -735,6 +815,36 @@ def cmd_elicit_wait(
             )
 
 
+def _emit_elicitation_created_stderr_line(
+    elicitation_id: str,
+    expires_at: object,
+    expires_in_seconds: int,
+) -> None:
+    """Write the ``UNIQUE_ELICITATION_CREATED`` contract line to stderr.
+
+    Format (stable, greppable, one line, stderr only)::
+
+        UNIQUE_ELICITATION_CREATED id=<id> expires_at=<iso8601>
+
+    Prefers the platform-returned ``expiresAt`` (authoritative); falls back
+    to a locally computed timestamp if the platform omitted it, so the line
+    is always emitted with a usable value.
+    """
+    if isinstance(expires_at, str) and expires_at:
+        resolved_expires_at = expires_at
+    else:
+        resolved_expires_at = (
+            (datetime.now(tz=timezone.utc) + timedelta(seconds=expires_in_seconds))
+            .isoformat(timespec="milliseconds")
+            .replace("+00:00", "Z")
+        )
+    print(
+        f"{ELICITATION_CREATED_STDERR_PREFIX} id={elicitation_id} "
+        f"expires_at={resolved_expires_at}",
+        file=sys.stderr,
+    )
+
+
 def cmd_elicit_ask(
     state: ShellState,
     *,
@@ -745,6 +855,7 @@ def cmd_elicit_ask(
     message_id: str | None = None,
     timeout: int = DEFAULT_WAIT_TIMEOUT_SECONDS,
     poll_interval: float = DEFAULT_POLL_INTERVAL_SECONDS,
+    expires_in_seconds: int | None = None,
     metadata: list[tuple[str, str]] | None = None,
     visible: bool = True,
     assistant_id: str | None = None,
@@ -756,6 +867,23 @@ def cmd_elicit_ask(
     When no ``--schema`` is passed, a minimal single-field form asking for a
     free-text ``answer`` is used. This is the preferred entry point when an
     agent needs to ask the user a clarifying question.
+
+    ``expires_in_seconds``, when given, decouples the server-side expiry
+    (``expiresInSeconds`` sent to the platform) from ``timeout`` (how long
+    *this process* blocks polling). When omitted (the default), behaviour is
+    unchanged from before this parameter existed: the elicitation expires
+    exactly when the local wait gives up, coupling the two. Pass this when
+    the caller's own wait budget (e.g. a harness's foreground timeout) is
+    shorter than how long a human should realistically have to answer --
+    otherwise the elicitation expires under the user before they see it.
+
+    Immediately after creation (before polling starts), a single line is
+    written to stderr for callers that want the elicitation id without
+    polling the pending list:
+
+        UNIQUE_ELICITATION_CREATED id=<id> expires_at=<iso8601>
+
+    This is stderr-only and does not change stdout's format.
 
     When ``chat_id`` is set and ``visible`` is ``True`` (the default), the
     elicitation is wrapped in a placeholder thinking timeline so the chat UI
@@ -778,16 +906,17 @@ def cmd_elicit_ask(
                 "required": ["answer"],
             }
 
-        # `ask` exposes a single knob: `--timeout` is both how long we wait and
-        # when the record expires. The two are always the same here, so the
-        # backend's default (5 minutes) never leaves the record PENDING after
-        # we have stopped waiting — which would otherwise prevent the chat UI
-        # from flipping the prompt to EXPIRED and offering the user a way to
-        # continue. The poll loop below reads the freshly EXPIRED record and the
-        # elicitation subscription delivers the terminal status to the chat.
-        # (Use `elicit create --expires-in` if you need expiry decoupled from a
-        # local wait.)
-        expires_in_seconds = timeout
+        # By default `ask` exposes a single knob: `--timeout` is both how long
+        # we wait and when the record expires. The two are the same unless the
+        # caller passes `--expires-in` explicitly, so the backend's default (5
+        # minutes) never leaves the record PENDING after we have stopped
+        # waiting — which would otherwise prevent the chat UI from flipping
+        # the prompt to EXPIRED and offering the user a way to continue. The
+        # poll loop below reads the freshly EXPIRED record and the elicitation
+        # subscription delivers the terminal status to the chat.
+        effective_expires_in_seconds = (
+            expires_in_seconds if expires_in_seconds is not None else timeout
+        )
 
         user_metadata = _parse_metadata_pairs(metadata)
         effective_message_id = message_id
@@ -836,7 +965,7 @@ def cmd_elicit_ask(
             url=None,
             chat_id=chat_id,
             message_id=effective_message_id,
-            expires_in_seconds=expires_in_seconds,
+            expires_in_seconds=effective_expires_in_seconds,
             external_elicitation_id=None,
             metadata=user_metadata,
         )
@@ -855,6 +984,12 @@ def cmd_elicit_ask(
         if not elicitation_id:
             _cleanup_placeholder_if_needed()
             return "elicit: platform did not return an elicitation id"
+
+        _emit_elicitation_created_stderr_line(
+            elicitation_id,
+            elicitation.get("expiresAt"),
+            effective_expires_in_seconds,
+        )
 
         # ``cmd_elicit_wait`` handles its own placeholder teardown by
         # reading the markers back from the elicitation's metadata.

--- a/unique_sdk/unique_sdk/cli/shell.py
+++ b/unique_sdk/unique_sdk/cli/shell.py
@@ -89,7 +89,10 @@ OVERVIEW_HELP = textwrap.dedent("""\
         --chat-id / -c <id>            Associated chat ID
         --message-id / -m <id>         Associated message ID
         --timeout <seconds>            Max wait time, also sets when the
-                                       request expires (default: 7200)
+                                       request expires unless --expires-in
+                                       is given (default: 7200)
+        --expires-in <seconds>         Decouple server-side expiry from
+                                       --timeout (defaults to --timeout)
         --poll-interval <seconds>      Poll frequency (default: 2.0)
         --metadata key=value           Metadata (repeatable)
         --no-visible                   Skip the UN-19815 visibility workaround
@@ -814,9 +817,12 @@ class UniqueShell(cmd.Cmd):
           --mode FORM|URL              Display mode (create only, default: FORM)
           --chat-id / -c <id>          Associated chat ID
           --message-id / -m <id>       Associated message ID
-          --expires-in <seconds>       Auto-expire the request (create only)
+          --expires-in <seconds>       Auto-expire the request. For ask, this
+                                       decouples expiry from --timeout
+                                       (defaults to --timeout when omitted)
           --timeout <seconds>          (ask / wait) max wait time, default 7200;
                                        for ask this also sets when it expires
+                                       unless --expires-in is given
           --poll-interval <seconds>    (ask / wait) poll frequency, default 2
           --external-id <id>           External identifier (create only)
           --metadata key=value         Metadata (repeatable)
@@ -999,13 +1005,6 @@ class UniqueShell(cmd.Cmd):
         if not message:
             self._print("Usage: elicit ask <message> [options]")
             return
-        if opts["expires_in_seconds"] is not None:
-            self._print(
-                "No such option: --expires-in for 'elicit ask'. Use --timeout "
-                "(it also sets when the request expires). For expiry decoupled "
-                "from a local wait, use 'elicit create --expires-in'."
-            )
-            return
 
         ask_kwargs: dict[str, Any] = {
             "message": message,
@@ -1014,6 +1013,7 @@ class UniqueShell(cmd.Cmd):
             "chat_id": opts["chat_id"],
             "message_id": opts["message_id"],
             "timeout": opts["timeout"],
+            "expires_in_seconds": opts["expires_in_seconds"],
             "poll_interval": opts["poll_interval"],
             "metadata": opts["metadata"] or None,
             "visible": opts["visible"],


### PR DESCRIPTION
## Summary
- Harden `unique-cli elicit ask` for unsupervised/supervised long waits: optional `--expires-in` decouples server-side expiry from the local `--timeout` poll budget (default behavior unchanged when omitted).
- Emit a stable, stderr-only creation contract so harnesses can learn the elicitation id without polling pending: `UNIQUE_ELICITATION_CREATED id=<id> expires_at=<iso8601>`.
- Retry transient mid-poll failures (5xx / connection errors) with bounded exponential backoff instead of aborting the wait on the first dropped connection; 4xx still fail immediately.

## Changes
- `unique_sdk/cli/commands/elicitation.py`: `--expires-in` support on `ask`, stderr creation line, transient retry helper for `wait`/`ask`
- `unique_sdk/cli/cli.py` + `shell.py`: wire `--expires-in` through Click and REPL (remove prior ask rejection)
- `docs/cli/elicitation.md`: document expiry decoupling, stderr contract, retry semantics
- `tests/cli/test_elicitation.py`: characterization + new coverage for expiry, stderr, 502 retry/give-up, 4xx no-retry

## Stderr contract (for PR1–PR3 consumers)
```
UNIQUE_ELICITATION_CREATED id=<id> expires_at=<iso8601>
```
- One line, stderr only; stdout format / exit codes / `TERMINAL_STATUSES` unchanged
- Emitted once after create, before polling starts

## Test plan
- [x] `uv run pytest tests/cli/test_elicitation.py` — 104 passed
- [x] `uv run pytest tests/` — 1087 passed, 39 skipped
- [x] `ruff check` / `ruff format` on touched files
- [x] `basedpyright` on touched modules — 0 errors

## Risk / rollout
- Additive only: old CLI callers (no `--expires-in`) keep coupled timeout/expiry behavior
- Harness may optionally start parsing the stderr line; matching monorepo changes are out of scope here
- Visibility/`messageLogId` workaround untouched (UN-23437)

Refs: UN-23310

Made with [Cursor](https://cursor.com)