### PR TITLE
docs(sdk): make elicitation guidance mode-agnostic, fix terminal-status gap

### DIFF
--- a/unique_sdk/docs/cli/elicitation.md
+++ b/unique_sdk/docs/cli/elicitation.md
@@ -7,30 +7,52 @@ Ask the user a structured question and get a typed answer back. Elicitations are
 
 The CLI exposes the full lifecycle:
 
-- `elicit ask` -- **create + wait** in a single call (the one you usually want)
+- `elicit ask` -- **create + wait** in a single call
 - `elicit create` -- fire-and-forget create (FORM or URL mode)
 - `elicit pending` -- list open requests for the current user
 - `elicit get` -- fetch one elicitation by ID
 - `elicit wait` -- poll an existing elicitation until it reaches a terminal state
 - `elicit respond` -- respond on behalf of the user (scripting / tests)
 
+### Choosing between `ask` and `create` + `wait`
+
+`elicit ask` and `elicit create` + `elicit wait` are two ways to get the same
+answer -- **which one to use depends on your calling context**, not a fixed
+rule of this doc:
+
+- **`elicit ask`** is the right choice for a single blocking call: scripts,
+  tests, ops usage, or an agent environment whose instructions say it
+  supervises long-running tool calls (does not silently background or kill
+  the process before a human answers).
+- **`elicit create` + a short polling loop with `elicit wait`** is the right
+  choice when the caller cannot safely block for the full wait in one call --
+  e.g. most agent harnesses, whose Bash/shell tool has its own short
+  foreground-wait timeout. See the [`unique-cli-elicitation` skill's "Two
+  patterns" section](../../unique_sdk/cli/skills/unique-cli-elicitation/SKILL.md)
+  for the agent-facing version of this guidance, including which one to
+  default to when instructions are silent.
+
 Elicitations move through these statuses:
 
 | Status | Meaning |
 |--------|---------|
 | `PENDING` | Created, waiting for a response |
-| `RESPONDED` / `COMPLETED` | The user submitted an answer (`responseContent` is populated) |
-| `DECLINED` | The user explicitly declined |
+| `RESPONDED` / `ACCEPTED` / `COMPLETED` | The user submitted an answer, or accepted an empty-schema confirmation (`responseContent` is populated for `RESPONDED`/`COMPLETED`) |
+| `DECLINED` / `REJECTED` | The user explicitly declined, or rejected an empty-schema confirmation |
 | `CANCELLED` | Cancelled by the user or system |
-| `EXPIRED` | Not answered before `expiresAt` |
+| `EXPIRED` | Not answered before `expiresAt` (`--expires-in`, or `--timeout` if `--expires-in` was not passed) |
 
-Any status other than `PENDING` is **terminal** -- `elicit wait` returns as soon as one of these is reached.
+`ACCEPTED`/`REJECTED` are accept/decline synonyms for `RESPONDED`/`DECLINED`
+produced by some response paths (e.g. the Codex approval-bridge integration);
+treat them identically (`ACCEPTED` → proceed, `REJECTED` → stop).
+
+Any status other than `PENDING` is **terminal** -- `elicit wait` returns as soon as one of these is reached. A non-terminal (`PENDING`) result -- including a local `--timeout` being reached while the platform-side request is still open -- is never itself a decline, cancellation, or answer; it only ever means "keep waiting."
 
 ---
 
 ## elicit ask
 
-Create a FORM elicitation and block until the user responds, declines, cancels, expires, or the local `--timeout` elapses. This is the idiomatic way for an agent to request input from the user.
+Create a FORM elicitation and block until the user responds, declines, cancels, expires, or the local `--timeout` elapses. This is the idiomatic single-call way to request input from the user -- appropriate for scripts, tests, ops usage, and agent environments that supervise long-running tool calls (see "Choosing between `ask` and `create` + `wait`" above).
 
 **Synopsis:**
 
@@ -372,7 +394,7 @@ For the common case of "ask and immediately use the answer", `elicit ask` collap
 
 - Always set `"required"` on fields that must be present -- this prevents empty submissions.
 - Use `"enum"` for finite choices so the UI renders a selector instead of a free-text box.
-- For pure yes/no confirmations use an empty-properties schema (`{"type": "object", "properties": {}}`) and gate on `Status: ACCEPTED` -- do **not** add a boolean `confirm` field. The UI's Confirm button and a checkbox are two separate signals: a user can press Confirm with the box unchecked, showing **Accepted** in the UI while the response carries `confirm: false`. Treat `DECLINED` / `CANCELLED` / `EXPIRED` as "stop". Reserve `"type": "boolean"` for genuine data fields where `false` is a valid submittable answer.
+- For pure yes/no confirmations use an empty-properties schema (`{"type": "object", "properties": {}}`) and gate on `Status: ACCEPTED` -- do **not** add a boolean `confirm` field. The UI's Confirm button and a checkbox are two separate signals: a user can press Confirm with the box unchecked, showing **Accepted** in the UI while the response carries `confirm: false`. Treat `DECLINED` / `REJECTED` / `CANCELLED` / `EXPIRED` as "stop". Reserve `"type": "boolean"` for genuine data fields where `false` is a valid submittable answer.
 - Add short `"description"` strings -- they appear as helper text next to each field.
 - Keep schemas small. Several sequential `elicit ask` calls are usually clearer than one giant form.
 
@@ -382,14 +404,15 @@ After `elicit ask` / `elicit wait` returns, always branch on the `Status:` value
 
 | Status | Typical action |
 |--------|----------------|
-| `RESPONDED` / `COMPLETED` | Parse `Response:` JSON and proceed with the task. |
-| `DECLINED` | Stop. Acknowledge to the user that you stopped and ask what to do next. |
+| `RESPONDED` / `ACCEPTED` / `COMPLETED` | Parse `Response:` JSON and proceed with the task (`ACCEPTED` is the accept-synonym produced by some response paths; treat it like `RESPONDED`). |
+| `DECLINED` / `REJECTED` | Stop. Acknowledge to the user that you stopped and ask what to do next (`REJECTED` is the decline-synonym produced by some response paths; treat it like `DECLINED`). |
 | `CANCELLED` | Stop. The user (or system) aborted the flow. |
 | `EXPIRED` | The request timed out platform-side. Decide whether to re-ask. |
-| `elicit: still PENDING after Ns ...` (CLI only) | Local wait exceeded `--timeout`. This is **not** a stopping condition -- the request is still live on the platform; call `elicit wait <id>` again immediately. |
+| `elicit: still PENDING after Ns ...` / `elicit: timed out after Ns ...` (CLI only) | Local wait exceeded `--timeout`. This is **not** a stopping condition and **not** the same as `EXPIRED` -- the request is still live on the platform (until its own `expiresAt`); call `elicit wait <id>` again immediately. |
 
 ## Related
 
+- [`unique-cli-elicitation` skill](../../unique_sdk/cli/skills/unique-cli-elicitation/SKILL.md) -- Agent-facing guidance, including which of `ask` vs `create` + `wait` to default to
 - [Elicitation API Reference](../api_resources/elicitation.md) -- Python SDK methods, return types, and async variants
 - [Command Reference](commands.md) -- All CLI commands
 - [Scheduled Tasks](scheduled_tasks.md) -- Another long-running platform workflow managed via the CLI

--- a/unique_sdk/unique_sdk/cli/skills/unique-cli-elicitation/SKILL.md
+++ b/unique_sdk/unique_sdk/cli/skills/unique-cli-elicitation/SKILL.md
@@ -6,8 +6,10 @@ description: >-
   (especially destructive actions), missing parameters, multiple-choice
   decisions, or structured form input. Elicitations are routed through
   the Unique AI Platform UI via `unique-cli elicit create` + `elicit wait`
-  (or `elicit ask` outside an agent harness) so the user gets a proper
-  structured prompt and you get a structured answer back.
+  (the default polling pattern) or a single supervised `unique-cli elicit
+  ask` call (only when your agent instructions say your environment
+  supervises the wait) so the user gets a proper structured prompt and
+  you get a structured answer back.
   Do NOT ask the user in plain chat when you can use this skill instead.
 ---
 
@@ -15,22 +17,55 @@ description: >-
 
 Use this skill **whenever you need input from the user** -- a clarifying question, a confirmation before a destructive action, a choice between options, or a structured form. Elicitations create a first-class UI prompt on the Unique AI Platform and return the answer as structured JSON.
 
-> **Rule of thumb:** if you catch yourself about to write "Could you clarify…?" or "Do you want me to…?" or "Which one should I pick?" in chat, stop and use `unique-cli elicit create` + `elicit wait` instead (see "The pattern" below).
+> **Rule of thumb:** if you catch yourself about to write "Could you clarify…?" or "Do you want me to…?" or "Which one should I pick?" in chat, stop and use an elicitation instead (see "Two patterns" below for which command sequence to use).
 
 !!! danger "`--visible` is currently MANDATORY"
     You **must always create elicitations with visibility on** (it is on by default for both `elicit create` and `elicit ask` — just don't pass `--no-visible`). Until the UN-19815 UI fix ships in your environment, an elicitation created without the visibility workaround is stored by the backend but **never rendered in the chat UI** — the user simply never sees the question and you will wait forever. There is no situation in which you should disable it today.
 
-## The pattern: `elicit create` + short polling loop with `elicit wait`
+!!! danger "A non-terminal status is not an answer"
+    This is the single rule that matters most, in **every** pattern below:
+    `PENDING` is not `DECLINED`, is not an answer, and is never a reason to
+    stop or proceed. Never treat a non-terminal status as a decline, never
+    proceed on an unanswered form, and never fabricate what you think the
+    user would say. If the last known status is `PENDING`, the only correct
+    next action is to keep waiting -- either loop `elicit wait` again
+    (Pattern A) or re-issue `elicit wait <id>` on the same elicitation
+    (Pattern B) -- until you observe one of the terminal statuses in
+    "Reading the response" below.
+
+## Two patterns -- your agent instructions decide which one to use
+
+There are two valid ways to wait for an elicitation's answer. **Which one you
+use is decided by your agent instructions (system prompt / `AGENTS.md`), not
+by this skill file guessing which harness you're running in:**
+
+- **Your instructions are silent, or say nothing about your environment
+  supervising long-running waits** -- use **Pattern A: `elicit create` +
+  short polling loop with `elicit wait`** below. This is the default and is
+  safe everywhere, including inside a harness whose Bash/shell tool has its
+  own foreground-wait timeout (Claude Code, Codex, ~2 minutes commonly).
+- **Your instructions explicitly say your environment supervises the wait**
+  for a single long-running tool call (it will not silently background or
+  kill the process before the human answers) -- use **Pattern B: a single
+  supervised `elicit ask` call** below instead.
+
+If in doubt, use Pattern A -- it is correct in every environment, whereas
+Pattern B is only correct in one that actually supervises the wait. Neither
+pattern is forbidden; pick the one your instructions call for.
+
+## Pattern A: `elicit create` + short polling loop with `elicit wait` (default)
 
 Do **not** call `elicit ask` from inside an agent harness (Claude Code, Codex,
 or any environment where your Bash/shell tool has its own foreground-wait
-timeout — commonly ~2 minutes). `elicit ask` blocks synchronously for up to
-`--timeout` seconds (default 2 hours) waiting for the human to answer, but a
-human reading and answering a prompt routinely takes longer than a typical
-Bash tool timeout. If that timeout fires first, your harness will silently
-detach the process to the background and hand you a "running in background"
-stub instead of the real answer — you will not see the user's response, and
-the chat may appear stuck to the user.
+timeout — commonly ~2 minutes) **unless your agent instructions explicitly
+say your environment supervises the wait (see Pattern B below)**. `elicit
+ask` blocks synchronously for up to `--timeout` seconds (default 2 hours)
+waiting for the human to answer, but a human reading and answering a prompt
+routinely takes longer than a typical Bash tool timeout. If that timeout
+fires first and your instructions did not say otherwise, your harness will
+silently detach the process to the background and hand you a "running in
+background" stub instead of the real answer — you will not see the user's
+response, and the chat may appear stuck to the user.
 
 Instead, use `elicit create` (returns immediately) followed by a short
 polling loop with `elicit wait`, where **every individual command finishes
@@ -86,7 +121,9 @@ default — comfortably under Claude Code's ~120s):
 `elicit ask` remains the right choice for **non-agent, scripted, or
 human-operated CLI usage** where a single blocking call is expected and
 there is no surrounding tool-timeout concern (tests, ops scripts, manual CLI
-use). Do not reach for it from inside an agent turn.
+use), and for **Pattern B below** when your instructions say your
+environment supervises the wait. Do not reach for it from inside an agent
+turn unless one of those two conditions applies.
 
 ```bash
 unique-cli elicit ask "<question>" [options]
@@ -98,6 +135,43 @@ unique-cli elicit ask "<question>" [options]
     the current turn's assistant message ID from `$UNIQUE_TURN_IDENTITY_FILE`
     (preferred) or `$UNIQUE_MESSAGE_ID`. Do **not** pass a stale
     `$UNIQUE_MESSAGE_ID` from a persistent process environment.
+
+## Pattern B: a single supervised `elicit ask` call
+
+Use this **only when your agent instructions explicitly say your
+environment supervises the wait** for a single long-running tool call --
+i.e. it will not silently background or kill the process before the human
+answers. Do not use Pattern B just because it is simpler; use it only
+because your instructions told you your environment can safely block for
+the full wait.
+
+```bash
+unique-cli elicit ask "<question>" \
+  --chat-id "$UNIQUE_CHAT_ID" \
+  --expires-in 7200 \
+  --timeout 1800
+```
+
+- **`--expires-in`** sets how long the request stays live on the platform
+  (a human-scale deadline, e.g. `7200` = 2 hours) independently of
+  **`--timeout`**, which is how long *this call* blocks. Set `--timeout` to
+  match your supervisor's own wait budget; omit `--expires-in` only if you
+  want it to default to `--timeout` (today's coupled behavior, unchanged).
+- Immediately after creating the elicitation -- before it starts waiting --
+  the CLI writes one line to **stderr** (never stdout):
+  `UNIQUE_ELICITATION_CREATED id=<id> expires_at=<iso8601>`. A supervisor
+  watching stderr can capture the elicitation id the instant it exists,
+  without waiting for `ask` to return.
+- While waiting, transient failures (connection errors, timeouts, 5xx) are
+  retried automatically with bounded exponential backoff and logged to
+  stderr -- you do not need your own retry loop around `ask` to survive a
+  single dropped connection. 4xx errors are not retried.
+- The result of the single call **is** the answer. Check `Status:` exactly
+  as described in "Reading the response" below, and the same rule applies
+  if `ask` still returns `PENDING` when `--timeout` elapses: that is **not**
+  a decline and not a reason to stop -- the elicitation is still live on
+  the platform (until `--expires-in`), so re-issue `elicit wait <id>` on the
+  same id to keep waiting for the real answer.
 
 ## When to use
 
@@ -113,9 +187,11 @@ unique-cli elicit ask "<question>" [options]
 ## Examples
 
 > The examples below use `elicit ask` for brevity to show the schema shapes.
-> From an agent harness, use the same `--schema`/`--message`/`--tool-name`
-> arguments with `elicit create` instead, then poll with `elicit wait` as
-> shown in "The pattern" above.
+> From an agent harness whose instructions are silent on supervision, use the
+> same `--schema`/`--message`/`--tool-name` arguments with `elicit create`
+> instead, then poll with `elicit wait` as shown in "Pattern A" above (or use
+> `elicit ask` directly per "Pattern B" if your instructions say your
+> environment supervises the wait).
 
 ### Minimal — free-text answer
 
@@ -173,7 +249,7 @@ unique-cli elicit ask "Permanently delete /Archive/2024 and everything inside it
   --schema '{"type": "object", "properties": {}}'
 ```
 
-Proceed **only** if the `Status:` is `ACCEPTED`. Treat `DECLINED`, `CANCELLED`, or `EXPIRED` all as "do not proceed" -- tell the user you stopped and return control. Put everything the user needs to decide into the message text, since the form has no fields.
+Proceed **only** if the `Status:` is `ACCEPTED`. Treat `DECLINED`, `REJECTED`, `CANCELLED`, or `EXPIRED` all as "do not proceed" -- tell the user you stopped and return control. Put everything the user needs to decide into the message text, since the form has no fields.
 
 ### Structured form (multiple fields)
 
@@ -194,11 +270,12 @@ unique-cli elicit ask "Please provide report settings" \
 
 ## Options
 
-The table below documents `elicit ask`'s flags. `elicit create` takes the
-same `--chat-id`, `--message-id`, `--tool-name`, `--schema`, `--metadata`,
-and `--assistant-id` flags, but uses `--expires-in <seconds>` instead of
-`--timeout`/`--poll-interval` (those two apply only to `elicit wait`, which
-you call separately in the polling pattern). `elicit create` also takes
+The table below documents `elicit ask`'s flags (used in both Pattern A's
+"scripting" case and Pattern B). `elicit create` takes the same `--chat-id`,
+`--message-id`, `--tool-name`, `--schema`, `--metadata`, and `--assistant-id`
+flags, plus `--expires-in <seconds>` (`elicit create` has no `--timeout`/
+`--poll-interval` -- those two apply only to `elicit wait`, which you call
+separately in the Pattern A polling loop). `elicit create` also takes
 `--mode FORM|URL` (default: `FORM` — you only need to pass it for URL
 elicitations).
 
@@ -208,7 +285,8 @@ elicitations).
 | `--message-id` | `-m` | auto | Optional. Prefer omitting this flag — the CLI resolves the current turn's message ID from `$UNIQUE_TURN_IDENTITY_FILE` (preferred) or `$UNIQUE_MESSAGE_ID`. Do not pass a stale env value from a persistent process. |
 | `--tool-name` | `-t` | `agent_question` | Short snake_case label shown to the user (e.g. `clarify`, `confirm_delete`, `choose_report`). |
 | `--schema` | | single `answer` string | JSON Schema for the form body. |
-| `--timeout` | | `7200` | Max seconds to block locally before giving up. This is the single knob for `ask`: it also sets when the request expires on the platform, so the prompt expires exactly when you stop waiting and the chat UI can offer the user a way to continue. |
+| `--expires-in` | | `--timeout`'s value | Seconds before the platform auto-expires the request, decoupled from `--timeout`. This is the flag Pattern B uses to give the elicitation a human-scale deadline (e.g. `7200`) independent of the caller's own wait budget. Omit it to keep today's coupled behavior. |
+| `--timeout` | | `7200` | Max seconds to block locally before giving up. Unless you pass `--expires-in`, this is also when the request expires on the platform, so the prompt expires exactly when you stop waiting and the chat UI can offer the user a way to continue. |
 | `--poll-interval` | | `2.0` | Seconds between status polls. |
 | `--metadata` | | none | `key=value` metadata (repeatable). |
 | `--assistant-id` | | `$UNIQUE_ASSISTANT_ID`, else latest assistant in chat | Assistant id for the placeholder message created by the visibility workaround. Set this (or export `UNIQUE_ASSISTANT_ID`) only if the chat is brand-new with no prior assistant messages. |
@@ -230,12 +308,19 @@ Terminal statuses:
 
 | Status | Meaning | What to do |
 |--------|---------|------------|
-| `RESPONDED` / `COMPLETED` | User answered | Parse `Response:` JSON and proceed. |
-| `DECLINED` | User explicitly declined | Do not proceed. Acknowledge and stop. |
+| `RESPONDED` / `ACCEPTED` / `COMPLETED` | User answered, or confirmed (accepted) an empty-schema confirmation | Parse `Response:` JSON and proceed. |
+| `DECLINED` / `REJECTED` | User explicitly declined, or rejected (declined) an empty-schema confirmation | Do not proceed. Acknowledge and stop. |
 | `CANCELLED` | Cancelled (by user or system) | Do not proceed. |
-| `EXPIRED` | Timed out on the platform — the user did not answer within `--timeout` | Ask again only if the task still needs it; do not treat the expiry as approval. |
+| `EXPIRED` | Timed out on the platform — the user did not answer before the request's expiry (`--timeout`, or `--expires-in` if you passed it) | Ask again only if the task still needs it; do not treat the expiry as approval. |
 
-Because `ask` derives the request's expiry from `--timeout`, when the user does not answer in time the platform expires the request and `elicit ask` returns a clean `EXPIRED` status (rather than a local-only timeout). If you instead see `elicit: timed out after Ns ...`, raise `--timeout` and try again. If this happens repeatedly, double-check that you passed `--chat-id` and did not pass `--no-visible` — an invisible elicitation is the most common cause of a local timeout.
+`ACCEPTED`/`REJECTED` and `RESPONDED`/`DECLINED` are functionally
+equivalent terminal outcomes -- `ACCEPTED`/`REJECTED` are the accept/decline
+synonyms produced by some response paths (e.g. the Codex approval-bridge
+integration), while `RESPONDED`/`DECLINED` are produced by others. Treat
+them the same way: `ACCEPTED` like `RESPONDED` (proceed), `REJECTED` like
+`DECLINED` (stop).
+
+Because `ask` derives the request's expiry from `--timeout` (unless you pass `--expires-in`), when the user does not answer in time the platform expires the request and `elicit ask` returns a clean `EXPIRED` status (rather than a local-only timeout). If you instead see `elicit: timed out after Ns ...` (Pattern B) or `elicit: still PENDING after Ns ...` (Pattern A's `elicit wait`), that is **not** `EXPIRED` -- see the danger box at the top of this file: keep waiting, do not treat it as a stopping condition. If this happens repeatedly, double-check that you passed `--chat-id` and did not pass `--no-visible` — an invisible elicitation is the most common cause of a local timeout.
 
 ### Repeat the answer back in chat
 
@@ -266,10 +351,12 @@ Do not expose raw JSON by default when a natural-language confirmation would be 
 
 This one-shot pattern is for **scripts, tests, or manual CLI use outside an
 agent harness** — i.e. contexts with no Bash-tool foreground timeout to worry
-about. From inside an agent harness, use the `elicit create` + `elicit wait`
-polling pattern from "The pattern" section above instead; the output parsing
-below (pulling `Response:` out of the text) is identical either way, only the
-command(s) producing that output differ.
+about. From inside an agent harness whose instructions are silent on
+supervision, use the `elicit create` + `elicit wait` polling pattern from
+"Pattern A" above instead (or "Pattern B" if your instructions say your
+environment supervises the wait); the output parsing below (pulling
+`Response:` out of the text) is identical either way, only the command(s)
+producing that output differ.
 
 In a shell script or agent tool wrapper, capture the output and pull out the `Response:` line:
 
@@ -301,7 +388,7 @@ esac
 
 ## Agent workflow rules
 
-1. **Default to `elicit create` + `elicit wait` polling.** If you need an answer from the user, use this pattern, not a chat message and not a single blocking `elicit ask` call. See "The pattern" above.
+1. **Default to `elicit create` + `elicit wait` polling (Pattern A).** If you need an answer from the user, use this pattern, not a chat message -- unless your agent instructions explicitly say your environment supervises the wait, in which case use a single `elicit ask` call (Pattern B). See "Two patterns" above.
 2. **Always pass `--chat-id "$UNIQUE_CHAT_ID"`.** Without it the elicitation is not attached to a chat and the user will not see it.
 3. **Omit `--message-id`.** The CLI resolves the current turn's assistant message ID from `$UNIQUE_TURN_IDENTITY_FILE` (preferred) or `$UNIQUE_MESSAGE_ID`. Do not pass a stale `$UNIQUE_MESSAGE_ID` from a persistent process environment.
 4. **Never pass `--no-visible`.** See the warning above. The visibility workaround is mandatory today.
@@ -309,10 +396,10 @@ esac
 6. **Pick a meaningful `--tool-name`.** `confirm_delete`, `choose_region`, `pick_report` -- short snake_case describing the intent.
 7. **Constrain answers with a schema** whenever the valid set is finite -- don't rely on parsing free text when `enum` is an option.
 8. **Repeat answered elicitations back in chat.** Summarize what the user chose in natural language before acting on it; hide raw JSON in a collapsible details block only when it adds value.
-9. **Handle non-`RESPONDED` outcomes explicitly.** If the status is `DECLINED` / `CANCELLED` / `EXPIRED`, tell the user you stopped and ask what they want to do next instead of silently proceeding.
+9. **Handle non-`RESPONDED`/`ACCEPTED` outcomes explicitly.** If the status is `DECLINED` / `REJECTED` / `CANCELLED` / `EXPIRED`, tell the user you stopped and ask what they want to do next instead of silently proceeding. A non-terminal (`PENDING`) status is never one of these outcomes -- see the danger box at the top of this file.
 10. **Don't spam elicitations.** One well-designed form with a few related fields is better than five sequential yes/no questions.
 11. **Cap each elicitation at 5 questions.** If you need more than 5 answers, split them into multiple focused elicitations so the user can respond confidently.
-12. **Never make a single blocking call longer than your harness's Bash foreground timeout.** Use `--expires-in` on `elicit create` to set the real, human-scale deadline (e.g. 7200s / 2 hours), but keep each individual `elicit wait --timeout N` call short (≈90s) and loop until a terminal status or the overall deadline is reached. Never call `elicit ask` with a multi-minute `--timeout` from an agent harness.
+12. **Never make a single blocking call longer than your harness's Bash foreground timeout, unless your instructions say your environment supervises the wait.** In Pattern A, use `--expires-in` on `elicit create` to set the real, human-scale deadline (e.g. 7200s / 2 hours), but keep each individual `elicit wait --timeout N` call short (≈90s) and loop until a terminal status or the overall deadline is reached. In Pattern B, `--expires-in` on `elicit ask` does the same job, decoupled from the (now safely long) `--timeout` your supervisor manages. Never call `elicit ask` with a multi-minute `--timeout` from an agent harness unless Pattern B applies.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary

Follow-up to #2171 (PR4). This PR is **docs-only** and additive/instructional — it does not change any Python logic, and no reader who was correctly following the today's polling-loop pattern is told to stop doing so.

- Rewrites the guidance in `unique_sdk/cli/skills/unique-cli-elicitation/SKILL.md` and `unique_sdk/docs/cli/elicitation.md` to document **both** valid patterns:
  - **Pattern A (default)** — `elicit create` + short polling loop with `elicit wait`. Used whenever an agent's instructions are silent on supervision. This is exactly today's behavior, unchanged.
  - **Pattern B** — a single supervised `elicit ask` call, used only when an agent's own instructions (`AGENTS.md` / system prompt) explicitly say its environment supervises long-running tool calls.
  - The authority for choosing is the agent's own instructions, not this skill file guessing which harness it's running in. Neither pattern is described as forbidden.
- The rule **"a non-terminal status is not an answer"** is preserved verbatim in force and promoted to the single most prominent statement in `SKILL.md` (a `!!! danger` box right at the top, before either pattern is introduced).
- **Separate, pre-existing bug fix** (not part of the mode-agnostic rewrite): both files' terminal-status tables were missing `ACCEPTED`/`REJECTED`, which are part of `TERMINAL_STATUSES` in `unique_sdk/unique_sdk/cli/commands/elicitation.py`. `ACCEPTED` behaves like `RESPONDED` (proceed), `REJECTED` behaves like `DECLINED` (stop) — confirmed against `_cleanup_visibility_context`'s `is_accepted` set and the CHANGELOG entry that introduced them (Codex approval-bridge accept/decline synonyms).
- Documents PR4's already-shipped, previously-undocumented CLI additions: `--expires-in` on `ask`, the `UNIQUE_ELICITATION_CREATED` stderr line, and transient-failure retry behavior.

## Why the mandate moved to harness instructions instead of being inverted

The prior doc hard-coded "never call `elicit ask` from an agent harness" as a blanket rule. That was correct for harnesses that cannot supervise a long-running call, but PR4 shipped exactly the primitives (`--expires-in` decoupling, the stderr creation line, transient retries) that make a *supervised* single call safe in the harnesses that can. Inverting the old mandate to "always use `ask`" would have broken every unsupervised harness; keeping it as an unconditional "never" would have made PR4's new primitives permanently undocumented and unusable. Deferring the choice to the agent's own instructions lets both be true without contradiction, and keeps Pattern A as the safe default when instructions say nothing.

## Scope

- Only `unique_sdk/cli/skills/unique-cli-elicitation/SKILL.md` and `unique_sdk/docs/cli/elicitation.md` were touched (confirmed via `git diff --stat`).
- Out of scope, untouched: `unique-cli-scheduled-tasks/SKILL.md`, `CLAUDE.md`, `docs/cli/index.md`, `cli.py`/`shell.py` help text, `CHANGELOG.md`, all Python, all tests.
- `rg "SKILL.md" tests/` confirms `tests/cli/test_skills.py` still does not assert on `unique-cli-elicitation/SKILL.md`'s content — no test changes needed or made.

## Test plan

Docs-only; verification is review-shaped:
- [x] `uv run ruff check .` — passes (no Python touched, no-op)
- [x] `uv run pytest tests/cli/test_skills.py tests/cli/test_elicitation.py -q` — 109 passed
- [x] Ran `--help` for `elicit ask`, `elicit create`, `elicit wait`, `elicit respond` and confirmed every flag referenced in the docs exists and is spelled correctly
- [x] Confirmed `git diff --stat` touches only the two intended files

## Not merge-ready yet

Per the elicitation-hardening roadmap, actual merge is gated on PR1–PR3 live-validation on QA. Opening as draft.

Made with [Cursor](https://cursor.com)