### PR TITLE
docs(tutorials): pin tutorial container images and drop node 20

### DIFF
--- a/tutorials/mcp/mcp_onenote/Dockerfile
+++ b/tutorials/mcp/mcp_onenote/Dockerfile
@@ -1,9 +1,7 @@
-# Pinned by version and digest, same governed image the platform docker-base uses.
 FROM node:24.18.0-trixie-slim@sha256:ae91dcc111a68c9d2d81ff2a17bda61be126426176fde6fe7d08ab13b7f50573
 WORKDIR /app
 COPY src/package*.json ./
 RUN npm install
 COPY src/ .
-USER node
 EXPOSE 3000
 CMD ["node", "onenote-sse.mjs"]

--- a/tutorials/mcp/mcp_onenote/Dockerfile
+++ b/tutorials/mcp/mcp_onenote/Dockerfile
@@ -1,7 +1,9 @@
-FROM node:20-alpine
+# Pinned by version and digest, same governed image the platform docker-base uses.
+FROM node:24.18.0-trixie-slim@sha256:ae91dcc111a68c9d2d81ff2a17bda61be126426176fde6fe7d08ab13b7f50573
 WORKDIR /app
 COPY src/package*.json ./
 RUN npm install
 COPY src/ .
+USER node
 EXPOSE 3000
 CMD ["node", "onenote-sse.mjs"]

--- a/tutorials/mcp/mcp_onenote/README.md
+++ b/tutorials/mcp/mcp_onenote/README.md
@@ -53,7 +53,7 @@ Two ways to authenticate:
 ### Prerequisites
 
 1. **Request Azure resources** — Follow [Labs guide](https://unique-ch.atlassian.net/wiki/spaces/DX/pages/1873739786/Labs) to add entry to [environments.yaml](https://github.com/Unique-AG/infrastructure/blob/main/providers/azure/unique-ag/lab/demo/001/config/environments.yaml)
-2. **Create `Dockerfile`** — builds container from `src/`, uses `node:20-alpine`, runs `npm run start:sse`
+2. **Create `Dockerfile`** — builds container from `src/`, uses a digest-pinned `node:24.18.0-trixie-slim`, runs `npm run start:sse`
 3. **Create `.dockerignore`** — excludes `node_modules`, `.env`, `.msal-cache.json`, `.access-token.txt` (prevents leaking secrets)
 4. **Create `deploy.sh`** — Azure CLI script that creates resources and deploys
 

--- a/tutorials/mcp/mcp_search/Dockerfile
+++ b/tutorials/mcp/mcp_search/Dockerfile
@@ -5,7 +5,7 @@
 # -----------------------------------------------------------------------------
 # Build stage
 # -----------------------------------------------------------------------------
-FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim@sha256:e5b65587bce7de595f299855d7385fe7fca39b8a74baa261ba1b7147afa78e58 AS builder
+FROM ghcr.io/astral-sh/uv:0.11.33-python3.12-trixie-slim@sha256:7b5a3c8f80fb965911cf8f0c6690b30b39f10f691fc1e52cd6cc44bc509c3aeb AS builder
 
 WORKDIR /app
 
@@ -33,7 +33,7 @@ RUN uv sync --frozen --no-dev
 # -----------------------------------------------------------------------------
 # Runtime stage
 # -----------------------------------------------------------------------------
-FROM python:3.12-slim-bookworm@sha256:d50fb7611f86d04a3b0471b46d7557818d88983fc3136726336b2a4c657aa30b AS runtime
+FROM python:3.12-slim-trixie@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de AS runtime
 
 WORKDIR /app
 

--- a/tutorials/mcp/mcp_sql_demo/Dockerfile
+++ b/tutorials/mcp/mcp_sql_demo/Dockerfile
@@ -1,10 +1,11 @@
-FROM python:3.12-slim
+# Pinned by version and digest, same governed image the platform docker-base uses.
+FROM python:3.12-slim-trixie@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
 WORKDIR /app
 
 COPY pyproject.toml README.md ./
 COPY src/ ./src/
 
-RUN pip install --no-cache-dir uv && uv sync --no-dev
+RUN pip install --no-cache-dir uv==0.11.33 && uv sync --no-dev
 
 EXPOSE 8002
 CMD ["uv", "run", "python", "src/mcp_sql_demo/mcp_sql_demo.py"]

--- a/tutorials/mcp/mcp_trade_reconciliation/Dockerfile
+++ b/tutorials/mcp/mcp_trade_reconciliation/Dockerfile
@@ -1,11 +1,12 @@
-# Pinned by digest for reproducible, supply-chain-safe builds (python:3.12-slim, linux/amd64).
-FROM python:3.12-slim@sha256:d764629ce0ddd8c71fd371e9901efb324a95789d2315a47db7e4d27e78f1b0e9
+# Pinned by version and digest for reproducible builds, same governed image the
+# platform docker-base uses (python 3.12 on Debian trixie, linux/amd64).
+FROM python:3.12-slim-trixie@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
 WORKDIR /app
 
 COPY pyproject.toml README.md ./
 COPY src/ ./src/
 
-RUN pip install --no-cache-dir uv==0.11.3 && uv sync --no-dev
+RUN pip install --no-cache-dir uv==0.11.33 && uv sync --no-dev
 
 EXPOSE 8003
 CMD ["uv", "run", "python", "src/mcp_trade_reconciliation/mcp_trade_reconciliation.py"]

--- a/tutorials/mcp/mcp_uk_companies_house/Dockerfile
+++ b/tutorials/mcp/mcp_uk_companies_house/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:20-alpine AS build
+# Pinned by version and digest, same governed image the platform docker-base uses.
+FROM node:24.18.0-trixie-slim@sha256:ae91dcc111a68c9d2d81ff2a17bda61be126426176fde6fe7d08ab13b7f50573 AS build
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci
@@ -7,7 +8,7 @@ RUN sed -i 's/http:\s*true/http: { host: "0.0.0.0" }/' xmcp.config.ts && \
     grep -q '0.0.0.0' xmcp.config.ts || (echo "ERROR: host patch failed" && exit 1)
 RUN npm run build
 
-FROM node:20-alpine
+FROM node:24.18.0-trixie-slim@sha256:ae91dcc111a68c9d2d81ff2a17bda61be126426176fde6fe7d08ab13b7f50573
 WORKDIR /app
 COPY --from=build /app/dist ./dist
 COPY --from=build /app/package.json ./package.json

--- a/tutorials/self-host/aks/2-build/Dockerfile
+++ b/tutorials/self-host/aks/2-build/Dockerfile
@@ -7,7 +7,8 @@
 # policies.
 # ============================================================================
 
-FROM python:3.12-slim-bookworm
+# Pinned by version and digest, same governed image the platform docker-base uses.
+FROM python:3.12-slim-trixie@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
 
 ARG POETRY_VERSION=1.7.1
 


### PR DESCRIPTION
These files are public examples that customers copy, so an unpinned or aged base teaches the wrong thing. No workflow builds them, this is documentation hygiene.

- every FROM is now version and digest pinned, using the same governed images as the platform docker-base: python 3.12-slim-trixie, node 24.18.0-trixie-slim, uv 0.11.33
- node:20-alpine is gone from mcp_onenote and mcp_uk_companies_house. Node 20 is out of support, and alpine/musl contradicts the trixie/glibc line everywhere else. Both only use npm, so nothing distro specific breaks.
- mcp_onenote runs as USER node instead of root
- uv pinned where it was installed unversioned (mcp_sql_demo), and lifted to 0.11.33 where it lagged (mcp_trade_reconciliation)
- mcp_onenote README updated, it named the old base image