### PR TITLE
chore(search-proxy): move image to trixie and declare the runtime uid

### DIFF
--- a/connectors/unique_search_proxy/unique_search_proxy_client/deploy/Dockerfile
+++ b/connectors/unique_search_proxy/unique_search_proxy_client/deploy/Dockerfile
@@ -9,7 +9,7 @@
 FROM ghcr.io/astral-sh/uv:0.11.33@sha256:77280f2f771df71f90786c314fe1bbc1e023feac652969bbf139c280babf2eb7 AS uv
 
 # ── Stage 1: install deps into an isolated venv ───────────────────────────────
-FROM python:3.12-slim-bookworm@sha256:31c0807da611e2e377a2e9b566ad4eb038ac5a5838cbbbe6f2262259b5dc77a0 AS builder
+FROM python:3.12-slim-trixie@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de AS builder
 
 COPY --from=uv /uv /usr/bin/uv
 
@@ -24,7 +24,7 @@ COPY . .
 RUN uv sync --frozen --package unique-search-proxy --no-dev --no-editable
 
 # ── Stage 2: lean runtime image ───────────────────────────────────────────────
-FROM python:3.12-slim-bookworm@sha256:31c0807da611e2e377a2e9b566ad4eb038ac5a5838cbbbe6f2262259b5dc77a0
+FROM python:3.12-slim-trixie@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
 
 ENV PYTHONFAULTHANDLER=1 \
     PYTHONUNBUFFERED=1 \
@@ -32,7 +32,8 @@ ENV PYTHONFAULTHANDLER=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     PATH="/app/.venv/bin:$PATH"
 
-RUN useradd -m appuser
+# uid 1000 is what the Helm chart pins as runAsUser
+RUN useradd -m -u 1000 appuser
 
 WORKDIR /app
 


### PR DESCRIPTION
- `python:3.12-slim-bookworm` becomes `python:3.12-slim-trixie`, digest identical to the one `docker-base/python/3.12` pins. bookworm is retired for new images, and the whole org standardises on trixie so there is one patch stream instead of two.
- The runtime uid is now declared: `useradd -m -u 1000 appuser`. The Helm chart pins `runAsUser: 1000` pod and container side, while the image relied on 1000 being the next free uid in the base image. Same result today, verified against the upstream `python:3.12-slim-trixie` Dockerfile which creates no user at 1000, but it was an undeclared dependency on someone else's user table.