### PR TITLE
feat(unique_mcp): add platform logging and ops helpers

### DIFF
--- a/unique_mcp/README.md
+++ b/unique_mcp/README.md
@@ -248,3 +248,20 @@ See [`docs/zitadel/README.md`](docs/zitadel/README.md) for step-by-step instruct
 ```bash
 cd unique_mcp && uv run pytest tests/ -q
 ```
+
+### Platform helpers (logging + metrics)
+
+On import, `unique_mcp` sets `FASTMCP_CHECK_FOR_UPDATES=off` (unless already set).
+
+```python
+from unique_mcp.logging import configure_logging
+from unique_mcp.monitoring import setup_ops
+
+configure_logging()  # always pino-json; silences /probe /health /metrics access logs
+
+mcp = FastMCP("my-server")
+middleware = [...]
+middleware.append(setup_ops(mcp))  # mounts /probe /health /metrics + HTTP metrics
+
+mcp.run(transport="http", middleware=middleware)
+```

--- a/unique_mcp/README.md
+++ b/unique_mcp/README.md
@@ -254,14 +254,18 @@ cd unique_mcp && uv run pytest tests/ -q
 On import, `unique_mcp` sets `FASTMCP_CHECK_FOR_UPDATES=off` (unless already set).
 
 ```python
+from unique_toolkit.monitoring import configure_tracing
 from unique_mcp.logging import configure_logging
 from unique_mcp.monitoring import setup_ops
 
-configure_logging()  # always pino-json; silences /probe /health /metrics access logs
+configure_tracing(service_name="my-mcp")  # opt-in via OTEL_* / ENABLE_OPENTELEMETRY
+configure_logging()  # pino-json; silences /probe /health /metrics access logs
 
 mcp = FastMCP("my-server")
 middleware = [...]
-middleware.append(setup_ops(mcp))  # mounts /probe /health /metrics + HTTP metrics
+# /probe /health /metrics + HTTP metrics + per-tool mcp_* metrics.
+# Traces: FastMCP tools/call spans (join via caller _meta.traceparent).
+middleware.append(setup_ops(mcp))
 
 mcp.run(transport="http", middleware=middleware)
 ```

--- a/unique_mcp/README.md
+++ b/unique_mcp/README.md
@@ -258,13 +258,11 @@ from unique_toolkit.monitoring import configure_tracing
 from unique_mcp.logging import configure_logging
 from unique_mcp.monitoring import setup_ops
 
-configure_tracing(service_name="my-mcp")  # opt-in via OTEL_* / ENABLE_OPENTELEMETRY
-configure_logging()  # pino-json; silences /probe /health /metrics access logs
+configure_tracing(service_name="my-mcp")
+configure_logging()
 
 mcp = FastMCP("my-server")
 middleware = [...]
-# /probe /health /metrics + HTTP metrics + per-tool mcp_* metrics.
-# Traces: FastMCP tools/call spans (join via caller _meta.traceparent).
 middleware.append(setup_ops(mcp))
 
 mcp.run(transport="http", middleware=middleware)

--- a/unique_mcp/README.md
+++ b/unique_mcp/README.md
@@ -252,6 +252,7 @@ cd unique_mcp && uv run pytest tests/ -q
 ### Platform helpers (logging + metrics)
 
 On import, `unique_mcp` sets `FASTMCP_CHECK_FOR_UPDATES=off` (unless already set).
+Call `configure_tracing` from `unique-toolkit[otel]` when you want Tempo/OTLP export.
 
 ```python
 from unique_toolkit.monitoring import configure_tracing

--- a/unique_mcp/pyproject.toml
+++ b/unique_mcp/pyproject.toml
@@ -20,10 +20,13 @@ dependencies = [
     # Declared directly: setup_ops imports starlette Middleware/Request/Response
     # (also pulled transitively via fastmcp; deptry flags undeclared use).
     "starlette>=1.3.1,<2",
+    # Direct import in logging.py for trace_id/span_id (also via toolkit[otel]/
+    # / fastmcp); declare for deptry.
+    "opentelemetry-api>=1.27,<2",
     # 4.6.0 is the floor: 4.4.0/4.5.0 fail to import on Python 3.12 (a
     # TypeVar subclassing incompatibility, fixed in 4.6.0), verified locally.
     "typing-extensions>=4.6.0",
-    "unique-toolkit[monitoring]>=2026.34.0.dev4,<2026.34.0rc0",
+    "unique-toolkit[monitoring,otel]>=2026.34.0.dev4,<2026.34.0rc0",
 ]
 
 [build-system]

--- a/unique_mcp/pyproject.toml
+++ b/unique_mcp/pyproject.toml
@@ -17,6 +17,9 @@ dependencies = [
     "pydantic>=2.12.5",
     "pydantic-settings>=2.0.0",
     "python-dotenv>=1.0.0",
+    # Declared directly: setup_ops imports starlette Middleware/Request/Response
+    # (also pulled transitively via fastmcp; deptry flags undeclared use).
+    "starlette>=1.3.1,<2",
     # 4.6.0 is the floor: 4.4.0/4.5.0 fail to import on Python 3.12 (a
     # TypeVar subclassing incompatibility, fixed in 4.6.0), verified locally.
     "typing-extensions>=4.6.0",

--- a/unique_mcp/pyproject.toml
+++ b/unique_mcp/pyproject.toml
@@ -1,10 +1,11 @@
 [project]
 name = "unique-mcp"
 version = "2026.34.0.dev1"
-description = "Add your description here"
+description = "Shared FastMCP platform helpers for Unique: auth injectors, pino-json logging, and ops/metrics routes"
 readme = "README.md"
 authors = [
-    { name = "Cedric Klinkert", email = "cedric@unique.ch" }
+    { name = "Cedric Klinkert", email = "cedric@unique.ch" },
+    { name = "Sanzio Monti", email = "github@sanziomonti.xyz" },
 ]
 requires-python = ">=3.12"
 dependencies = [

--- a/unique_mcp/pyproject.toml
+++ b/unique_mcp/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     # 4.6.0 is the floor: 4.4.0/4.5.0 fail to import on Python 3.12 (a
     # TypeVar subclassing incompatibility, fixed in 4.6.0), verified locally.
     "typing-extensions>=4.6.0",
-    "unique-toolkit>=2026.34.0.dev4,<2026.34.0rc0",
+    "unique-toolkit[monitoring]>=2026.34.0.dev4,<2026.34.0rc0",
 ]
 
 [build-system]

--- a/unique_mcp/pyproject.toml
+++ b/unique_mcp/pyproject.toml
@@ -17,11 +17,9 @@ dependencies = [
     "pydantic>=2.12.5",
     "pydantic-settings>=2.0.0",
     "python-dotenv>=1.0.0",
-    # Declared directly: setup_ops imports starlette Middleware/Request/Response
-    # (also pulled transitively via fastmcp; deptry flags undeclared use).
+    # Declared for deptry (also transitive via fastmcp).
     "starlette>=1.3.1,<2",
-    # Direct import in logging.py for trace_id/span_id (also via toolkit[otel]/
-    # / fastmcp); declare for deptry.
+    # Declared for deptry (also via toolkit[otel] / fastmcp).
     "opentelemetry-api>=1.27,<2",
     # 4.6.0 is the floor: 4.4.0/4.5.0 fail to import on Python 3.12 (a
     # TypeVar subclassing incompatibility, fixed in 4.6.0), verified locally.

--- a/unique_mcp/src/unique_mcp/__init__.py
+++ b/unique_mcp/src/unique_mcp/__init__.py
@@ -1,3 +1,5 @@
+# Apply FASTMCP_* process defaults before any submodule imports fastmcp.
+from unique_mcp import _bootstrap as _bootstrap  # noqa: F401
 from unique_mcp.meta import (
     CONFIG_META_KEY,
     CONFIG_SCHEMA_META_KEY,

--- a/unique_mcp/src/unique_mcp/_bootstrap.py
+++ b/unique_mcp/src/unique_mcp/_bootstrap.py
@@ -1,0 +1,11 @@
+"""Default FASTMCP_CHECK_FOR_UPDATES=off; sync live settings if already loaded."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+os.environ.setdefault("FASTMCP_CHECK_FOR_UPDATES", "off")
+_fastmcp = sys.modules.get("fastmcp")
+if _fastmcp is not None:
+    _fastmcp.settings.check_for_updates = os.environ["FASTMCP_CHECK_FOR_UPDATES"]

--- a/unique_mcp/src/unique_mcp/logging.py
+++ b/unique_mcp/src/unique_mcp/logging.py
@@ -12,10 +12,7 @@ from typing import Any, Literal
 
 from opentelemetry import trace
 
-# Exact request paths to silence in ASGI access logs (not substring matches).
 _SKIP_PATHS = frozenset({"/probe", "/health", "/metrics", "/ready"})
-# METHOD + path as in uvicorn, combined/CLF, and simple ASGI access lines.
-# Query string is excluded from the path group.
 _ACCESS_PATH = re.compile(
     r'(?:^|[\s"])(?:GET|HEAD|POST|PUT|PATCH|DELETE|OPTIONS)\s+([^?\s"]+)',
     re.IGNORECASE,
@@ -41,8 +38,7 @@ _RESERVED = frozenset(logging.LogRecord("", 0, "", 0, "", (), None).__dict__) | 
 
 class _QuietAccess(logging.Filter):
     def filter(self, record: logging.LogRecord) -> bool:
-        msg = record.getMessage()
-        match = _ACCESS_PATH.search(msg)
+        match = _ACCESS_PATH.search(record.getMessage())
         if match is None:
             return True
         path = match.group(1).rstrip("/") or "/"

--- a/unique_mcp/src/unique_mcp/logging.py
+++ b/unique_mcp/src/unique_mcp/logging.py
@@ -6,7 +6,10 @@ import json
 import logging
 import os
 import sys
+import traceback
 from typing import Any, Literal
+
+from opentelemetry import trace
 
 _SKIP = ("/probe", "/health", "/metrics", "/ready")
 _PINO_LEVEL = {
@@ -27,6 +30,28 @@ class _QuietAccess(logging.Filter):
         return not any(p in msg for p in _SKIP)
 
 
+def _trace_fields() -> dict[str, str | int]:
+    ctx = trace.get_current_span().get_span_context()
+    if not ctx.is_valid:
+        return {}
+    return {
+        "trace_id": format(ctx.trace_id, "032x"),
+        "span_id": format(ctx.span_id, "016x"),
+        "trace_flags": int(ctx.trace_flags),
+    }
+
+
+def _err_payload(
+    exc_info: tuple[type[BaseException], BaseException, Any],
+) -> dict[str, str]:
+    exc_type, exc, tb = exc_info
+    return {
+        "name": exc_type.__name__,
+        "message": str(exc),
+        "stack": "".join(traceback.format_exception(exc_type, exc, tb)),
+    }
+
+
 class _PinoJson(logging.Formatter):
     def format(self, record: logging.LogRecord) -> str:
         payload: dict[str, Any] = {
@@ -34,12 +59,13 @@ class _PinoJson(logging.Formatter):
             "time": int(record.created * 1000),
             "msg": record.getMessage(),
             "context": record.name,
+            **_trace_fields(),
         }
         for key, value in record.__dict__.items():
             if key not in _RESERVED and not key.startswith("_"):
                 payload[key] = value
-        if record.exc_info:
-            payload["err"] = self.formatException(record.exc_info)
+        if record.exc_info and not isinstance(payload.get("err"), dict):
+            payload["err"] = _err_payload(record.exc_info)  # type: ignore[arg-type]
         return json.dumps(payload, default=str, ensure_ascii=False)
 
 

--- a/unique_mcp/src/unique_mcp/logging.py
+++ b/unique_mcp/src/unique_mcp/logging.py
@@ -1,0 +1,70 @@
+"""Pino-JSON logging for Unique MCP servers (Loki label: pino-json)."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+from typing import Any, Literal
+
+_SKIP = ("/probe", "/health", "/metrics", "/ready")
+_PINO_LEVEL = {
+    logging.DEBUG: 20,
+    logging.INFO: 30,
+    logging.WARNING: 40,
+    logging.ERROR: 50,
+    logging.CRITICAL: 60,
+}
+_RESERVED = frozenset(logging.LogRecord("", 0, "", 0, "", (), None).__dict__) | {
+    "message"
+}
+
+
+class _QuietAccess(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        msg = record.getMessage()
+        return not any(p in msg for p in _SKIP)
+
+
+class _PinoJson(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        payload: dict[str, Any] = {
+            "level": _PINO_LEVEL.get(record.levelno, 30),
+            "time": int(record.created * 1000),
+            "msg": record.getMessage(),
+            "context": record.name,
+        }
+        for key, value in record.__dict__.items():
+            if key not in _RESERVED and not key.startswith("_"):
+                payload[key] = value
+        if record.exc_info:
+            payload["err"] = self.formatException(record.exc_info)
+        return json.dumps(payload, default=str, ensure_ascii=False)
+
+
+def configure_logging(
+    *,
+    level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] | str | None = None,
+) -> None:
+    resolved = (level or os.getenv("LOG_LEVEL") or "INFO").upper()
+    if resolved not in {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}:
+        resolved = "INFO"
+
+    root = logging.getLogger()
+    root.setLevel(resolved)
+    has_pino = any(
+        isinstance(getattr(h, "formatter", None), _PinoJson) for h in root.handlers
+    )
+    if not has_pino:
+        handler = logging.StreamHandler(sys.stderr)
+        handler.setFormatter(_PinoJson())
+        root.addHandler(handler)
+    for handler in root.handlers:
+        handler.setLevel(resolved)
+
+    quiet = _QuietAccess()
+    for name in ("uvicorn.access", "uvicorn.asgi"):
+        log = logging.getLogger(name)
+        if not any(isinstance(f, _QuietAccess) for f in log.filters):
+            log.addFilter(quiet)

--- a/unique_mcp/src/unique_mcp/logging.py
+++ b/unique_mcp/src/unique_mcp/logging.py
@@ -5,13 +5,17 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import sys
 import traceback
 from typing import Any, Literal
 
 from opentelemetry import trace
 
-_SKIP = ("/probe", "/health", "/metrics", "/ready")
+# Exact request paths to silence in uvicorn access logs (not substring matches).
+_SKIP_PATHS = frozenset({"/probe", "/health", "/metrics", "/ready"})
+# Uvicorn: '127.0.0.1:1 - "GET /path?query HTTP/1.1" 200'
+_ACCESS_PATH = re.compile(r'"[A-Z]+ ([^?\s"]+)(?:\?[^"\s]*)? HTTP/')
 _PINO_LEVEL = {
     logging.DEBUG: 20,
     logging.INFO: 30,
@@ -27,7 +31,11 @@ _RESERVED = frozenset(logging.LogRecord("", 0, "", 0, "", (), None).__dict__) | 
 class _QuietAccess(logging.Filter):
     def filter(self, record: logging.LogRecord) -> bool:
         msg = record.getMessage()
-        return not any(p in msg for p in _SKIP)
+        match = _ACCESS_PATH.search(msg)
+        if match is None:
+            return True
+        path = match.group(1).rstrip("/") or "/"
+        return path not in _SKIP_PATHS
 
 
 def _trace_fields() -> dict[str, str | int]:

--- a/unique_mcp/src/unique_mcp/logging.py
+++ b/unique_mcp/src/unique_mcp/logging.py
@@ -12,10 +12,21 @@ from typing import Any, Literal
 
 from opentelemetry import trace
 
-# Exact request paths to silence in uvicorn access logs (not substring matches).
+# Exact request paths to silence in ASGI access logs (not substring matches).
 _SKIP_PATHS = frozenset({"/probe", "/health", "/metrics", "/ready"})
-# Uvicorn: '127.0.0.1:1 - "GET /path?query HTTP/1.1" 200'
-_ACCESS_PATH = re.compile(r'"[A-Z]+ ([^?\s"]+)(?:\?[^"\s]*)? HTTP/')
+# METHOD + path as in uvicorn, combined/CLF, and simple ASGI access lines.
+# Query string is excluded from the path group.
+_ACCESS_PATH = re.compile(
+    r'(?:^|[\s"])(?:GET|HEAD|POST|PUT|PATCH|DELETE|OPTIONS)\s+([^?\s"]+)',
+    re.IGNORECASE,
+)
+_ACCESS_LOGGERS = (
+    "uvicorn.access",
+    "uvicorn.asgi",
+    "hypercorn.access",
+    "granian.access",
+    "daphne.access",
+)
 _PINO_LEVEL = {
     logging.DEBUG: 20,
     logging.INFO: 30,
@@ -98,7 +109,7 @@ def configure_logging(
         handler.setLevel(resolved)
 
     quiet = _QuietAccess()
-    for name in ("uvicorn.access", "uvicorn.asgi"):
+    for name in _ACCESS_LOGGERS:
         log = logging.getLogger(name)
         if not any(isinstance(f, _QuietAccess) for f in log.filters):
             log.addFilter(quiet)

--- a/unique_mcp/src/unique_mcp/monitoring.py
+++ b/unique_mcp/src/unique_mcp/monitoring.py
@@ -1,18 +1,25 @@
-"""Ops routes (/probe, /health, /metrics) + toolkit Prometheus middleware."""
+"""Ops routes (/probe, /health, /metrics) + HTTP and MCP Prometheus metrics."""
 
 from __future__ import annotations
 
+import logging
+import time
 from collections.abc import Sequence
 
 from fastmcp import FastMCP
+from fastmcp.server.middleware import CallNext, MiddlewareContext
+from fastmcp.server.middleware import Middleware as McpMw
 from starlette.middleware import Middleware
 from starlette.requests import Request
 from starlette.responses import JSONResponse, PlainTextResponse
-from unique_toolkit.monitoring import MetricsMiddleware, get_metrics
+from unique_toolkit.monitoring import MetricNamespace, MetricsMiddleware, get_metrics
 
 _EXCLUDED = frozenset({"/", "/probe", "/health", "/ready", "/metrics", "/favicon.ico"})
-
 _OPS = FastMCP(name="unique-mcp-ops")
+_log = logging.getLogger("unique_mcp")
+_m = MetricNamespace("mcp")
+_calls = _m.counter("calls_total", "MCP calls", ["kind", "name", "status"])
+_duration = _m.histogram("call_duration_seconds", "MCP call duration", ["kind", "name"])
 
 
 @_OPS.custom_route("/probe", methods=["GET"])
@@ -30,14 +37,73 @@ async def _metrics(_request: Request) -> PlainTextResponse:
     )
 
 
+class _McpMetrics(McpMw):
+    async def _track(self, kind: str, name: str, context: MiddlewareContext, call_next):
+        start = time.perf_counter()
+        status = "ok"
+        err: BaseException | None = None
+        try:
+            return await call_next(context)
+        except Exception as e:
+            status = type(e).__name__
+            err = e
+            raise
+        finally:
+            elapsed = time.perf_counter() - start
+            _duration.labels(kind=kind, name=name).observe(elapsed)
+            _calls.labels(kind=kind, name=name, status=status).inc()
+            # LogRecord reserves `name`; use `operation` for the MCP name.
+            extra = {
+                "kind": kind,
+                "operation": name,
+                "status": status,
+                "duration_ms": round(elapsed * 1000, 2),
+            }
+            if err is not None:
+                _log.error("%s '%s' failed", kind, name, exc_info=err, extra=extra)
+            else:
+                _log.info("%s '%s' completed", kind, name, extra=extra)
+
+    async def on_call_tool(self, context: MiddlewareContext, call_next: CallNext):
+        return await self._track(
+            "tool", getattr(context.message, "name", "unknown"), context, call_next
+        )
+
+    async def on_read_resource(self, context: MiddlewareContext, call_next: CallNext):
+        return await self._track(
+            "resource",
+            str(getattr(context.message, "uri", "unknown")),
+            context,
+            call_next,
+        )
+
+    async def on_get_prompt(self, context: MiddlewareContext, call_next: CallNext):
+        return await self._track(
+            "prompt", getattr(context.message, "name", "unknown"), context, call_next
+        )
+
+
 def setup_ops(
     mcp: FastMCP,
     *,
     excluded_paths: set[str] | None = None,
     duration_buckets: Sequence[float] | None = None,
 ) -> Middleware:
-    """Mount ops routes on ``mcp``; return metrics middleware."""
-    mcp.mount(_OPS)
+    """Mount ops routes + MCP metrics; return HTTP metrics middleware.
+
+    FastMCP owns MCP ``tools/call`` spans (continues ``_meta.traceparent`` /
+    an active context). Call ``configure_tracing()`` at startup so those spans
+    export. HTTP ``TraceContextMiddleware`` is intentionally not installed —
+    on streamable HTTP it often creates an orphan root beside FastMCP's tree.
+
+    Idempotent for MCP mount/middleware: a second call on the same ``mcp`` does
+    not remount ops or attach another ``_McpMetrics`` (which would inflate
+    ``mcp_*``). Append the returned Starlette ``Middleware`` only once.
+    """
+    if not any(getattr(p, "server", None) is _OPS for p in mcp.providers):
+        mcp.mount(_OPS)
+    if not any(isinstance(mw, _McpMetrics) for mw in mcp.middleware):
+        mcp.add_middleware(_McpMetrics())
     return Middleware(
         MetricsMiddleware,
         excluded_paths=excluded_paths if excluded_paths is not None else set(_EXCLUDED),

--- a/unique_mcp/src/unique_mcp/monitoring.py
+++ b/unique_mcp/src/unique_mcp/monitoring.py
@@ -1,0 +1,45 @@
+"""Ops routes (/probe, /health, /metrics) + toolkit Prometheus middleware."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from fastmcp import FastMCP
+from starlette.middleware import Middleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse, PlainTextResponse
+from unique_toolkit.monitoring import MetricsMiddleware, get_metrics
+
+_EXCLUDED = frozenset({"/", "/probe", "/health", "/ready", "/metrics", "/favicon.ico"})
+
+_OPS = FastMCP(name="unique-mcp-ops")
+
+
+@_OPS.custom_route("/probe", methods=["GET"])
+@_OPS.custom_route("/health", methods=["GET"])
+async def _liveness(request: Request) -> JSONResponse:
+    status = "healthy" if request.url.path.endswith("/health") else "ok"
+    return JSONResponse({"status": status})
+
+
+@_OPS.custom_route("/metrics", methods=["GET"])
+async def _metrics(_request: Request) -> PlainTextResponse:
+    return PlainTextResponse(
+        content=get_metrics(),
+        media_type="text/plain; version=0.0.4; charset=utf-8",
+    )
+
+
+def setup_ops(
+    mcp: FastMCP,
+    *,
+    excluded_paths: set[str] | None = None,
+    duration_buckets: Sequence[float] | None = None,
+) -> Middleware:
+    """Mount ops routes on ``mcp``; return metrics middleware."""
+    mcp.mount(_OPS)
+    return Middleware(
+        MetricsMiddleware,
+        excluded_paths=excluded_paths if excluded_paths is not None else set(_EXCLUDED),
+        duration_buckets=duration_buckets,
+    )

--- a/unique_mcp/src/unique_mcp/monitoring.py
+++ b/unique_mcp/src/unique_mcp/monitoring.py
@@ -52,7 +52,6 @@ class _McpMetrics(McpMw):
             elapsed = time.perf_counter() - start
             _duration.labels(kind=kind, name=name).observe(elapsed)
             _calls.labels(kind=kind, name=name, status=status).inc()
-            # LogRecord reserves `name`; use `operation` for the MCP name.
             extra = {
                 "kind": kind,
                 "operation": name,
@@ -89,17 +88,7 @@ def setup_ops(
     excluded_paths: set[str] | None = None,
     duration_buckets: Sequence[float] | None = None,
 ) -> Middleware:
-    """Mount ops routes + MCP metrics; return HTTP metrics middleware.
-
-    FastMCP owns MCP ``tools/call`` spans (continues ``_meta.traceparent`` /
-    an active context). Call ``configure_tracing()`` at startup so those spans
-    export. HTTP ``TraceContextMiddleware`` is intentionally not installed —
-    on streamable HTTP it often creates an orphan root beside FastMCP's tree.
-
-    Idempotent for MCP mount/middleware: a second call on the same ``mcp`` does
-    not remount ops or attach another ``_McpMetrics`` (which would inflate
-    ``mcp_*``). Append the returned Starlette ``Middleware`` only once.
-    """
+    """Mount ops routes + MCP metrics; return HTTP metrics middleware."""
     if not any(getattr(p, "server", None) is _OPS for p in mcp.providers):
         mcp.mount(_OPS)
     if not any(isinstance(mw, _McpMetrics) for mw in mcp.middleware):

--- a/unique_mcp/tests/test_bootstrap.py
+++ b/unique_mcp/tests/test_bootstrap.py
@@ -1,0 +1,53 @@
+"""Tests for FastMCP process defaults applied on unique_mcp import."""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+
+import pytest
+
+
+@pytest.mark.ai
+@pytest.mark.unit
+def test_bootstrap__sets_check_for_updates_env__when_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Purpose: Verify FASTMCP_CHECK_FOR_UPDATES defaults to off.
+    Why this matters: Update checks add noisy startup network calls in containers.
+    Setup summary: Clear env, reload bootstrap, assert env + live settings.
+    """
+    monkeypatch.delenv("FASTMCP_CHECK_FOR_UPDATES", raising=False)
+    sys.modules.pop("unique_mcp._bootstrap", None)
+
+    import unique_mcp._bootstrap as bootstrap
+
+    importlib.reload(bootstrap)
+
+    assert os.environ["FASTMCP_CHECK_FOR_UPDATES"] == "off"
+
+    import fastmcp
+
+    assert fastmcp.settings.check_for_updates == "off"
+
+
+@pytest.mark.ai
+@pytest.mark.unit
+def test_bootstrap__does_not_override_explicit_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Purpose: Verify setdefault leaves an explicit FASTMCP_CHECK_FOR_UPDATES alone.
+    Why this matters: Operators must be able to opt back into update checks.
+    Setup summary: Set env to stable, reload bootstrap, assert value unchanged.
+    """
+    monkeypatch.setenv("FASTMCP_CHECK_FOR_UPDATES", "stable")
+    sys.modules.pop("unique_mcp._bootstrap", None)
+
+    import unique_mcp._bootstrap as bootstrap
+
+    importlib.reload(bootstrap)
+
+    assert os.environ["FASTMCP_CHECK_FOR_UPDATES"] == "stable"

--- a/unique_mcp/tests/test_logging.py
+++ b/unique_mcp/tests/test_logging.py
@@ -18,6 +18,7 @@ from unique_mcp.logging import _PinoJson, _QuietAccess, configure_logging
 @pytest.mark.parametrize(
     ("message", "expected"),
     [
+        # uvicorn
         ('127.0.0.1:1 - "GET /probe HTTP/1.1" 200', False),
         ('127.0.0.1:1 - "GET /probe/ HTTP/1.1" 200', False),
         ('127.0.0.1:1 - "GET /metrics HTTP/1.1" 200', False),
@@ -25,6 +26,18 @@ from unique_mcp.logging import _PinoJson, _QuietAccess, configure_logging
         ('127.0.0.1:1 - "GET /ready HTTP/1.1" 200', False),
         ('127.0.0.1:1 - "GET /mcp HTTP/1.1" 200', True),
         ('127.0.0.1:1 - "POST /mcp HTTP/1.1" 200', True),
+        # combined / CLF-style (hypercorn and others)
+        (
+            '127.0.0.1 - - [03/Aug/2026:12:00:00 +0000] "GET /metrics HTTP/1.1" 200 12',
+            False,
+        ),
+        (
+            '127.0.0.1 - - [03/Aug/2026:12:00:00 +0000] "POST /mcp HTTP/1.1" 200 12',
+            True,
+        ),
+        # bare METHOD path status
+        ("GET /ready 200", False),
+        ("POST /mcp 200", True),
         # Substring / query must not suppress real traffic (Bugbot MEDIUM).
         ('127.0.0.1:1 - "GET /mcp?next=/probe HTTP/1.1" 200', True),
         ('127.0.0.1:1 - "GET /api/healthcheck HTTP/1.1" 200', True),
@@ -36,7 +49,7 @@ def test_quiet_access__skips_probe_and_metrics(message: str, expected: bool) -> 
     """
     Purpose: Verify access logs for exact ops paths are dropped, not substrings.
     Why this matters: Scrapes drown logs; substring skips hid attacker-controlled URLs.
-    Setup summary: Filter sample uvicorn access lines; assert keep/drop.
+    Setup summary: Filter sample ASGI access lines; assert keep/drop.
     """
     record = logging.LogRecord(
         name="uvicorn.access",
@@ -146,12 +159,16 @@ def test_configure_logging__installs_access_filter_idempotently() -> None:
     """
     Purpose: Verify configure_logging attaches a single quiet-access filter.
     Why this matters: Re-configure must not stack duplicate filters.
-    Setup summary: Clear filters, configure twice, assert one _QuietAccess.
+    Setup summary: Clear filters on common ASGI access loggers, configure twice.
     """
-    access = logging.getLogger("uvicorn.access")
-    access.filters.clear()
+    for name in ("uvicorn.access", "hypercorn.access", "granian.access"):
+        logging.getLogger(name).filters.clear()
 
     configure_logging(level="INFO")
     configure_logging(level="INFO")
 
-    assert sum(isinstance(f, _QuietAccess) for f in access.filters) == 1
+    for name in ("uvicorn.access", "hypercorn.access", "granian.access"):
+        assert (
+            sum(isinstance(f, _QuietAccess) for f in logging.getLogger(name).filters)
+            == 1
+        )

--- a/unique_mcp/tests/test_logging.py
+++ b/unique_mcp/tests/test_logging.py
@@ -19,16 +19,23 @@ from unique_mcp.logging import _PinoJson, _QuietAccess, configure_logging
     ("message", "expected"),
     [
         ('127.0.0.1:1 - "GET /probe HTTP/1.1" 200', False),
+        ('127.0.0.1:1 - "GET /probe/ HTTP/1.1" 200', False),
         ('127.0.0.1:1 - "GET /metrics HTTP/1.1" 200', False),
         ('127.0.0.1:1 - "GET /health HTTP/1.1" 200', False),
+        ('127.0.0.1:1 - "GET /ready HTTP/1.1" 200', False),
         ('127.0.0.1:1 - "GET /mcp HTTP/1.1" 200', True),
         ('127.0.0.1:1 - "POST /mcp HTTP/1.1" 200', True),
+        # Substring / query must not suppress real traffic (Bugbot MEDIUM).
+        ('127.0.0.1:1 - "GET /mcp?next=/probe HTTP/1.1" 200', True),
+        ('127.0.0.1:1 - "GET /api/healthcheck HTTP/1.1" 200', True),
+        ('127.0.0.1:1 - "POST /tools/metrics-export HTTP/1.1" 200', True),
+        ("not an access line at all", True),
     ],
 )
 def test_quiet_access__skips_probe_and_metrics(message: str, expected: bool) -> None:
     """
-    Purpose: Verify access logs for probe/health/metrics are dropped.
-    Why this matters: Scrapes and k8s probes otherwise drown real request logs.
+    Purpose: Verify access logs for exact ops paths are dropped, not substrings.
+    Why this matters: Scrapes drown logs; substring skips hid attacker-controlled URLs.
     Setup summary: Filter sample uvicorn access lines; assert keep/drop.
     """
     record = logging.LogRecord(

--- a/unique_mcp/tests/test_logging.py
+++ b/unique_mcp/tests/test_logging.py
@@ -38,7 +38,6 @@ from unique_mcp.logging import _PinoJson, _QuietAccess, configure_logging
         # bare METHOD path status
         ("GET /ready 200", False),
         ("POST /mcp 200", True),
-        # Substring / query must not suppress real traffic (Bugbot MEDIUM).
         ('127.0.0.1:1 - "GET /mcp?next=/probe HTTP/1.1" 200', True),
         ('127.0.0.1:1 - "GET /api/healthcheck HTTP/1.1" 200', True),
         ('127.0.0.1:1 - "POST /tools/metrics-export HTTP/1.1" 200', True),
@@ -47,9 +46,9 @@ from unique_mcp.logging import _PinoJson, _QuietAccess, configure_logging
 )
 def test_quiet_access__skips_probe_and_metrics(message: str, expected: bool) -> None:
     """
-    Purpose: Verify access logs for exact ops paths are dropped, not substrings.
-    Why this matters: Scrapes drown logs; substring skips hid attacker-controlled URLs.
-    Setup summary: Filter sample ASGI access lines; assert keep/drop.
+    Purpose: Verify only exact ops paths are dropped from ASGI access logs.
+    Why this matters: Scrapes drown logs; substrings must not hide real traffic.
+    Setup summary: Filter sample access lines; assert keep/drop.
     """
     record = logging.LogRecord(
         name="uvicorn.access",

--- a/unique_mcp/tests/test_logging.py
+++ b/unique_mcp/tests/test_logging.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 import json
 import logging
+import sys
 
 import pytest
+from opentelemetry import context, trace
+from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags
 
 from unique_mcp.logging import _PinoJson, _QuietAccess, configure_logging
 
@@ -66,6 +69,68 @@ def test_pino_json__emits_level_time_msg() -> None:
     assert payload["context"] == "unique_mcp.test"
     assert payload["company_id"] == "co-1"
     assert isinstance(payload["time"], int)
+
+
+@pytest.mark.ai
+@pytest.mark.unit
+def test_pino_json__err_is_structured_object() -> None:
+    """
+    Purpose: Verify exceptions serialize like connectors TS err shape.
+    Why this matters: Loki Explore expects err.name / message / stack, not a string.
+    Setup summary: Format a LogRecord with exc_info from a RuntimeError.
+    """
+    try:
+        raise RuntimeError("nope")
+    except RuntimeError:
+        record = logging.LogRecord(
+            name="unique_mcp.test",
+            level=logging.ERROR,
+            pathname=__file__,
+            lineno=1,
+            msg="operation failed",
+            args=(),
+            exc_info=sys.exc_info(),
+        )
+
+    payload = json.loads(_PinoJson().format(record))
+
+    assert payload["err"]["name"] == "RuntimeError"
+    assert payload["err"]["message"] == "nope"
+    assert "RuntimeError: nope" in payload["err"]["stack"]
+
+
+@pytest.mark.ai
+@pytest.mark.unit
+def test_pino_json__includes_trace_fields_from_active_span() -> None:
+    """
+    Purpose: Verify trace_id/span_id/trace_flags come from the active OTel span.
+    Why this matters: QA Loki correlates MCP logs the same way as TS MCPs.
+    Setup summary: Attach a NonRecordingSpan and format a record.
+    """
+    span_ctx = SpanContext(
+        trace_id=0xA048E90ACEF882E46FDFE481C06237C1,
+        span_id=0x745E84549F5E6FE3,
+        is_remote=False,
+        trace_flags=TraceFlags(0x01),
+    )
+    token = context.attach(trace.set_span_in_context(NonRecordingSpan(span_ctx)))
+    try:
+        record = logging.LogRecord(
+            name="unique_mcp.test",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg="traced",
+            args=(),
+            exc_info=None,
+        )
+        payload = json.loads(_PinoJson().format(record))
+    finally:
+        context.detach(token)
+
+    assert payload["trace_id"] == "a048e90acef882e46fdfe481c06237c1"
+    assert payload["span_id"] == "745e84549f5e6fe3"
+    assert payload["trace_flags"] == 1
 
 
 @pytest.mark.ai

--- a/unique_mcp/tests/test_logging.py
+++ b/unique_mcp/tests/test_logging.py
@@ -1,0 +1,85 @@
+"""Tests for unique_mcp.logging helpers."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import pytest
+
+from unique_mcp.logging import _PinoJson, _QuietAccess, configure_logging
+
+
+@pytest.mark.ai
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("message", "expected"),
+    [
+        ('127.0.0.1:1 - "GET /probe HTTP/1.1" 200', False),
+        ('127.0.0.1:1 - "GET /metrics HTTP/1.1" 200', False),
+        ('127.0.0.1:1 - "GET /health HTTP/1.1" 200', False),
+        ('127.0.0.1:1 - "GET /mcp HTTP/1.1" 200', True),
+        ('127.0.0.1:1 - "POST /mcp HTTP/1.1" 200', True),
+    ],
+)
+def test_quiet_access__skips_probe_and_metrics(message: str, expected: bool) -> None:
+    """
+    Purpose: Verify access logs for probe/health/metrics are dropped.
+    Why this matters: Scrapes and k8s probes otherwise drown real request logs.
+    Setup summary: Filter sample uvicorn access lines; assert keep/drop.
+    """
+    record = logging.LogRecord(
+        name="uvicorn.access",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg=message,
+        args=(),
+        exc_info=None,
+    )
+    assert _QuietAccess().filter(record) is expected
+
+
+@pytest.mark.ai
+@pytest.mark.unit
+def test_pino_json__emits_level_time_msg() -> None:
+    """
+    Purpose: Verify JSON formatter matches pino-json field names.
+    Why this matters: Alloy/Loki expect numeric level, time ms, msg, context.
+    Setup summary: Format a LogRecord and parse the JSON payload.
+    """
+    record = logging.LogRecord(
+        name="unique_mcp.test",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="hello %s",
+        args=("world",),
+        exc_info=None,
+    )
+    record.company_id = "co-1"  # type: ignore[attr-defined]
+
+    payload = json.loads(_PinoJson().format(record))
+
+    assert payload["level"] == 30
+    assert payload["msg"] == "hello world"
+    assert payload["context"] == "unique_mcp.test"
+    assert payload["company_id"] == "co-1"
+    assert isinstance(payload["time"], int)
+
+
+@pytest.mark.ai
+@pytest.mark.unit
+def test_configure_logging__installs_access_filter_idempotently() -> None:
+    """
+    Purpose: Verify configure_logging attaches a single quiet-access filter.
+    Why this matters: Re-configure must not stack duplicate filters.
+    Setup summary: Clear filters, configure twice, assert one _QuietAccess.
+    """
+    access = logging.getLogger("uvicorn.access")
+    access.filters.clear()
+
+    configure_logging(level="INFO")
+    configure_logging(level="INFO")
+
+    assert sum(isinstance(f, _QuietAccess) for f in access.filters) == 1

--- a/unique_mcp/tests/test_monitoring.py
+++ b/unique_mcp/tests/test_monitoring.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import pytest
-from fastmcp import FastMCP
+from fastmcp import Client, FastMCP
 from starlette.middleware import Middleware
 from starlette.testclient import TestClient
+from unique_toolkit.monitoring import MetricsMiddleware, get_metrics
 
-from unique_mcp.monitoring import setup_ops
+from unique_mcp.monitoring import _OPS, _McpMetrics, setup_ops
 
 
 @pytest.mark.ai
@@ -34,3 +35,75 @@ def test_setup_ops__mounts_probe_health_and_metrics() -> None:
     assert "text/plain" in metrics.headers["content-type"]
     assert metrics.text
     assert isinstance(middleware, Middleware)
+    assert middleware.cls is MetricsMiddleware
+
+
+@pytest.mark.ai
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_setup_ops__auto_instruments_mcp_calls() -> None:
+    """
+    Purpose: Verify setup_ops metrics cover tools/resources and error types.
+    Why this matters: HTTP path metrics alone cannot distinguish MCP operations.
+    Setup summary: Register tool + resource, call setup_ops, invoke via Client.
+    """
+    mcp = FastMCP("metrics-server")
+
+    @mcp.tool
+    def ping() -> str:
+        return "pong"
+
+    @mcp.tool
+    def boom() -> str:
+        raise RuntimeError("nope")
+
+    @mcp.resource("resource://note")
+    def note() -> str:
+        return "hi"
+
+    setup_ops(mcp)
+
+    async with Client(mcp) as client:
+        assert (await client.call_tool("ping")).is_error is False
+        with pytest.raises(Exception):
+            await client.call_tool("boom")
+        assert await client.read_resource("resource://note")
+
+    body = get_metrics().decode()
+    assert 'mcp_calls_total{kind="tool",name="ping",status="ok"}' in body
+    assert 'mcp_calls_total{kind="tool",name="boom",status="ToolError"}' in body
+    assert 'mcp_calls_total{kind="resource",name="resource://note",status="ok"}' in body
+    assert 'mcp_call_duration_seconds_count{kind="tool",name="ping"}' in body
+    assert (
+        'mcp_call_duration_seconds_count{kind="resource",name="resource://note"}'
+        in body
+    )
+
+
+@pytest.mark.ai
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_setup_ops__idempotent_mcp_metrics() -> None:
+    """
+    Purpose: Verify calling setup_ops twice does not double-count MCP metrics.
+    Why this matters: Entrypoints that set up ops in more than one place must
+    not inflate mcp_calls_total.
+    Setup summary: setup_ops twice, call one tool, assert counter is 1.
+    """
+    mcp = FastMCP("idempotent-server")
+
+    @mcp.tool
+    def idempotent_ping() -> str:
+        return "pong"
+
+    setup_ops(mcp)
+    setup_ops(mcp)
+
+    assert sum(isinstance(mw, _McpMetrics) for mw in mcp.middleware) == 1
+    assert sum(getattr(p, "server", None) is _OPS for p in mcp.providers) == 1
+
+    async with Client(mcp) as client:
+        assert (await client.call_tool("idempotent_ping")).is_error is False
+
+    body = get_metrics().decode()
+    assert 'mcp_calls_total{kind="tool",name="idempotent_ping",status="ok"} 1.0' in body

--- a/unique_mcp/tests/test_monitoring.py
+++ b/unique_mcp/tests/test_monitoring.py
@@ -1,0 +1,36 @@
+"""Tests for unique_mcp.monitoring helpers."""
+
+from __future__ import annotations
+
+import pytest
+from fastmcp import FastMCP
+from starlette.middleware import Middleware
+from starlette.testclient import TestClient
+
+from unique_mcp.monitoring import setup_ops
+
+
+@pytest.mark.ai
+@pytest.mark.unit
+def test_setup_ops__mounts_probe_health_and_metrics() -> None:
+    """
+    Purpose: Verify setup_ops mounts /probe, /health, and /metrics.
+    Why this matters: Platform probes and ServiceMonitors need these paths.
+    Setup summary: Call setup_ops on a FastMCP app and GET each route.
+    """
+    mcp = FastMCP("test-server")
+    middleware = setup_ops(mcp)
+    client = TestClient(mcp.http_app())
+
+    probe = client.get("/probe")
+    health = client.get("/health")
+    metrics = client.get("/metrics")
+
+    assert probe.status_code == 200
+    assert probe.json()["status"] == "ok"
+    assert health.status_code == 200
+    assert health.json()["status"] == "healthy"
+    assert metrics.status_code == 200
+    assert "text/plain" in metrics.headers["content-type"]
+    assert metrics.text
+    assert isinstance(middleware, Middleware)

--- a/uv.lock
+++ b/uv.lock
@@ -5260,6 +5260,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
+    { name = "starlette" },
     { name = "typing-extensions" },
     { name = "unique-toolkit", extra = ["monitoring"] },
 ]
@@ -5272,6 +5273,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
+    { name = "starlette", specifier = ">=1.3.1,<2" },
     { name = "typing-extensions", specifier = ">=4.6.0" },
     { name = "unique-toolkit", extras = ["monitoring"], editable = "unique_toolkit" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -5261,7 +5261,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
     { name = "typing-extensions" },
-    { name = "unique-toolkit" },
+    { name = "unique-toolkit", extra = ["monitoring"] },
 ]
 
 [package.metadata]
@@ -5273,7 +5273,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "typing-extensions", specifier = ">=4.6.0" },
-    { name = "unique-toolkit", editable = "unique_toolkit" },
+    { name = "unique-toolkit", extras = ["monitoring"], editable = "unique_toolkit" },
 ]
 
 [package.metadata.requires-dev]

--- a/uv.lock
+++ b/uv.lock
@@ -5256,26 +5256,28 @@ source = { editable = "unique_mcp" }
 dependencies = [
     { name = "fastmcp" },
     { name = "httpx" },
+    { name = "opentelemetry-api" },
     { name = "platformdirs" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
     { name = "starlette" },
     { name = "typing-extensions" },
-    { name = "unique-toolkit", extra = ["monitoring"] },
+    { name = "unique-toolkit", extra = ["monitoring", "otel"] },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "fastmcp", specifier = ">=3.3.0,<4" },
     { name = "httpx", specifier = ">=0.28.0" },
+    { name = "opentelemetry-api", specifier = ">=1.27,<2" },
     { name = "platformdirs", specifier = ">=4.0.0" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "starlette", specifier = ">=1.3.1,<2" },
     { name = "typing-extensions", specifier = ">=4.6.0" },
-    { name = "unique-toolkit", extras = ["monitoring"], editable = "unique_toolkit" },
+    { name = "unique-toolkit", extras = ["monitoring", "otel"], editable = "unique_toolkit" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary
- Add shared unique_mcp platform helpers: pino-json logging, FastMCP update-check bootstrap, and `setup_ops` for `/probe` `/health` `/metrics` plus toolkit MetricsMiddleware.
- Depend on `unique-toolkit[monitoring]` by default so MCP servers get Prometheus ops wiring without a separate unique-mcp extra.
- Document the usage snippet and cover bootstrap/logging/ops with unit tests.

## Changes
- `unique_mcp/_bootstrap.py`: setdefault `FASTMCP_CHECK_FOR_UPDATES=off` and sync live FastMCP settings when already loaded
- `unique_mcp/logging.py`: always emit pino-json; quiet probe/health/metrics/ready access logs
- `unique_mcp/monitoring.py`: `setup_ops(mcp)` mounts ops routes and returns MetricsMiddleware
- `unique_mcp/pyproject.toml` + `uv.lock`: default monitoring extra on unique-toolkit
- README usage snippet + tests for bootstrap, logging, and monitoring

## Test plan
- [ ] `cd unique_mcp && uv run pytest tests/test_bootstrap.py tests/test_logging.py tests/test_monitoring.py -q`
- [ ] Import `unique_mcp` and confirm `FASTMCP_CHECK_FOR_UPDATES` defaults to `off` unless already set
- [ ] Call `configure_logging()` and verify stderr JSON looks like pino (`level`/`time`/`msg`/`context`)
- [ ] Call `setup_ops(mcp)` and GET `/probe`, `/health`, `/metrics` successfully
- [ ] Confirm probe/health/metrics access lines are filtered from uvicorn access logs

## Risk / rollout
- Low: additive helpers; existing servers opt in by calling `configure_logging` / `setup_ops`
- Default dep now includes `unique-toolkit[monitoring]` (Prometheus client stack) for unique-mcp consumers