### PR TITLE
feat(monitoring): add FastAPI/requests auto-instrumentation to the OTel bootstrap [UN-23824]

### DIFF
--- a/unique_toolkit/pyproject.toml
+++ b/unique_toolkit/pyproject.toml
@@ -66,6 +66,8 @@ monitoring = [
 otel = [
     "opentelemetry-sdk>=1.27,<2",
     "opentelemetry-exporter-otlp-proto-http>=1.27,<2",
+    "opentelemetry-instrumentation-fastapi>=0.65b0,<1",
+    "opentelemetry-instrumentation-requests>=0.65b0,<1",
 ]
 [build-system]
 requires = ["uv_build>=0.8.14,<0.9.0"]
@@ -79,6 +81,8 @@ dev = [
     "types-cachetools>=5.0,<6",
     "opentelemetry-sdk>=1.27,<2",
     "opentelemetry-exporter-otlp-proto-http>=1.27,<2",
+    "opentelemetry-instrumentation-fastapi>=0.65b0,<1",
+    "opentelemetry-instrumentation-requests>=0.65b0,<1",
 ]
 
 [tool.uv]
@@ -132,6 +136,8 @@ DEP002 = [
     "uvicorn",
     "opentelemetry-sdk",
     "opentelemetry-exporter-otlp-proto-http",
+    "opentelemetry-instrumentation-fastapi",
+    "opentelemetry-instrumentation-requests",
 ]
 DEP004 = ["langchain_openai", "langchain_core"]
 

--- a/unique_toolkit/tests/monitoring/conftest.py
+++ b/unique_toolkit/tests/monitoring/conftest.py
@@ -1,0 +1,12 @@
+import pytest
+
+from unique_toolkit.monitoring.tracing import TracingSettings
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _isolate_tracing_settings_from_env_file():
+    """env_file is resolved at import time, so monkeypatch is too late."""
+    original = TracingSettings.model_config.get("env_file")
+    TracingSettings.model_config["env_file"] = None
+    yield
+    TracingSettings.model_config["env_file"] = original

--- a/unique_toolkit/tests/monitoring/test_tracing.py
+++ b/unique_toolkit/tests/monitoring/test_tracing.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import builtins
+from pathlib import Path
 
 import pytest
 from opentelemetry import trace
@@ -207,6 +208,27 @@ def test_tracing_settings__treats_empty_service_values_as_unset(
 
     assert settings.service_name is None
     assert settings.service_version == "node-version"
+
+
+@pytest.mark.ai
+@pytest.mark.unit
+def test_tracing_settings__reads_enable_opentelemetry__from_env_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    Purpose: Verify ENABLE_OPENTELEMETRY is read from a .env file, not just os.environ.
+    Why this matters: pydantic-settings does not populate os.environ from .env, so a local
+    dev opt-in written only to .env would otherwise silently never enable tracing.
+    Setup summary: Write the flag to a temp .env, delete it from real os.environ, assert on.
+    """
+    monkeypatch.delenv("ENABLE_OPENTELEMETRY", raising=False)
+    env_file = tmp_path / ".env"
+    env_file.write_text("ENABLE_OPENTELEMETRY=true\n")
+
+    settings = TracingSettings(_env_file=str(env_file))
+
+    assert settings.enabled is True
+    assert settings.exporter is TraceExporter.OTLP
 
 
 @pytest.mark.ai
@@ -566,6 +588,86 @@ def test_instrument_fastapi_app__traces_inbound_requests() -> None:
 
     assert response.status_code == 200
     assert any(span.name.endswith("/ping") for span in exporter.get_finished_spans())
+
+
+@pytest.mark.ai
+@pytest.mark.unit
+def test_instrument_fastapi_app__excludes_urls_matching_excluded_urls() -> None:
+    """
+    Purpose: Verify excluded_urls actually suppresses spans for the matching route.
+    Why this matters: This is what keeps polled routes like /metrics out of every trace.
+    Setup summary: Instrument with excluded_urls, call both routes, assert only one traced.
+    """
+    pytest.importorskip("fastapi")
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+        InMemorySpanExporter,
+    )
+
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+
+    app = FastAPI()
+
+    @app.get("/ping")
+    def ping() -> dict[str, bool]:
+        return {"ok": True}
+
+    @app.get("/metrics")
+    def metrics() -> dict[str, bool]:
+        return {"metrics": True}
+
+    instrument_fastapi_app(app, excluded_urls="/metrics")
+
+    client = TestClient(app)
+    client.get("/ping")
+    client.get("/metrics")
+
+    span_names = [span.name for span in exporter.get_finished_spans()]
+    assert any(name.endswith("/ping") for name in span_names)
+    assert not any(name.endswith("/metrics") for name in span_names)
+
+
+@pytest.mark.ai
+@pytest.mark.unit
+def test_instrument_fastapi_app__is_idempotent() -> None:
+    """
+    Purpose: Verify calling the FastAPI helper twice on the same app does not raise.
+    Why this matters: Process startup paths may configure tracing more than once.
+    Setup summary: Instrument the same app twice and assert one span per request.
+    """
+    pytest.importorskip("fastapi")
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+        InMemorySpanExporter,
+    )
+
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+
+    app = FastAPI()
+
+    @app.get("/ping")
+    def ping() -> dict[str, bool]:
+        return {"ok": True}
+
+    instrument_fastapi_app(app)
+    instrument_fastapi_app(app)
+
+    TestClient(app).get("/ping")
+
+    route_spans = [s for s in exporter.get_finished_spans() if s.name == "GET /ping"]
+    assert len(route_spans) == 1
 
 
 @pytest.mark.ai

--- a/unique_toolkit/tests/monitoring/test_tracing.py
+++ b/unique_toolkit/tests/monitoring/test_tracing.py
@@ -15,6 +15,8 @@ from unique_toolkit.monitoring import (
     TracingSettings,
     configure_tracing,
     inject_trace_headers,
+    instrument_fastapi_app,
+    instrument_requests,
 )
 
 
@@ -472,3 +474,138 @@ def test_configure_tracing__does_not_replace_an_existing_provider(
 
     assert configure_tracing() is True
     assert trace.get_tracer_provider() is provider
+
+
+@pytest.mark.ai
+@pytest.mark.unit
+def test_instrument_fastapi_app__raises_fastapi_install_hint__when_fastapi_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Purpose: Verify a missing fastapi package is attributed to the fastapi extra, not otel.
+    Why this matters: opentelemetry-instrumentation-fastapi imports fastapi internally, so
+    its own ImportError would otherwise be misreported as a missing otel extra.
+    Setup summary: Block the fastapi import and assert the fastapi-specific install hint.
+    """
+    pytest.importorskip("fastapi")
+    from fastapi import FastAPI
+
+    app = FastAPI()
+    original_import = builtins.__import__
+
+    def import_without_fastapi(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "fastapi":
+            raise ImportError("fastapi is unavailable")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", import_without_fastapi)
+
+    with pytest.raises(ImportError, match=r"unique_toolkit\[fastapi\]"):
+        instrument_fastapi_app(app)
+
+
+@pytest.mark.ai
+@pytest.mark.unit
+def test_instrument_fastapi_app__raises_otel_install_hint__when_otel_extra_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Purpose: Verify the FastAPI helper explains how to install its optional dependency.
+    Why this matters: An opaque ImportError would make onboarding a new service harder.
+    Setup summary: Block the fastapi instrumentation import and assert the install hint.
+    """
+    pytest.importorskip("fastapi")
+    from fastapi import FastAPI
+
+    original_import = builtins.__import__
+
+    def import_without_fastapi_instrumentation(
+        name, globals=None, locals=None, fromlist=(), level=0
+    ):
+        if name == "opentelemetry.instrumentation.fastapi":
+            raise ImportError("instrumentation package is unavailable")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", import_without_fastapi_instrumentation)
+
+    with pytest.raises(ImportError, match=r"unique_toolkit\[otel\]"):
+        instrument_fastapi_app(FastAPI())
+
+
+@pytest.mark.ai
+@pytest.mark.unit
+def test_instrument_fastapi_app__traces_inbound_requests() -> None:
+    """
+    Purpose: Verify an instrumented app produces a valid server span for inbound requests.
+    Why this matters: This is what joins assistants-core's spans to a caller's trace.
+    Setup summary: Instrument a FastAPI app, call it via TestClient, assert a recorded span.
+    """
+    pytest.importorskip("fastapi")
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+        InMemorySpanExporter,
+    )
+
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+
+    app = FastAPI()
+
+    @app.get("/ping")
+    def ping() -> dict[str, bool]:
+        return {"ok": True}
+
+    instrument_fastapi_app(app, excluded_urls="/metrics")
+
+    response = TestClient(app).get("/ping")
+
+    assert response.status_code == 200
+    assert any(span.name.endswith("/ping") for span in exporter.get_finished_spans())
+
+
+@pytest.mark.ai
+@pytest.mark.unit
+def test_instrument_requests__raises_install_hint__when_otel_extra_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Purpose: Verify the requests helper explains how to install its optional dependency.
+    Why this matters: An opaque ImportError would make onboarding a new service harder.
+    Setup summary: Block the requests instrumentation import and assert the install hint.
+    """
+    original_import = builtins.__import__
+
+    def import_without_requests_instrumentation(
+        name, globals=None, locals=None, fromlist=(), level=0
+    ):
+        if name == "opentelemetry.instrumentation.requests":
+            raise ImportError("instrumentation package is unavailable")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", import_without_requests_instrumentation)
+
+    with pytest.raises(ImportError, match=r"unique_toolkit\[otel\]"):
+        instrument_requests()
+
+
+@pytest.mark.ai
+@pytest.mark.unit
+def test_instrument_requests__is_idempotent() -> None:
+    """
+    Purpose: Verify calling the requests helper twice does not raise.
+    Why this matters: Process startup paths may configure tracing more than once.
+    Setup summary: Instrument requests twice and assert no exception, then uninstrument.
+    """
+    from opentelemetry.instrumentation.requests import RequestsInstrumentor
+
+    instrument_requests()
+    try:
+        instrument_requests()
+        assert RequestsInstrumentor().is_instrumented_by_opentelemetry is True
+    finally:
+        RequestsInstrumentor().uninstrument()

--- a/unique_toolkit/unique_toolkit/monitoring/__init__.py
+++ b/unique_toolkit/unique_toolkit/monitoring/__init__.py
@@ -4,6 +4,8 @@ from unique_toolkit.monitoring.tracing import (
     TracingSettings,
     configure_tracing,
     inject_trace_headers,
+    instrument_fastapi_app,
+    instrument_requests,
 )
 
 __all__ = [
@@ -12,6 +14,8 @@ __all__ = [
     "TracingSettings",
     "configure_tracing",
     "inject_trace_headers",
+    "instrument_fastapi_app",
+    "instrument_requests",
 ]
 
 _MONITORING_AVAILABLE = False

--- a/unique_toolkit/unique_toolkit/monitoring/tracing.py
+++ b/unique_toolkit/unique_toolkit/monitoring/tracing.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING, ClassVar, Self, TypeAlias, cast
 from pydantic import AliasChoices, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from unique_toolkit.app.find_env_file import find_env_file
+
 if TYPE_CHECKING:
     from fastapi import FastAPI  # pyright: ignore[reportMissingImports]
     from opentelemetry.trace.propagation.tracecontext import (
@@ -47,6 +49,8 @@ class TracingSettings(BaseSettings):
         env_prefix="OTEL_",
         env_ignore_empty=True,
         extra="ignore",
+        env_file=find_env_file(".env", required=False),
+        env_file_encoding="utf-8",
     )
 
     traces_exporter: TraceExporter | None = None
@@ -175,9 +179,12 @@ def configure_tracing(
 
     try:
         from opentelemetry import trace
+        from opentelemetry.baggage.propagation import W3CBaggagePropagator
         from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
             OTLPSpanExporter,
         )
+        from opentelemetry.propagate import set_global_textmap
+        from opentelemetry.propagators.composite import CompositePropagator
         from opentelemetry.sdk.resources import Resource
         from opentelemetry.sdk.trace import TracerProvider
         from opentelemetry.sdk.trace.export import (
@@ -186,6 +193,9 @@ def configure_tracing(
             SimpleSpanProcessor,
         )
         from opentelemetry.trace import ProxyTracerProvider
+        from opentelemetry.trace.propagation.tracecontext import (
+            TraceContextTextMapPropagator,
+        )
     except ImportError as error:
         raise _missing_otel_extra() from error
 
@@ -206,8 +216,20 @@ def configure_tracing(
     if exporter is TraceExporter.CONSOLE:
         provider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter()))
     else:
-        provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+        # Sizing pinned to match the Node services' instrumentation.ts.
+        provider.add_span_processor(
+            BatchSpanProcessor(
+                OTLPSpanExporter(),
+                max_queue_size=2048,
+                max_export_batch_size=512,
+                schedule_delay_millis=5000,
+            )
+        )
     trace.set_tracer_provider(provider)
+    # Trace-context + baggage, the shared subset of the Node services' propagator.
+    set_global_textmap(
+        CompositePropagator([TraceContextTextMapPropagator(), W3CBaggagePropagator()])
+    )
     return True
 
 

--- a/unique_toolkit/unique_toolkit/monitoring/tracing.py
+++ b/unique_toolkit/unique_toolkit/monitoring/tracing.py
@@ -10,6 +10,7 @@ from pydantic import AliasChoices, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 if TYPE_CHECKING:
+    from fastapi import FastAPI
     from opentelemetry.trace.propagation.tracecontext import (
         TraceContextTextMapPropagator,
     )
@@ -24,6 +25,10 @@ ASGIApp: TypeAlias = Callable[[ASGIScope, ASGIReceive, ASGISend], Awaitable[None
 _OTEL_EXTRA_MESSAGE = (
     "OpenTelemetry tracing requires the unique_toolkit[otel] extra. "
     "Install it with: uv add 'unique-toolkit[otel]'"
+)
+_FASTAPI_EXTRA_MESSAGE = (
+    "FastAPI instrumentation requires the unique_toolkit[fastapi] extra. "
+    "Install it with: uv add 'unique-toolkit[fastapi]'"
 )
 
 
@@ -88,6 +93,11 @@ class TracingSettings(BaseSettings):
 def _missing_otel_extra() -> ImportError:
     """Create a consistent error for an unavailable optional tracing dependency."""
     return ImportError(_OTEL_EXTRA_MESSAGE)
+
+
+def _missing_fastapi_extra() -> ImportError:
+    """Create a consistent error for an unavailable optional FastAPI dependency."""
+    return ImportError(_FASTAPI_EXTRA_MESSAGE)
 
 
 def _trace_context_propagator() -> TraceContextTextMapPropagator:
@@ -199,3 +209,39 @@ def configure_tracing(
         provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
     trace.set_tracer_provider(provider)
     return True
+
+
+def instrument_fastapi_app(app: FastAPI, *, excluded_urls: str | None = None) -> None:
+    """Trace inbound requests for an already-created FastAPI app instance.
+
+    Uses ``FastAPIInstrumentor.instrument_app`` rather than the global
+    ``FastAPIInstrumentor().instrument()``: the global form swaps out the
+    ``fastapi.FastAPI`` class, so it only takes effect for app objects created
+    afterward. Instrumenting the instance has no such ordering requirement.
+    """
+    try:
+        import fastapi  # noqa: F401  # pyright: ignore[reportUnusedImport]
+    except ImportError as error:
+        # opentelemetry-instrumentation-fastapi imports fastapi internally, so without
+        # this explicit check its own ImportError would be misreported below as a
+        # missing otel extra when fastapi itself is what's actually missing.
+        raise _missing_fastapi_extra() from error
+
+    try:
+        from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+    except ImportError as error:
+        raise _missing_otel_extra() from error
+    FastAPIInstrumentor.instrument_app(app, excluded_urls=excluded_urls)
+
+
+def instrument_requests() -> None:
+    """Trace outbound calls made with the ``requests`` library.
+
+    Patches ``requests`` at module level, so callers that already imported it
+    are still covered.
+    """
+    try:
+        from opentelemetry.instrumentation.requests import RequestsInstrumentor
+    except ImportError as error:
+        raise _missing_otel_extra() from error
+    RequestsInstrumentor().instrument()

--- a/unique_toolkit/unique_toolkit/monitoring/tracing.py
+++ b/unique_toolkit/unique_toolkit/monitoring/tracing.py
@@ -10,7 +10,7 @@ from pydantic import AliasChoices, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 if TYPE_CHECKING:
-    from fastapi import FastAPI
+    from fastapi import FastAPI  # pyright: ignore[reportMissingImports]
     from opentelemetry.trace.propagation.tracecontext import (
         TraceContextTextMapPropagator,
     )
@@ -220,7 +220,7 @@ def instrument_fastapi_app(app: FastAPI, *, excluded_urls: str | None = None) ->
     afterward. Instrumenting the instance has no such ordering requirement.
     """
     try:
-        import fastapi  # noqa: F401  # pyright: ignore[reportUnusedImport]
+        import fastapi  # noqa: F401  # pyright: ignore[reportMissingImports, reportUnusedImport]
     except ImportError as error:
         # opentelemetry-instrumentation-fastapi imports fastapi internally, so without
         # this explicit check its own ImportError would be misreported below as a

--- a/uv.lock
+++ b/uv.lock
@@ -341,6 +341,15 @@ wheels = [
 ]
 
 [[package]]
+name = "asgiref"
+version = "3.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/26/3b59f2bdae5f640389becb1f673cded775287f5fc4f816309d9ca9a3f93d/asgiref-3.12.1.tar.gz", hash = "sha256:59dcb51c272ad209d59bed5708a64a333083e86017d7fcdd67498eeab7784340", size = 42378, upload-time = "2026-07-14T09:56:18.087Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/1b/54f4ad77cd8a584fa70746c47df988e002cf1ee1eba43364d46f87803647/asgiref-3.12.1-py3-none-any.whl", hash = "sha256:fe386d1c2bff7259ea95929266d12a8cf9a8b5a1c2598402967d8792e7a7c094", size = 25478, upload-time = "2026-07-14T09:56:16.926Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "25.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3268,6 +3277,68 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-instrumentation"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "packaging" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/91/3c58961cb0360cd60509064734f0be4275383c8681d73c580a40ca83ddce/opentelemetry_instrumentation-0.65b0.tar.gz", hash = "sha256:071d9d9eced9bd6460444ec3b0c77229870ed05a881c22c84fdede58e4eed09b", size = 42689, upload-time = "2026-07-16T15:25:50.275Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/7b/85eab1215f72adf0e68d3dc4a679b9bff993fa679ff34cd8dd378e2659fd/opentelemetry_instrumentation-0.65b0-py3-none-any.whl", hash = "sha256:ea967a72b9939b5fcfdad572753b4306c59dcb99e3f382d95dae04286805e137", size = 36717, upload-time = "2026-07-16T15:24:51.424Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-asgi"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/17/83/8e8e83b7ac285281687c7be2fd305213ccccbb8c0a2dd4fb45a8ccaf12c7/opentelemetry_instrumentation_asgi-0.65b0.tar.gz", hash = "sha256:892bca67c56522ffa85a8a83cf934d7b50b3be2132e45cbee705825f0a5ba426", size = 26140, upload-time = "2026-07-16T15:25:54.544Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/9c/376962840b619d2d55fe8ee2285f8c70971c090e5fff614516fc654a6f3a/opentelemetry_instrumentation_asgi-0.65b0-py3-none-any.whl", hash = "sha256:3a845a8ebd1c4ef0d8263401e6545f5b219b2feee612090d50f578a87e71fd65", size = 15903, upload-time = "2026-07-16T15:24:57.198Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-fastapi"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-instrumentation-asgi" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/30/23/b057f8196d06efdc1b50e3ff11fbc499a7d96b35c87f217eb7885542f4ea/opentelemetry_instrumentation_fastapi-0.65b0.tar.gz", hash = "sha256:10a3a95486036230413a58fe4fdf4a83fa6bba46918407e527476994bd92bd97", size = 26236, upload-time = "2026-07-16T15:26:05.954Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b0/c9b0300d33349ecc3dfd2362516eaffc44877e90970e6a52178ff953fec3/opentelemetry_instrumentation_fastapi-0.65b0-py3-none-any.whl", hash = "sha256:cda2610a0ec1b22d19886f33e4d861e9f5dbb886aeaa3a1263b47aff82c36943", size = 13261, upload-time = "2026-07-16T15:25:12.429Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-requests"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c8/84/f46bf7976a81827419b085c9ed14562410c7599e07509786e9f6eb3c5438/opentelemetry_instrumentation_requests-0.65b0.tar.gz", hash = "sha256:1d601548f89236d5ab373c7208a2e1e162a8d6462b5b972f9ad8fb0ed82d7438", size = 18107, upload-time = "2026-07-16T15:26:18.532Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/45/6201afe846263d775cd4fc8d6a87dc8c15eb7921cdade4dca1e1227b04b6/opentelemetry_instrumentation_requests-0.65b0-py3-none-any.whl", hash = "sha256:91688ec0d4d1fed75ea8d026ef2c66274ed9868c22b6be211ef85d832d16f957", size = 13386, upload-time = "2026-07-16T15:25:31.093Z" },
+]
+
+[[package]]
 name = "opentelemetry-proto"
 version = "1.44.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3304,6 +3375,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8f/73/0cbdebcb4cf545fdd328da14f5137e37d0770c3f26185e478b0d15d94f50/opentelemetry_semantic_conventions-0.65b0.tar.gz", hash = "sha256:f9b2b81e9d5b64f11bc952075e7e9c7fb0aab075c7fd1c46d597f1b919852d60", size = 148774, upload-time = "2026-07-16T15:25:46.902Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a6/0e/49df70d9b81fb5cbae4bbf2a49d865b09bcbcbc4eb53f5851b1027738d78/opentelemetry_semantic_conventions-0.65b0-py3-none-any.whl", hash = "sha256:1cacde7b0ad306f84c5ef08c3dbe1bbaf20165bba6f8bff43b670e555a086bcb", size = 204645, upload-time = "2026-07-16T15:25:30.688Z" },
+]
+
+[[package]]
+name = "opentelemetry-util-http"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/32/a9/d7525a59fdd240e69b5af4a6338e78fafa1b4203394122cbd6701fb5f84a/opentelemetry_util_http-0.65b0.tar.gz", hash = "sha256:84f82d826978bba416ab453460ff6a7391cdc3534c93a786595e4068680016b7", size = 11243, upload-time = "2026-07-16T15:26:27.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/3f/ab8d29df207ce5f470a07fa96ebb48af4e95b7fab7e7635311b9a32f2fab/opentelemetry_util_http-0.65b0-py3-none-any.whl", hash = "sha256:7553b606f963097cb190536dc30556cce85090692e471a422fff30ca29b04348", size = 8245, upload-time = "2026-07-16T15:25:46.482Z" },
 ]
 
 [[package]]
@@ -5692,12 +5772,16 @@ monitoring = [
 ]
 otel = [
     { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-instrumentation-fastapi" },
+    { name = "opentelemetry-instrumentation-requests" },
     { name = "opentelemetry-sdk" },
 ]
 
 [package.dev-dependencies]
 dev = [
     { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-instrumentation-fastapi" },
+    { name = "opentelemetry-instrumentation-requests" },
     { name = "opentelemetry-sdk" },
     { name = "types-cachetools" },
 ]
@@ -5721,6 +5805,8 @@ requires-dist = [
     { name = "openai", specifier = ">=1.105.0,<3" },
     { name = "openai", marker = "extra == 'langchain'", specifier = ">=1.105.0,<3" },
     { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'otel'", specifier = ">=1.27,<2" },
+    { name = "opentelemetry-instrumentation-fastapi", marker = "extra == 'otel'", specifier = ">=0.65b0,<1" },
+    { name = "opentelemetry-instrumentation-requests", marker = "extra == 'otel'", specifier = ">=0.65b0,<1" },
     { name = "opentelemetry-sdk", marker = "extra == 'otel'", specifier = ">=1.27,<2" },
     { name = "pandas", specifier = ">=2.3.0,<3" },
     { name = "pillow", specifier = ">=12.1.1" },
@@ -5749,6 +5835,8 @@ provides-extras = ["langchain", "fastapi", "monitoring", "otel"]
 [package.metadata.requires-dev]
 dev = [
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.27,<2" },
+    { name = "opentelemetry-instrumentation-fastapi", specifier = ">=0.65b0,<1" },
+    { name = "opentelemetry-instrumentation-requests", specifier = ">=0.65b0,<1" },
     { name = "opentelemetry-sdk", specifier = ">=1.27,<2" },
     { name = "types-cachetools", specifier = ">=5.0,<6" },
 ]
@@ -6190,6 +6278,70 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/86/eb/20b6cdf273913d0ad05a6a14aed4b9a85591c18a987a3d47f20fa13dcc47/websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa", size = 176393, upload-time = "2025-03-05T20:02:53.814Z" },
     { url = "https://files.pythonhosted.org/packages/1b/6c/c65773d6cab416a64d191d6ee8a8b1c68a09970ea6909d16965d26bfed1e/websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561", size = 176837, upload-time = "2025-03-05T20:02:55.237Z" },
     { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/a4/282c8e64300a59fc834518a54bf0afabb4ff9218b5fa76958b450459a844/wrapt-2.2.2.tar.gz", hash = "sha256:0788e321027c999bf221b667bd4a54aaefd1a36283749a860ac3eb77daed0302", size = 129068, upload-time = "2026-06-20T23:49:44.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/85/180b40628b23772692a0c76e8030114e1c0ae068470ed531919f0a5f2a4a/wrapt-2.2.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8417fd3c674d3c8023d080292d29301531a12daf8bd938dd419710dd2f464f2b", size = 81484, upload-time = "2026-06-20T23:47:59.924Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f2/21c90f2a16689702e2aaff45795b11018dff2c9b1242bac10d225483f676/wrapt-2.2.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e7070c7472582e31af3dfc2622b2381a0df7435110a9388ed8db5ffbce67efb", size = 82151, upload-time = "2026-06-20T23:48:01.303Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/b3/7e6e9fcf4fe7e1b69a49fe6cc5a44e8224bab6283c5233c97e132f14908e/wrapt-2.2.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2e096c9d39a59b35b63c9aacfbbbec2088ff51ff1fc31051acc60a07f42f273a", size = 169828, upload-time = "2026-06-20T23:48:02.719Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/43/894f132d857ed5a9904d937baf368badcbe5ea9e436e2f1930fe21c9f1f0/wrapt-2.2.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d1a6050405bf334be33bf66296f113563622972a34900ae6fa60fd283a1a900", size = 171544, upload-time = "2026-06-20T23:48:04.266Z" },
+    { url = "https://files.pythonhosted.org/packages/29/de/3c833e03725b477e9ea34028224dd21a48781830101e4e036f77e8b6b102/wrapt-2.2.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:10adb01371408c6de504a6658b9886480f1a4919a83752748a387a504a21df79", size = 160663, upload-time = "2026-06-20T23:48:05.708Z" },
+    { url = "https://files.pythonhosted.org/packages/33/be/27edce350b24e3054d9d047f65f16d4c4d4c1f3f31c4278a1f8a95c723c8/wrapt-2.2.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3442eee2a5798f9b451f1b2cd7518ce8b7e28a2a364696c414460a0e295c012a", size = 169387, upload-time = "2026-06-20T23:48:07.243Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/c4/9fd9679af8bf38e146652c7f47b6b352c3e5795b4ad1c0b7f94e15ac2aa7/wrapt-2.2.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6c99012a22f735a85eed7c4b86a3e99c30fdd57d9e115b2b45f796264b58d0bf", size = 158849, upload-time = "2026-06-20T23:48:08.91Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/c2/aa6c0c2206803068c6859dabe01f8c84c43744da93d4c67b8946d21655ee/wrapt-2.2.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3b686cfc008776a3952d6213cb296ed7f45d782a8453936406faa89eac0835ab", size = 168147, upload-time = "2026-06-20T23:48:10.374Z" },
+    { url = "https://files.pythonhosted.org/packages/42/63/3eb25da41049d20ae18fcab2dd8b056e02387c4bfa626cbdfb7c3b872e4f/wrapt-2.2.2-cp312-cp312-win32.whl", hash = "sha256:ef2cce266b5b0b07e19fa82e59673b81142b7a3607c8ed1254113d048ed668da", size = 77734, upload-time = "2026-06-20T23:48:11.769Z" },
+    { url = "https://files.pythonhosted.org/packages/da/09/0390e008a305360948fa9ce69507d041ac12cb2ee5d28e34467e2ee79391/wrapt-2.2.2-cp312-cp312-win_amd64.whl", hash = "sha256:abf8c20a2d72ee69e16328b3c91342c446e723bfe48bfcc4dded3b9722ac027f", size = 80585, upload-time = "2026-06-20T23:48:13.117Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b3/84c445c66969f2d3457276b183a48c91097d59bbef9af6c075366b0f8c36/wrapt-2.2.2-cp312-cp312-win_arm64.whl", hash = "sha256:c6c64c5d02578bc4c4bca4f0aef1504de933c1d5b4ac2710b9131111459506c8", size = 79553, upload-time = "2026-06-20T23:48:14.5Z" },
+    { url = "https://files.pythonhosted.org/packages/43/fc/f32f4b22c6511173c11d9e541ab4e7d8467a0f1b3455acaf784115d31ff8/wrapt-2.2.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9e8b648270c613720a202d9a45ebabc33261b22c3a839b115ac5bce8c0bb0d69", size = 81296, upload-time = "2026-06-20T23:48:15.881Z" },
+    { url = "https://files.pythonhosted.org/packages/72/06/4d117d5d77a9344776c0248b24dae3d3dd2f58e5f765fa08cf887072e719/wrapt-2.2.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6fb7e94e8fe3e4c3067bb1653a91cce7c5e83acc119fdd41501b1bf74654617", size = 81841, upload-time = "2026-06-20T23:48:17.262Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ff/63ad96f98eb58a742b1a20d80f21da88924405910149950b912368150468/wrapt-2.2.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fb18fc51e813df0d9c98049e3bf2298a5495a648602040e21fa3c7329371159e", size = 167882, upload-time = "2026-06-20T23:48:18.764Z" },
+    { url = "https://files.pythonhosted.org/packages/20/1f/8bb62d8933df7acf3247194e6e9fc68edf9d2fa203252c89c94b319dd472/wrapt-2.2.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94b00b00f806eb3ef2abe9049ed45994a81ee9284884d96e6b8314927c6cea3d", size = 167411, upload-time = "2026-06-20T23:48:20.315Z" },
+    { url = "https://files.pythonhosted.org/packages/17/09/8789dcb09ee1de715727db7521aabbb68ffa68dfade3a49468440cfced49/wrapt-2.2.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:62415fd095bc590b842b6d092f2b5d9ccbaeb7e0b28535c03dcea2718b48636b", size = 158607, upload-time = "2026-06-20T23:48:21.728Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/20/66e02562d53ee67d841f175e38e3c993c2d78a3e104c576cad61c028b43c/wrapt-2.2.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a41e758d80dc0ab8c210f641ac892009d356cf1f955d97db544c8dd317b4d14c", size = 166367, upload-time = "2026-06-20T23:48:23.177Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a3/832ac4e41222fb263b3042d42c2f08d305db7d0f0c9b1d3a271a9eede8f6/wrapt-2.2.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:b84cd4058001c9727b0e9980b7a9e66325b5ca748b1b578e822cade1bc6b304f", size = 157176, upload-time = "2026-06-20T23:48:24.711Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/01/1bd5e4d2df9c0178989ac8da9186543465388588ee2ef153e2591accebef/wrapt-2.2.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:26fc73a1b15e0946d2942b9a4426d162b51676338327dc067ccd8d2d76385f94", size = 167025, upload-time = "2026-06-20T23:48:26.118Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/69/583ed25291ab53e1ec117135fb1c33425e2f46d2bc8f29c17f7a94cf4274/wrapt-2.2.2-cp313-cp313-win32.whl", hash = "sha256:3c4095803491f6ef72128914c28ec05bbad9758433bb35f6715a3e9c8e46fb2d", size = 77605, upload-time = "2026-06-20T23:48:27.643Z" },
+    { url = "https://files.pythonhosted.org/packages/29/68/e69fc6d06e1523c68e0d00f95c9aed1158ce9908ee41603f7f2eae3d5db6/wrapt-2.2.2-cp313-cp313-win_amd64.whl", hash = "sha256:2cb07f414fab25dbe6b5c7398e1491423a5c81a6209533639969a6c928d474a4", size = 80508, upload-time = "2026-06-20T23:48:29.013Z" },
+    { url = "https://files.pythonhosted.org/packages/55/21/fe7a393d9e5dc0923bed8f5d857e9dcff210f1fa0888c02cc8f3ffaa55aa/wrapt-2.2.2-cp313-cp313-win_arm64.whl", hash = "sha256:1fc7691f070220215cccb2a20836b9adbaecb8ff22ad47abe63de5f110994fac", size = 79565, upload-time = "2026-06-20T23:48:30.429Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/e5/c120d13bf5091164f68c3c1657e84f16f57e71d978421b626393ac5bd7eb/wrapt-2.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:ec8f83949028366531383603139403cac7a826e4011955813cdd640017845ce5", size = 83264, upload-time = "2026-06-20T23:48:31.807Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b0/d4a1eb97e0e286625bdf21bc7f702637f9607787ffbbdb5ec14d50c79dbf/wrapt-2.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4b481fb0c40d9fd90a5809911208da700987d373a20a4709dc9e3944af7a6bec", size = 83791, upload-time = "2026-06-20T23:48:33.482Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1e/f060df47755e87b57684cee7bfc1362b204df55fac96ffebc0631b697b79/wrapt-2.2.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0065a3b657cec06813b4241d2462ccec287f6863103d7445b725fb3a889736f9", size = 203399, upload-time = "2026-06-20T23:48:34.97Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/de/2316a757a1abb6453700b79d83e532146dcef2611348282d4d8889792161/wrapt-2.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:30f7424af5c5c345b7f26490e097f74a2ef45b3d08b664dc33571aee3bd3b56c", size = 210461, upload-time = "2026-06-20T23:48:36.569Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/29/d1160785ae18ca2495a6d82a21154103d74f656c9fd457fb35f6b11b965a/wrapt-2.2.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:07fdcb012821859168641acf68afad61ef9783cf37100af85f152550e9677194", size = 195313, upload-time = "2026-06-20T23:48:38.175Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/2d/7caa9598ae61a9cf0989cc501739cbeeb7d650ab3193cca1407b9af0c6ab/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f90038ab58fafb584801ca62d72384d7d5225d93c76f7b773c22fae545bd8066", size = 206116, upload-time = "2026-06-20T23:48:39.804Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/02/281ea1088b8650d865f311b35cf86fd21df89128e2909714f1161e01c9d0/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:c5d7825491bfa2d08b97e9557768987952c7b9ae687d06c3320b40a37ccb7f20", size = 192668, upload-time = "2026-06-20T23:48:41.346Z" },
+    { url = "https://files.pythonhosted.org/packages/be/7d/976e2d5b4b5c5babda40974edd54d0a5585cb60132ed86b46f4b80239b16/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:0ad520e6daa9bbf136f14de735474dbec7dcc0891f718e1d274ce8dc92e645af", size = 198891, upload-time = "2026-06-20T23:48:43.056Z" },
+    { url = "https://files.pythonhosted.org/packages/59/b7/e47651797c097f75a37e2ce86dcf04048ff576f3a674f7c558df7b5e9622/wrapt-2.2.2-cp313-cp313t-win32.whl", hash = "sha256:25904acb9475f46c24fe0423dbc8fda8cc5fbc282ab3dc6e72e919748c53f4e9", size = 78537, upload-time = "2026-06-20T23:48:44.509Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/6f/9fa5d59fb06d890defb5a8f727ce6a14d2932c8760153f96956628559fee/wrapt-2.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:305d4c247d61c4115794a169141823c62f719525ddb90b23aa332741c77d2c28", size = 82005, upload-time = "2026-06-20T23:48:46.391Z" },
+    { url = "https://files.pythonhosted.org/packages/15/80/4c7bd9873d1f9f7d138d93556b500469dbe24f42710b877519c2b9eb380d/wrapt-2.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:c20279cd1a29800815d7b2d6338b60a6c6e78263f9d6e62e0eda251ba9cae2d0", size = 80762, upload-time = "2026-06-20T23:48:47.964Z" },
+    { url = "https://files.pythonhosted.org/packages/24/05/7fd9c3f83b2c74cbfc572a0b88aa37431e04bd8aed70d2c0efd3464206de/wrapt-2.2.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:0e64826f920c42d9d9f87e8cc09ffae66c51ede12d59061a5a426deb9aa71745", size = 81341, upload-time = "2026-06-20T23:48:49.39Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/68/1bfa43100dd90d4ef74a05897b86275cf57e1313ca14aae2545bc9f872c9/wrapt-2.2.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:dcaa5e1451bd8751d7bd1568dfa3321c78092a52a7ecb5d1a0f18a5791e1fd00", size = 81921, upload-time = "2026-06-20T23:48:50.986Z" },
+    { url = "https://files.pythonhosted.org/packages/74/eb/df7b7f0b631dbbc750f39be27d8b55f65777d8ac86da80e12be41a644c4b/wrapt-2.2.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0abfd648dac9ac9c5b3aa9b523d27f1789046640b58dcd5652a720ddb325e1fc", size = 167713, upload-time = "2026-06-20T23:48:52.598Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/9a/d1bd36f6d088c8e652a9383cabbd49af30b8c576302a7eccddbab6963e3f/wrapt-2.2.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f4bfd8d1eb438153eff8b8cfe87f032ba65731e1ce06138b5090f745a33f6f95", size = 166779, upload-time = "2026-06-20T23:48:54.33Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/ae/24ffacd4187fac2740a1972093929e836dea092d42c87d728cd98fee11a6/wrapt-2.2.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c427c9d06d859848a69f0d928fe28b5c33a941b2265d10a0e1f15cd244f1ee33", size = 158407, upload-time = "2026-06-20T23:48:55.944Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ed/974427668249a356051e8d67d47fa54ef6c777f0fcf3bae9d292c047d4b6/wrapt-2.2.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4250b43d1a129d947e083c4dc6baf333c9bb34edd26f912d5b0457841fc858ab", size = 166594, upload-time = "2026-06-20T23:48:57.617Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/5f/e1d7c6e4523f78db2fbd7826babd0348da1d5e0834c4f918b9ab5757dfae/wrapt-2.2.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:173e5bb5ca350a6e0abab60b7ec7cdd7992a814cb14b4de670a28f067f105663", size = 157068, upload-time = "2026-06-20T23:48:59.171Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c1/7ebd1027f00700c0b0233b20aceef2b4784294ed64971424c4a78e069e34/wrapt-2.2.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:aa14b01804bce36c6d63d7b6a4f55df390f29f8648cc13a1f40b166f4d54680d", size = 166470, upload-time = "2026-06-20T23:49:00.737Z" },
+    { url = "https://files.pythonhosted.org/packages/99/eb/974e471a6a978b8180186b8a9dc5ae3361ce269a967190b709b8ce17abfb/wrapt-2.2.2-cp314-cp314-win32.whl", hash = "sha256:58f9f8d637c9a6e245c6ef5b109b67ec187d2faed23d1405656b51d96e0a5b56", size = 78062, upload-time = "2026-06-20T23:49:02.327Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ec/e1281156cdc7a66693838ad7a0865ad641c74abd337a957d668b575aaffb/wrapt-2.2.2-cp314-cp314-win_amd64.whl", hash = "sha256:385cb1866f20479e83299af585375bfa0a4b0c6c9907a981483ea782ea8ae406", size = 80832, upload-time = "2026-06-20T23:49:03.837Z" },
+    { url = "https://files.pythonhosted.org/packages/45/7d/1b6b5ddd94005a2dac97a4490c9838f3154977850d633abcb65b30089437/wrapt-2.2.2-cp314-cp314-win_arm64.whl", hash = "sha256:8ffbeaea6771a6eba6e6eeb09767864995726bc8240bb54baf88a9bb1db34d5c", size = 80029, upload-time = "2026-06-20T23:49:05.237Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/33/9ebcf8aafe91c601127cbd93708c16aa8f688f34a10bf004046803ecdc4f/wrapt-2.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:09f811d43f6f33ec7515f0be76b159569f4057ab54d3e079c3204dddb90afa2a", size = 83357, upload-time = "2026-06-20T23:49:06.632Z" },
+    { url = "https://files.pythonhosted.org/packages/39/38/ec45b635153327b52e52732a0ea980e5f00b7efba65f9e018828f1e69daa/wrapt-2.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a795d3c06e5fbf9ea2f13196180b77aeab1b4685917256ee0d014cc163d90063", size = 83794, upload-time = "2026-06-20T23:49:08.098Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/ea/1a89e6d3b7a83c3affe5c09cde77792c947e63e4bc85ad84cd5bb9abb0d8/wrapt-2.2.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:45c2f2768e790c9f8db90f239ef23a2af8e7570f25a35619ef902df4a738447f", size = 203362, upload-time = "2026-06-20T23:49:09.811Z" },
+    { url = "https://files.pythonhosted.org/packages/19/d8/3b58763d9863b5a73771c0d97110f9595d248db454009e07e1535ee905a4/wrapt-2.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bbf00ee0cb55ec24e2b0995a71942b85b21a066db8f3f46e1dbfdb9433ffba81", size = 210449, upload-time = "2026-06-20T23:49:11.521Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/6f/17fd9e053103d8be148d20d5d7505facc72d5fe1f9127973904ceaed79cf/wrapt-2.2.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2252f77663651b89255895f58cc6ac08fcb206d4371813e5af61bb62d4f7689c", size = 195349, upload-time = "2026-06-20T23:49:13.346Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/04/d0d1ccaaa12cb7dccf28a23f0279a608ba498f71e81d949d5ed54bcfd5c1/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2cd7181ab1c31192ff5219269830744b5a62020b3a6d433588c4f1c95b8f8bff", size = 206099, upload-time = "2026-06-20T23:49:15.051Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b3/e8aa07b619890a2aa6cde1931b1887abb08820721b564a5f80b7ca3f3aa0/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:6fe35fd51b74867d8b80174c277bd6bbf6a73e443f908129dc531c4b688a20d5", size = 192728, upload-time = "2026-06-20T23:49:16.854Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/f0/1819fb50f0d3c9bd758d8a83b56f1b470dee8b5b8eac8702b7c137cea9d4/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:11d95fc2fbad3163596c39d440e6f21ca9fccece74b56e30a37ac2fca786a07c", size = 198842, upload-time = "2026-06-20T23:49:18.504Z" },
+    { url = "https://files.pythonhosted.org/packages/67/7c/e88313f16a99930b899ef970d91c281544a470749a359decad994483bbda/wrapt-2.2.2-cp314-cp314t-win32.whl", hash = "sha256:d8a15813215f33fa83667bfc978b300e35669ea8bb424e970a1426bcb7bc6cca", size = 79059, upload-time = "2026-06-20T23:49:20.107Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/4f/ac12fda57a55068a094ec42851fb0a40e8489d8941863d517452de62e507/wrapt-2.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:d09db0f7e8357060d3c38fc22a018aba683a796bf184360fd1a58f6fc180dc77", size = 82462, upload-time = "2026-06-20T23:49:21.631Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a7/df732dac86d9b2027c56bd163dbc883e037b16c3469614752e148d219c61/wrapt-2.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:f32fe639c39561ccc187bcae17e9271be0eb45f1c2952510d2f29b33ab577347", size = 81182, upload-time = "2026-06-20T23:49:23.199Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/d2/6317eb6d4554855bbf12d61857774af34747bf88a42c19bf306de67e2fa3/wrapt-2.2.2-py3-none-any.whl", hash = "sha256:5bad217350f19ce99ca5b5e71d406765ea86fe541628426772b657375ee1c048", size = 61460, upload-time = "2026-06-20T23:49:42.966Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

`configure_tracing()` gives toolkit consumers a manual `TraceContextMiddleware` (ASGI) and a manual `inject_trace_headers()` helper for outbound calls, but nothing auto-instruments FastAPI or `requests` — a consumer has to remember to call `inject_trace_headers()` at every outbound call site to actually join a distributed trace.

This adds two optional helpers:
- `instrument_fastapi_app(app, *, excluded_urls=None)` — wraps `FastAPIInstrumentor.instrument_app` (the instance form, not the global `FastAPIInstrumentor().instrument()`, so app-creation order doesn't matter).
- `instrument_requests()` — wraps `RequestsInstrumentor().instrument()`, patching `requests` at module level so callers that already imported it are still covered.

Both are opt-in calls a consumer makes alongside `configure_tracing()`; nothing changes for existing consumers that don't call them.

### Dependency notes
- `opentelemetry-instrumentation-fastapi`/`-requests` are added to the `otel` extra (and mirrored into the `dev` group, matching how `opentelemetry-sdk`/`-exporter-otlp-proto-http` are already handled there so tests run under CI's default `--extra fastapi --extra monitoring` toolkit install args).
- Verified `fastapi` is **not** pulled in transitively by the `otel` extra: `opentelemetry-instrumentation-fastapi` only lists `fastapi` under its own optional `instruments` extra, which isn't requested here. `fastapi` stays gated behind `unique_toolkit[fastapi]`, same as before.
- `instrument_fastapi_app` explicitly checks for `fastapi` before touching the OTel instrumentation package: `opentelemetry-instrumentation-fastapi` imports `fastapi` internally at module scope, so without this check its `ImportError` would be misreported as a missing `otel` extra when `fastapi` is what's actually missing. Added a matching `unique_toolkit[fastapi]` install hint.

### Propagator and BatchSpanProcessor sizing
Both now pinned explicitly in `configure_tracing()` rather than relying on the OTel SDK's current defaults (which happen to equal these values today, but aren't guaranteed to stay that way):
- `set_global_textmap(CompositePropagator([TraceContextTextMapPropagator(), W3CBaggagePropagator()]))` — the shared subset of the Node services' composite propagator.
- `BatchSpanProcessor(..., max_queue_size=2048, max_export_batch_size=512, schedule_delay_millis=5000)` — matches Node's `instrumentation.ts` and assistants-core's own `instrumentation.py`.

### `.env` gap on `TracingSettings`
`TracingSettings` had no `env_file`, so it only ever read `ENABLE_OPENTELEMETRY` from real `os.environ` — never from a bundle's local `.env` (pydantic-settings does not populate `os.environ` from `.env`). It now gets the `find_env_file()` treatment every other `BaseSettings` subclass in the toolkit already has (`UniqueAuth`, `UniqueApp`, `UniqueApi`, `UniqueChatEventFilterOptions`, `FeatureFlagSettings`) — it was the one outlier missing it. Confirmed against assistants-core's actual CD config (`docker_context: python/assistants/bundles/core/src`, no `chdir` anywhere in `entrypoint.sh`/`gunicorn.conf.py`) that its container's cwd and its own `__file__`-relative `.env` resolution point at the same file, so `find_env_file`'s cwd-based search lands on it too.

Refs: UN-23824, follow-up from [monorepo#27770](https://github.com/Unique-AG/monorepo/pull/27770), tracked in [UN-23934][].

## Test plan
- [x] `uv run pytest tests/monitoring/test_tracing.py -v` — 29 passed, including:
  - `instrument_fastapi_app`/`instrument_requests` install-hint errors (fastapi missing vs. otel extra missing, distinguished)
  - `instrument_fastapi_app`/`instrument_requests` idempotency (calling twice doesn't raise or double-instrument)
  - real inbound span via `TestClient` + `InMemorySpanExporter`
  - `excluded_urls` actually suppresses spans for the matching route (not just that a normal route gets traced)
  - `ENABLE_OPENTELEMETRY` resolves from a `.env`-only file, with nothing in real `os.environ`
- [x] `uv run pytest tests/ -q` (full toolkit suite) — 2839 passed, 1 skipped, no regressions
- [x] `uv run ruff check .` / `uv run ruff format --check .` — clean
- [x] `uv run basedpyright unique_toolkit/monitoring/tracing.py` — 0 errors, 0 warnings
- [x] `uv run deptry .` — no dependency issues
- [x] Confirmed `fastapi` is not a transitive dependency of the `otel` extra alone (`opentelemetry-instrumentation-fastapi`'s own metadata gates it behind its `instruments` extra)

[UN-23934]: https://unique-ch.atlassian.net/browse/UN-23934
