### PR TITLE
fix(web-search): accept null agentId in Bing config (#2209)

### DIFF
--- a/tool_packages/unique_web_search/src/unique_web_search/services/search_engine/bing.py
+++ b/tool_packages/unique_web_search/src/unique_web_search/services/search_engine/bing.py
@@ -1,10 +1,11 @@
 import asyncio
-from typing import override
+from typing import Annotated, Any, override
 
-from pydantic import Field
+from pydantic import BeforeValidator, Field
 from unique_search_proxy_core.agent_engines.base import AgentEngineType
 from unique_search_proxy_core.agent_engines.bing.schema import BingAgentConfig
 from unique_toolkit._common.default_language_model import DEFAULT_LANGUAGE_MODEL
+from unique_toolkit._common.pydantic.rjsf_tags import RJSFMetaTag
 from unique_toolkit._common.validators import LMI, get_LMI_default_field
 from unique_toolkit.language_model import LanguageModelService
 
@@ -34,12 +35,34 @@ from unique_web_search.services.search_engine.utils.grounding.bing import (
 from unique_web_search.settings import env_settings
 
 
+def _none_as_empty(value: Any) -> Any:
+    """Accept the ``null`` written by previously stored configs."""
+    return "" if value is None else value
+
+
+# Plain ``str`` instead of ``str | None`` so the config form renders a single
+# text input; a union would render an RJSF branch selector ("… option 1/2").
+_OptionalText = Annotated[str, BeforeValidator(_none_as_empty)]
+
+
 class BingSearchConfig(BingAgentConfig):
-    agent_id: str = Field(
+    agent_id: Annotated[  # pyright: ignore[reportIncompatibleVariableOverride]
+        _OptionalText,
+        RJSFMetaTag.StringWidget.textfield(
+            placeholder="Leave empty to use the auto-provisioned agent",
+            empty_value="",
+        ),
+    ] = Field(
         default=env_settings.azure_ai_assistant_id or "",
         description="The ID of the agent to use for the search. **This parameter is temporary and will be auto-provisioned in future versions.**",
     )
-    endpoint: str = Field(
+    endpoint: Annotated[
+        _OptionalText,
+        RJSFMetaTag.StringWidget.textfield(
+            placeholder="Leave empty to use the auto-provisioned resource",
+            empty_value="",
+        ),
+    ] = Field(
         default=env_settings.azure_ai_project_endpoint or "",
         description="The endpoint to use for the search. **This parameter is not required to be set. It's loaded automatically from auto-provisioned resource**",
     )

--- a/tool_packages/unique_web_search/tests/test_bing_runner.py
+++ b/tool_packages/unique_web_search/tests/test_bing_runner.py
@@ -1074,6 +1074,24 @@ class TestBingSearchConfig:
         assert config.endpoint == ""
 
     @pytest.mark.ai
+    def test_config__agent_id_and_endpoint_null__are_accepted(self) -> None:
+        """
+        Purpose: Verify stored ``agentId``/``endpoint`` nulls validate against the config schema.
+        Why this matters: Migrated space configurations persist null for an unset agent or
+            endpoint, and rejecting it breaks the admin configuration form.
+        Setup summary: Validate a payload with both fields set to None; assert they are
+            coerced to the empty string that marks an unset value.
+        """
+        from unique_web_search.services.search_engine.bing import BingSearchConfig
+
+        # Act
+        config = BingSearchConfig.model_validate({"agent_id": None, "endpoint": None})
+
+        # Assert
+        assert config.agent_id == ""
+        assert config.endpoint == ""
+
+    @pytest.mark.ai
     def test_config__custom_agent_id_and_endpoint__stored_correctly(self) -> None:
         """
         Purpose: Verify agent_id and endpoint can be overridden with custom values.


### PR DESCRIPTION
## Summary

On `release/2026.28` the Bing web search config breaks with `Instance type "null" is invalid. Expected "string".` — the admin config form refuses to save. Two things cause it, and this PR fixes both:

1. **Existing configs contain a null.** The `20260630000000_migrate_web_search_engine_config_to_engine_schema` data migration in the monorepo normalized empty/missing agent IDs to `null`. `BingSearchConfig.agent_id` is a plain `str`, so a stored `null` is not a valid value and the form rejects it on load.
2. **The form keeps re-creating the null.** Even with clean data, typing a value into **Agent Id** and then clearing it writes `null` again, and you are back to the same error. This is the part a data cleanup alone cannot fix.

## Changes

### `tool_packages/unique_web_search/`
- Wrapped `agent_id` and `endpoint` in `_OptionalText` — an `Annotated[str, BeforeValidator(...)]` that coerces an incoming `null` to `""`. This makes already-stored nulls validate instead of erroring (fixes cause 1).
- Tagged both fields with `RJSFMetaTag.StringWidget.textfield(empty_value="")`, which emits `ui:emptyValue: ""` in the generated uiSchema so the form writes `""` rather than `null` when the field is cleared (fixes cause 2).
- Field defaults are unchanged. Call sites, `_legacy_search`, `_proxy_search`, `supports_proxy_search` and `base.py` are all untouched.
- Ported the corresponding test from #2209 (`test_config__agent_id_and_endpoint_null__are_accepted`).

Kept as a plain `str` rather than `str | None` deliberately: a union makes RJSF render a branch selector ("… option 1/2") instead of a single text input.

## Where this was fixed on main

af3654ebdc9ec5bd60ef1feece372afb8da17385 — "fix: config validation error bing grounding" (#2209).

## Why this is not a cherry-pick of that commit

`git cherry-pick af3654ebd` onto `release/2026.28` conflicts in both files it touches. Three separate reasons:

1. **It has an unlanded prerequisite.** #2209's parent chain runs through #2206 (`92b9d2e8b`), merged ~1h earlier the same day. #2209's diff is written against the state #2206 left behind, so its hunks do not match this branch.
2. **Replaying #2206 first would be pointless churn.** On these fields #2206 is a round-trip: it changes `str` / `default=... or ""` → `str | None` / `default=...`, and #2209 changes it straight back to `str` / `or ""`. Net effect on this branch is zero, at the cost of two conflict resolutions. #2206's other half — the `base.py` guard `if value is None or value == "":` — has no target here at all; that `_build_invocation` block does not exist in this branch's 62-line `base.py`.
3. **The upstream file has since diverged structurally.** Beyond the config fix, `bing.py` on the 2026.32+ line also carries the Agents v2 / search-proxy refactor: `RequestContext`/`LOCAL_REQUEST_CONTEXT` constructor args, `ExposedParams`, removal of `_proxy_search` and `supports_proxy_search`, and a changed `_legacy_search` signature. None of that belongs in a hotfix.

So the config-schema portion of #2209 is applied by hand and nothing else. No dependency bumps were needed: `RJSFMetaTag` has shipped since `unique-toolkit` v1.82.0 / 2026.18.0 and is present at `unique-toolkit-v2026.28.3`, and `textfield(placeholder=..., empty_value=...)` is supported by that version.

## Relationship to the monorepo PR

This PR and Unique-AG/monorepo#27816 fix the two halves of the same bug and are both needed on the 2026.28 line:

| | Repo | What it does |
|---|---|---|
| Unique-AG/monorepo#27816 | monorepo | Data migration that strips the `agentId` key from configs where the value is already `null` — cleans up **existing** rows |
| **this PR** | ai | Stops the form **writing** a new `null`, and tolerates any `null` that is still present — prevents **recurrence** |

Neither closes the bug alone. The migration cannot stop the form from re-creating the null, and this PR's `BeforeValidator` does not widen the emitted JSON schema (it stays `"type": "string"`), so a null already sitting in the database would still fail client-side validation before the user can save. Cleanup plus prevention.

Note that the equivalent pairing already exists on the newer lines — monorepo#27746/#27750 carry the migration, while #2206/#2209 carry the schema fix, which is released in `unique-web-search` 2026.32.2. Only the 2026.28 line was missing both.

## Testing

- `pytest tests/test_bing_runner.py tests/test_search_engines.py` → 96 passed
- `ruff check` / `ruff format --check` → clean
- `basedpyright src/unique_web_search/services/search_engine/bing.py` → 0 errors, 0 warnings, 0 notes
- Verified `ui_schema_for_model(BingSearchConfig)` emits `ui:emptyValue: ""` for both fields
- Verified against a local 2026.28 stack: reproduced the error, applied the fix, and confirmed the type-then-clear repro on **Agent Id** no longer breaks the config

Jira: UN-23780
