### PR TITLE
ci: bump uv to 0.11.28 across workflows

### DIFF
--- a/.github/actions/publish-to-pypi-with-uv/action.yml
+++ b/.github/actions/publish-to-pypi-with-uv/action.yml
@@ -31,7 +31,7 @@ runs:
     - name: Install uv
       uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
       with:
-        version: '0.10.11'
+        version: '0.11.28'
 
     - name: Build Package
       shell: bash

--- a/.github/actions/publish-to-pypi-with-uv/action.yml
+++ b/.github/actions/publish-to-pypi-with-uv/action.yml
@@ -29,7 +29,7 @@ runs:
         python-version: ${{ inputs.python_version }}
 
     - name: Install uv
-      uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+      uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
       with:
         version: '0.11.28'
 

--- a/.github/actions/setup-uv/action.yml
+++ b/.github/actions/setup-uv/action.yml
@@ -35,7 +35,7 @@ runs:
       id: install-uv
       uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
       with:
-        version: '0.11.5'
+        version: '0.11.28'
 
     - name: Print versions
       shell: bash

--- a/.github/actions/setup-uv/action.yml
+++ b/.github/actions/setup-uv/action.yml
@@ -33,7 +33,7 @@ runs:
 
     - name: Install uv
       id: install-uv
-      uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+      uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
       with:
         version: '0.11.28'
 

--- a/.github/workflows/cd-publish-dev.yaml
+++ b/.github/workflows/cd-publish-dev.yaml
@@ -160,7 +160,7 @@ jobs:
 
       - name: Install uv
         if: fromJson(steps.publishable.outputs.matrix).include[0] != null
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           version: '0.11.28'
 
@@ -220,7 +220,7 @@ jobs:
           python-version: ${{ matrix.python }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           version: '0.11.28'
 
@@ -429,7 +429,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           version: '0.11.28'
 

--- a/.github/workflows/cd-publish-dev.yaml
+++ b/.github/workflows/cd-publish-dev.yaml
@@ -162,7 +162,7 @@ jobs:
         if: fromJson(steps.publishable.outputs.matrix).include[0] != null
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
-          version: '0.11.5'
+          version: '0.11.28'
 
       - name: Compute CalVer cycle
         id: calver
@@ -222,7 +222,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
-          version: '0.11.5'
+          version: '0.11.28'
 
       - name: Rewrite pyproject.toml for dev version
         env:
@@ -431,7 +431,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
-          version: '0.11.5'
+          version: '0.11.28'
 
       - name: Ensure dev-version-bump label exists
         env:

--- a/.github/workflows/cd-publish-rc.yaml
+++ b/.github/workflows/cd-publish-rc.yaml
@@ -141,7 +141,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
-          version: '0.11.5'
+          version: '0.11.28'
 
       - name: Compute CalVer cycle
         id: calver
@@ -263,7 +263,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
-          version: '0.11.5'
+          version: '0.11.28'
 
       - name: Rewrite pyproject.toml for rc version
         env:

--- a/.github/workflows/cd-publish-rc.yaml
+++ b/.github/workflows/cd-publish-rc.yaml
@@ -139,7 +139,7 @@ jobs:
           fi
 
       - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           version: '0.11.28'
 
@@ -261,7 +261,7 @@ jobs:
           python-version: ${{ matrix.python }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           version: '0.11.28'
 

--- a/.github/workflows/ci-helm-lint.yaml
+++ b/.github/workflows/ci-helm-lint.yaml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           version: '0.11.28'
 
@@ -107,7 +107,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           version: '0.11.28'
 

--- a/.github/workflows/ci-helm-lint.yaml
+++ b/.github/workflows/ci-helm-lint.yaml
@@ -25,6 +25,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          version: '0.11.28'
 
       - name: Check generated Helm artifacts drift
         run: |
@@ -106,6 +108,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          version: '0.11.28'
 
       # Hermetic gate — no registry access required. Catches the common breakages
       # (wrong keys, malformed structures) by validating values.yaml against the

--- a/.github/workflows/scripts-test.yaml
+++ b/.github/workflows/scripts-test.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
-          version: '0.11.5'
+          version: '0.11.28'
 
       - name: Run Python unit tests
         run: |

--- a/.github/workflows/scripts-test.yaml
+++ b/.github/workflows/scripts-test.yaml
@@ -34,7 +34,7 @@ jobs:
           bats .github/scripts/tests/*.bats --tap
 
       - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           version: '0.11.28'
 

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ conflicts = [[
 ]]
 
 [options]
-exclude-newer = "2026-07-08T10:16:13.192198Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P2W"
 
 [options.exclude-newer-package]


### PR DESCRIPTION
## Summary
- Bump all CI/CD uv pins to `0.11.28` so CI matches developer tooling.
- Older CI uv (`0.11.5`) wrote absolute `exclude-newer` timestamps; uv ≥0.11.8 (incl. 0.11.28) writes the sentinel `0001-01-01` alongside `exclude-newer-span`, which caused lockfile flip-flops between local and CI/bots.
- Normalize `uv.lock` `[options]` to the sentinel timestamp + `exclude-newer-span = P2W`.

## Changes
- `.github/actions/setup-uv` / `publish-to-pypi-with-uv`: pin uv `0.11.28`
- Workflows: `cd-publish-dev`, `cd-publish-rc`, `scripts-test`, `ci-helm-lint` (also pin jobs that previously had no version)
- `uv.lock`: sentinel `exclude-newer` for span compatibility

## Test plan
- [ ] Confirm PR CI runs with uv `0.11.28` (setup-uv / workflow logs)
- [ ] Confirm no unintended lockfile churn on a follow-up `uv lock` / CI lock check
- [ ] Spot-check publish-related workflows still resolve the action version input

## Risk / rollout
- Low: version pin + lockfile metadata only; no app code changes.
- Rollback: revert the pin to the previous versions if a workflow fails on 0.11.28.