### PR TITLE
ci(containerize): sign images and attach provenance and SBOM

### DIFF
--- a/.github/workflows/cd-containerize-batch.yaml
+++ b/.github/workflows/cd-containerize-batch.yaml
@@ -37,6 +37,7 @@ on:
 permissions:
   contents: read
   packages: write
+  id-token: write # forwarded to cd-containerize.yaml for keyless cosign signing
 
 jobs:
   prepare:

--- a/.github/workflows/cd-containerize.yaml
+++ b/.github/workflows/cd-containerize.yaml
@@ -36,7 +36,9 @@ on:
         default: ''
 
 permissions:
+  contents: read
   packages: write
+  id-token: write # keyless cosign signing
 
 jobs:
   containerize:
@@ -69,6 +71,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push container
+        id: build-and-push
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           cache-from: type=registry,ref=${{ inputs.image_repo }}:cache
@@ -77,6 +80,30 @@ jobs:
           file: ${{ inputs.package_dir }}/deploy/Dockerfile
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64
-          provenance: false
+          # Full provenance and an SBOM are attached to the image. Customers pull
+          # these images directly, so they need to be able to see how it was built
+          # and what is in it without us shipping a separate document.
+          provenance: mode=max
+          sbom: true
           push: true
           tags: ${{ steps.meta.outputs.tags }}
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      # Sign the digest, not the tags. Verification pins the workflow identity, so a
+      # signature can only come from this workflow on main or on a release tag.
+      - name: Sign and verify the image with the GitHub OIDC token
+        env:
+          DIGEST: ${{ steps.build-and-push.outputs.digest }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          set -euo pipefail
+          images=""
+          for tag in ${TAGS}; do
+            images+="${tag}@${DIGEST} "
+          done
+          cosign sign --yes ${images}
+          cosign verify ${images} \
+            --certificate-identity-regexp="^https://github.com/${{ github.repository }}/\.github/workflows/.*@refs/(heads/main|tags/.*)$" \
+            --certificate-oidc-issuer=https://token.actions.githubusercontent.com

--- a/.github/workflows/cd-publish-dev.yaml
+++ b/.github/workflows/cd-publish-dev.yaml
@@ -333,6 +333,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write # keyless cosign signing in cd-containerize.yaml
     uses: ./.github/workflows/cd-containerize-batch.yaml
     secrets: inherit
     with:

--- a/.github/workflows/cd-publish-rc.yaml
+++ b/.github/workflows/cd-publish-rc.yaml
@@ -320,6 +320,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write # keyless cosign signing in cd-containerize.yaml
     uses: ./.github/workflows/cd-containerize-batch.yaml
     secrets: inherit
     with:

--- a/.github/workflows/cd-publish.yaml
+++ b/.github/workflows/cd-publish.yaml
@@ -124,6 +124,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write # keyless cosign signing in cd-containerize.yaml
     uses: ./.github/workflows/cd-containerize-batch.yaml
     secrets: inherit
     with:


### PR DESCRIPTION
The search proxy image is public on ghcr and runs at customers, but it shipped with `provenance: false`, no SBOM and no signature. Nothing downstream can tell whether an image with our name on it came from this pipeline.

- provenance mode=max and sbom true on the build
- cosign keyless sign of the digest, then verify in the same job, so a broken signing setup fails the release instead of shipping unsigned
- id-token: write added along the whole call chain, cd-publish, cd-publish-dev, cd-publish-rc, cd-containerize-batch, cd-containerize. A reusable workflow only gets what the calling job grants.

The verify identity accepts this repository's workflows on refs/heads/main and on refs/tags/*, because dev and rc publishes run from main while stable publishes run from a release tag. Worth watching the first stable release run.