### PR TITLE
feat(unique-toolkit): add Kimi K3 model info [UN-23208]

### DIFF
--- a/.claude/skills/model-deployment/SKILL.md
+++ b/.claude/skills/model-deployment/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: model-deployment
-description: Deploy a new LLM model via LiteLLM (GitOps) and/or Azure (Terraform + node backend), add it to the ai toolkit, and verify end-to-end. Use when rolling out a model to any environment, adding a model to the toolkit, troubleshooting "model not available" errors, or finding pricing/token limits/model ids for any provider.
+description: Deploy a new LLM model via LiteLLM (GitOps) and/or Azure (Terraform + node backend), add it to the ai toolkit, create the required pull requests, and verify end-to-end. Use when rolling out a model to any environment, adding a model to the toolkit, troubleshooting "model not available" errors, or finding pricing/token limits/model ids for any provider.
 license: MIT
 compatibility: claude cursor opencode
 metadata:
-  version: "3.0.0"
+  version: "3.1.0"
   languages: all
   audience: developers operators
   workflow: operations
@@ -86,7 +86,7 @@ Edit `monorepo/gitops-resources/argocd/clusters/<cluster>/<env>/value-overlays/l
 
 - **Branch:** `feat/litellm-<model-name>`
 - **Commit:** `feat(litellm): add <model_name> model to <envs>`
-- PR body: env overlays changed, model names, source links, verification steps.
+- Commit, push, and create the PR after validation. Include the env overlays changed, model names, source links, and verification steps in the PR body.
 
 ### A4) After merge — sync + restart
 
@@ -156,10 +156,11 @@ Add `LanguageModelName` enum entry and `LanguageModelInfo.from_name()` case. See
 
 **Critical:** for `default_options`, use the string `"none"` — never Python `None`. See [LESSONS-LEARNED.md](references/LESSONS-LEARNED.md).
 
-### C3) Release
+### C3) PR + release
 
 - **Branch:** `feat/toolkit-<model-slug>`
 - **Commit:** `feat(toolkit): add <model_name> model info`
+- Commit, push, and create the PR after validation. Include the exact model identifier, cited model specifications, and tests run in the PR body.
 - Merge with a conventional commit (`feat(toolkit): add <model_name> model info`). release-please updates `unique_toolkit` version and `CHANGELOG.md` on the standing Release PR — do not edit those files in the feature PR.
 
 For early exposure before the toolkit release, use the `LANGUAGE_MODEL_INFOS` env override — see [TOOLKIT-REGISTRY.md](references/TOOLKIT-REGISTRY.md).
@@ -174,8 +175,23 @@ For early exposure before the toolkit release, use the `LANGUAGE_MODEL_INFOS` en
 
 ---
 
+## Pull request completion
+
+When implementing a model deployment, finish each repository's code changes by:
+
+1. Running the relevant formatter, linter, and targeted tests.
+2. Committing with the track's conventional commit message.
+3. Pushing the branch and creating a non-draft PR.
+4. Linking the Jira ticket and authoritative model sources in the PR body.
+5. Returning every created PR URL to the user.
+
+Create separate PRs for separate repositories. A direct request to run this skill and implement the deployment authorizes creating the required PRs; stop before PR creation only when the user asks for local changes, a draft, or a plan.
+
+---
+
 ## Final checklist (every track)
 
+- [ ] Required PRs created and URLs returned
 - [ ] Correct environment(s) targeted and rollout order followed (qa → uat → prod)
 - [ ] Config synced in ArgoCD where applicable
 - [ ] Correct **Deployment** rolled (not HPA)

--- a/unique_toolkit/tests/language_model/test_language_model_infos.py
+++ b/unique_toolkit/tests/language_model/test_language_model_infos.py
@@ -106,6 +106,7 @@ class TestLanguageModelInfos:
             LanguageModelName.LITELLM_GLM_5_1,
             LanguageModelName.LITELLM_GLM_5_2,
             LanguageModelName.LITELLM_KIMI_K2_6,
+            LanguageModelName.LITELLM_KIMI_K3,
             LanguageModelName.LITELLM_QWEN_3,
             LanguageModelName.LITELLM_QWEN_3_THINKING,
             LanguageModelName.LITELLM_OPENAI_O1,

--- a/unique_toolkit/unique_toolkit/language_model/infos.py
+++ b/unique_toolkit/unique_toolkit/language_model/infos.py
@@ -138,6 +138,7 @@ class LanguageModelName(StrEnum):
     LITELLM_GLM_5_1 = "litellm:glm-5.1"
     LITELLM_GLM_5_2 = "litellm:glm-5.2"
     LITELLM_KIMI_K2_6 = "litellm:kimi-k2.6"
+    LITELLM_KIMI_K3 = "litellm:kimi-k3"
     LITELLM_QWEN_3 = "litellm:qwen-3-235B-A22B"
     LITELLM_QWEN_3_THINKING = "litellm:qwen-3-235B-A22B-thinking"
     VERTEX_CLAUDE_SONNET_4_6 = "litellm:vertex-claude-sonnet-4-6"
@@ -2878,6 +2879,27 @@ class LanguageModelInfo(BaseModel):
                         token_limit_input=256_000, token_limit_output=32_000
                     ),
                     published_at=date(2026, 1, 1),
+                    supported_reasoning_efforts=[],
+                )
+            case LanguageModelName.LITELLM_KIMI_K3:
+                return cls(
+                    name=model_name,
+                    provider=LanguageModelProvider.LITELLM,
+                    family=ModelFamily.KIMI,
+                    version="kimi-k3",
+                    encoder_name=EncoderName.O200K_BASE,
+                    capabilities=[
+                        ModelCapabilities.FUNCTION_CALLING,
+                        ModelCapabilities.STRUCTURED_OUTPUT,
+                        ModelCapabilities.REASONING,
+                        ModelCapabilities.STREAMING,
+                        ModelCapabilities.VISION,
+                    ],
+                    token_limits=LanguageModelTokenLimits(
+                        token_limit_input=1_000_000,
+                        token_limit_output=128_000,
+                    ),
+                    published_at=date(2026, 7, 27),
                     supported_reasoning_efforts=[],
                 )
             case LanguageModelName.LITELLM_QWEN_3:


### PR DESCRIPTION
## Summary
- Register the LiteLLM-backed Kimi K3 model in `unique_toolkit`
- Expose its 1M-token context, vision, reasoning, structured output, function calling, and streaming capabilities

## Changes
- Add `litellm:kimi-k3` to `LanguageModelName`
- Add Kimi K3 metadata and token limits to `LanguageModelInfo.from_name()`
- Include Kimi K3 in the model registry coverage test

## Test plan
- [x] `uv run ruff check --fix unique_toolkit/language_model/infos.py tests/language_model/test_language_model_infos.py`
- [x] `uv run ruff format unique_toolkit/language_model/infos.py tests/language_model/test_language_model_infos.py`
- [x] `uv run pytest tests/language_model/test_language_model_infos.py` (24 passed)

## Risk / rollout
- Low risk: registry-only addition; no existing model definitions are changed
- LiteLLM route: `litellm:kimi-k3`
- Model specifications: https://www.together.ai/models/kimi-k3

Refs: UN-23208