### PR TITLE
fix(unique_orchestrator): await get_selected_uploaded_content_ids before constructing UniqueAI

### DIFF
--- a/unique_orchestrator/unique_orchestrator/unique_ai.py
+++ b/unique_orchestrator/unique_orchestrator/unique_ai.py
@@ -15,9 +15,6 @@ from unique_toolkit.agentic.evaluation.evaluation_manager import EvaluationManag
 from unique_toolkit.agentic.evaluation.schemas import EvaluationMetricName
 from unique_toolkit.agentic.feature_flags import feature_flags
 from unique_toolkit.agentic.history_manager.history_manager import HistoryManager
-from unique_toolkit.agentic.history_manager.utils import (
-    get_selected_uploaded_content_ids,
-)
 from unique_toolkit.agentic.loop_runner import (
     LoopIterationRunner,
     ResponsesLoopIterationRunner,
@@ -122,6 +119,7 @@ class UniqueAI:
         agent_file_registry: list[str] | None = None,
         uploaded_documents: list[Content] | None = None,
         user_memory_text: str = "",
+        selected_uploaded_content_ids: frozenset[str] | None = None,
     ) -> None: ...
 
     # Responses API Dependencies
@@ -147,6 +145,7 @@ class UniqueAI:
         agent_file_registry: list[str] | None = None,
         uploaded_documents: list[Content] | None = None,
         user_memory_text: str = "",
+        selected_uploaded_content_ids: frozenset[str] | None = None,
     ) -> None: ...
 
     def __init__(
@@ -171,6 +170,7 @@ class UniqueAI:
         agent_file_registry: list[str] | None = None,
         uploaded_documents: list[Content] | None = None,
         user_memory_text: str = "",
+        selected_uploaded_content_ids: frozenset[str] | None = None,
     ) -> None:
         self._logger = logger
         self._event = event
@@ -202,7 +202,6 @@ class UniqueAI:
                 agent_file_registry if agent_file_registry is not None else []
             )
             file_cfg = self._config.agent.experimental.open_file_tool_config
-            selected_ids = get_selected_uploaded_content_ids(event)
             self._open_file_runtime = OpenFileToolRuntime(
                 logger=logger,
                 config=OpenFileToolRuntimeConfig(
@@ -213,9 +212,7 @@ class UniqueAI:
                         self._config.agent.experimental.responses_api_config.use_responses_api
                         or self._config.agent.experimental.use_responses_api
                     ),
-                    selected_content_ids=(
-                        frozenset(selected_ids) if selected_ids is not None else None
-                    ),
+                    selected_content_ids=selected_uploaded_content_ids,
                 ),
                 content_service=content_service,
                 tool_manager=tool_manager,

--- a/unique_orchestrator/unique_orchestrator/unique_ai_builder.py
+++ b/unique_orchestrator/unique_orchestrator/unique_ai_builder.py
@@ -22,6 +22,9 @@ from unique_toolkit.agentic.evaluation.hallucination.hallucination_evaluation im
     HallucinationEvaluation,
 )
 from unique_toolkit.agentic.history_manager.history_manager import HistoryManager
+from unique_toolkit.agentic.history_manager.utils import (
+    get_selected_uploaded_content_ids,
+)
 from unique_toolkit.agentic.message_log_manager.service import MessageStepLogger
 from unique_toolkit.agentic.postprocessor.postprocessor_manager import (
     PostprocessorManager,
@@ -662,6 +665,12 @@ async def _build_responses(
         response_watcher=common_components.response_watcher,
     )
 
+    selected_uploaded_content_ids = (
+        await get_selected_uploaded_content_ids(event)
+        if config.agent.experimental.open_file_tool_config.enabled
+        else None
+    )
+
     return UniqueAI(
         event=event,
         config=config,
@@ -682,6 +691,11 @@ async def _build_responses(
         loop_iteration_runner=loop_iteration_runner,
         agent_file_registry=agent_file_registry,
         user_memory_text=common_components.user_memory_text,
+        selected_uploaded_content_ids=(
+            frozenset(selected_uploaded_content_ids)
+            if selected_uploaded_content_ids is not None
+            else None
+        ),
     )
 
 


### PR DESCRIPTION
## Summary

`UniqueAI.__init__` called `get_selected_uploaded_content_ids(event)` — an `async def` in `unique_toolkit.agentic.history_manager.utils` — synchronously, whenever `config.agent.experimental.open_file_tool_config.enabled` is true. That returns a coroutine object, and the subsequent `frozenset(selected_ids)` crashes with `TypeError: 'coroutine' object is not iterable`.

This surfaced now via the `release-please` tracking PR's aggregated CI (min-deps + regular `Test / test-orchestrator` jobs), the first time `unique_orchestrator`'s suite ran against a `unique_toolkit` release containing the async migration from [#1970](https://github.com/Unique-AG/ai/pull/1970). The bug itself is pre-existing on `main` and unrelated to that PR's own changes — `open_file_tool_config.enabled` requires the Responses API (enforced in `config.py`), and any test/mock that makes that flag truthy hits the same crash in `__init__`, which explains the wide blast radius (62 failures / 51 errors across many test files).

## Fix

`__init__` can't `await`, so the async call moves to `_build_responses` (already `async def`, and already precomputes other values like `uploaded_documents`/`agent_file_registry` the same way) and the resolved value is passed into `UniqueAI.__init__` as a new `selected_uploaded_content_ids` parameter, replacing the synchronous call inside the constructor. `_build_completions` doesn't need the same treatment since the open-file-tool feature is Responses-API-only by config validation.

## Test plan
- [x] Full `unique_orchestrator` suite: 138 passed (was 62 failed / 51 errors)
- [x] `ruff check` clean on both changed files
- [x] `basedpyright` clean on both changed files