### PR TITLE
feat(toolkit): add opt-in OpenTelemetry tracing

### DIFF
--- a/unique_toolkit/pyproject.toml
+++ b/unique_toolkit/pyproject.toml
@@ -63,6 +63,10 @@ fastapi = [
 monitoring = [
     "prometheus_client>=0.24.1,<1",
 ]
+otel = [
+    "opentelemetry-sdk>=1.27,<2",
+    "opentelemetry-exporter-otlp-proto-http>=1.27,<2",
+]
 [build-system]
 requires = ["uv_build>=0.8.14,<0.9.0"]
 build-backend = "uv_build"
@@ -73,6 +77,8 @@ module-root = ""
 [dependency-groups]
 dev = [
     "types-cachetools>=5.0,<6",
+    "opentelemetry-sdk>=1.27,<2",
+    "opentelemetry-exporter-otlp-proto-http>=1.27,<2",
 ]
 
 [tool.uv]
@@ -119,7 +125,14 @@ known_first_party = ["unique_toolkit"]
 extend_exclude = ["docs", "tests", "unique_toolkit/.*/test", "unique_toolkit/.*/tests"]
 
 [tool.deptry.per_rule_ignores]
-DEP002 = ["langchain", "fastapi", "starlette", "uvicorn"]
+DEP002 = [
+    "langchain",
+    "fastapi",
+    "starlette",
+    "uvicorn",
+    "opentelemetry-sdk",
+    "opentelemetry-exporter-otlp-proto-http",
+]
 DEP004 = ["langchain_openai", "langchain_core"]
 
 # -----------------------------------------------------------------------------

--- a/unique_toolkit/tests/monitoring/test_tracing.py
+++ b/unique_toolkit/tests/monitoring/test_tracing.py
@@ -169,6 +169,7 @@ def test_resolve_exporter__treats_empty_values_as_unset(
     monkeypatch.setenv("OTEL_SPAN_PROCESSOR", "")
     monkeypatch.setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "")
     monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+    monkeypatch.delenv("ENABLE_OPENTELEMETRY", raising=False)
 
     assert TracingSettings().exporter_name is None
 
@@ -177,6 +178,26 @@ def test_resolve_exporter__treats_empty_values_as_unset(
 
     monkeypatch.setenv("ENABLE_OPENTELEMETRY", "false")
     assert TracingSettings().exporter_name is None
+
+
+@pytest.mark.ai
+@pytest.mark.unit
+def test_tracing_settings__treats_empty_service_values_as_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Purpose: Verify blank service attributes do not block the deployment version fallback.
+    Why this matters: Trace resources must not contain empty service attributes.
+    Setup summary: Set blank standard service values and assert the Node version remains usable.
+    """
+    monkeypatch.setenv("OTEL_SERVICE_NAME", "")
+    monkeypatch.setenv("OTEL_SERVICE_VERSION", "")
+    monkeypatch.setenv("VERSION", "node-version")
+
+    settings = TracingSettings()
+
+    assert settings.service_name is None
+    assert settings.resolved_service_version == "node-version"
 
 
 @pytest.mark.ai

--- a/unique_toolkit/tests/monitoring/test_tracing.py
+++ b/unique_toolkit/tests/monitoring/test_tracing.py
@@ -1,29 +1,35 @@
 """Tests for the optional OpenTelemetry tracing bootstrap."""
 
+from __future__ import annotations
+
 import builtins
-import os
-import subprocess
-import sys
 
 import pytest
+from opentelemetry import trace
+from opentelemetry.util._once import Once
 
-from unique_toolkit.monitoring import configure_tracing
+from unique_toolkit.monitoring import (
+    TraceContextMiddleware,
+    configure_tracing,
+    inject_trace_headers,
+)
 from unique_toolkit.monitoring.tracing import _resolve_exporter
 
 
-def _run_tracing_script(script: str, environment: dict[str, str] | None = None) -> None:
-    result = subprocess.run(
-        [sys.executable, "-c", script],
-        capture_output=True,
-        check=False,
-        env=environment or (os.environ | {"OTEL_TRACES_EXPORTER": "console"}),
-        text=True,
-    )
+def _reset_tracer_provider() -> None:
+    trace._TRACER_PROVIDER = None  # noqa: SLF001
+    trace._TRACER_PROVIDER_SET_ONCE = Once()  # noqa: SLF001
 
-    assert result.returncode == 0, result.stderr
+
+@pytest.fixture(autouse=True)
+def _clean_tracer_provider():
+    _reset_tracer_provider()
+    yield
+    _reset_tracer_provider()
 
 
 @pytest.mark.ai
+@pytest.mark.unit
 def test_configure_tracing__returns_false__when_exporter_is_none(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -38,6 +44,7 @@ def test_configure_tracing__returns_false__when_exporter_is_none(
 
 
 @pytest.mark.ai
+@pytest.mark.unit
 def test_configure_tracing__returns_false__without_exporter_or_endpoint(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -47,6 +54,7 @@ def test_configure_tracing__returns_false__without_exporter_or_endpoint(
     Setup summary: Clear exporter and endpoint variables and assert configuration is disabled.
     """
     monkeypatch.delenv("OTEL_TRACES_EXPORTER", raising=False)
+    monkeypatch.delenv("ENABLE_OPENTELEMETRY", raising=False)
     monkeypatch.delenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", raising=False)
     monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
 
@@ -54,6 +62,7 @@ def test_configure_tracing__returns_false__without_exporter_or_endpoint(
 
 
 @pytest.mark.ai
+@pytest.mark.unit
 @pytest.mark.parametrize(
     ("processor", "expected"),
     [
@@ -63,7 +72,7 @@ def test_configure_tracing__returns_false__without_exporter_or_endpoint(
 )
 def test_resolve_exporter__maps_node_alias__when_tracing_is_enabled(
     monkeypatch: pytest.MonkeyPatch,
-    processor: str | None,
+    processor: str,
     expected: str,
 ) -> None:
     """
@@ -79,6 +88,7 @@ def test_resolve_exporter__maps_node_alias__when_tracing_is_enabled(
 
 
 @pytest.mark.ai
+@pytest.mark.unit
 def test_resolve_exporter__defaults_to_otlp__when_node_tracing_is_enabled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -95,6 +105,7 @@ def test_resolve_exporter__defaults_to_otlp__when_node_tracing_is_enabled(
 
 
 @pytest.mark.ai
+@pytest.mark.unit
 def test_resolve_exporter__returns_none__when_node_tracing_is_disabled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -111,6 +122,7 @@ def test_resolve_exporter__returns_none__when_node_tracing_is_disabled(
 
 
 @pytest.mark.ai
+@pytest.mark.unit
 def test_resolve_exporter__prefers_standard_exporter__over_node_aliases(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -127,6 +139,24 @@ def test_resolve_exporter__prefers_standard_exporter__over_node_aliases(
 
 
 @pytest.mark.ai
+@pytest.mark.unit
+def test_resolve_exporter__uses_endpoint__when_exporter_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Purpose: Verify an OTLP endpoint alone enables the otlp exporter.
+    Why this matters: Deployments often set only the collector URL.
+    Setup summary: Clear exporter flags, set an endpoint, assert otlp.
+    """
+    monkeypatch.delenv("OTEL_TRACES_EXPORTER", raising=False)
+    monkeypatch.delenv("ENABLE_OPENTELEMETRY", raising=False)
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://collector:4318")
+
+    assert _resolve_exporter() == "otlp"
+
+
+@pytest.mark.ai
+@pytest.mark.unit
 def test_configure_tracing__raises_install_hint__when_otel_extra_is_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -152,120 +182,178 @@ def test_configure_tracing__raises_install_hint__when_otel_extra_is_missing(
 
 
 @pytest.mark.ai
-def test_configure_tracing__creates_valid_span_context__with_console_exporter() -> None:
+@pytest.mark.unit
+def test_configure_tracing__raises__for_unsupported_exporter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Purpose: Verify unknown exporters fail fast with a clear error.
+    Why this matters: Typos in env config should not silently no-op.
+    Setup summary: Set an unsupported exporter name and assert ValueError.
+    """
+    monkeypatch.setenv("OTEL_TRACES_EXPORTER", "jaeger")
+
+    with pytest.raises(ValueError, match="Unsupported trace exporter"):
+        configure_tracing()
+
+
+@pytest.mark.ai
+@pytest.mark.unit
+def test_configure_tracing__creates_valid_span_context__with_console_exporter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """
     Purpose: Verify console configuration creates a provider that records spans.
     Why this matters: MCP instrumentation needs a valid active context for log correlation.
-    Setup summary: Run configuration in an isolated process and assert a created span is valid.
+    Setup summary: Configure console tracing in-process and assert a created span is valid.
     """
-    script = """
-from opentelemetry import trace
-from unique_toolkit.monitoring import configure_tracing
+    monkeypatch.setenv("OTEL_TRACES_EXPORTER", "console")
 
-assert configure_tracing(service_name="test-service") is True
-with trace.get_tracer(__name__).start_as_current_span("test-span") as span:
-    assert span.get_span_context().is_valid
-"""
-
-    _run_tracing_script(script)
+    assert configure_tracing(service_name="test-service") is True
+    with trace.get_tracer(__name__).start_as_current_span("test-span") as span:
+        assert span.get_span_context().is_valid
 
 
 @pytest.mark.ai
-def test_configure_tracing__uses_node_version__when_standard_version_is_unset() -> None:
+@pytest.mark.unit
+def test_configure_tracing__uses_node_version__when_standard_version_is_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """
     Purpose: Verify the Node deployment version is added to the tracing resource.
     Why this matters: Trace backends need service version parity across Node and Python services.
-    Setup summary: Configure console tracing in a child process and assert its resource uses VERSION.
+    Setup summary: Configure console tracing with VERSION and assert the resource attribute.
     """
-    script = """
-from opentelemetry import trace
-from unique_toolkit.monitoring import configure_tracing
+    monkeypatch.setenv("OTEL_TRACES_EXPORTER", "console")
+    monkeypatch.setenv("VERSION", "node-version")
+    monkeypatch.delenv("OTEL_SERVICE_VERSION", raising=False)
 
-assert configure_tracing() is True
-assert trace.get_tracer_provider().resource.attributes["service.version"] == "node-version"
-"""
-    environment = os.environ | {
-        "OTEL_TRACES_EXPORTER": "console",
-        "VERSION": "node-version",
-    }
-    environment.pop("OTEL_SERVICE_VERSION", None)
-
-    _run_tracing_script(script, environment)
+    assert configure_tracing() is True
+    assert (
+        trace.get_tracer_provider().resource.attributes["service.version"]
+        == "node-version"
+    )
 
 
 @pytest.mark.ai
-def test_trace_context_middleware__continues_incoming_trace_context() -> None:
+@pytest.mark.unit
+def test_configure_tracing__installs_otlp_exporter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Purpose: Verify OTLP exporter path constructs a TracerProvider successfully.
+    Why this matters: Production Alloy/OTLP is the primary export mode.
+    Setup summary: Enable otlp exporter and assert configure_tracing returns True.
+    """
+    monkeypatch.setenv("OTEL_TRACES_EXPORTER", "otlp")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://127.0.0.1:4318")
+
+    assert configure_tracing(service_name="otlp-service") is True
+    assert not isinstance(trace.get_tracer_provider(), trace.ProxyTracerProvider)
+
+
+@pytest.mark.ai
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_trace_context_middleware__continues_incoming_trace_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """
     Purpose: Verify ASGI requests create a child span of the incoming trace.
     Why this matters: MCP and Assistants Core must appear in the caller's distributed trace.
-    Setup summary: Send a traceparent through middleware in a child process and assert its trace ID.
+    Setup summary: Send a traceparent through middleware and assert its trace ID.
     """
-    script = """
-import asyncio
+    monkeypatch.setenv("OTEL_TRACES_EXPORTER", "console")
+    assert configure_tracing() is True
 
-from opentelemetry import trace
-from unique_toolkit.monitoring import TraceContextMiddleware, configure_tracing
+    trace_id = "1234567890abcdef1234567890abcdef"
+    parent_span_id = "1234567890abcdef"
+    seen: dict[str, str] = {}
 
-trace_id = "1234567890abcdef1234567890abcdef"
-parent_span_id = "1234567890abcdef"
+    async def app(scope, receive, send):
+        span_context = trace.get_current_span().get_span_context()
+        seen["trace_id"] = format(span_context.trace_id, "032x")
+        seen["span_id"] = format(span_context.span_id, "016x")
 
-async def app(scope, receive, send):
-    span_context = trace.get_current_span().get_span_context()
-    assert format(span_context.trace_id, "032x") == trace_id
-    assert format(span_context.span_id, "016x") != parent_span_id
+    async def receive():
+        return {"type": "http.request"}
 
-async def receive():
-    return {"type": "http.request"}
+    async def send(message):
+        return None
 
-async def send(message):
-    return None
-
-assert configure_tracing() is True
-middleware = TraceContextMiddleware(app, span_name="test-request")
-asyncio.run(
-    middleware(
+    middleware = TraceContextMiddleware(app, span_name="test-request")
+    await middleware(
         {
             "type": "http",
-            "headers": [(b"traceparent", f"00-{trace_id}-{parent_span_id}-01".encode())],
+            "headers": [
+                (b"traceparent", f"00-{trace_id}-{parent_span_id}-01".encode())
+            ],
         },
         receive,
         send,
     )
-)
-"""
 
-    _run_tracing_script(script)
+    assert seen["trace_id"] == trace_id
+    assert seen["span_id"] != parent_span_id
 
 
 @pytest.mark.ai
-def test_trace_context_middleware__combines_repeated_tracestate_headers() -> None:
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_trace_context_middleware__passes_through_non_http(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Purpose: Verify non-HTTP ASGI scopes skip span creation.
+    Why this matters: Lifespan/websocket must not require trace headers.
+    Setup summary: Invoke middleware with a lifespan scope and assert the app runs.
+    """
+    monkeypatch.setenv("OTEL_TRACES_EXPORTER", "console")
+    assert configure_tracing() is True
+    called = False
+
+    async def app(scope, receive, send):
+        nonlocal called
+        called = True
+
+    await TraceContextMiddleware(app)({"type": "lifespan"}, None, None)
+    assert called is True
+
+
+@pytest.mark.ai
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_trace_context_middleware__combines_repeated_tracestate_headers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """
     Purpose: Verify ASGI middleware preserves every incoming tracestate entry.
     Why this matters: Dropping vendor state can change downstream trace sampling decisions.
     Setup summary: Send repeated tracestate headers and assert the active context preserves both.
     """
-    script = """
-import asyncio
+    monkeypatch.setenv("OTEL_TRACES_EXPORTER", "console")
+    assert configure_tracing() is True
+    seen: dict[str, str] = {}
 
-from opentelemetry import trace
-from unique_toolkit.monitoring import TraceContextMiddleware, configure_tracing
+    async def app(scope, receive, send):
+        seen["state"] = (
+            trace.get_current_span().get_span_context().trace_state.to_header()
+        )
 
-async def app(scope, receive, send):
-    assert trace.get_current_span().get_span_context().trace_state.to_header() == "foo=bar,bar=baz"
+    async def receive():
+        return {"type": "http.request"}
 
-async def receive():
-    return {"type": "http.request"}
+    async def send(message):
+        return None
 
-async def send(message):
-    return None
-
-assert configure_tracing() is True
-asyncio.run(
-    TraceContextMiddleware(app)(
+    await TraceContextMiddleware(app)(
         {
             "type": "http",
             "headers": [
-                (b"traceparent", b"00-1234567890abcdef1234567890abcdef-1234567890abcdef-01"),
+                (
+                    b"traceparent",
+                    b"00-1234567890abcdef1234567890abcdef-1234567890abcdef-01",
+                ),
                 (b"tracestate", b"foo=bar"),
                 (b"tracestate", b"bar=baz"),
             ],
@@ -273,50 +361,44 @@ asyncio.run(
         receive,
         send,
     )
-)
-"""
 
-    _run_tracing_script(script)
+    assert seen["state"] == "foo=bar,bar=baz"
 
 
 @pytest.mark.ai
-def test_inject_trace_headers__adds_active_w3c_trace_context() -> None:
+@pytest.mark.unit
+def test_inject_trace_headers__adds_active_w3c_trace_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """
     Purpose: Verify outgoing requests receive the active trace context.
     Why this matters: Downstream Node services need a parent trace to continue correlation.
-    Setup summary: Start a span in a child process, inject headers, and assert its trace ID is present.
+    Setup summary: Start a span, inject headers, and assert its trace ID is present.
     """
-    script = """
-from opentelemetry import trace
-from unique_toolkit.monitoring import configure_tracing, inject_trace_headers
+    monkeypatch.setenv("OTEL_TRACES_EXPORTER", "console")
+    assert configure_tracing() is True
 
-assert configure_tracing() is True
-with trace.get_tracer(__name__).start_as_current_span("source") as span:
-    headers = {}
-    inject_trace_headers(headers)
-    assert headers["traceparent"].split("-")[1] == format(
-        span.get_span_context().trace_id, "032x"
-    )
-"""
-
-    _run_tracing_script(script)
+    with trace.get_tracer(__name__).start_as_current_span("source") as span:
+        headers: dict[str, str] = {}
+        inject_trace_headers(headers)
+        assert headers["traceparent"].split("-")[1] == format(
+            span.get_span_context().trace_id, "032x"
+        )
 
 
 @pytest.mark.ai
-def test_configure_tracing__does_not_replace_provider__when_called_twice() -> None:
+@pytest.mark.unit
+def test_configure_tracing__does_not_replace_provider__when_called_twice(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """
     Purpose: Verify repeated setup does not replace the global trace provider.
     Why this matters: Process startup paths may configure tracing more than once.
-    Setup summary: Configure console tracing twice in an isolated process and assert identity remains.
+    Setup summary: Configure console tracing twice and assert provider identity remains.
     """
-    script = """
-from opentelemetry import trace
-from unique_toolkit.monitoring import configure_tracing
+    monkeypatch.setenv("OTEL_TRACES_EXPORTER", "console")
 
-assert configure_tracing() is True
-provider = trace.get_tracer_provider()
-assert configure_tracing() is True
-assert trace.get_tracer_provider() is provider
-"""
-
-    _run_tracing_script(script)
+    assert configure_tracing() is True
+    provider = trace.get_tracer_provider()
+    assert configure_tracing() is True
+    assert trace.get_tracer_provider() is provider

--- a/unique_toolkit/tests/monitoring/test_tracing.py
+++ b/unique_toolkit/tests/monitoring/test_tracing.py
@@ -10,6 +10,7 @@ from opentelemetry.util._once import Once
 
 from unique_toolkit.monitoring import (
     TraceContextMiddleware,
+    TraceExporter,
     TracingSettings,
     configure_tracing,
     inject_trace_headers,
@@ -66,14 +67,14 @@ def test_configure_tracing__returns_false__without_exporter_or_endpoint(
 @pytest.mark.parametrize(
     ("processor", "expected"),
     [
-        ("console", "console"),
-        ("none", "none"),
+        ("console", TraceExporter.CONSOLE),
+        ("none", TraceExporter.NONE),
     ],
 )
 def test_resolve_exporter__maps_node_alias__when_tracing_is_enabled(
     monkeypatch: pytest.MonkeyPatch,
     processor: str,
-    expected: str,
+    expected: TraceExporter,
 ) -> None:
     """
     Purpose: Verify the Node enable flag maps its configured span processor.
@@ -101,7 +102,7 @@ def test_resolve_exporter__defaults_to_otlp__when_node_tracing_is_enabled(
     monkeypatch.setenv("ENABLE_OPENTELEMETRY", "true")
     monkeypatch.delenv("OTEL_SPAN_PROCESSOR", raising=False)
 
-    assert TracingSettings().exporter_name == "otlp"
+    assert TracingSettings().exporter_name is TraceExporter.OTLP
 
 
 @pytest.mark.ai
@@ -238,7 +239,7 @@ def test_configure_tracing__raises__for_unsupported_exporter(
     """
     monkeypatch.setenv("OTEL_TRACES_EXPORTER", "jaeger")
 
-    with pytest.raises(ValueError, match="Unsupported trace exporter"):
+    with pytest.raises(ValueError, match="Input should be"):
         configure_tracing()
 
 

--- a/unique_toolkit/tests/monitoring/test_tracing.py
+++ b/unique_toolkit/tests/monitoring/test_tracing.py
@@ -6,6 +6,7 @@ import builtins
 
 import pytest
 from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.util._once import Once
 
 from unique_toolkit.monitoring import (
@@ -107,19 +108,19 @@ def test_resolve_exporter__defaults_to_otlp__when_node_tracing_is_enabled(
 
 @pytest.mark.ai
 @pytest.mark.unit
-def test_resolve_exporter__returns_none__when_node_tracing_is_disabled(
+def test_resolve_exporter__prefers_standard_endpoint__over_node_tracing_disable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """
-    Purpose: Verify the Node disable flag prevents endpoint-based setup.
-    Why this matters: Services must be able to opt out despite shared OTLP endpoint settings.
-    Setup summary: Disable Node-compatible tracing with an endpoint present and assert no exporter.
+    Purpose: Verify standard endpoint settings override the Node compatibility disable flag.
+    Why this matters: Standard OpenTelemetry configuration must take precedence.
+    Setup summary: Disable Node-compatible tracing with an endpoint present and assert OTLP.
     """
     monkeypatch.delenv("OTEL_TRACES_EXPORTER", raising=False)
     monkeypatch.setenv("ENABLE_OPENTELEMETRY", "false")
     monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://collector:4318")
 
-    assert TracingSettings().exporter_name is None
+    assert TracingSettings().exporter_name is TraceExporter.OTLP
 
 
 @pytest.mark.ai
@@ -446,5 +447,23 @@ def test_configure_tracing__does_not_replace_provider__when_called_twice(
 
     assert configure_tracing() is True
     provider = trace.get_tracer_provider()
+    assert configure_tracing() is True
+    assert trace.get_tracer_provider() is provider
+
+
+@pytest.mark.ai
+@pytest.mark.unit
+def test_configure_tracing__does_not_replace_an_existing_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Purpose: Verify tracing preserves SDK configuration installed before toolkit startup.
+    Why this matters: Applications may initialize OpenTelemetry outside this bootstrap.
+    Setup summary: Install a provider, configure tracing, and assert its identity remains.
+    """
+    monkeypatch.setenv("OTEL_TRACES_EXPORTER", "console")
+    provider = TracerProvider()
+    trace.set_tracer_provider(provider)
+
     assert configure_tracing() is True
     assert trace.get_tracer_provider() is provider

--- a/unique_toolkit/tests/monitoring/test_tracing.py
+++ b/unique_toolkit/tests/monitoring/test_tracing.py
@@ -10,10 +10,10 @@ from opentelemetry.util._once import Once
 
 from unique_toolkit.monitoring import (
     TraceContextMiddleware,
+    TracingSettings,
     configure_tracing,
     inject_trace_headers,
 )
-from unique_toolkit.monitoring.tracing import _resolve_exporter
 
 
 def _reset_tracer_provider() -> None:
@@ -84,7 +84,7 @@ def test_resolve_exporter__maps_node_alias__when_tracing_is_enabled(
     monkeypatch.setenv("ENABLE_OPENTELEMETRY", "true")
     monkeypatch.setenv("OTEL_SPAN_PROCESSOR", processor)
 
-    assert _resolve_exporter() == expected
+    assert TracingSettings().exporter_name == expected
 
 
 @pytest.mark.ai
@@ -101,7 +101,7 @@ def test_resolve_exporter__defaults_to_otlp__when_node_tracing_is_enabled(
     monkeypatch.setenv("ENABLE_OPENTELEMETRY", "true")
     monkeypatch.delenv("OTEL_SPAN_PROCESSOR", raising=False)
 
-    assert _resolve_exporter() == "otlp"
+    assert TracingSettings().exporter_name == "otlp"
 
 
 @pytest.mark.ai
@@ -118,7 +118,7 @@ def test_resolve_exporter__returns_none__when_node_tracing_is_disabled(
     monkeypatch.setenv("ENABLE_OPENTELEMETRY", "false")
     monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://collector:4318")
 
-    assert _resolve_exporter() is None
+    assert TracingSettings().exporter_name is None
 
 
 @pytest.mark.ai
@@ -135,7 +135,7 @@ def test_resolve_exporter__prefers_standard_exporter__over_node_aliases(
     monkeypatch.setenv("ENABLE_OPENTELEMETRY", "false")
     monkeypatch.setenv("OTEL_SPAN_PROCESSOR", "none")
 
-    assert _resolve_exporter() == "console"
+    assert TracingSettings().exporter_name == "console"
 
 
 @pytest.mark.ai
@@ -152,7 +152,7 @@ def test_resolve_exporter__uses_endpoint__when_exporter_unset(
     monkeypatch.delenv("ENABLE_OPENTELEMETRY", raising=False)
     monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://collector:4318")
 
-    assert _resolve_exporter() == "otlp"
+    assert TracingSettings().exporter_name == "otlp"
 
 
 @pytest.mark.ai
@@ -170,13 +170,13 @@ def test_resolve_exporter__treats_empty_values_as_unset(
     monkeypatch.setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "")
     monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
 
-    assert _resolve_exporter() is None
+    assert TracingSettings().exporter_name is None
 
     monkeypatch.setenv("ENABLE_OPENTELEMETRY", "true")
-    assert _resolve_exporter() == "otlp"
+    assert TracingSettings().exporter_name == "otlp"
 
     monkeypatch.setenv("ENABLE_OPENTELEMETRY", "false")
-    assert _resolve_exporter() is None
+    assert TracingSettings().exporter_name is None
 
 
 @pytest.mark.ai

--- a/unique_toolkit/tests/monitoring/test_tracing.py
+++ b/unique_toolkit/tests/monitoring/test_tracing.py
@@ -86,7 +86,7 @@ def test_resolve_exporter__maps_node_alias__when_tracing_is_enabled(
     monkeypatch.setenv("ENABLE_OPENTELEMETRY", "true")
     monkeypatch.setenv("OTEL_SPAN_PROCESSOR", processor)
 
-    assert TracingSettings().exporter_name == expected
+    assert TracingSettings().exporter == expected
 
 
 @pytest.mark.ai
@@ -103,7 +103,8 @@ def test_resolve_exporter__defaults_to_otlp__when_node_tracing_is_enabled(
     monkeypatch.setenv("ENABLE_OPENTELEMETRY", "true")
     monkeypatch.delenv("OTEL_SPAN_PROCESSOR", raising=False)
 
-    assert TracingSettings().exporter_name is TraceExporter.OTLP
+    assert TracingSettings().exporter is TraceExporter.OTLP
+    assert TracingSettings.try_load() is not None
 
 
 @pytest.mark.ai
@@ -120,7 +121,8 @@ def test_resolve_exporter__prefers_standard_endpoint__over_node_tracing_disable(
     monkeypatch.setenv("ENABLE_OPENTELEMETRY", "false")
     monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://collector:4318")
 
-    assert TracingSettings().exporter_name is TraceExporter.OTLP
+    assert TracingSettings().exporter is TraceExporter.OTLP
+    assert TracingSettings.try_load() is not None
 
 
 @pytest.mark.ai
@@ -137,7 +139,8 @@ def test_resolve_exporter__prefers_standard_exporter__over_node_aliases(
     monkeypatch.setenv("ENABLE_OPENTELEMETRY", "false")
     monkeypatch.setenv("OTEL_SPAN_PROCESSOR", "none")
 
-    assert TracingSettings().exporter_name == "console"
+    assert TracingSettings().exporter is TraceExporter.CONSOLE
+    assert TracingSettings.try_load() is not None
 
 
 @pytest.mark.ai
@@ -154,7 +157,8 @@ def test_resolve_exporter__uses_endpoint__when_exporter_unset(
     monkeypatch.delenv("ENABLE_OPENTELEMETRY", raising=False)
     monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://collector:4318")
 
-    assert TracingSettings().exporter_name == "otlp"
+    assert TracingSettings().exporter is TraceExporter.OTLP
+    assert TracingSettings.try_load() is not None
 
 
 @pytest.mark.ai
@@ -173,13 +177,14 @@ def test_resolve_exporter__treats_empty_values_as_unset(
     monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
     monkeypatch.delenv("ENABLE_OPENTELEMETRY", raising=False)
 
-    assert TracingSettings().exporter_name is None
+    assert TracingSettings.try_load() is None
 
     monkeypatch.setenv("ENABLE_OPENTELEMETRY", "true")
-    assert TracingSettings().exporter_name == "otlp"
+    assert TracingSettings().exporter is TraceExporter.OTLP
+    assert TracingSettings.try_load() is not None
 
     monkeypatch.setenv("ENABLE_OPENTELEMETRY", "false")
-    assert TracingSettings().exporter_name is None
+    assert TracingSettings.try_load() is None
 
 
 @pytest.mark.ai
@@ -199,7 +204,7 @@ def test_tracing_settings__treats_empty_service_values_as_unset(
     settings = TracingSettings()
 
     assert settings.service_name is None
-    assert settings.resolved_service_version == "node-version"
+    assert settings.service_version == "node-version"
 
 
 @pytest.mark.ai

--- a/unique_toolkit/tests/monitoring/test_tracing.py
+++ b/unique_toolkit/tests/monitoring/test_tracing.py
@@ -157,6 +157,30 @@ def test_resolve_exporter__uses_endpoint__when_exporter_unset(
 
 @pytest.mark.ai
 @pytest.mark.unit
+def test_resolve_exporter__treats_empty_values_as_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Purpose: Verify blank OpenTelemetry values do not enable or invalidate tracing.
+    Why this matters: OpenTelemetry defines empty environment variables as unset.
+    Setup summary: Set blank exporter, processor, and endpoints and assert tracing is disabled.
+    """
+    monkeypatch.setenv("OTEL_TRACES_EXPORTER", "")
+    monkeypatch.setenv("OTEL_SPAN_PROCESSOR", "")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+
+    assert _resolve_exporter() is None
+
+    monkeypatch.setenv("ENABLE_OPENTELEMETRY", "true")
+    assert _resolve_exporter() == "otlp"
+
+    monkeypatch.setenv("ENABLE_OPENTELEMETRY", "false")
+    assert _resolve_exporter() is None
+
+
+@pytest.mark.ai
+@pytest.mark.unit
 def test_configure_tracing__raises_install_hint__when_otel_extra_is_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/unique_toolkit/tests/monitoring/test_tracing.py
+++ b/unique_toolkit/tests/monitoring/test_tracing.py
@@ -1,0 +1,322 @@
+"""Tests for the optional OpenTelemetry tracing bootstrap."""
+
+import builtins
+import os
+import subprocess
+import sys
+
+import pytest
+
+from unique_toolkit.monitoring import configure_tracing
+from unique_toolkit.monitoring.tracing import _resolve_exporter
+
+
+def _run_tracing_script(script: str, environment: dict[str, str] | None = None) -> None:
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        check=False,
+        env=environment or (os.environ | {"OTEL_TRACES_EXPORTER": "console"}),
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.ai
+def test_configure_tracing__returns_false__when_exporter_is_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Purpose: Verify explicit trace disabling does not install a provider.
+    Why this matters: Prometheus-only deployments must remain free of OTel initialization.
+    Setup summary: Set the exporter to none and assert configuration reports disabled.
+    """
+    monkeypatch.setenv("OTEL_TRACES_EXPORTER", "none")
+
+    assert configure_tracing() is False
+
+
+@pytest.mark.ai
+def test_configure_tracing__returns_false__without_exporter_or_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Purpose: Verify unset tracing configuration is a no-op.
+    Why this matters: OTel must stay opt-in for existing toolkit consumers.
+    Setup summary: Clear exporter and endpoint variables and assert configuration is disabled.
+    """
+    monkeypatch.delenv("OTEL_TRACES_EXPORTER", raising=False)
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", raising=False)
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+
+    assert configure_tracing() is False
+
+
+@pytest.mark.ai
+@pytest.mark.parametrize(
+    ("processor", "expected"),
+    [
+        ("console", "console"),
+        ("none", "none"),
+    ],
+)
+def test_resolve_exporter__maps_node_alias__when_tracing_is_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+    processor: str | None,
+    expected: str,
+) -> None:
+    """
+    Purpose: Verify the Node enable flag maps its configured span processor.
+    Why this matters: Shared deployment settings must enable the intended exporter.
+    Setup summary: Enable Node-compatible tracing, vary the processor, and assert its mapping.
+    """
+    monkeypatch.delenv("OTEL_TRACES_EXPORTER", raising=False)
+    monkeypatch.setenv("ENABLE_OPENTELEMETRY", "true")
+    monkeypatch.setenv("OTEL_SPAN_PROCESSOR", processor)
+
+    assert _resolve_exporter() == expected
+
+
+@pytest.mark.ai
+def test_resolve_exporter__defaults_to_otlp__when_node_tracing_is_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Purpose: Verify enabled Node-compatible tracing defaults to OTLP.
+    Why this matters: It matches the Node service default without extra configuration.
+    Setup summary: Enable tracing without a processor value and assert the OTLP selection.
+    """
+    monkeypatch.delenv("OTEL_TRACES_EXPORTER", raising=False)
+    monkeypatch.setenv("ENABLE_OPENTELEMETRY", "true")
+    monkeypatch.delenv("OTEL_SPAN_PROCESSOR", raising=False)
+
+    assert _resolve_exporter() == "otlp"
+
+
+@pytest.mark.ai
+def test_resolve_exporter__returns_none__when_node_tracing_is_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Purpose: Verify the Node disable flag prevents endpoint-based setup.
+    Why this matters: Services must be able to opt out despite shared OTLP endpoint settings.
+    Setup summary: Disable Node-compatible tracing with an endpoint present and assert no exporter.
+    """
+    monkeypatch.delenv("OTEL_TRACES_EXPORTER", raising=False)
+    monkeypatch.setenv("ENABLE_OPENTELEMETRY", "false")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://collector:4318")
+
+    assert _resolve_exporter() is None
+
+
+@pytest.mark.ai
+def test_resolve_exporter__prefers_standard_exporter__over_node_aliases(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Purpose: Verify standard OpenTelemetry configuration overrides compatibility aliases.
+    Why this matters: Python applications need predictable standard OTel behavior.
+    Setup summary: Configure conflicting standard and Node variables and assert the standard exporter wins.
+    """
+    monkeypatch.setenv("OTEL_TRACES_EXPORTER", "console")
+    monkeypatch.setenv("ENABLE_OPENTELEMETRY", "false")
+    monkeypatch.setenv("OTEL_SPAN_PROCESSOR", "none")
+
+    assert _resolve_exporter() == "console"
+
+
+@pytest.mark.ai
+def test_configure_tracing__raises_install_hint__when_otel_extra_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Purpose: Verify enabled tracing explains how to install its optional dependencies.
+    Why this matters: An opaque module error would make production configuration difficult.
+    Setup summary: Block OpenTelemetry imports, enable console tracing, and assert the install hint.
+    """
+    original_import = builtins.__import__
+
+    def import_without_opentelemetry(
+        name, globals=None, locals=None, fromlist=(), level=0
+    ):
+        if name.startswith("opentelemetry"):
+            raise ImportError("OpenTelemetry is unavailable")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", import_without_opentelemetry)
+    monkeypatch.setenv("OTEL_TRACES_EXPORTER", "console")
+
+    with pytest.raises(ImportError, match=r"unique_toolkit\[otel\]"):
+        configure_tracing()
+
+
+@pytest.mark.ai
+def test_configure_tracing__creates_valid_span_context__with_console_exporter() -> None:
+    """
+    Purpose: Verify console configuration creates a provider that records spans.
+    Why this matters: MCP instrumentation needs a valid active context for log correlation.
+    Setup summary: Run configuration in an isolated process and assert a created span is valid.
+    """
+    script = """
+from opentelemetry import trace
+from unique_toolkit.monitoring import configure_tracing
+
+assert configure_tracing(service_name="test-service") is True
+with trace.get_tracer(__name__).start_as_current_span("test-span") as span:
+    assert span.get_span_context().is_valid
+"""
+
+    _run_tracing_script(script)
+
+
+@pytest.mark.ai
+def test_configure_tracing__uses_node_version__when_standard_version_is_unset() -> None:
+    """
+    Purpose: Verify the Node deployment version is added to the tracing resource.
+    Why this matters: Trace backends need service version parity across Node and Python services.
+    Setup summary: Configure console tracing in a child process and assert its resource uses VERSION.
+    """
+    script = """
+from opentelemetry import trace
+from unique_toolkit.monitoring import configure_tracing
+
+assert configure_tracing() is True
+assert trace.get_tracer_provider().resource.attributes["service.version"] == "node-version"
+"""
+    environment = os.environ | {
+        "OTEL_TRACES_EXPORTER": "console",
+        "VERSION": "node-version",
+    }
+    environment.pop("OTEL_SERVICE_VERSION", None)
+
+    _run_tracing_script(script, environment)
+
+
+@pytest.mark.ai
+def test_trace_context_middleware__continues_incoming_trace_context() -> None:
+    """
+    Purpose: Verify ASGI requests create a child span of the incoming trace.
+    Why this matters: MCP and Assistants Core must appear in the caller's distributed trace.
+    Setup summary: Send a traceparent through middleware in a child process and assert its trace ID.
+    """
+    script = """
+import asyncio
+
+from opentelemetry import trace
+from unique_toolkit.monitoring import TraceContextMiddleware, configure_tracing
+
+trace_id = "1234567890abcdef1234567890abcdef"
+parent_span_id = "1234567890abcdef"
+
+async def app(scope, receive, send):
+    span_context = trace.get_current_span().get_span_context()
+    assert format(span_context.trace_id, "032x") == trace_id
+    assert format(span_context.span_id, "016x") != parent_span_id
+
+async def receive():
+    return {"type": "http.request"}
+
+async def send(message):
+    return None
+
+assert configure_tracing() is True
+middleware = TraceContextMiddleware(app, span_name="test-request")
+asyncio.run(
+    middleware(
+        {
+            "type": "http",
+            "headers": [(b"traceparent", f"00-{trace_id}-{parent_span_id}-01".encode())],
+        },
+        receive,
+        send,
+    )
+)
+"""
+
+    _run_tracing_script(script)
+
+
+@pytest.mark.ai
+def test_trace_context_middleware__combines_repeated_tracestate_headers() -> None:
+    """
+    Purpose: Verify ASGI middleware preserves every incoming tracestate entry.
+    Why this matters: Dropping vendor state can change downstream trace sampling decisions.
+    Setup summary: Send repeated tracestate headers and assert the active context preserves both.
+    """
+    script = """
+import asyncio
+
+from opentelemetry import trace
+from unique_toolkit.monitoring import TraceContextMiddleware, configure_tracing
+
+async def app(scope, receive, send):
+    assert trace.get_current_span().get_span_context().trace_state.to_header() == "foo=bar,bar=baz"
+
+async def receive():
+    return {"type": "http.request"}
+
+async def send(message):
+    return None
+
+assert configure_tracing() is True
+asyncio.run(
+    TraceContextMiddleware(app)(
+        {
+            "type": "http",
+            "headers": [
+                (b"traceparent", b"00-1234567890abcdef1234567890abcdef-1234567890abcdef-01"),
+                (b"tracestate", b"foo=bar"),
+                (b"tracestate", b"bar=baz"),
+            ],
+        },
+        receive,
+        send,
+    )
+)
+"""
+
+    _run_tracing_script(script)
+
+
+@pytest.mark.ai
+def test_inject_trace_headers__adds_active_w3c_trace_context() -> None:
+    """
+    Purpose: Verify outgoing requests receive the active trace context.
+    Why this matters: Downstream Node services need a parent trace to continue correlation.
+    Setup summary: Start a span in a child process, inject headers, and assert its trace ID is present.
+    """
+    script = """
+from opentelemetry import trace
+from unique_toolkit.monitoring import configure_tracing, inject_trace_headers
+
+assert configure_tracing() is True
+with trace.get_tracer(__name__).start_as_current_span("source") as span:
+    headers = {}
+    inject_trace_headers(headers)
+    assert headers["traceparent"].split("-")[1] == format(
+        span.get_span_context().trace_id, "032x"
+    )
+"""
+
+    _run_tracing_script(script)
+
+
+@pytest.mark.ai
+def test_configure_tracing__does_not_replace_provider__when_called_twice() -> None:
+    """
+    Purpose: Verify repeated setup does not replace the global trace provider.
+    Why this matters: Process startup paths may configure tracing more than once.
+    Setup summary: Configure console tracing twice in an isolated process and assert identity remains.
+    """
+    script = """
+from opentelemetry import trace
+from unique_toolkit.monitoring import configure_tracing
+
+assert configure_tracing() is True
+provider = trace.get_tracer_provider()
+assert configure_tracing() is True
+assert trace.get_tracer_provider() is provider
+"""
+
+    _run_tracing_script(script)

--- a/unique_toolkit/unique_toolkit/monitoring/__init__.py
+++ b/unique_toolkit/unique_toolkit/monitoring/__init__.py
@@ -1,5 +1,6 @@
 from unique_toolkit.monitoring.tracing import (
     TraceContextMiddleware,
+    TraceExporter,
     TracingSettings,
     configure_tracing,
     inject_trace_headers,
@@ -7,6 +8,7 @@ from unique_toolkit.monitoring.tracing import (
 
 __all__ = [
     "TraceContextMiddleware",
+    "TraceExporter",
     "TracingSettings",
     "configure_tracing",
     "inject_trace_headers",

--- a/unique_toolkit/unique_toolkit/monitoring/__init__.py
+++ b/unique_toolkit/unique_toolkit/monitoring/__init__.py
@@ -1,10 +1,16 @@
 from unique_toolkit.monitoring.tracing import (
     TraceContextMiddleware,
+    TracingSettings,
     configure_tracing,
     inject_trace_headers,
 )
 
-__all__ = ["TraceContextMiddleware", "configure_tracing", "inject_trace_headers"]
+__all__ = [
+    "TraceContextMiddleware",
+    "TracingSettings",
+    "configure_tracing",
+    "inject_trace_headers",
+]
 
 _MONITORING_AVAILABLE = False
 try:

--- a/unique_toolkit/unique_toolkit/monitoring/__init__.py
+++ b/unique_toolkit/unique_toolkit/monitoring/__init__.py
@@ -1,3 +1,11 @@
+from unique_toolkit.monitoring.tracing import (
+    TraceContextMiddleware,
+    configure_tracing,
+    inject_trace_headers,
+)
+
+__all__ = ["TraceContextMiddleware", "configure_tracing", "inject_trace_headers"]
+
 _MONITORING_AVAILABLE = False
 try:
     from prometheus_client import (  # pyright: ignore[reportMissingImports]
@@ -27,7 +35,7 @@ if _MONITORING_AVAILABLE:
         track_execution,
     )
 
-    __all__ = [
+    __all__ += [
         "REGISTRY",
         "MetricNamespace",
         "MetricsMiddleware",

--- a/unique_toolkit/unique_toolkit/monitoring/tracing.py
+++ b/unique_toolkit/unique_toolkit/monitoring/tracing.py
@@ -1,7 +1,21 @@
 """OpenTelemetry tracing bootstrap for toolkit consumers."""
 
+from __future__ import annotations
+
 import os
-from collections.abc import MutableMapping
+from collections.abc import Awaitable, Callable, Iterable, MutableMapping
+from typing import TYPE_CHECKING, TypeAlias, cast
+
+if TYPE_CHECKING:
+    from opentelemetry.trace.propagation.tracecontext import (
+        TraceContextTextMapPropagator,
+    )
+
+ASGIScope: TypeAlias = MutableMapping[str, object]
+ASGIMessage: TypeAlias = MutableMapping[str, object]
+ASGIReceive: TypeAlias = Callable[[], Awaitable[ASGIMessage]]
+ASGISend: TypeAlias = Callable[[ASGIMessage], Awaitable[None]]
+ASGIApp: TypeAlias = Callable[[ASGIScope, ASGIReceive, ASGISend], Awaitable[None]]
 
 _OTEL_EXTRA_MESSAGE = (
     "OpenTelemetry tracing requires the unique_toolkit[otel] extra. "
@@ -12,18 +26,17 @@ _OTEL_EXTRA_MESSAGE = (
 def _resolve_exporter() -> str | None:
     """Resolve standard OTel settings with Node service compatibility aliases."""
     exporter_name = os.getenv("OTEL_TRACES_EXPORTER")
-    if exporter_name is not None:
+    if exporter_name:
         return exporter_name
 
     enabled = os.getenv("ENABLE_OPENTELEMETRY")
     if enabled == "false":
         return None
     if enabled == "true":
-        return os.getenv("OTEL_SPAN_PROCESSOR", "otlp")
+        return os.getenv("OTEL_SPAN_PROCESSOR") or "otlp"
 
-    if (
-        os.getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT") is not None
-        or os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT") is not None
+    if os.getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT") or os.getenv(
+        "OTEL_EXPORTER_OTLP_ENDPOINT"
     ):
         return "otlp"
     return None
@@ -34,7 +47,7 @@ def _missing_otel_extra() -> ImportError:
     return ImportError(_OTEL_EXTRA_MESSAGE)
 
 
-def _trace_context_propagator():
+def _trace_context_propagator() -> TraceContextTextMapPropagator:
     """Return a W3C trace-context propagator without forwarding baggage."""
     try:
         from opentelemetry.trace.propagation.tracecontext import (
@@ -48,11 +61,13 @@ def _trace_context_propagator():
 class TraceContextMiddleware:
     """ASGI middleware that continues W3C trace context with one server span."""
 
-    def __init__(self, app, span_name: str = "HTTP request"):
-        self.app = app
-        self._span_name = span_name
+    def __init__(self, app: ASGIApp, span_name: str = "HTTP request") -> None:
+        self.app: ASGIApp = app
+        self._span_name: str = span_name
 
-    async def __call__(self, scope, receive, send):
+    async def __call__(
+        self, scope: ASGIScope, receive: ASGIReceive, send: ASGISend
+    ) -> None:
         if scope["type"] != "http":
             return await self.app(scope, receive, send)
 
@@ -63,7 +78,8 @@ class TraceContextMiddleware:
             raise _missing_otel_extra() from error
 
         headers: dict[str, str] = {}
-        for name, value in scope.get("headers", []):
+        raw_headers = cast(Iterable[tuple[bytes, bytes]], scope.get("headers", ()))
+        for name, value in raw_headers:
             key = name.decode("latin-1").lower()
             if key not in {"traceparent", "tracestate"}:
                 continue
@@ -131,7 +147,7 @@ def configure_tracing(
     except ImportError as error:
         raise _missing_otel_extra() from error
 
-    attributes = {}
+    attributes: dict[str, str] = {}
     resolved_service_name = (
         service_name if service_name is not None else os.getenv("OTEL_SERVICE_NAME")
     )

--- a/unique_toolkit/unique_toolkit/monitoring/tracing.py
+++ b/unique_toolkit/unique_toolkit/monitoring/tracing.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
         TraceContextTextMapPropagator,
     )
 
+# Keep ASGI aliases local; tracing should not depend on asgiref solely for typing.
 ASGIScope: TypeAlias = MutableMapping[str, object]
 ASGIMessage: TypeAlias = MutableMapping[str, object]
 ASGIReceive: TypeAlias = Callable[[], Awaitable[ASGIMessage]]

--- a/unique_toolkit/unique_toolkit/monitoring/tracing.py
+++ b/unique_toolkit/unique_toolkit/monitoring/tracing.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable, Iterable, MutableMapping
+from enum import StrEnum
 from typing import TYPE_CHECKING, ClassVar, TypeAlias, cast
 
 from pydantic import Field
@@ -26,6 +27,14 @@ _OTEL_EXTRA_MESSAGE = (
 )
 
 
+class TraceExporter(StrEnum):
+    """Trace exporters supported by the toolkit bootstrap."""
+
+    NONE = "none"
+    CONSOLE = "console"
+    OTLP = "otlp"
+
+
 class TracingSettings(BaseSettings):
     """Environment settings for optional OpenTelemetry tracing."""
 
@@ -35,12 +44,12 @@ class TracingSettings(BaseSettings):
         extra="ignore",
     )
 
-    traces_exporter: str | None = None
+    traces_exporter: TraceExporter | None = None
     service_name: str | None = None
     service_version: str | None = None
     exporter_otlp_traces_endpoint: str | None = None
     exporter_otlp_endpoint: str | None = None
-    span_processor: str | None = None
+    span_processor: TraceExporter | None = None
     enabled: bool | None = Field(
         default=None,
         validation_alias="ENABLE_OPENTELEMETRY",
@@ -48,16 +57,16 @@ class TracingSettings(BaseSettings):
     version: str | None = Field(default=None, validation_alias="VERSION")
 
     @property
-    def exporter_name(self) -> str | None:
+    def exporter_name(self) -> TraceExporter | None:
         """Resolve standard OTel settings with Node service compatibility aliases."""
         if self.traces_exporter:
             return self.traces_exporter
         if self.enabled is False:
             return None
         if self.enabled is True:
-            return self.span_processor or "otlp"
+            return self.span_processor or TraceExporter.OTLP
         if self.exporter_otlp_traces_endpoint or self.exporter_otlp_endpoint:
-            return "otlp"
+            return TraceExporter.OTLP
         return None
 
     @property
@@ -141,13 +150,8 @@ def configure_tracing(
     settings = TracingSettings()
     exporter_name = settings.exporter_name
 
-    if exporter_name in {None, "none"}:
+    if exporter_name in {None, TraceExporter.NONE}:
         return False
-
-    if exporter_name not in {None, "console", "otlp"}:
-        raise ValueError(
-            "Unsupported trace exporter. Expected 'none', 'console', or 'otlp'."
-        )
 
     try:
         from opentelemetry import trace
@@ -187,7 +191,7 @@ def configure_tracing(
         attributes["service.version"] = resolved_service_version
 
     provider = TracerProvider(resource=Resource.create(attributes))
-    if exporter_name == "console":
+    if exporter_name == TraceExporter.CONSOLE:
         provider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter()))
     else:
         provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))

--- a/unique_toolkit/unique_toolkit/monitoring/tracing.py
+++ b/unique_toolkit/unique_toolkit/monitoring/tracing.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable, Iterable, MutableMapping
 from enum import StrEnum
-from typing import TYPE_CHECKING, ClassVar, TypeAlias, cast
+from typing import TYPE_CHECKING, ClassVar, Self, TypeAlias, cast
 
-from pydantic import Field
+from pydantic import AliasChoices, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 if TYPE_CHECKING:
@@ -46,22 +46,29 @@ class TracingSettings(BaseSettings):
 
     traces_exporter: TraceExporter | None = None
     service_name: str | None = None
-    service_version: str | None = None
-    exporter_otlp_traces_endpoint: str | None = None
-    exporter_otlp_endpoint: str | None = None
+    service_version: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("OTEL_SERVICE_VERSION", "VERSION"),
+    )
+    otlp_endpoint: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices(
+            "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+            "OTEL_EXPORTER_OTLP_ENDPOINT",
+        ),
+    )
     span_processor: TraceExporter | None = None
     enabled: bool | None = Field(
         default=None,
         validation_alias="ENABLE_OPENTELEMETRY",
     )
-    version: str | None = Field(default=None, validation_alias="VERSION")
 
     @property
-    def exporter_name(self) -> TraceExporter | None:
+    def exporter(self) -> TraceExporter | None:
         """Resolve standard OTel settings with Node service compatibility aliases."""
         if self.traces_exporter:
             return self.traces_exporter
-        if self.exporter_otlp_traces_endpoint or self.exporter_otlp_endpoint:
+        if self.otlp_endpoint:
             return TraceExporter.OTLP
         if self.enabled is False:
             return None
@@ -69,10 +76,13 @@ class TracingSettings(BaseSettings):
             return self.span_processor or TraceExporter.OTLP
         return None
 
-    @property
-    def resolved_service_version(self) -> str | None:
-        """Return the standard OTel version with the Node deployment fallback."""
-        return self.service_version or self.version
+    @classmethod
+    def try_load(cls) -> Self | None:
+        """Load env settings, or ``None`` when tracing cannot be enabled."""
+        settings = cls()
+        if settings.exporter in {None, TraceExporter.NONE}:
+            return None
+        return settings
 
 
 def _missing_otel_extra() -> ImportError:
@@ -147,22 +157,14 @@ def configure_tracing(
     tracing configuration. Prometheus metrics and application logging remain
     separate, so ``OTEL_METRICS_READER`` and ``OTEL_LOGS_PROCESSOR`` are ignored.
     """
-    settings = TracingSettings()
-    exporter_name = settings.exporter_name
-
-    if exporter_name in {None, TraceExporter.NONE}:
+    settings = TracingSettings.try_load()
+    if settings is None:
         return False
+    exporter = settings.exporter
+    assert exporter is not None  # try_load guarantees a concrete exporter
 
     try:
         from opentelemetry import trace
-        from opentelemetry.trace import ProxyTracerProvider
-    except ImportError as error:
-        raise _missing_otel_extra() from error
-
-    if not isinstance(trace.get_tracer_provider(), ProxyTracerProvider):
-        return True
-
-    try:
         from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
             OTLPSpanExporter,
         )
@@ -173,25 +175,25 @@ def configure_tracing(
             ConsoleSpanExporter,
             SimpleSpanProcessor,
         )
+        from opentelemetry.trace import ProxyTracerProvider
     except ImportError as error:
         raise _missing_otel_extra() from error
 
-    attributes: dict[str, str] = {}
-    resolved_service_name = (
-        service_name if service_name is not None else settings.service_name
+    if not isinstance(trace.get_tracer_provider(), ProxyTracerProvider):
+        return True
+
+    name = service_name if service_name is not None else settings.service_name
+    version = (
+        service_version if service_version is not None else settings.service_version
     )
-    resolved_service_version = (
-        service_version
-        if service_version is not None
-        else settings.resolved_service_version
-    )
-    if resolved_service_name is not None:
-        attributes["service.name"] = resolved_service_name
-    if resolved_service_version is not None:
-        attributes["service.version"] = resolved_service_version
+    attributes = {
+        key: value
+        for key, value in (("service.name", name), ("service.version", version))
+        if value is not None
+    }
 
     provider = TracerProvider(resource=Resource.create(attributes))
-    if exporter_name == TraceExporter.CONSOLE:
+    if exporter is TraceExporter.CONSOLE:
         provider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter()))
     else:
         provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))

--- a/unique_toolkit/unique_toolkit/monitoring/tracing.py
+++ b/unique_toolkit/unique_toolkit/monitoring/tracing.py
@@ -61,12 +61,12 @@ class TracingSettings(BaseSettings):
         """Resolve standard OTel settings with Node service compatibility aliases."""
         if self.traces_exporter:
             return self.traces_exporter
+        if self.exporter_otlp_traces_endpoint or self.exporter_otlp_endpoint:
+            return TraceExporter.OTLP
         if self.enabled is False:
             return None
         if self.enabled is True:
             return self.span_processor or TraceExporter.OTLP
-        if self.exporter_otlp_traces_endpoint or self.exporter_otlp_endpoint:
-            return TraceExporter.OTLP
         return None
 
     @property

--- a/unique_toolkit/unique_toolkit/monitoring/tracing.py
+++ b/unique_toolkit/unique_toolkit/monitoring/tracing.py
@@ -1,0 +1,154 @@
+"""OpenTelemetry tracing bootstrap for toolkit consumers."""
+
+import os
+from collections.abc import MutableMapping
+
+_OTEL_EXTRA_MESSAGE = (
+    "OpenTelemetry tracing requires the unique_toolkit[otel] extra. "
+    "Install it with: uv add 'unique-toolkit[otel]'"
+)
+
+
+def _resolve_exporter() -> str | None:
+    """Resolve standard OTel settings with Node service compatibility aliases."""
+    exporter_name = os.getenv("OTEL_TRACES_EXPORTER")
+    if exporter_name is not None:
+        return exporter_name
+
+    enabled = os.getenv("ENABLE_OPENTELEMETRY")
+    if enabled == "false":
+        return None
+    if enabled == "true":
+        return os.getenv("OTEL_SPAN_PROCESSOR", "otlp")
+
+    if (
+        os.getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT") is not None
+        or os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT") is not None
+    ):
+        return "otlp"
+    return None
+
+
+def _missing_otel_extra() -> ImportError:
+    """Create a consistent error for an unavailable optional tracing dependency."""
+    return ImportError(_OTEL_EXTRA_MESSAGE)
+
+
+def _trace_context_propagator():
+    """Return a W3C trace-context propagator without forwarding baggage."""
+    try:
+        from opentelemetry.trace.propagation.tracecontext import (
+            TraceContextTextMapPropagator,
+        )
+    except ImportError as error:
+        raise _missing_otel_extra() from error
+    return TraceContextTextMapPropagator()
+
+
+class TraceContextMiddleware:
+    """ASGI middleware that continues W3C trace context with one server span."""
+
+    def __init__(self, app, span_name: str = "HTTP request"):
+        self.app = app
+        self._span_name = span_name
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            return await self.app(scope, receive, send)
+
+        try:
+            from opentelemetry import trace
+            from opentelemetry.trace import SpanKind
+        except ImportError as error:
+            raise _missing_otel_extra() from error
+
+        headers: dict[str, str] = {}
+        for name, value in scope.get("headers", []):
+            key = name.decode("latin-1").lower()
+            if key not in {"traceparent", "tracestate"}:
+                continue
+            header_value = value.decode("latin-1")
+            if key == "tracestate" and key in headers:
+                headers[key] = f"{headers[key]},{header_value}"
+            elif key not in headers:
+                headers[key] = header_value
+        parent_context = _trace_context_propagator().extract(headers)
+        with trace.get_tracer(__name__).start_as_current_span(
+            self._span_name,
+            context=parent_context,
+            kind=SpanKind.SERVER,
+        ):
+            return await self.app(scope, receive, send)
+
+
+def inject_trace_headers(headers: MutableMapping[str, str]) -> None:
+    """Inject the active W3C trace context into outgoing request headers."""
+    _trace_context_propagator().inject(headers)
+
+
+def configure_tracing(
+    *,
+    service_name: str | None = None,
+    service_version: str | None = None,
+) -> bool:
+    """Install an OpenTelemetry trace provider from standard and Node-compatible env.
+
+    ``OTEL_TRACES_EXPORTER`` takes precedence. When it is unset,
+    ``ENABLE_OPENTELEMETRY`` and ``OTEL_SPAN_PROCESSOR`` mirror the Node service
+    tracing configuration. Prometheus metrics and application logging remain
+    separate, so ``OTEL_METRICS_READER`` and ``OTEL_LOGS_PROCESSOR`` are ignored.
+    """
+    exporter_name = _resolve_exporter()
+
+    if exporter_name in {None, "none"}:
+        return False
+
+    if exporter_name not in {None, "console", "otlp"}:
+        raise ValueError(
+            "Unsupported trace exporter. Expected 'none', 'console', or 'otlp'."
+        )
+
+    try:
+        from opentelemetry import trace
+        from opentelemetry.trace import ProxyTracerProvider
+    except ImportError as error:
+        raise _missing_otel_extra() from error
+
+    if not isinstance(trace.get_tracer_provider(), ProxyTracerProvider):
+        return True
+
+    try:
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+            OTLPSpanExporter,
+        )
+        from opentelemetry.sdk.resources import Resource
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import (
+            BatchSpanProcessor,
+            ConsoleSpanExporter,
+            SimpleSpanProcessor,
+        )
+    except ImportError as error:
+        raise _missing_otel_extra() from error
+
+    attributes = {}
+    resolved_service_name = (
+        service_name if service_name is not None else os.getenv("OTEL_SERVICE_NAME")
+    )
+    resolved_service_version = (
+        service_version
+        if service_version is not None
+        else os.getenv("OTEL_SERVICE_VERSION", os.getenv("VERSION"))
+    )
+    if resolved_service_name is not None:
+        attributes["service.name"] = resolved_service_name
+    if resolved_service_version is not None:
+        attributes["service.version"] = resolved_service_version
+
+    provider = TracerProvider(resource=Resource.create(attributes))
+    if exporter_name == "console":
+        provider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter()))
+    else:
+        provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+    trace.set_tracer_provider(provider)
+    return True

--- a/unique_toolkit/unique_toolkit/monitoring/tracing.py
+++ b/unique_toolkit/unique_toolkit/monitoring/tracing.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
-import os
 from collections.abc import Awaitable, Callable, Iterable, MutableMapping
-from typing import TYPE_CHECKING, TypeAlias, cast
+from typing import TYPE_CHECKING, ClassVar, TypeAlias, cast
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 if TYPE_CHECKING:
     from opentelemetry.trace.propagation.tracecontext import (
@@ -24,23 +26,44 @@ _OTEL_EXTRA_MESSAGE = (
 )
 
 
-def _resolve_exporter() -> str | None:
-    """Resolve standard OTel settings with Node service compatibility aliases."""
-    exporter_name = os.getenv("OTEL_TRACES_EXPORTER")
-    if exporter_name:
-        return exporter_name
+class TracingSettings(BaseSettings):
+    """Environment settings for optional OpenTelemetry tracing."""
 
-    enabled = os.getenv("ENABLE_OPENTELEMETRY")
-    if enabled == "false":
+    model_config: ClassVar[SettingsConfigDict] = SettingsConfigDict(
+        env_prefix="OTEL_",
+        env_ignore_empty=True,
+        extra="ignore",
+    )
+
+    traces_exporter: str | None = None
+    service_name: str | None = None
+    service_version: str | None = None
+    exporter_otlp_traces_endpoint: str | None = None
+    exporter_otlp_endpoint: str | None = None
+    span_processor: str | None = None
+    enabled: bool | None = Field(
+        default=None,
+        validation_alias="ENABLE_OPENTELEMETRY",
+    )
+    version: str | None = Field(default=None, validation_alias="VERSION")
+
+    @property
+    def exporter_name(self) -> str | None:
+        """Resolve standard OTel settings with Node service compatibility aliases."""
+        if self.traces_exporter:
+            return self.traces_exporter
+        if self.enabled is False:
+            return None
+        if self.enabled is True:
+            return self.span_processor or "otlp"
+        if self.exporter_otlp_traces_endpoint or self.exporter_otlp_endpoint:
+            return "otlp"
         return None
-    if enabled == "true":
-        return os.getenv("OTEL_SPAN_PROCESSOR") or "otlp"
 
-    if os.getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT") or os.getenv(
-        "OTEL_EXPORTER_OTLP_ENDPOINT"
-    ):
-        return "otlp"
-    return None
+    @property
+    def resolved_service_version(self) -> str | None:
+        """Return the standard OTel version with the Node deployment fallback."""
+        return self.service_version or self.version
 
 
 def _missing_otel_extra() -> ImportError:
@@ -115,7 +138,8 @@ def configure_tracing(
     tracing configuration. Prometheus metrics and application logging remain
     separate, so ``OTEL_METRICS_READER`` and ``OTEL_LOGS_PROCESSOR`` are ignored.
     """
-    exporter_name = _resolve_exporter()
+    settings = TracingSettings()
+    exporter_name = settings.exporter_name
 
     if exporter_name in {None, "none"}:
         return False
@@ -150,12 +174,12 @@ def configure_tracing(
 
     attributes: dict[str, str] = {}
     resolved_service_name = (
-        service_name if service_name is not None else os.getenv("OTEL_SERVICE_NAME")
+        service_name if service_name is not None else settings.service_name
     )
     resolved_service_version = (
         service_version
         if service_version is not None
-        else os.getenv("OTEL_SERVICE_VERSION", os.getenv("VERSION"))
+        else settings.resolved_service_version
     )
     if resolved_service_name is not None:
         attributes["service.name"] = resolved_service_name

--- a/uv.lock
+++ b/uv.lock
@@ -3227,14 +3227,83 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-api"
-version = "1.42.1"
+version = "1.44.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b4/1c/125e1c936c0873796771b7f04f6c93b9f1bf5d424cea90fda94a99f61da8/opentelemetry_api-1.42.1.tar.gz", hash = "sha256:56c63bea9f77b62856be8c47600474acad853b2924b99b1687c4cb6297166716", size = 72296, upload-time = "2026-05-21T16:32:49.335Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/ca/9520cc1f3dfbbd03ac5903bbf55833e257bc64b1cf30fa8b0d6df374d821/opentelemetry_api-1.42.1-py3-none-any.whl", hash = "sha256:51a69edacadbc03a8950ace1c4c21099cacc538820ac2c9e36277e78cebba714", size = 61311, upload-time = "2026-05-21T16:32:28.822Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/09/4d717852c1cf3f854b76c7110a5d00883bc3c99288b9b0dbcbeb9e306eb6/opentelemetry_exporter_otlp_proto_common-1.44.0.tar.gz", hash = "sha256:dc87a5a5bc58f149a56d1547e4691588fa12994cdc3bc039a694ccb3375862ac", size = 20202, upload-time = "2026-07-16T15:25:37.658Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/71/65fd9d54c10b860f87c045ccee1264cab7011268895d3528818a29c1172a/opentelemetry_exporter_otlp_proto_common-1.44.0-py3-none-any.whl", hash = "sha256:9a9fe61bba73d802904bc989f1d6b4a7b1ee40f06c40e98d6f85af65aaebb694", size = 17045, upload-time = "2026-07-16T15:25:18.201Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/87/95e2a5aaa795b4e2260d74e16df2d5541deb2ea9de010bcd615f4dee2654/opentelemetry_exporter_otlp_proto_http-1.44.0.tar.gz", hash = "sha256:c633d7270ad6b57cd4cfbe8b0007a9e2e7c0cb50bd6c50fe2a7b245f721a09d8", size = 25806, upload-time = "2026-07-16T15:25:39.162Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/d0/fdeb1a98d8d3a6205f5f297c51b4a9bfe65126ab60339669bbe3dd54c2e2/opentelemetry_exporter_otlp_proto_http-1.44.0-py3-none-any.whl", hash = "sha256:838592fce774c1c8bb7b9a0a7facbfa82e17be5a8a4e94cef10cb84ae026bae3", size = 21850, upload-time = "2026-07-16T15:25:20.006Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/01/40ac4ae9a149263cc52c2cee200ddd80cb6d8db1a4610abf8eabce0fe771/opentelemetry_proto-1.44.0.tar.gz", hash = "sha256:c547a79c2f8c0c515d31509154682e5921c7cfd5ca67b70e1f9266e2c3e103f3", size = 46488, upload-time = "2026-07-16T15:25:45.34Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/7c/8be563d68e93bbefa5c8affb82ddcff91b3ad858ce49957ba7b16fd3e0ab/opentelemetry_proto-1.44.0-py3-none-any.whl", hash = "sha256:898b155a0e1557afd867478fb6158e8122a46329ca0bb8dc53cc55e98f017f56", size = 72483, upload-time = "2026-07-16T15:25:28.429Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/77/a6592cbc7c8d9bcc9d6757a9df45e04a7c585e3e6e7a13456da522b21109/opentelemetry_sdk-1.44.0.tar.gz", hash = "sha256:cebe7f65dc12f26ead75c6064de12fd2a9052e5060c0272d402cfa203aae123b", size = 208624, upload-time = "2026-07-16T15:25:46.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/23/ff077e61886ee020a17ce9c8b6fa11c601c8d8345b09ea24f605445df62a/opentelemetry_sdk-1.44.0-py3-none-any.whl", hash = "sha256:df081c4c6bcfdb1211e3e86140376792643128a25f8d72d1d27675936e7e96ad", size = 137221, upload-time = "2026-07-16T15:25:29.534Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/73/0cbdebcb4cf545fdd328da14f5137e37d0770c3f26185e478b0d15d94f50/opentelemetry_semantic_conventions-0.65b0.tar.gz", hash = "sha256:f9b2b81e9d5b64f11bc952075e7e9c7fb0aab075c7fd1c46d597f1b919852d60", size = 148774, upload-time = "2026-07-16T15:25:46.902Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/0e/49df70d9b81fb5cbae4bbf2a49d865b09bcbcbc4eb53f5851b1027738d78/opentelemetry_semantic_conventions-0.65b0-py3-none-any.whl", hash = "sha256:1cacde7b0ad306f84c5ef08c3dbe1bbaf20165bba6f8bff43b670e555a086bcb", size = 204645, upload-time = "2026-07-16T15:25:30.688Z" },
 ]
 
 [[package]]
@@ -5617,9 +5686,15 @@ langchain = [
 monitoring = [
     { name = "prometheus-client" },
 ]
+otel = [
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-sdk" },
+]
 
 [package.dev-dependencies]
 dev = [
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-sdk" },
     { name = "types-cachetools" },
 ]
 
@@ -5641,6 +5716,8 @@ requires-dist = [
     { name = "numpy", specifier = ">=2.4.2,<3" },
     { name = "openai", specifier = ">=1.105.0,<3" },
     { name = "openai", marker = "extra == 'langchain'", specifier = ">=1.105.0,<3" },
+    { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'otel'", specifier = ">=1.27,<2" },
+    { name = "opentelemetry-sdk", marker = "extra == 'otel'", specifier = ">=1.27,<2" },
     { name = "pandas", specifier = ">=2.3.0,<3" },
     { name = "pillow", specifier = ">=12.1.1" },
     { name = "platformdirs", specifier = ">=4.0.0,<5" },
@@ -5663,10 +5740,14 @@ requires-dist = [
     { name = "unique-sdk", editable = "unique_sdk" },
     { name = "uvicorn", marker = "extra == 'fastapi'", specifier = ">=0.37.0,<0.38" },
 ]
-provides-extras = ["langchain", "fastapi", "monitoring"]
+provides-extras = ["langchain", "fastapi", "monitoring", "otel"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "types-cachetools", specifier = ">=5.0,<6" }]
+dev = [
+    { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.27,<2" },
+    { name = "opentelemetry-sdk", specifier = ">=1.27,<2" },
+    { name = "types-cachetools", specifier = ">=5.0,<6" },
+]
 
 [[package]]
 name = "unique-user-memory"


### PR DESCRIPTION
## Summary
- add an opt-in OpenTelemetry SDK bootstrap with OTLP HTTP and console exporters
- support Node-compatible tracing environment aliases and W3C trace propagation helpers
- keep Prometheus metrics and logging independent from tracing

## Test plan
- [x] `uv run --no-sync pytest tests/monitoring/test_tracing.py -q`
- [x] `ruff format --check` and `ruff check` for tracing files
- [x] `basedpyright unique_toolkit/monitoring/tracing.py`
- [x] `deptry .`

## Risk / rollout
- Tracing remains opt-in; existing services do not install a provider unless configured.
- HTTP propagation is explicit through the ASGI middleware and outgoing header helper.