### PR TITLE
fix(release): publish packaged skills in dev builds

### DIFF
--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -13,6 +13,11 @@ runs:
       id: filter
       with:
         predicate-quantifier: 'every'
+        # Each `<id>` filter excludes *.md, because markdown is normally docs.
+        # A `<id>_skills` filter adds back the markdown that is packaged into
+        # the wheel and read at runtime; `serialize` ORs it into `<id>`. Add
+        # one for every package that grows a `skills/` directory, otherwise
+        # editing a shipped skill silently publishes nothing.
         filters: |
           toolkit:
             - 'unique_toolkit/**'
@@ -23,6 +28,8 @@ runs:
           sdk:
             - 'unique_sdk/**'
             - '!unique_sdk/**/*.md'
+          sdk_skills:
+            - 'unique_sdk/unique_sdk/**/skills/**'
           mcp:
             - 'unique_mcp/**'
             - '!unique_mcp/**/*.md'
@@ -32,6 +39,8 @@ runs:
           web_search:
             - 'tool_packages/unique_web_search/**'
             - '!tool_packages/unique_web_search/**/*.md'
+          web_search_skills:
+            - 'tool_packages/unique_web_search/src/**/skills/**'
           swot:
             - 'tool_packages/unique_swot/**'
             - '!tool_packages/unique_swot/**/*.md'
@@ -75,4 +84,16 @@ runs:
       shell: bash
       run: |
         CHANGES_JSON='${{ toJson(steps.filter.outputs) }}'
-        echo "changes=$(echo "$CHANGES_JSON" | jq -c .)" >> $GITHUB_OUTPUT
+        # paths-filter also emits a `changes` array of matched filter names.
+        # Nothing consumes it, and after the fold it would still name the
+        # `_skills` helpers, so drop it and keep the output a pure id -> bool map.
+        MERGED=$(jq -c '
+          reduce (keys[] | select(endswith("_skills"))) as $helper (.;
+            ($helper | rtrimstr("_skills")) as $pkg
+            | (if .[$helper] == "true" then .[$pkg] = "true" else . end)
+            | del(.[$helper])
+          )
+          | del(.changes)
+        ' <<<"$CHANGES_JSON")
+        echo "changes=$MERGED" >> $GITHUB_OUTPUT
+        echo "$MERGED" | jq .

--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -13,11 +13,6 @@ runs:
       id: filter
       with:
         predicate-quantifier: 'every'
-        # Each `<id>` filter excludes *.md, because markdown is normally docs.
-        # A `<id>_skills` filter adds back the markdown that is packaged into
-        # the wheel and read at runtime; `serialize` ORs it into `<id>`. Add
-        # one for every package that grows a `skills/` directory, otherwise
-        # editing a shipped skill silently publishes nothing.
         filters: |
           toolkit:
             - 'unique_toolkit/**'
@@ -84,9 +79,6 @@ runs:
       shell: bash
       run: |
         CHANGES_JSON='${{ toJson(steps.filter.outputs) }}'
-        # paths-filter also emits a `changes` array of matched filter names.
-        # Nothing consumes it, and after the fold it would still name the
-        # `_skills` helpers, so drop it and keep the output a pure id -> bool map.
         MERGED=$(jq -c '
           reduce (keys[] | select(endswith("_skills"))) as $helper (.;
             ($helper | rtrimstr("_skills")) as $pkg

--- a/.github/actions/select-packages/action.yml
+++ b/.github/actions/select-packages/action.yml
@@ -24,11 +24,11 @@ runs:
     - name: Build matrix
       id: build
       shell: bash
+      env:
+        PACKAGES: ${{ inputs.packages }}
+        SELECTED: ${{ inputs.selected }}
+        CHANGES: ${{ inputs.changes }}
       run: |
-        PACKAGES='${{ inputs.packages }}'
-        SELECTED="${{ inputs.selected }}"
-        CHANGES='${{ inputs.changes }}'
-
         if [ "$SELECTED" = "all" ]; then
           # Compact the JSON so GITHUB_OUTPUT below stays single-line.
           # inputs.packages arrives pretty-printed from get-packages-matrix

--- a/.github/workflows/cd-publish-dev.yaml
+++ b/.github/workflows/cd-publish-dev.yaml
@@ -2,12 +2,12 @@ name: "[CD] Publish dev builds to PyPI"
 
 # On every push to `main`, build and publish `.devN` wheels of the
 # publishable AI-repo packages whose sources actually changed in the
-# push range. Also dispatchable — see "Manual dispatch" below.
+# push range.
 #
 # Change detection reuses the same `detect-changes` + `select-packages`
 # composite actions that drive pull-request CI, so the definition of
-# "this package changed" (including which markdown counts as docs rather
-# than shipped source) is identical across lint/test/typecheck/publish.
+# "this package changed" (including doc/markdown exclusions) is
+# identical across lint/test/typecheck/publish.
 #
 # The release-please / release-cut / release-tag skip guard lands in
 # the follow-up release-process PR alongside those workflows — none of
@@ -48,16 +48,6 @@ name: "[CD] Publish dev builds to PyPI"
 #   lists every package version produced by the run. This gives `cd-publish-rc`
 #   a stable, reproducible promotion target — pick a `dev-cut-*` tag and
 #   republish that exact set of packages as `{cycle}.0rcN`.
-#
-# Manual dispatch
-# ===============
-#   `cd-publish.yaml` cannot re-publish: it builds whatever version sits in
-#   pyproject.toml, which on `main` is always the last stable release, so PyPI
-#   rejects it as a duplicate file. Cutting a fresh dev build is therefore the
-#   only way to get an unreleased `main` onto PyPI on demand, and it needs its
-#   own dispatch entry point. Dispatch skips change detection and publishes
-#   the requested selection; `main` only, since the CalVer cycle and the
-#   dev-bump PR are both main-relative.
 
 on:
   push:
@@ -82,7 +72,7 @@ jobs:
   resolve:
     # Skip when the push is the automated dev-bump commit itself — merging
     # that PR only updates pyproject.toml version pins and must not trigger
-    # a new publish cycle. A dispatch has no head_commit and is never skipped.
+    # a new publish cycle.
     if: >-
       github.event_name == 'workflow_dispatch'
       || !startsWith(github.event.head_commit.message, 'chore: bump dev versions')
@@ -96,9 +86,6 @@ jobs:
       cycle: ${{ steps.calver.outputs.cycle }}
       cut_sha: ${{ github.sha }}
     steps:
-      # `open-dev-bump-pr` rewrites and pushes against `main`, and the CalVer
-      # cycle is only meaningful there, so a dispatch off another ref would
-      # publish one branch's code under main's version line.
       - name: Reject dispatch from a non-main ref
         if: github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main'
         run: |
@@ -117,8 +104,6 @@ jobs:
           AFTER: ${{ github.event.after }}
           DISPATCH_PACKAGES: ${{ inputs.packages }}
         run: |
-          # A dispatch states its selection outright; there is no push range
-          # to diff and no auto-detection to invalidate.
           if [[ -n "$DISPATCH_PACKAGES" ]]; then
             echo "manual dispatch — selected=${DISPATCH_PACKAGES}" >&2
             echo "selected=${DISPATCH_PACKAGES}" >> "$GITHUB_OUTPUT"
@@ -160,8 +145,6 @@ jobs:
           done
           echo "selected=" >> "$GITHUB_OUTPUT"
 
-      # paths-filter has no push range to diff on a dispatch, and the explicit
-      # selection makes its result unused anyway.
       - uses: ./.github/actions/detect-changes
         id: detect
         if: github.event_name != 'workflow_dispatch'
@@ -187,9 +170,6 @@ jobs:
           # Strip publish_skip entries and any package without a pypi_name.
           MATRIX=$(jq -c '{include: [.include[] | select((.publish_skip != true) and (.pypi_name != null))]}' <<<"$RAW_MATRIX")
           SELECTED_IDS=$(jq -c '[.include[].id]' <<<"$MATRIX")
-          # An empty matrix is the normal outcome for a push that touched no
-          # package, but on a dispatch it means the requested id was wrong —
-          # fail instead of reporting success for a run that published nothing.
           if [[ "$IS_DISPATCH" == "true" && "$(jq '.include | length' <<<"$MATRIX")" -eq 0 ]]; then
             VALID=$(jq -r '[.[] | select((.publish_skip != true) and (.pypi_name != null)) | .id] | sort | join(", ")' <<<"$ALL_PACKAGES")
             echo "::error::'${DISPATCH_PACKAGES}' matched no publishable package. Valid ids: all, ${VALID}"
@@ -396,9 +376,6 @@ jobs:
           TAG="dev-cut-${SHORT}"
           echo "tag=$TAG"     >> "$GITHUB_OUTPUT"
           echo "short=$SHORT" >> "$GITHUB_OUTPUT"
-          # A dispatch can re-cut a SHA that already carries a tag. The wheels
-          # are on PyPI by now, so treat the existing tag as satisfied rather
-          # than failing the run over it.
           if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
             echo "::notice::${TAG} already exists — keeping the existing cut"
             echo "existed=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/cd-publish-dev.yaml
+++ b/.github/workflows/cd-publish-dev.yaml
@@ -389,6 +389,7 @@ jobs:
           # not whatever main looks like by the time this job runs.
           ref: ${{ github.sha }}
           fetch-depth: 0
+          fetch-tags: true
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Tag dev cut

--- a/.github/workflows/cd-publish-dev.yaml
+++ b/.github/workflows/cd-publish-dev.yaml
@@ -58,7 +58,27 @@ on:
       packages:
         description: 'Which packages to cut: "all", or a single package id (e.g. sdk).'
         required: true
-        type: string
+        type: choice
+        options:
+          - all
+          - sdk
+          - toolkit
+          - mcp
+          - orchestrator
+          - web_search
+          - swot
+          - follow_up_questions
+          - stock_ticker
+          - user_memory
+          - deep_research
+          - internal_search
+          - skill_tool
+          - quartr
+          - six
+          - search_proxy
+          - search_proxy_core
+          - search_proxy_sdk
+          - uqadm
         default: all
 
 permissions:
@@ -88,8 +108,10 @@ jobs:
     steps:
       - name: Reject dispatch from a non-main ref
         if: github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main'
+        env:
+          DISPATCH_REF: ${{ github.ref }}
         run: |
-          echo "::error::dev cuts can only be dispatched from main, got '${{ github.ref }}'"
+          echo "::error::dev cuts can only be dispatched from main, got '${DISPATCH_REF}'"
           exit 1
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -166,6 +188,7 @@ jobs:
           IS_DISPATCH: ${{ github.event_name == 'workflow_dispatch' }}
           DISPATCH_PACKAGES: ${{ inputs.packages }}
           ALL_PACKAGES: ${{ steps.pkgs.outputs.packages }}
+          SELECTED_OVERRIDE: ${{ steps.invalidator.outputs.selected || 'auto-detect' }}
         run: |
           # Strip publish_skip entries and any package without a pypi_name.
           MATRIX=$(jq -c '{include: [.include[] | select((.publish_skip != true) and (.pypi_name != null))]}' <<<"$RAW_MATRIX")
@@ -180,7 +203,7 @@ jobs:
           {
             echo "### Dev publish — selection"
             echo ""
-            echo "- Selected override: \`${{ steps.invalidator.outputs.selected || 'auto-detect' }}\`"
+            echo "- Selected override: \`${SELECTED_OVERRIDE}\`"
             echo "- Packages queued: $(jq '.include | length' <<<"$MATRIX")"
             echo ""
             echo '```json'

--- a/.github/workflows/cd-publish-dev.yaml
+++ b/.github/workflows/cd-publish-dev.yaml
@@ -2,12 +2,12 @@ name: "[CD] Publish dev builds to PyPI"
 
 # On every push to `main`, build and publish `.devN` wheels of the
 # publishable AI-repo packages whose sources actually changed in the
-# push range.
+# push range. Also dispatchable — see "Manual dispatch" below.
 #
 # Change detection reuses the same `detect-changes` + `select-packages`
 # composite actions that drive pull-request CI, so the definition of
-# "this package changed" (including doc/markdown exclusions) is
-# identical across lint/test/typecheck/publish.
+# "this package changed" (including which markdown counts as docs rather
+# than shipped source) is identical across lint/test/typecheck/publish.
 #
 # The release-please / release-cut / release-tag skip guard lands in
 # the follow-up release-process PR alongside those workflows — none of
@@ -48,11 +48,28 @@ name: "[CD] Publish dev builds to PyPI"
 #   lists every package version produced by the run. This gives `cd-publish-rc`
 #   a stable, reproducible promotion target — pick a `dev-cut-*` tag and
 #   republish that exact set of packages as `{cycle}.0rcN`.
+#
+# Manual dispatch
+# ===============
+#   `cd-publish.yaml` cannot re-publish: it builds whatever version sits in
+#   pyproject.toml, which on `main` is always the last stable release, so PyPI
+#   rejects it as a duplicate file. Cutting a fresh dev build is therefore the
+#   only way to get an unreleased `main` onto PyPI on demand, and it needs its
+#   own dispatch entry point. Dispatch skips change detection and publishes
+#   the requested selection; `main` only, since the CalVer cycle and the
+#   dev-bump PR are both main-relative.
 
 on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      packages:
+        description: 'Which packages to cut: "all", or a single package id (e.g. sdk).'
+        required: true
+        type: string
+        default: all
 
 permissions:
   contents: read
@@ -65,8 +82,10 @@ jobs:
   resolve:
     # Skip when the push is the automated dev-bump commit itself — merging
     # that PR only updates pyproject.toml version pins and must not trigger
-    # a new publish cycle.
-    if: "!startsWith(github.event.head_commit.message, 'chore: bump dev versions')"
+    # a new publish cycle. A dispatch has no head_commit and is never skipped.
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || !startsWith(github.event.head_commit.message, 'chore: bump dev versions')
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.publishable.outputs.matrix }}
@@ -77,6 +96,15 @@ jobs:
       cycle: ${{ steps.calver.outputs.cycle }}
       cut_sha: ${{ github.sha }}
     steps:
+      # `open-dev-bump-pr` rewrites and pushes against `main`, and the CalVer
+      # cycle is only meaningful there, so a dispatch off another ref would
+      # publish one branch's code under main's version line.
+      - name: Reject dispatch from a non-main ref
+        if: github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main'
+        run: |
+          echo "::error::dev cuts can only be dispatched from main, got '${{ github.ref }}'"
+          exit 1
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # Enough history for paths-filter to diff before..after.
@@ -87,7 +115,15 @@ jobs:
         env:
           BEFORE: ${{ github.event.before }}
           AFTER: ${{ github.event.after }}
+          DISPATCH_PACKAGES: ${{ inputs.packages }}
         run: |
+          # A dispatch states its selection outright; there is no push range
+          # to diff and no auto-detection to invalidate.
+          if [[ -n "$DISPATCH_PACKAGES" ]]; then
+            echo "manual dispatch — selected=${DISPATCH_PACKAGES}" >&2
+            echo "selected=${DISPATCH_PACKAGES}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           # If any file that affects the publish machinery itself changed,
           # set selected=all so every publishable package is rebuilt and
           # the change is exercised end-to-end. Otherwise we stay in
@@ -124,8 +160,11 @@ jobs:
           done
           echo "selected=" >> "$GITHUB_OUTPUT"
 
+      # paths-filter has no push range to diff on a dispatch, and the explicit
+      # selection makes its result unused anyway.
       - uses: ./.github/actions/detect-changes
         id: detect
+        if: github.event_name != 'workflow_dispatch'
 
       - uses: ./.github/actions/get-packages-matrix
         id: pkgs
@@ -135,16 +174,27 @@ jobs:
         with:
           packages: ${{ steps.pkgs.outputs.packages }}
           selected: ${{ steps.invalidator.outputs.selected }}
-          changes: ${{ steps.detect.outputs.changes }}
+          changes: ${{ steps.detect.outputs.changes || '{}' }}
 
       - name: Drop non-publishable packages
         id: publishable
         env:
           RAW_MATRIX: ${{ steps.select.outputs.matrix }}
+          IS_DISPATCH: ${{ github.event_name == 'workflow_dispatch' }}
+          DISPATCH_PACKAGES: ${{ inputs.packages }}
+          ALL_PACKAGES: ${{ steps.pkgs.outputs.packages }}
         run: |
           # Strip publish_skip entries and any package without a pypi_name.
           MATRIX=$(jq -c '{include: [.include[] | select((.publish_skip != true) and (.pypi_name != null))]}' <<<"$RAW_MATRIX")
           SELECTED_IDS=$(jq -c '[.include[].id]' <<<"$MATRIX")
+          # An empty matrix is the normal outcome for a push that touched no
+          # package, but on a dispatch it means the requested id was wrong —
+          # fail instead of reporting success for a run that published nothing.
+          if [[ "$IS_DISPATCH" == "true" && "$(jq '.include | length' <<<"$MATRIX")" -eq 0 ]]; then
+            VALID=$(jq -r '[.[] | select((.publish_skip != true) and (.pypi_name != null)) | .id] | sort | join(", ")' <<<"$ALL_PACKAGES")
+            echo "::error::'${DISPATCH_PACKAGES}' matched no publishable package. Valid ids: all, ${VALID}"
+            exit 1
+          fi
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
           echo "selected_ids=$SELECTED_IDS" >> "$GITHUB_OUTPUT"
           {
@@ -344,15 +394,25 @@ jobs:
         run: |
           SHORT="$(git rev-parse --short=12 "$SHA")"
           TAG="dev-cut-${SHORT}"
+          echo "tag=$TAG"     >> "$GITHUB_OUTPUT"
+          echo "short=$SHORT" >> "$GITHUB_OUTPUT"
+          # A dispatch can re-cut a SHA that already carries a tag. The wheels
+          # are on PyPI by now, so treat the existing tag as satisfied rather
+          # than failing the run over it.
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            echo "::notice::${TAG} already exists — keeping the existing cut"
+            echo "existed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag "$TAG" "$SHA"
           git push origin "$TAG"
-          echo "tag=$TAG"     >> "$GITHUB_OUTPUT"
-          echo "short=$SHORT" >> "$GITHUB_OUTPUT"
+          echo "existed=false" >> "$GITHUB_OUTPUT"
         id: tag
 
       - name: Create GitHub pre-release for cut
+        if: steps.tag.outputs.existed != 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           NEW_VERSIONS: ${{ needs.resolve.outputs.new_versions }}

--- a/.github/workflows/cd-publish.yaml
+++ b/.github/workflows/cd-publish.yaml
@@ -1,5 +1,15 @@
 name: "[CD] Publish to PyPI"
 
+# Stable channel. Normally fires on the `release: published` event that
+# release-please creates, and builds the version already written into
+# pyproject.toml by the release PR.
+#
+# The manual dispatch is a retry path for a release whose publish job failed,
+# not a way to ship unreleased work: it has no version-bumping step, so
+# dispatching it against `main` rebuilds the last released version and PyPI
+# rejects the upload as a duplicate file. To get unreleased `main` onto PyPI,
+# dispatch `cd-publish-dev.yaml` for a `.devN` cut instead.
+
 on:
   release:
     types: [published]
@@ -30,7 +40,7 @@ on:
           - skill_tool
         default: ""
       ref:
-        description: "Git ref (SHA or tag) to check out. Defaults to github.sha when omitted."
+        description: "Release tag to retry (e.g. unique-sdk-v2026.30.0). Defaults to github.sha, which only publishes if that ref carries an unreleased version."
         required: false
         default: ""
 

--- a/.github/workflows/cd-publish.yaml
+++ b/.github/workflows/cd-publish.yaml
@@ -1,15 +1,5 @@
 name: "[CD] Publish to PyPI"
 
-# Stable channel. Normally fires on the `release: published` event that
-# release-please creates, and builds the version already written into
-# pyproject.toml by the release PR.
-#
-# The manual dispatch is a retry path for a release whose publish job failed,
-# not a way to ship unreleased work: it has no version-bumping step, so
-# dispatching it against `main` rebuilds the last released version and PyPI
-# rejects the upload as a duplicate file. To get unreleased `main` onto PyPI,
-# dispatch `cd-publish-dev.yaml` for a `.devN` cut instead.
-
 on:
   release:
     types: [published]


### PR DESCRIPTION
## Summary
- treat packaged SDK and web-search skill markdown as runtime source so skill-only changes trigger dev publishes
- add a guarded manual dispatch path for fresh `.devN` cuts from `main`
- clarify that stable publish dispatch only retries an existing release version

## Changes
- fold dedicated `*_skills` path filters into their package selection
- validate manual package selection and reject non-`main` dispatches
- make repeated dev cuts tolerate an existing cut tag

## Test plan
- [x] validate edited YAML with PyYAML
- [x] verify skill globs with picomatch
- [x] simulate PR #2174 change detection through the real package matrix
- [x] validate `sdk`, `all`, and invalid manual selections
- [x] run actionlint and confirm no new findings versus `main`

## Risk / rollout
- Merging changes the dev-publish invalidators, so the merge intentionally triggers a full dev cut for all publishable packages and ships the pending skill update from #2174.

Follow-up to #2174.

Made with [Cursor](https://cursor.com)