### PR TITLE
fix(agentic-table): wait_for_artifacts must not pin on stale duplicate artifact records [UN-23742]

### DIFF
--- a/unique_toolkit/tests/agentic_table/test_service_lifecycle.py
+++ b/unique_toolkit/tests/agentic_table/test_service_lifecycle.py
@@ -118,7 +118,10 @@ class TestImportQuestionsAndSources:
 
 class TestGenerateArtifacts:
     async def test_triggers_generation(self, service):
-        with _patch("generate_artifact", return_value={"status": True}) as mock:
+        with (
+            _patch("generate_artifact", return_value={"status": True}) as mock,
+            _patch("list_artifacts", return_value=[]),
+        ):
             await service.generate_artifacts([MagicTableArtifactType.FULL_REPORT])
 
         mock.assert_awaited_once_with(
@@ -129,9 +132,21 @@ class TestGenerateArtifacts:
         )
 
     async def test_raises_on_failure_status(self, service):
-        with _patch("generate_artifact", return_value={"status": False}):
+        with (
+            _patch("generate_artifact", return_value={"status": False}),
+            _patch("list_artifacts", return_value=[]),
+        ):
             with pytest.raises(Exception, match="Failed to trigger"):
                 await service.generate_artifacts([MagicTableArtifactType.QUESTIONS])
+
+    async def test_failed_trigger_does_not_arm_the_baseline(self, service):
+        with (
+            _patch("generate_artifact", return_value={"status": False}),
+            _patch("list_artifacts", return_value=[]),
+        ):
+            with pytest.raises(Exception, match="Failed to trigger"):
+                await service.generate_artifacts([MagicTableArtifactType.QUESTIONS])
+        assert service._artifact_baseline is None
 
 
 class TestRerunRow:
@@ -448,3 +463,103 @@ class TestWaitForArtifacts:
                 await service.wait_for_artifacts(
                     [MagicTableArtifactType.FULL_REPORT], timeout=0, poll_interval=0
                 )
+
+
+class TestWaitForArtifactsWithBaseline:
+    """generate_artifacts + wait_for_artifacts on the same instance: the wait
+    is fenced by the pre-trigger snapshot instead of the IN_PROGRESS heuristic."""
+
+    _artifact = staticmethod(TestWaitForArtifacts._artifact)
+
+    @staticmethod
+    def _stale_pair():
+        # A completed earlier export: the durable nameless IN_PROGRESS marker
+        # plus the DONE report it produced.
+        return [
+            TestWaitForArtifactsWithBaseline._artifact(
+                "FULL_REPORT",
+                "DONE",
+                "artifact_old_done",
+                updated_at="2026-01-01T00:01:02.000Z",
+            ),
+            TestWaitForArtifactsWithBaseline._artifact(
+                "FULL_REPORT",
+                "IN_PROGRESS",
+                "artifact_old_marker",
+                updated_at="2026-01-01T00:01:00.000Z",
+            ),
+        ]
+
+    async def _generate_and_wait(self, service, list_responses, timeout=10):
+        with (
+            _patch("generate_artifact", return_value={"status": True}),
+            _patch("list_artifacts", side_effect=list_responses),
+        ):
+            await service.generate_artifacts([MagicTableArtifactType.FULL_REPORT])
+            return await service.wait_for_artifacts(
+                [MagicTableArtifactType.FULL_REPORT], timeout=timeout, poll_interval=0
+            )
+
+    async def test_leftovers_from_earlier_generation_are_fenced_out(self, service):
+        stale = self._stale_pair()
+        new_done = self._artifact(
+            "FULL_REPORT",
+            "DONE",
+            "artifact_new_done",
+            updated_at="2026-01-01T00:02:05.000Z",
+        )
+        artifacts = await self._generate_and_wait(
+            service,
+            [
+                stale,  # snapshot taken by generate_artifacts
+                stale,  # first poll: only leftovers -> keep waiting
+                [new_done, *stale],
+            ],
+        )
+        assert artifacts[0].id == "artifact_new_done"
+
+    async def test_stale_marker_does_not_open_the_gate(self, service):
+        # Bugbot scenario: the durable IN_PROGRESS marker of an earlier export
+        # must not let the wait return that export's DONE record.
+        stale = self._stale_pair()
+        with pytest.raises(AgenticTableRunTimeoutError):
+            await self._generate_and_wait(service, [stale, stale, stale], timeout=0)
+
+    async def test_accepts_export_finishing_before_first_poll(self, service):
+        # No IN_PROGRESS phase is ever observed; freshness alone accepts it.
+        new_done = self._artifact(
+            "FULL_REPORT",
+            "DONE",
+            "artifact_new_done",
+            updated_at="2026-01-01T00:02:05.000Z",
+        )
+        artifacts = await self._generate_and_wait(service, [[], [new_done]])
+        assert artifacts[0].id == "artifact_new_done"
+
+    async def test_accepts_record_refreshed_in_place(self, service):
+        before = self._artifact(
+            "FULL_REPORT",
+            "DONE",
+            "artifact_reused",
+            updated_at="2026-01-01T00:01:02.000Z",
+        )
+        after = self._artifact(
+            "FULL_REPORT",
+            "DONE",
+            "artifact_reused",
+            updated_at="2026-01-01T00:02:05.000Z",
+        )
+        artifacts = await self._generate_and_wait(service, [[before], [after]])
+        assert artifacts[0].id == "artifact_reused"
+        assert artifacts[0].updated_at == "2026-01-01T00:02:05.000Z"
+
+    async def test_raises_on_fresh_error_record(self, service):
+        stale = self._stale_pair()
+        new_error = self._artifact(
+            "FULL_REPORT",
+            "ERROR",
+            "artifact_new_error",
+            updated_at="2026-01-01T00:02:05.000Z",
+        )
+        with pytest.raises(AgenticTableArtifactError):
+            await self._generate_and_wait(service, [stale, [new_error, *stale]])

--- a/unique_toolkit/tests/agentic_table/test_service_lifecycle.py
+++ b/unique_toolkit/tests/agentic_table/test_service_lifecycle.py
@@ -146,7 +146,7 @@ class TestGenerateArtifacts:
         ):
             with pytest.raises(Exception, match="Failed to trigger"):
                 await service.generate_artifacts([MagicTableArtifactType.QUESTIONS])
-        assert service._artifact_baseline is None
+        assert service._artifact_baselines == {}
 
 
 class TestRerunRow:
@@ -563,3 +563,42 @@ class TestWaitForArtifactsWithBaseline:
         )
         with pytest.raises(AgenticTableArtifactError):
             await self._generate_and_wait(service, [stale, [new_error, *stale]])
+
+    async def test_later_trigger_for_other_type_keeps_earlier_fence(self, service):
+        # A FULL_REPORT export completes, then QUESTIONS is triggered: the second
+        # snapshot must not fence out the already-completed FULL_REPORT record.
+        report_done = self._artifact(
+            "FULL_REPORT",
+            "DONE",
+            "artifact_report_done",
+            updated_at="2026-01-01T00:02:05.000Z",
+        )
+        questions_done = self._artifact(
+            "QUESTIONS",
+            "DONE",
+            "artifact_questions_done",
+            updated_at="2026-01-01T00:03:05.000Z",
+        )
+        with (
+            _patch("generate_artifact", return_value={"status": True}),
+            _patch(
+                "list_artifacts",
+                side_effect=[
+                    [],  # snapshot for the FULL_REPORT trigger
+                    [report_done],  # snapshot for the QUESTIONS trigger
+                    [report_done],  # wait poll: FULL_REPORT must count as fresh
+                    [report_done, questions_done],
+                ],
+            ),
+        ):
+            await service.generate_artifacts([MagicTableArtifactType.FULL_REPORT])
+            await service.generate_artifacts([MagicTableArtifactType.QUESTIONS])
+            artifacts = await service.wait_for_artifacts(
+                [MagicTableArtifactType.FULL_REPORT, MagicTableArtifactType.QUESTIONS],
+                timeout=10,
+                poll_interval=0,
+            )
+        assert [a.id for a in artifacts] == [
+            "artifact_report_done",
+            "artifact_questions_done",
+        ]

--- a/unique_toolkit/tests/agentic_table/test_service_lifecycle.py
+++ b/unique_toolkit/tests/agentic_table/test_service_lifecycle.py
@@ -277,14 +277,19 @@ class TestWaitForRun:
 
 class TestWaitForArtifacts:
     @staticmethod
-    def _artifact(artifact_type: str, state: str, artifact_id: str = "artifact_1"):
+    def _artifact(
+        artifact_type: str,
+        state: str,
+        artifact_id: str = "artifact_1",
+        updated_at: str = "2026-01-01T00:01:00.000Z",
+    ):
         return {
             "id": artifact_id,
             "artifactType": artifact_type,
             "artifactState": state,
             "contentId": "cont_export" if state == "DONE" else None,
             "createdAt": "2026-01-01T00:00:00.000Z",
-            "updatedAt": "2026-01-01T00:01:00.000Z",
+            "updatedAt": updated_at,
         }
 
     async def test_returns_when_all_types_done(self, service):
@@ -346,6 +351,80 @@ class TestWaitForArtifacts:
             )
         assert len(artifacts) == 1
         assert artifacts[0].artifact_state == MagicTableArtifactState.DONE
+
+    async def test_tolerates_stale_in_progress_duplicate_from_export_trigger(
+        self, service
+    ):
+        # First export on a sheet: the trigger's nameless IN_PROGRESS record is not
+        # the one the worker completes, so a stale IN_PROGRESS row remains next to
+        # the DONE result (observed on QA, sheet with two FULL_REPORT records).
+        stale = self._artifact(
+            "FULL_REPORT",
+            "IN_PROGRESS",
+            "artifact_stale",
+            updated_at="2026-01-01T00:01:00.000Z",
+        )
+        done = self._artifact(
+            "FULL_REPORT",
+            "DONE",
+            "artifact_done",
+            updated_at="2026-01-01T00:01:02.000Z",
+        )
+        responses = [
+            [stale],
+            [done, stale],  # API returns newest-first
+        ]
+        with _patch("list_artifacts", side_effect=responses):
+            artifacts = await service.wait_for_artifacts(
+                [MagicTableArtifactType.FULL_REPORT], timeout=10, poll_interval=0
+            )
+        assert len(artifacts) == 1
+        assert artifacts[0].id == "artifact_done"
+        assert artifacts[0].content_id == "cont_export"
+
+    async def test_newest_record_decides_regardless_of_list_order(self, service):
+        stale = self._artifact(
+            "FULL_REPORT",
+            "IN_PROGRESS",
+            "artifact_stale",
+            updated_at="2026-01-01T00:01:00.000Z",
+        )
+        done = self._artifact(
+            "FULL_REPORT",
+            "DONE",
+            "artifact_done",
+            updated_at="2026-01-01T00:01:02.000Z",
+        )
+        responses = [
+            [stale],
+            [stale, done],  # oldest-first order must give the same result
+        ]
+        with _patch("list_artifacts", side_effect=responses):
+            artifacts = await service.wait_for_artifacts(
+                [MagicTableArtifactType.FULL_REPORT], timeout=10, poll_interval=0
+            )
+        assert artifacts[0].id == "artifact_done"
+
+    async def test_returns_when_generation_finishes_before_first_poll(self, service):
+        # Fast exports can complete before the first poll: the stale IN_PROGRESS
+        # duplicate still proves the run started, and the newest record is DONE.
+        stale = self._artifact(
+            "FULL_REPORT",
+            "IN_PROGRESS",
+            "artifact_stale",
+            updated_at="2026-01-01T00:01:00.000Z",
+        )
+        done = self._artifact(
+            "FULL_REPORT",
+            "DONE",
+            "artifact_done",
+            updated_at="2026-01-01T00:01:02.000Z",
+        )
+        with _patch("list_artifacts", return_value=[done, stale]):
+            artifacts = await service.wait_for_artifacts(
+                [MagicTableArtifactType.FULL_REPORT], timeout=10, poll_interval=0
+            )
+        assert artifacts[0].id == "artifact_done"
 
     async def test_raises_on_error_state(self, service):
         with _patch(

--- a/unique_toolkit/unique_toolkit/agentic_table/service.py
+++ b/unique_toolkit/unique_toolkit/agentic_table/service.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import time
+from datetime import datetime
 from typing import Any, cast
 
 from typing_extensions import deprecated
@@ -47,6 +48,11 @@ def _sheet_batch_cells_include_row_metadata_from_api(
     first = cells[0]
     rm = first.get("rowMetadata")
     return "rowMetadata" in first and isinstance(rm, list)
+
+
+def _artifact_timestamp(value: str) -> datetime:
+    """Parse an artifact ISO-8601 timestamp (e.g. ``2026-07-31T16:26:36.344Z``)."""
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
 
 
 class LockedAgenticTableError(Exception):
@@ -798,11 +804,16 @@ class AgenticTableService:
     ) -> list[MagicTableArtifact]:
         """Wait until artifacts of the given types are DONE, by polling ``list_artifacts``.
 
-        Artifact records are upserted per type: triggering an export flips the record
-        of that type to IN_PROGRESS and back to DONE when the file is ready. A
-        terminal state is accepted only after IN_PROGRESS has been observed for
-        that artifact type, so a result left over from an earlier generation is
-        not mistaken for the newly triggered one.
+        Triggering an export records an IN_PROGRESS artifact of that type, which is
+        flipped to DONE (or ERROR) when the file is ready. A terminal state is accepted
+        only after IN_PROGRESS has been observed for that artifact type, so a result
+        left over from an earlier generation is not mistaken for the newly triggered one.
+
+        A sheet can hold several records of the same type: on the first export the
+        trigger's nameless IN_PROGRESS record is not always the record the worker
+        completes, leaving a stale IN_PROGRESS row next to the DONE result. The state
+        decision is therefore made on the newest record (by ``updated_at``) of each
+        requested type, while IN_PROGRESS detection considers all of them.
 
         Because the API exposes only the current artifact state, a complete
         IN_PROGRESS-to-terminal transition between two polls cannot be observed.
@@ -825,12 +836,19 @@ class AgenticTableService:
         deadline = time.monotonic() + timeout
         while True:
             artifacts = await self.list_artifacts()
-            current = {
-                a.artifact_type: a for a in artifacts if a.artifact_type in wanted
-            }
+            relevant = [a for a in artifacts if a.artifact_type in wanted]
+            # Newest record per type decides the state; older duplicates (e.g. the
+            # stale nameless IN_PROGRESS row from the export trigger) are ignored.
+            current: dict[MagicTableArtifactType, MagicTableArtifact] = {}
+            for artifact in relevant:
+                newest = current.get(artifact.artifact_type)
+                if newest is None or _artifact_timestamp(
+                    artifact.updated_at
+                ) > _artifact_timestamp(newest.updated_at):
+                    current[artifact.artifact_type] = artifact
             started.update(
-                artifact_type
-                for artifact_type, artifact in current.items()
+                artifact.artifact_type
+                for artifact in relevant
                 if artifact.artifact_state == MagicTableArtifactState.IN_PROGRESS
             )
             failed = [

--- a/unique_toolkit/unique_toolkit/agentic_table/service.py
+++ b/unique_toolkit/unique_toolkit/agentic_table/service.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import time
 from datetime import datetime
-from typing import Any, cast
+from typing import Any, NamedTuple, cast
 
 from typing_extensions import deprecated
 from unique_sdk import (
@@ -55,6 +55,44 @@ def _artifact_timestamp(value: str) -> datetime:
     return datetime.fromisoformat(value.replace("Z", "+00:00"))
 
 
+class _ArtifactBaseline(NamedTuple):
+    """What a sheet's artifacts looked like just before an export was triggered.
+
+    ``ids`` are the records that already existed; ``latest`` is the newest
+    ``updated_at`` per type. Two signals because either can carry the result: a
+    finished report normally arrives as a new record (the trigger's nameless
+    IN_PROGRESS marker and the named report are separate rows), but a re-export
+    can also refresh an existing record in place.
+
+    Mirrors the ``_ArtifactBaseline`` used by the SDK CLI's export wait.
+    """
+
+    ids: frozenset[str]
+    latest: dict[MagicTableArtifactType, datetime]
+
+
+def _snapshot_artifacts(artifacts: list[MagicTableArtifact]) -> _ArtifactBaseline:
+    latest: dict[MagicTableArtifactType, datetime] = {}
+    for artifact in artifacts:
+        timestamp = _artifact_timestamp(artifact.updated_at)
+        if (
+            artifact.artifact_type not in latest
+            or timestamp > latest[artifact.artifact_type]
+        ):
+            latest[artifact.artifact_type] = timestamp
+    return _ArtifactBaseline(
+        ids=frozenset(artifact.id for artifact in artifacts), latest=latest
+    )
+
+
+def _is_fresh(artifact: MagicTableArtifact, baseline: _ArtifactBaseline) -> bool:
+    """Whether *artifact* came out of a generation triggered after *baseline*."""
+    if artifact.id not in baseline.ids:
+        return True
+    latest = baseline.latest.get(artifact.artifact_type)
+    return latest is not None and _artifact_timestamp(artifact.updated_at) > latest
+
+
 class LockedAgenticTableError(Exception):
     pass
 
@@ -94,6 +132,9 @@ class AgenticTableService:
         self.table_id = table_id
         self.logger = logger
         self.created_sheet: CreatedMagicTableSheet | None = None
+        # Snapshot taken by generate_artifacts so wait_for_artifacts can tell the
+        # new export apart from records left by earlier generations.
+        self._artifact_baseline: _ArtifactBaseline | None = None
 
     @classmethod
     async def create_sheet(
@@ -640,9 +681,14 @@ class AgenticTableService:
         (or poll ``list_artifacts``) to detect completion, then download the artifact's
         ``content_id`` via the Content API.
 
+        Snapshots the sheet's artifacts before triggering, so a following
+        ``wait_for_artifacts`` on this instance can tell the new export apart
+        from records left over from earlier generations.
+
         Raises:
             Exception: If the API reports a non-success status.
         """
+        baseline = _snapshot_artifacts(await self.list_artifacts())
         result = await AgenticTable.generate_artifact(
             user_id=self._user_id,
             company_id=self._company_id,
@@ -653,6 +699,7 @@ class AgenticTableService:
             raise Exception(
                 result.get("message") or "Failed to trigger artifact generation"
             )
+        self._artifact_baseline = baseline
 
     async def rerun_row(self, row_order: int) -> None:
         """Re-run the agent for a single row (`POST .../row/{rowOrder}/rerun`).
@@ -804,20 +851,25 @@ class AgenticTableService:
     ) -> list[MagicTableArtifact]:
         """Wait until artifacts of the given types are DONE, by polling ``list_artifacts``.
 
-        Triggering an export records an IN_PROGRESS artifact of that type, which is
-        flipped to DONE (or ERROR) when the file is ready. A terminal state is accepted
-        only after IN_PROGRESS has been observed for that artifact type, so a result
-        left over from an earlier generation is not mistaken for the newly triggered one.
+        A sheet can hold several records of the same type: the export trigger
+        records a nameless IN_PROGRESS marker that is not always the record the
+        worker completes, so a stale IN_PROGRESS row can sit next to the DONE
+        result, and reports from earlier generations remain listed. Two fences
+        keep the wait from mistaking leftovers for the new export:
 
-        A sheet can hold several records of the same type: on the first export the
-        trigger's nameless IN_PROGRESS record is not always the record the worker
-        completes, leaving a stale IN_PROGRESS row next to the DONE result. The state
-        decision is therefore made on the newest record (by ``updated_at``) of each
-        requested type, while IN_PROGRESS detection considers all of them.
+        - When ``generate_artifacts`` was called on this instance, only records
+          that are *fresh* relative to its pre-trigger snapshot count: a record
+          id that did not exist before, or an ``updated_at`` newer than the
+          snapshot. This also accepts exports that finish before the first poll.
+        - Without a snapshot (export triggered elsewhere), a terminal state is
+          accepted only after IN_PROGRESS has been observed for that type, and
+          the newest record (by ``updated_at``) per type decides the state. This
+          cannot distinguish a result of an earlier generation whose trigger
+          marker is still IN_PROGRESS — prefer triggering and waiting on the
+          same service instance.
 
-        Because the API exposes only the current artifact state, a complete
-        IN_PROGRESS-to-terminal transition between two polls cannot be observed.
-        Keep ``poll_interval`` shorter than the expected minimum generation time.
+        Because the API exposes only the current artifact state, keep
+        ``poll_interval`` shorter than the expected minimum generation time.
 
         Args:
             artifact_types: The artifact types to wait for (as passed to ``generate_artifacts``).
@@ -832,29 +884,36 @@ class AgenticTableService:
             AgenticTableRunTimeoutError: Not all artifacts were DONE within ``timeout``.
         """
         wanted = set(artifact_types)
+        baseline = self._artifact_baseline
         started: set[MagicTableArtifactType] = set()
         deadline = time.monotonic() + timeout
         while True:
             artifacts = await self.list_artifacts()
             relevant = [a for a in artifacts if a.artifact_type in wanted]
+            if baseline is not None:
+                candidates = [a for a in relevant if _is_fresh(a, baseline)]
+                gate = {a.artifact_type for a in candidates}
+            else:
+                candidates = relevant
+                started.update(
+                    artifact.artifact_type
+                    for artifact in relevant
+                    if artifact.artifact_state == MagicTableArtifactState.IN_PROGRESS
+                )
+                gate = started
             # Newest record per type decides the state; older duplicates (e.g. the
             # stale nameless IN_PROGRESS row from the export trigger) are ignored.
             current: dict[MagicTableArtifactType, MagicTableArtifact] = {}
-            for artifact in relevant:
+            for artifact in candidates:
                 newest = current.get(artifact.artifact_type)
                 if newest is None or _artifact_timestamp(
                     artifact.updated_at
                 ) > _artifact_timestamp(newest.updated_at):
                     current[artifact.artifact_type] = artifact
-            started.update(
-                artifact.artifact_type
-                for artifact in relevant
-                if artifact.artifact_state == MagicTableArtifactState.IN_PROGRESS
-            )
             failed = [
                 artifact
                 for artifact_type, artifact in current.items()
-                if artifact_type in started
+                if artifact_type in gate
                 and artifact.artifact_state == MagicTableArtifactState.ERROR
             ]
             if failed:
@@ -865,7 +924,7 @@ class AgenticTableService:
             done = {
                 artifact_type: artifact
                 for artifact_type, artifact in current.items()
-                if artifact_type in started
+                if artifact_type in gate
                 and artifact.artifact_state == MagicTableArtifactState.DONE
             }
             if wanted <= set(done.keys()):

--- a/unique_toolkit/unique_toolkit/agentic_table/service.py
+++ b/unique_toolkit/unique_toolkit/agentic_table/service.py
@@ -56,41 +56,48 @@ def _artifact_timestamp(value: str) -> datetime:
 
 
 class _ArtifactBaseline(NamedTuple):
-    """What a sheet's artifacts looked like just before an export was triggered.
+    """What a sheet's artifacts of one type looked like just before an export of
+    that type was triggered.
 
-    ``ids`` are the records that already existed; ``latest`` is the newest
-    ``updated_at`` per type. Two signals because either can carry the result: a
-    finished report normally arrives as a new record (the trigger's nameless
-    IN_PROGRESS marker and the named report are separate rows), but a re-export
-    can also refresh an existing record in place.
+    ``ids`` are the records of the type that already existed; ``latest`` is
+    their newest ``updated_at``. Two signals because either can carry the
+    result: a finished report normally arrives as a new record (the trigger's
+    nameless IN_PROGRESS marker and the named report are separate rows), but a
+    re-export can also refresh an existing record in place.
+
+    Kept per artifact type so that triggering one type does not fence out an
+    already-completed export of another type.
 
     Mirrors the ``_ArtifactBaseline`` used by the SDK CLI's export wait.
     """
 
     ids: frozenset[str]
-    latest: dict[MagicTableArtifactType, datetime]
+    latest: datetime | None
 
 
-def _snapshot_artifacts(artifacts: list[MagicTableArtifact]) -> _ArtifactBaseline:
-    latest: dict[MagicTableArtifactType, datetime] = {}
-    for artifact in artifacts:
-        timestamp = _artifact_timestamp(artifact.updated_at)
-        if (
-            artifact.artifact_type not in latest
-            or timestamp > latest[artifact.artifact_type]
-        ):
-            latest[artifact.artifact_type] = timestamp
-    return _ArtifactBaseline(
-        ids=frozenset(artifact.id for artifact in artifacts), latest=latest
-    )
+def _snapshot_artifacts(
+    artifacts: list[MagicTableArtifact],
+    artifact_types: list[MagicTableArtifactType],
+) -> dict[MagicTableArtifactType, _ArtifactBaseline]:
+    baselines: dict[MagicTableArtifactType, _ArtifactBaseline] = {}
+    for artifact_type in artifact_types:
+        records = [a for a in artifacts if a.artifact_type == artifact_type]
+        timestamps = [_artifact_timestamp(a.updated_at) for a in records]
+        baselines[artifact_type] = _ArtifactBaseline(
+            ids=frozenset(a.id for a in records),
+            latest=max(timestamps) if timestamps else None,
+        )
+    return baselines
 
 
 def _is_fresh(artifact: MagicTableArtifact, baseline: _ArtifactBaseline) -> bool:
     """Whether *artifact* came out of a generation triggered after *baseline*."""
     if artifact.id not in baseline.ids:
         return True
-    latest = baseline.latest.get(artifact.artifact_type)
-    return latest is not None and _artifact_timestamp(artifact.updated_at) > latest
+    return (
+        baseline.latest is not None
+        and _artifact_timestamp(artifact.updated_at) > baseline.latest
+    )
 
 
 class LockedAgenticTableError(Exception):
@@ -132,9 +139,9 @@ class AgenticTableService:
         self.table_id = table_id
         self.logger = logger
         self.created_sheet: CreatedMagicTableSheet | None = None
-        # Snapshot taken by generate_artifacts so wait_for_artifacts can tell the
-        # new export apart from records left by earlier generations.
-        self._artifact_baseline: _ArtifactBaseline | None = None
+        # Per-type snapshots taken by generate_artifacts so wait_for_artifacts can
+        # tell a new export apart from records left by earlier generations.
+        self._artifact_baselines: dict[MagicTableArtifactType, _ArtifactBaseline] = {}
 
     @classmethod
     async def create_sheet(
@@ -681,14 +688,17 @@ class AgenticTableService:
         (or poll ``list_artifacts``) to detect completion, then download the artifact's
         ``content_id`` via the Content API.
 
-        Snapshots the sheet's artifacts before triggering, so a following
-        ``wait_for_artifacts`` on this instance can tell the new export apart
-        from records left over from earlier generations.
+        Snapshots the sheet's artifacts of the requested types before
+        triggering, so a following ``wait_for_artifacts`` on this instance can
+        tell the new export apart from records left over from earlier
+        generations. Only the requested types' snapshots are replaced; a
+        baseline armed by an earlier trigger for another type is kept, so its
+        completed export stays recognisable.
 
         Raises:
             Exception: If the API reports a non-success status.
         """
-        baseline = _snapshot_artifacts(await self.list_artifacts())
+        baselines = _snapshot_artifacts(await self.list_artifacts(), artifact_types)
         result = await AgenticTable.generate_artifact(
             user_id=self._user_id,
             company_id=self._company_id,
@@ -699,7 +709,7 @@ class AgenticTableService:
             raise Exception(
                 result.get("message") or "Failed to trigger artifact generation"
             )
-        self._artifact_baseline = baseline
+        self._artifact_baselines.update(baselines)
 
     async def rerun_row(self, row_order: int) -> None:
         """Re-run the agent for a single row (`POST .../row/{rowOrder}/rerun`).
@@ -857,16 +867,17 @@ class AgenticTableService:
         result, and reports from earlier generations remain listed. Two fences
         keep the wait from mistaking leftovers for the new export:
 
-        - When ``generate_artifacts`` was called on this instance, only records
-          that are *fresh* relative to its pre-trigger snapshot count: a record
-          id that did not exist before, or an ``updated_at`` newer than the
-          snapshot. This also accepts exports that finish before the first poll.
-        - Without a snapshot (export triggered elsewhere), a terminal state is
-          accepted only after IN_PROGRESS has been observed for that type, and
-          the newest record (by ``updated_at``) per type decides the state. This
-          cannot distinguish a result of an earlier generation whose trigger
-          marker is still IN_PROGRESS — prefer triggering and waiting on the
-          same service instance.
+        - For a type that ``generate_artifacts`` was called for on this
+          instance, only records that are *fresh* relative to that trigger's
+          snapshot count: a record id that did not exist before, or an
+          ``updated_at`` newer than the snapshot. This also accepts exports
+          that finish before the first poll.
+        - For a type without a snapshot (export triggered elsewhere), a
+          terminal state is accepted only after IN_PROGRESS has been observed
+          for that type, and the newest record (by ``updated_at``) decides the
+          state. This cannot distinguish a result of an earlier generation
+          whose trigger marker is still IN_PROGRESS — prefer triggering and
+          waiting on the same service instance.
 
         Because the API exposes only the current artifact state, keep
         ``poll_interval`` shorter than the expected minimum generation time.
@@ -884,23 +895,28 @@ class AgenticTableService:
             AgenticTableRunTimeoutError: Not all artifacts were DONE within ``timeout``.
         """
         wanted = set(artifact_types)
-        baseline = self._artifact_baseline
+        baselines = {
+            artifact_type: baseline
+            for artifact_type, baseline in self._artifact_baselines.items()
+            if artifact_type in wanted
+        }
         started: set[MagicTableArtifactType] = set()
         deadline = time.monotonic() + timeout
         while True:
             artifacts = await self.list_artifacts()
             relevant = [a for a in artifacts if a.artifact_type in wanted]
-            if baseline is not None:
-                candidates = [a for a in relevant if _is_fresh(a, baseline)]
-                gate = {a.artifact_type for a in candidates}
-            else:
-                candidates = relevant
-                started.update(
-                    artifact.artifact_type
-                    for artifact in relevant
-                    if artifact.artifact_state == MagicTableArtifactState.IN_PROGRESS
-                )
-                gate = started
+            candidates: list[MagicTableArtifact] = []
+            for artifact in relevant:
+                baseline = baselines.get(artifact.artifact_type)
+                if baseline is None:
+                    candidates.append(artifact)
+                    if artifact.artifact_state == MagicTableArtifactState.IN_PROGRESS:
+                        started.add(artifact.artifact_type)
+                elif _is_fresh(artifact, baseline):
+                    candidates.append(artifact)
+            gate = started | {
+                a.artifact_type for a in candidates if a.artifact_type in baselines
+            }
             # Newest record per type decides the state; older duplicates (e.g. the
             # stale nameless IN_PROGRESS row from the export trigger) are ignored.
             current: dict[MagicTableArtifactType, MagicTableArtifact] = {}


### PR DESCRIPTION
## Summary

- `AgenticTableService.wait_for_artifacts` timed out on **every first export of a fresh sheet** even though the report was ready. The backend leaves a stale nameless `IN_PROGRESS` artifact row next to the worker's `DONE` row ([UN-23742](https://unique-ch.atlassian.net/browse/UN-23742): the trigger's upsert and the worker's completion call disagree on `name` in the match filter), and the helper's per-type dict kept the *oldest* record from the newest-first list — pinning the wait on the stale row.
- The state decision is now made on the **newest record per type** (by parsed `updated_at`); `IN_PROGRESS` detection scans **all** records of a wanted type, so fast exports that complete before the first poll are still accepted (the stale duplicate proves the run started).

Found while validating the UBP Agentic Table CLI flow (UN-22183 / R1) end-to-end on QA on 2026-07-31; affects released `unique-toolkit` 2026.30.0–2026.32.0. Client guide documents a workaround until this ships: https://unique-ch.atlassian.net/wiki/x/igB1m

## Test plan

- [x] 3 new unit tests: stale duplicate from the export trigger (exact QA scenario), list-order independence, generation finishing before the first poll
- [x] `unique_toolkit/tests/agentic_table` suite passes (27 tests)
- [x] Verified live against the QA sheet that exposed the bug (re-trigger → `wait_for_artifacts` returned in 5.2s → report downloaded) and against local master

Made with [Cursor](https://cursor.com)

[UN-23742]: https://unique-ch.atlassian.net/browse/UN-23742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ