### PR TITLE
ci: authorize config-check override via Gatekeeper

### DIFF
--- a/.github/scripts/check-gatekeeper.sh
+++ b/.github/scripts/check-gatekeeper.sh
@@ -1,0 +1,406 @@
+#!/usr/bin/env bash
+# Gatekeeper decision for CI / Gatekeeper.
+#
+# Evaluates required job results. A config-check failure is non-blocking only
+# when ALL of the following hold (fail closed otherwise):
+#   1. PR targets main and is internal (not a fork)
+#   2. PR has the config-check-override label
+#   3. Current head SHA has an APPROVED review from a Unique-AG/ds-engels
+#      member who is not the PR author (latest non-dismissed review per reviewer)
+#   4. The only failing required check is config with actual failure
+#      (cancelled / unavailable still blocks)
+#
+# Membership is probed via the Teams membership API using GITHUB_TOKEN.
+# If membership cannot be verified, override is denied (fail closed).
+# TODO(platform): if GITHUB_TOKEN cannot read org team membership in Actions
+# (org "Read organization members" workflow permission), either enable that
+# setting or provide a supported token — do not fall back to a static allowlist
+# without an explicit Platform decision.
+#
+# Usage (CI): source env vars then run as a script. Writes status/description
+# to $GITHUB_OUTPUT when set. Exit 0 always for the decision step; callers
+# fail the job based on the status output.
+#
+# Env (job results — success|failure|cancelled|skipped|empty):
+#   DETECT_CHANGES LINT TEST TYPES COVERAGE DEPS CONTAINERIZE HELM_LINT
+#   CONFIG PR_TITLE NO_MANUAL_RELEASE RELEASE_LINEAGE
+# Env (GitHub context):
+#   GH_TOKEN / GITHUB_TOKEN, GITHUB_REPOSITORY
+#   EVENT_NAME (pull_request|merge_group|...)
+#   PR_NUMBER, PR_BASE_REF, PR_HEAD_SHA, PR_AUTHOR, PR_IS_FORK (true|false)
+#   MERGE_GROUP_HEAD_REF (optional; used to recover PR number on merge_group)
+# Optional:
+#   OVERRIDE_LABEL (default: config-check-override)
+#   DS_ENGELS_ORG / DS_ENGELS_TEAM (default: Unique-AG / ds-engels)
+#   SKIP_AUDIT_COMMENT (default: false) — set true in unit tests
+
+set -euo pipefail
+
+OVERRIDE_LABEL="${OVERRIDE_LABEL:-config-check-override}"
+DS_ENGELS_ORG="${DS_ENGELS_ORG:-Unique-AG}"
+DS_ENGELS_TEAM="${DS_ENGELS_TEAM:-ds-engels}"
+AUDIT_MARKER="<!-- config-check-override-audit -->"
+SKIP_AUDIT_COMMENT="${SKIP_AUDIT_COMMENT:-false}"
+
+REQUIRED_CHECKS=(
+  "detect-changes:DETECT_CHANGES"
+  "lint:LINT"
+  "test:TEST"
+  "types:TYPES"
+  "coverage:COVERAGE"
+  "deps:DEPS"
+  "containerize:CONTAINERIZE"
+  "helm-lint:HELM_LINT"
+  "config:CONFIG"
+  "pr-title:PR_TITLE"
+  "no-manual-release:NO_MANUAL_RELEASE"
+  "release-lineage:RELEASE_LINEAGE"
+)
+
+emit_result() {
+  local status="$1"
+  local description="$2"
+  echo "status=${status}"
+  echo "description=${description}"
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    {
+      echo "status=${status}"
+      echo "description=${description}"
+    } >>"${GITHUB_OUTPUT}"
+  fi
+}
+
+gh_api() {
+  # Thin wrapper so tests can stub gh.
+  gh api "$@"
+}
+
+print_status_summary() {
+  echo "=== CI Status Summary ==="
+  echo "detect-changes: ${DETECT_CHANGES:-}"
+  echo "lint: ${LINT:-}"
+  echo "test: ${TEST:-}"
+  echo "types: ${TYPES:-}"
+  echo "coverage: ${COVERAGE:-}"
+  echo "deps: ${DEPS:-}"
+  echo "containerize: ${CONTAINERIZE:-}"
+  echo "helm-lint: ${HELM_LINT:-}"
+  echo "config: ${CONFIG:-}"
+  echo "pr-title: ${PR_TITLE:-}"
+  echo "no-manual-release: ${NO_MANUAL_RELEASE:-}"
+  echo "release-lineage: ${RELEASE_LINEAGE:-}"
+  echo "========================="
+}
+
+# Collect blocking failures. Sets globals:
+#   BLOCKING_FAILURES — space-separated "name:result" for non-config blocks
+#   CONFIG_RESULT — config job result
+#   HAS_NON_CONFIG_BLOCK — true|false
+#   CONFIG_IS_FAILURE — true|false
+#   CONFIG_IS_CANCELLED — true|false
+classify_results() {
+  BLOCKING_FAILURES=()
+  CONFIG_RESULT="${CONFIG:-}"
+  HAS_NON_CONFIG_BLOCK=false
+  CONFIG_IS_FAILURE=false
+  CONFIG_IS_CANCELLED=false
+
+  local entry name var result
+  for entry in "${REQUIRED_CHECKS[@]}"; do
+    name="${entry%%:*}"
+    var="${entry##*:}"
+    result="${!var:-}"
+    if [[ "$result" != "failure" && "$result" != "cancelled" ]]; then
+      continue
+    fi
+    if [[ "$name" == "config" ]]; then
+      if [[ "$result" == "failure" ]]; then
+        CONFIG_IS_FAILURE=true
+      else
+        CONFIG_IS_CANCELLED=true
+      fi
+      echo "❌ $name: $result"
+      continue
+    fi
+    echo "❌ $name: $result"
+    BLOCKING_FAILURES+=("${name}:${result}")
+    HAS_NON_CONFIG_BLOCK=true
+  done
+}
+
+is_team_member() {
+  # Returns 0 if username is an active member of DS_ENGELS_ORG/DS_ENGELS_TEAM.
+  # Non-zero on non-member or any API/permission error (fail closed).
+  local username="$1"
+  local http_body http_code
+  local tmp
+  tmp="$(mktemp)"
+  # Capture body + status; membership endpoint 404s for non-members.
+  set +e
+  http_body="$(gh_api \
+    -H "Accept: application/vnd.github+json" \
+    "orgs/${DS_ENGELS_ORG}/teams/${DS_ENGELS_TEAM}/memberships/${username}" \
+    2>"${tmp}.err")"
+  http_code=$?
+  set -e
+
+  if [[ "$http_code" -ne 0 ]]; then
+    local err
+    err="$(cat "${tmp}.err" 2>/dev/null || true)"
+    rm -f "$tmp" "${tmp}.err"
+    # Distinguish "not a member" (404) from auth/permission failures.
+    if echo "$err" | grep -qiE '404|Not Found'; then
+      echo "membership: ${username} is not in ${DS_ENGELS_ORG}/${DS_ENGELS_TEAM}" >&2
+      return 1
+    fi
+    echo "membership API error for ${username}: ${err:-unknown}" >&2
+    echo "MEMBERSHIP_API_FAILED=1" >&2
+    return 2
+  fi
+  rm -f "$tmp" "${tmp}.err"
+
+  local state
+  state="$(echo "$http_body" | jq -r '.state // empty')"
+  if [[ "$state" == "active" ]]; then
+    return 0
+  fi
+  echo "membership: ${username} state=${state:-empty} (need active)" >&2
+  return 1
+}
+
+resolve_pr_number() {
+  # Prefer explicit PR_NUMBER; on merge_group parse head_ref .../pr-N-...
+  if [[ -n "${PR_NUMBER:-}" ]]; then
+    echo "$PR_NUMBER"
+    return 0
+  fi
+  local head_ref="${MERGE_GROUP_HEAD_REF:-}"
+  if [[ "$head_ref" =~ pr-([0-9]+) ]]; then
+    echo "${BASH_REMATCH[1]}"
+    return 0
+  fi
+  return 1
+}
+
+fetch_pr_json() {
+  local pr_number="$1"
+  local repo="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+  gh_api "repos/${repo}/pulls/${pr_number}"
+}
+
+pr_has_override_label() {
+  local pr_json="$1"
+  echo "$pr_json" | jq -e --arg label "$OVERRIDE_LABEL" \
+    '[.labels[].name] | index($label) != null' >/dev/null
+}
+
+# Find a current DS-Engels approval for head_sha, not from author.
+# Prints "login" of the first matching approver on success.
+# Exit 1 = no valid approver; exit 2 = membership API failure.
+find_ds_engels_approver() {
+  local pr_number="$1"
+  local head_sha="$2"
+  local author="$3"
+  local repo="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+  local reviews
+  reviews="$(gh_api "repos/${repo}/pulls/${pr_number}/reviews")"
+
+  # Latest non-dismissed review per user (array order is chronological).
+  local candidates
+  candidates="$(echo "$reviews" | jq -r --arg sha "$head_sha" --arg author "$author" '
+    map(select(.state != "DISMISSED" and .user.login != null))
+    | group_by(.user.login)
+    | map(sort_by(.submitted_at // .id) | last)
+    | map(select(
+        .state == "APPROVED"
+        and (.commit_id // "") == $sha
+        and .user.login != $author
+      ))
+    | .[].user.login
+  ')"
+
+  if [[ -z "$candidates" ]]; then
+    echo "No current APPROVED review on head ${head_sha} from a non-author reviewer" >&2
+    return 1
+  fi
+
+  local login rc
+  while IFS= read -r login; do
+    [[ -z "$login" ]] && continue
+    set +e
+    is_team_member "$login"
+    rc=$?
+    set -e
+    if [[ "$rc" -eq 0 ]]; then
+      echo "$login"
+      return 0
+    fi
+    if [[ "$rc" -eq 2 ]]; then
+      return 2
+    fi
+    echo "Approver ${login} is not an active ${DS_ENGELS_ORG}/${DS_ENGELS_TEAM} member" >&2
+  done <<<"$candidates"
+
+  return 1
+}
+
+post_or_update_audit_comment() {
+  local pr_number="$1"
+  local author="$2"
+  local approver="$3"
+  local head_sha="$4"
+  local repo="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+
+  if [[ "$SKIP_AUDIT_COMMENT" == "true" ]]; then
+    return 0
+  fi
+
+  local body
+  body="$(cat <<EOF
+${AUDIT_MARKER}
+**Config-check override authorized**
+
+| | |
+|---|---|
+| PR author | \`@${author}\` |
+| Approving DS-Engels reviewer | \`@${approver}\` |
+| Head SHA | \`${head_sha}\` |
+
+The \`config\` check remains failed. Gatekeeper accepted the failure because this PR has the \`${OVERRIDE_LABEL}\` label and a current approval from \`@${DS_ENGELS_ORG}/${DS_ENGELS_TEAM}\`. Justification lives in normal PR review.
+EOF
+)"
+
+  local comments existing_id
+  comments="$(gh_api "repos/${repo}/issues/${pr_number}/comments?per_page=100")"
+  existing_id="$(echo "$comments" | jq -r --arg marker "$AUDIT_MARKER" \
+    '[.[] | select(.body | contains($marker))] | first | .id // empty')"
+
+  if [[ -n "$existing_id" ]]; then
+    gh_api --method PATCH "repos/${repo}/issues/comments/${existing_id}" -f body="$body" >/dev/null
+  else
+    gh_api --method POST "repos/${repo}/issues/${pr_number}/comments" -f body="$body" >/dev/null
+  fi
+}
+
+evaluate_config_override() {
+  # Sets OVERRIDE_PR_NUMBER, OVERRIDE_AUTHOR, OVERRIDE_HEAD_SHA, OVERRIDE_APPROVER
+  # when authorized.
+  # Exit 0 authorized; 1 denied; 2 verification error (fail closed).
+  OVERRIDE_PR_NUMBER=""
+  OVERRIDE_AUTHOR=""
+  OVERRIDE_HEAD_SHA=""
+  OVERRIDE_APPROVER=""
+
+  local event_name="${EVENT_NAME:-}"
+  local head_sha="${PR_HEAD_SHA:-}"
+  local author="${PR_AUTHOR:-}"
+
+  local pr_number
+  if ! pr_number="$(resolve_pr_number)"; then
+    echo "Override denied: no verifiable PR context (event=${event_name})" >&2
+    return 1
+  fi
+
+  local pr_json
+  if ! pr_json="$(fetch_pr_json "$pr_number")"; then
+    echo "Override denied: failed to fetch PR #${pr_number}" >&2
+    return 2
+  fi
+
+  head_sha="${head_sha:-$(echo "$pr_json" | jq -r '.head.sha // empty')}"
+  author="${author:-$(echo "$pr_json" | jq -r '.user.login // empty')}"
+  local base_ref
+  base_ref="$(echo "$pr_json" | jq -r '.base.ref // empty')"
+  local is_fork=false
+  if echo "$pr_json" | jq -e \
+    '(.head.repo.fork == true) or (.head.repo.full_name != .base.repo.full_name)' \
+    >/dev/null; then
+    is_fork=true
+  fi
+
+  if ! pr_has_override_label "$pr_json"; then
+    echo "Override denied: missing label ${OVERRIDE_LABEL}" >&2
+    return 1
+  fi
+  if [[ "$base_ref" != "main" ]]; then
+    echo "Override denied: base ref is '${base_ref}', need main" >&2
+    return 1
+  fi
+  if [[ "$is_fork" == "true" ]]; then
+    echo "Override denied: fork PRs are not eligible" >&2
+    return 1
+  fi
+  if [[ -z "$head_sha" || -z "$author" ]]; then
+    echo "Override denied: missing head SHA or author" >&2
+    return 1
+  fi
+
+  local approver rc
+  set +e
+  approver="$(find_ds_engels_approver "$pr_number" "$head_sha" "$author")"
+  rc=$?
+  set -e
+  if [[ "$rc" -ne 0 ]]; then
+    return "$rc"
+  fi
+
+  OVERRIDE_PR_NUMBER="$pr_number"
+  OVERRIDE_AUTHOR="$author"
+  OVERRIDE_HEAD_SHA="$head_sha"
+  OVERRIDE_APPROVER="$approver"
+  return 0
+}
+
+run_gatekeeper() {
+  print_status_summary
+  classify_results
+
+  if [[ "$HAS_NON_CONFIG_BLOCK" == "true" ]]; then
+    emit_result "failure" "CI checks failed"
+    return 0
+  fi
+
+  if [[ "$CONFIG_IS_CANCELLED" == "true" ]]; then
+    emit_result "failure" "CI checks failed"
+    return 0
+  fi
+
+  if [[ "$CONFIG_IS_FAILURE" != "true" ]]; then
+    emit_result "success" "All CI checks passed"
+    return 0
+  fi
+
+  # Only config failed — evaluate override (no command-sub so globals stick).
+  local rc
+  set +e
+  evaluate_config_override
+  rc=$?
+  set -e
+
+  if [[ "$rc" -eq 0 ]]; then
+    echo "Config-check override authorized by @${OVERRIDE_APPROVER}"
+    post_or_update_audit_comment \
+      "${OVERRIDE_PR_NUMBER}" \
+      "${OVERRIDE_AUTHOR}" \
+      "${OVERRIDE_APPROVER}" \
+      "${OVERRIDE_HEAD_SHA}"
+    emit_result "success" "Config check overridden (approved by @${OVERRIDE_APPROVER})"
+    return 0
+  fi
+
+  if [[ "$rc" -eq 2 ]]; then
+    emit_result "failure" "Config override verification failed (fail closed)"
+    return 0
+  fi
+
+  emit_result "failure" "CI checks failed"
+  return 0
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  # Prefer GH_TOKEN; fall back to GITHUB_TOKEN for local/scripts.
+  if [[ -z "${GH_TOKEN:-}" && -n "${GITHUB_TOKEN:-}" ]]; then
+    export GH_TOKEN="$GITHUB_TOKEN"
+  fi
+  run_gatekeeper
+fi

--- a/.github/scripts/tests/README.md
+++ b/.github/scripts/tests/README.md
@@ -82,3 +82,6 @@ Tests run automatically on:
 - Pushes to `main` that modify `.github/scripts/**`
 
 See `.github/workflows/scripts-test.yaml` for the CI configuration.
+
+Gatekeeper override logic lives in `check-gatekeeper.sh` and is covered by
+`test_check_gatekeeper.bats`.

--- a/.github/scripts/tests/test_check_gatekeeper.bats
+++ b/.github/scripts/tests/test_check_gatekeeper.bats
@@ -1,0 +1,353 @@
+#!/usr/bin/env bats
+#
+# Tests for .github/scripts/check-gatekeeper.sh — config-check override rules.
+#
+# Override is authorized only when:
+#   - PR targets main, not a fork
+#   - label config-check-override is present
+#   - current head SHA has APPROVED review from Unique-AG/ds-engels (not author)
+#   - the only failing required check is config == failure
+#
+# Everything else stays blocking. Membership / API errors fail closed.
+
+load test_helper
+
+SCRIPT="$SCRIPTS_DIR/check-gatekeeper.sh"
+HEAD_SHA="abc123def456"
+AUTHOR="pr-author"
+APPROVER="ds-approver"
+OUTSIDER="random-reviewer"
+
+setup() {
+  export TEST_TMPDIR="$(mktemp -d)"
+  cd "$TEST_TMPDIR" || exit 1
+  export GITHUB_OUTPUT="$TEST_TMPDIR/github_output"
+  : >"$GITHUB_OUTPUT"
+  export GITHUB_REPOSITORY="Unique-AG/ai"
+  export SKIP_AUDIT_COMMENT=true
+  export EVENT_NAME="pull_request"
+  export PR_NUMBER="42"
+  export PR_HEAD_SHA="$HEAD_SHA"
+  export PR_AUTHOR="$AUTHOR"
+
+  # Default: all checks success except what each test overrides.
+  export DETECT_CHANGES=success
+  export LINT=success
+  export TEST=success
+  export TYPES=success
+  export COVERAGE=success
+  export DEPS=success
+  export CONTAINERIZE=success
+  export HELM_LINT=success
+  export CONFIG=success
+  export PR_TITLE=success
+  export NO_MANUAL_RELEASE=skipped
+  export RELEASE_LINEAGE=skipped
+
+  # Fixture knobs controlled per-test via MOCK_* env vars.
+  export MOCK_LABELS='["config-check-override"]'
+  export MOCK_BASE_REF="main"
+  export MOCK_IS_FORK="false"
+  export MOCK_REVIEWS="[]"
+  export MOCK_MEMBERSHIP_MODE="ok" # ok | deny | error
+  export MOCK_MEMBERS="$APPROVER"
+  export MOCK_PR_FETCH_FAIL="false"
+  export MOCK_AUDIT_POSTS="$TEST_TMPDIR/audit_posts"
+  : >"$MOCK_AUDIT_POSTS"
+
+  # shellcheck source=/dev/null
+  source "$SCRIPT"
+
+  gh_api() {
+    local args=("$@")
+    local joined="${args[*]}"
+
+    if [[ "$joined" =~ pulls/[0-9]+(/|$|\ ) ]] && [[ "$joined" != *"/reviews"* ]] && [[ "$joined" != *"/comments"* ]]; then
+      if [[ "${MOCK_PR_FETCH_FAIL}" == "true" ]]; then
+        echo "HTTP 500: boom" >&2
+        return 1
+      fi
+      local fork_json="false"
+      if [[ "${MOCK_IS_FORK}" == "true" ]]; then
+        fork_json="true"
+      fi
+      local head_repo="Unique-AG/ai"
+      local base_repo="Unique-AG/ai"
+      if [[ "${MOCK_IS_FORK}" == "true" ]]; then
+        head_repo="fork-user/ai"
+      fi
+      jq -n \
+        --argjson labels "${MOCK_LABELS}" \
+        --arg base "$MOCK_BASE_REF" \
+        --arg author "$AUTHOR" \
+        --arg sha "$HEAD_SHA" \
+        --argjson fork "$fork_json" \
+        --arg head_repo "$head_repo" \
+        --arg base_repo "$base_repo" \
+        '{
+          number: 42,
+          user: {login: $author},
+          head: {sha: $sha, repo: {fork: $fork, full_name: $head_repo}},
+          base: {ref: $base, repo: {full_name: $base_repo}},
+          labels: ($labels | map({name: .}))
+        }'
+      return 0
+    fi
+
+    if [[ "$joined" == *"/reviews"* ]]; then
+      echo "${MOCK_REVIEWS}"
+      return 0
+    fi
+
+    if [[ "$joined" == *"/memberships/"* ]]; then
+      local user="${joined##*/memberships/}"
+      user="${user%% *}"
+      case "${MOCK_MEMBERSHIP_MODE}" in
+        error)
+          echo "HTTP 403: Resource not accessible by integration" >&2
+          return 1
+          ;;
+        deny)
+          echo "gh: Not Found (HTTP 404)" >&2
+          return 1
+          ;;
+        ok)
+          if [[ " ${MOCK_MEMBERS} " == *" ${user} "* ]]; then
+            echo '{"state":"active","role":"member"}'
+            return 0
+          fi
+          echo "gh: Not Found (HTTP 404)" >&2
+          return 1
+          ;;
+        *)
+          echo "unknown MOCK_MEMBERSHIP_MODE" >&2
+          return 1
+          ;;
+      esac
+    fi
+
+    if [[ "$joined" == *"/comments"* ]]; then
+      if [[ "$joined" == *"PATCH"* || "$joined" == *"POST"* || "$joined" == *"--method"* ]]; then
+        # Only record write attempts (POST/PATCH), not GET list.
+        if [[ "$joined" == *"POST"* || "$joined" == *"PATCH"* ]]; then
+          echo "$joined" >>"$MOCK_AUDIT_POSTS"
+        fi
+        if [[ "$joined" == *"POST"* || "$joined" == *"PATCH"* ]]; then
+          echo '{"id":1}'
+          return 0
+        fi
+      fi
+      echo '[]'
+      return 0
+    fi
+
+    echo "unexpected gh_api call: $joined" >&2
+    return 1
+  }
+
+  # Re-export so nested calls see the mock (bash functions are dynamic).
+  export -f gh_api
+}
+
+teardown() {
+  cd "$TESTS_DIR" || true
+  if [ -n "$TEST_TMPDIR" ] && [ -d "$TEST_TMPDIR" ]; then
+    rm -rf "$TEST_TMPDIR"
+  fi
+}
+
+read_status() {
+  grep '^status=' "$GITHUB_OUTPUT" | tail -1 | cut -d= -f2-
+}
+
+read_description() {
+  grep '^description=' "$GITHUB_OUTPUT" | tail -1 | cut -d= -f2-
+}
+
+set_approved_review() {
+  local login="${1:-$APPROVER}"
+  local sha="${2:-$HEAD_SHA}"
+  local state="${3:-APPROVED}"
+  MOCK_REVIEWS="$(jq -n \
+    --arg login "$login" \
+    --arg sha "$sha" \
+    --arg state "$state" \
+    '[{
+      id: 1,
+      user: {login: $login},
+      state: $state,
+      commit_id: $sha,
+      submitted_at: "2026-08-05T12:00:00Z"
+    }]')"
+  export MOCK_REVIEWS
+}
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+@test "override: label + current DS-Engels approval => Gatekeeper success" {
+  export CONFIG=failure
+  set_approved_review "$APPROVER" "$HEAD_SHA"
+  run run_gatekeeper
+  [ "$status" -eq 0 ]
+  [ "$(read_status)" = "success" ]
+  [[ "$(read_description)" == *"overridden"* ]]
+  [[ "$(read_description)" == *"@${APPROVER}"* ]]
+}
+
+@test "all checks passed => success without override" {
+  export CONFIG=success
+  run run_gatekeeper
+  [ "$status" -eq 0 ]
+  [ "$(read_status)" = "success" ]
+  [ "$(read_description)" = "All CI checks passed" ]
+}
+
+# ---------------------------------------------------------------------------
+# Denial cases
+# ---------------------------------------------------------------------------
+
+@test "override denied: missing label" {
+  export CONFIG=failure
+  export MOCK_LABELS='[]'
+  set_approved_review "$APPROVER" "$HEAD_SHA"
+  run run_gatekeeper
+  [ "$status" -eq 0 ]
+  [ "$(read_status)" = "failure" ]
+  [ "$(read_description)" = "CI checks failed" ]
+}
+
+@test "override denied: non-team approval" {
+  export CONFIG=failure
+  set_approved_review "$OUTSIDER" "$HEAD_SHA"
+  export MOCK_MEMBERS="$APPROVER"
+  run run_gatekeeper
+  [ "$status" -eq 0 ]
+  [ "$(read_status)" = "failure" ]
+  [ "$(read_description)" = "CI checks failed" ]
+}
+
+@test "override denied: approval on stale head SHA" {
+  export CONFIG=failure
+  set_approved_review "$APPROVER" "oldsha000"
+  run run_gatekeeper
+  [ "$status" -eq 0 ]
+  [ "$(read_status)" = "failure" ]
+}
+
+@test "override denied: dismissed approval" {
+  export CONFIG=failure
+  # Approval was dismissed — no remaining non-dismissed APPROVED review.
+  set_approved_review "$APPROVER" "$HEAD_SHA" "DISMISSED"
+  run run_gatekeeper
+  [ "$status" -eq 0 ]
+  [ "$(read_status)" = "failure" ]
+}
+
+@test "override denied: latest non-dismissed review is CHANGES_REQUESTED" {
+  export CONFIG=failure
+  MOCK_REVIEWS="$(jq -n \
+    --arg login "$APPROVER" \
+    --arg sha "$HEAD_SHA" \
+    '[
+      {id:1, user:{login:$login}, state:"APPROVED", commit_id:$sha, submitted_at:"2026-08-05T11:00:00Z"},
+      {id:2, user:{login:$login}, state:"CHANGES_REQUESTED", commit_id:$sha, submitted_at:"2026-08-05T12:00:00Z"}
+    ]')"
+  export MOCK_REVIEWS
+  run run_gatekeeper
+  [ "$status" -eq 0 ]
+  [ "$(read_status)" = "failure" ]
+}
+
+@test "override denied: self-approval by PR author" {
+  export CONFIG=failure
+  set_approved_review "$AUTHOR" "$HEAD_SHA"
+  export MOCK_MEMBERS="$AUTHOR"
+  run run_gatekeeper
+  [ "$status" -eq 0 ]
+  [ "$(read_status)" = "failure" ]
+}
+
+@test "cancelled config stays blocking even with override label+approval" {
+  export CONFIG=cancelled
+  set_approved_review "$APPROVER" "$HEAD_SHA"
+  run run_gatekeeper
+  [ "$status" -eq 0 ]
+  [ "$(read_status)" = "failure" ]
+  [ "$(read_description)" = "CI checks failed" ]
+}
+
+@test "unrelated CI failure stays blocking despite override authorization" {
+  export CONFIG=failure
+  export TEST=failure
+  set_approved_review "$APPROVER" "$HEAD_SHA"
+  run run_gatekeeper
+  [ "$status" -eq 0 ]
+  [ "$(read_status)" = "failure" ]
+  [ "$(read_description)" = "CI checks failed" ]
+}
+
+@test "membership API failure fail-closed" {
+  export CONFIG=failure
+  set_approved_review "$APPROVER" "$HEAD_SHA"
+  export MOCK_MEMBERSHIP_MODE="error"
+  run run_gatekeeper
+  [ "$status" -eq 0 ]
+  [ "$(read_status)" = "failure" ]
+  [ "$(read_description)" = "Config override verification failed (fail closed)" ]
+}
+
+@test "merge_group without verifiable PR context fail-closed" {
+  export CONFIG=failure
+  export EVENT_NAME="merge_group"
+  unset PR_NUMBER
+  export PR_NUMBER=""
+  export MERGE_GROUP_HEAD_REF="refs/heads/gh-readonly-queue/main/merge-without-pr"
+  set_approved_review "$APPROVER" "$HEAD_SHA"
+  run run_gatekeeper
+  [ "$status" -eq 0 ]
+  [ "$(read_status)" = "failure" ]
+}
+
+@test "merge_group recovers PR number from head_ref and can authorize" {
+  export CONFIG=failure
+  export EVENT_NAME="merge_group"
+  unset PR_NUMBER
+  export PR_NUMBER=""
+  export MERGE_GROUP_HEAD_REF="refs/heads/gh-readonly-queue/main/pr-42-${HEAD_SHA}"
+  export PR_AUTHOR=""
+  set_approved_review "$APPROVER" "$HEAD_SHA"
+  run run_gatekeeper
+  [ "$status" -eq 0 ]
+  [ "$(read_status)" = "success" ]
+  [[ "$(read_description)" == *"overridden"* ]]
+}
+
+@test "fork PR cannot use override" {
+  export CONFIG=failure
+  export MOCK_IS_FORK="true"
+  set_approved_review "$APPROVER" "$HEAD_SHA"
+  run run_gatekeeper
+  [ "$status" -eq 0 ]
+  [ "$(read_status)" = "failure" ]
+}
+
+@test "non-main base cannot use override" {
+  export CONFIG=failure
+  export MOCK_BASE_REF="release/2026.08"
+  set_approved_review "$APPROVER" "$HEAD_SHA"
+  run run_gatekeeper
+  [ "$status" -eq 0 ]
+  [ "$(read_status)" = "failure" ]
+}
+
+@test "audit comment posted when override authorized and SKIP_AUDIT_COMMENT=false" {
+  export CONFIG=failure
+  export SKIP_AUDIT_COMMENT=false
+  set_approved_review "$APPROVER" "$HEAD_SHA"
+  run run_gatekeeper
+  [ "$status" -eq 0 ]
+  [ "$(read_status)" = "success" ]
+  grep -q "POST\|comments" "$MOCK_AUDIT_POSTS"
+}

--- a/.github/workflows/ci-config-check.yaml
+++ b/.github/workflows/ci-config-check.yaml
@@ -198,6 +198,17 @@ jobs:
             else
               echo "Validation failed. See job logs for details." >> $GITHUB_STEP_SUMMARY
             fi
+            {
+              echo ""
+              echo "### Intentional override"
+              echo "Config compatibility check failed. To proceed intentionally:"
+              echo "1. Add the \`config-check-override\` label to this PR"
+              echo "2. Get approval from \`@Unique-AG/ds-engels\` (not the PR author) on the current head SHA"
+              echo "3. Re-run **Gatekeeper** (or re-run failed jobs)"
+              echo ""
+              echo "The config job stays red; only Gatekeeper can become green when the override is authorized."
+              echo "Justification belongs in normal PR review — no special comment is required."
+            } >> "$GITHUB_STEP_SUMMARY"
           else
             echo "## ✓ Configuration Check Passed for ${{ matrix.id }}" >> $GITHUB_STEP_SUMMARY
             if [ -f ./config-check-report.md ]; then
@@ -212,4 +223,9 @@ jobs:
         if: steps.validate.outcome == 'failure'
         run: |
           echo "❌ Configuration compatibility check failed"
+          echo ""
+          echo "To proceed intentionally:"
+          echo "  1. Add the config-check-override label"
+          echo "  2. Get approval from @Unique-AG/ds-engels on the current head SHA"
+          echo "  3. Re-run Gatekeeper (or re-run failed jobs)"
           exit 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -144,11 +144,20 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       statuses: write
+      pull-requests: write
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github/scripts/check-gatekeeper.sh
+          sparse-checkout-cone-mode: false
+
       - name: Check results
         id: check
         env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
           DETECT_CHANGES: ${{ needs.detect-changes.result }}
           LINT: ${{ needs.lint.result }}
           TEST: ${{ needs.test.result }}
@@ -161,47 +170,19 @@ jobs:
           PR_TITLE: ${{ needs.pr-title.result }}
           NO_MANUAL_RELEASE: ${{ needs.no-manual-release.result }}
           RELEASE_LINEAGE: ${{ needs.release-lineage.result }}
-        run: |
-          echo "=== CI Status Summary ==="
-          echo "detect-changes: $DETECT_CHANGES"
-          echo "lint: $LINT"
-          echo "test: $TEST"
-          echo "types: $TYPES"
-          echo "coverage: $COVERAGE"
-          echo "deps: $DEPS"
-          echo "containerize: $CONTAINERIZE"
-          echo "helm-lint: $HELM_LINT"
-          echo "config: $CONFIG"
-          echo "pr-title: $PR_TITLE"
-          echo "no-manual-release: $NO_MANUAL_RELEASE"
-          echo "release-lineage: $RELEASE_LINEAGE"
-          echo "========================="
-
-          failed=false
-
-          # Required checks (skipped is OK for when no packages changed or merge_group).
-          # Types: failure means a package with typecheck_require_zero_errors failed, so we treat it as blocking.
-          for check in "detect-changes:$DETECT_CHANGES" "lint:$LINT" "test:$TEST" "types:$TYPES" "coverage:$COVERAGE" "deps:$DEPS" "containerize:$CONTAINERIZE" "helm-lint:$HELM_LINT" "config:$CONFIG" "pr-title:$PR_TITLE" "no-manual-release:$NO_MANUAL_RELEASE" "release-lineage:$RELEASE_LINEAGE"; do
-            name="${check%%:*}"
-            result="${check##*:}"
-            if [[ "$result" == "failure" || "$result" == "cancelled" ]]; then
-              echo "❌ $name: $result"
-              failed=true
-            fi
-          done
-
-          if [[ "$failed" == "true" ]]; then
-            echo "status=failure" >> $GITHUB_OUTPUT
-            echo "description=CI checks failed" >> $GITHUB_OUTPUT
-          else
-            echo "status=success" >> $GITHUB_OUTPUT
-            echo "description=All CI checks passed" >> $GITHUB_OUTPUT
-          fi
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref || '' }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login || '' }}
+          PR_IS_FORK: ${{ github.event.pull_request.head.repo.fork || false }}
+          MERGE_GROUP_HEAD_REF: ${{ github.event.merge_group.head_ref || '' }}
+        run: bash .github/scripts/check-gatekeeper.sh
 
       - name: Post commit status
         env:
           GH_TOKEN: ${{ github.token }}
-          SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
           STATE: ${{ steps.check.outputs.status }}
           DESCRIPTION: ${{ steps.check.outputs.description }}
         run: |

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -14,16 +14,13 @@ An explicit result from the configuration check indicating that a proposed chang
 The trusted merge decision that all required checks are acceptable, with a configuration-check failure accepted only when override authorization is present.
 
 **Configuration-check override**:
-An explicitly justified exception to a failing configuration check, authorized by the designated DS-Engels approver authority.
+An exception to a failing configuration check, authorized when an eligible pull request has the `config-check-override` label and a current approval from a DS-Engels approver. Justification lives in normal PR review; no dedicated justification comment is required.
 
 **Override authorization**:
-The combination of an eligible pull request, a valid override justification, and a current approval from a DS-Engels approver; inability to verify any part means the override is not authorized.
-
-**Authorization attestation**:
-A trusted, app-owned record bound to the current pull-request revision that confirms override authorization; it is distinct from the requester’s request and from the CI result.
+The combination of an eligible pull request, the `config-check-override` label, and a current approval from a DS-Engels approver who is not the PR author; inability to verify any part means the override is not authorized (fail closed).
 
 **Override audit record**:
-A single bot-maintained record on the pull request showing the authorized override's requester, approver, current revision, and where its justification can be found.
+A single bot-maintained record on the pull request showing the authorized override's PR author, approving DS-Engels reviewer, and current head SHA.
 
 **Override revocation**:
 The loss of any authorization condition; it makes the override inactive while retaining its audit record.
@@ -31,20 +28,19 @@ The loss of any authorization condition; it makes the override inactive while re
 **DS-Engels approver**:
 A member of `Unique-AG/ds-engels` who is authorized to approve a configuration-check override.
 
-**Override requester**:
-The pull-request author who explains the configuration risk in a dedicated authorization comment and accepts responsibility for requesting an override.
-
-**Override request**:
-The requester’s explicit indication that a configuration-check failure should be reviewed for an override; the request is not authorization by itself.
-
-**Override justification**:
-A non-empty explanation from the override requester describing what changed, why the configuration failure is believed safe to accept, and any relevant risk or follow-up.
-
 **Current approval**:
-The latest non-dismissed approval from a DS-Engels approver for the pull request's current revision.
+The latest non-dismissed review from a reviewer for the pull request's current head SHA is `APPROVED`.
 
 **Override approval**:
-At least one current approval from a DS-Engels approver other than the override requester.
+At least one current approval from a DS-Engels approver other than the pull-request author.
 
 **Eligible pull request**:
-A pull request from an internal repository branch targeting `main` whose configuration-check failure is being considered for an authorized override.
+A pull request from an internal repository branch (not a fork) targeting `main` whose configuration-check failure is being considered for an authorized override.
+
+## Operational notes
+
+- Only a `config` job result of `failure` can be overridden; `cancelled` or unavailable results stay blocking.
+- Any other failing or cancelled required check keeps Gatekeeper failing.
+- After adding the label or approval, re-run Gatekeeper (or re-run failed jobs). There is no automatic re-dispatch on label/review events.
+- CI reads the `config-check-override` label; it never creates or mutates labels. Create the label once in the repo if missing:
+  `gh label create config-check-override --description "Authorize Gatekeeper to pass despite a config-check failure (requires DS-Engels approval)" --color B60205`

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,50 @@
+# CI Configuration Safety
+
+This context defines the language for reviewing and governing configuration compatibility changes.
+
+## Language
+
+**Configuration check**:
+A review gate that determines whether a proposed change preserves compatibility of supported configuration schemas.
+
+**Configuration-check failure**:
+An explicit result from the configuration check indicating that a proposed change may be incompatible with an existing configuration schema.
+
+**Gatekeeper decision**:
+The trusted merge decision that all required checks are acceptable, with a configuration-check failure accepted only when override authorization is present.
+
+**Configuration-check override**:
+An explicitly justified exception to a failing configuration check, authorized by the designated DS-Engels approver authority.
+
+**Override authorization**:
+The combination of an eligible pull request, a valid override justification, and a current approval from a DS-Engels approver; inability to verify any part means the override is not authorized.
+
+**Authorization attestation**:
+A trusted, app-owned record bound to the current pull-request revision that confirms override authorization; it is distinct from the requester’s request and from the CI result.
+
+**Override audit record**:
+A single bot-maintained record on the pull request showing the authorized override's requester, approver, current revision, and where its justification can be found.
+
+**Override revocation**:
+The loss of any authorization condition; it makes the override inactive while retaining its audit record.
+
+**DS-Engels approver**:
+A member of `Unique-AG/ds-engels` who is authorized to approve a configuration-check override.
+
+**Override requester**:
+The pull-request author who explains the configuration risk in a dedicated authorization comment and accepts responsibility for requesting an override.
+
+**Override request**:
+The requester’s explicit indication that a configuration-check failure should be reviewed for an override; the request is not authorization by itself.
+
+**Override justification**:
+A non-empty explanation from the override requester describing what changed, why the configuration failure is believed safe to accept, and any relevant risk or follow-up.
+
+**Current approval**:
+The latest non-dismissed approval from a DS-Engels approver for the pull request's current revision.
+
+**Override approval**:
+At least one current approval from a DS-Engels approver other than the override requester.
+
+**Eligible pull request**:
+A pull request from an internal repository branch targeting `main` whose configuration-check failure is being considered for an authorized override.

--- a/unique_toolkit/unique_toolkit/_common/config_checker/README.md
+++ b/unique_toolkit/unique_toolkit/_common/config_checker/README.md
@@ -349,13 +349,15 @@ To fix: Either restore the class or use `@register_config()` to map the old name
 
 ### Q: Can I ignore a specific breaking change?
 
-**A:** Not recommended (defeats the purpose), but you can:
+**A:** Prefer fixing the schema to maintain compatibility. When an intentional, reviewed exception is needed on a PR targeting `main`:
 
-1. **Fix the schema** to maintain compatibility
+1. Add the `config-check-override` label (create it once in the repo if it does not exist — CI never creates labels)
+2. Get approval from `@Unique-AG/ds-engels` on the **current** head SHA (not the PR author)
+3. Re-run **Gatekeeper** (or re-run failed jobs)
 
-2. **Create a migration guide** for users
+The config job stays failed and explains this path in its summary. Only Gatekeeper becomes green when the override is authorized. Justification belongs in normal PR review — no special comment body is required. See `CONTEXT.md` for the domain language.
 
-The system is designed to catch issues early. If you need to skip, understand why.
+Fork PRs, non-`main` base branches, cancelled config checks, other failing CI jobs, stale/dismissed approvals, and membership verification failures all remain blocking.
 
 ## Performance
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements [UN-23874](https://unique-ch.atlassian.net/browse/UN-23874): a minimal Gatekeeper override so a **config-only** failure can become non-blocking when an internal PR to `main` has the `config-check-override` label and a **current** `@Unique-AG/ds-engels` approval (not the author). No mandatory justification comment — justification lives in normal PR review.

UN-23873 registration work is out of scope.

## Behavior

Authorized only when **all** are true:
1. PR targets `main` and is not a fork
2. PR has `config-check-override`
3. Latest non-dismissed review for the current head SHA is `APPROVED` from a DS-Engels member other than the author
4. The only failing required check is `config` with actual `failure` (not cancelled)

Otherwise Gatekeeper stays red (fail closed on membership/API errors). Config job stays failed and documents the override path. Re-run Gatekeeper (or failed jobs) after label/approval; no auto re-dispatch.

## Changes

- Extract Gatekeeper decision into `.github/scripts/check-gatekeeper.sh` (Teams membership via `GITHUB_TOKEN`)
- Wire override + idempotent audit comment from `ci.yaml`
- Config-check failure messaging for label / DS-Engels / re-run
- BATS coverage for authorize/deny paths
- Align `CONTEXT.md` + config_checker README (no mandatory justification comment)

## Test plan

- [x] `bats .github/scripts/tests/*.bats`
- [ ] Label + current DS-Engels approval + config-only failure → Gatekeeper success with override description
- [ ] Missing label / stale or self-approval / fork / cancelled config / other failures / membership API error → Gatekeeper failure
- [ ] Confirm org Actions setting allows `GITHUB_TOKEN` to read team membership (`Unique-AG/ds-engels`); otherwise override always fail-closes

## Ops note

One-time label bootstrap (CI does not create labels):

```bash
gh label create config-check-override \
  --description "Authorize Gatekeeper to pass despite a config-check failure (requires DS-Engels approval)" \
  --color B60205
```

Refs: UN-23874

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-816f57fc-1f82-4e8a-9f33-d0e9b7fab812?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-816f57fc-1f82-4e8a-9f33-d0e9b7fab812&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[UN-23874]: https://unique-ch.atlassian.net/browse/UN-23874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ